### PR TITLE
feat(ci): add autobuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+on:
+- push
+- pull_request
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: rui314/setup-mold@v1
+    - uses: taiki-e/install-action@just
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: aarch64-unknown-linux-gnu
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install cross main
+      run: |
+        just install-cross
+    - run: |
+        just build-all-release
+    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     steps:
     - uses: actions/checkout@v2
     - uses: rui314/setup-mold@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 on:
-- push:
-    branches:
-    - production
-- pull_request
+  push:
+    branches: [production]
+  pull_request:
 
 jobs:
   build:
@@ -28,4 +27,9 @@ jobs:
         just install-cross
     - run: |
         just build-all-release
+    - uses: actions/upload-artifact@v4
+      with:
+        name: tempo-x86_64-unknown-linux-gnu
+        path: target/x86_64-unknown-linux-gnu/release/reth-malachite
+
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: taiki-e/install-action@just
     - uses: dtolnay/rust-toolchain@stable
       with:
-        target: aarch64-unknown-linux-gnu
+        target: x86_64-unknown-linux-gnu
     - name: Cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on:
-- push
+- push:
+    branches:
+    - production
 - pull_request
 
 jobs:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,16 @@
+[build]
+pre-build = [
+    # Use HTTPS for package sources
+    "apt-get update && apt-get install --assume-yes --no-install-recommends ca-certificates",
+    "find /etc/apt/ -type f \\( -name '*.list' -o -name '*.sources' \\) -exec sed -i 's|http://|https://|g' {} +",
+
+    # Configure APT retries and timeouts to handle network issues
+    "echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::http::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+    "echo 'Acquire::ftp::Timeout \"60\";' >> /etc/apt/apt.conf.d/80-retries",
+
+    # rust-bindgen dependencies: llvm-dev libclang-dev (>= 10) clang (>= 10)
+    # See: https://github.com/cross-rs/cross/wiki/FAQ#using-clang--bindgen for
+    # recommended clang versions for the given cross and bindgen version.
+    "apt-get update && apt-get install --assume-yes --no-install-recommends llvm-dev libclang-dev clang",
+]

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,20 @@
+cross_compile := "true"
+cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
+
+[group('deps')]
+install-cross:
+    cargo install cross --git https://github.com/cross-rs/cross
+
+[group('build')]
+[doc('Builds all tempo binaries in cargo release mode')]
+build-all-release extra_args="": (_build-release "reth-malachite" extra_args)
+
+[group('build')]
+[doc('Builds all tempo binaries')]
+build-all extra_args="": (_build "reth-malachite" extra_args)
+
+_build-release target extra_args="": (_build target "-r " + extra_args)
+
+_build target extra_args="":
+    CROSS_CONTAINER_IN_CONTAINER=true RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
+        {{cargo_build_binary}} build {{extra_args}} --bin {{target}}

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 cross_compile := "true"
 cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
-act_debug_mode := "false"
+act_debug_mode := env("ACT")
 
 [group('deps')]
 install-cross:
@@ -14,8 +14,8 @@ build-all-release extra_args="": (_build-release "reth-malachite" extra_args)
 [doc('Builds all tempo binaries')]
 build-all extra_args="": (_build "reth-malachite" extra_args)
 
-_build-release target extra_args="": (_build target "-r " + extra_args)
+_build-release binary extra_args="": (_build binary "-r " + extra_args)
 
-_build target extra_args="":
+_build binary extra_args="":
     CROSS_CONTAINER_IN_CONTAINER={{act_debug_mode}} RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-        {{cargo_build_binary}} build {{extra_args}} --bin {{target}}
+        {{cargo_build_binary}} build {{extra_args}} --target x86_64-unknown-linux-gnu --bin {{binary}}

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 cross_compile := "true"
 cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
-act_debug_mode := env("ACT")
+act_debug_mode := env("ACT", "false")
 
 [group('deps')]
 install-cross:

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
 cross_compile := "true"
 cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
+act_debug_mode := "false"
 
 [group('deps')]
 install-cross:
@@ -16,5 +17,5 @@ build-all extra_args="": (_build "reth-malachite" extra_args)
 _build-release target extra_args="": (_build target "-r " + extra_args)
 
 _build target extra_args="":
-    CROSS_CONTAINER_IN_CONTAINER=true RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
+    CROSS_CONTAINER_IN_CONTAINER={{act_debug_mode}} RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
         {{cargo_build_binary}} build {{extra_args}} --bin {{target}}


### PR DESCRIPTION
uses `cross-rs` like in reth, not exactly 100% on how it all functions yet, but it avoids the issues of different libraries needed on different types of hosts. lmk if anyone has any concerns about how the Justfile / workflows are structured