### PR TITLE
fix(tempo-bench): lower default generated genesis gas limit

### DIFF
--- a/bin/tempo-bench/src/cmd/genesis.rs
+++ b/bin/tempo-bench/src/cmd/genesis.rs
@@ -84,7 +84,7 @@ impl GenesisArgs {
         };
 
         let mut genesis = Genesis::default()
-            .with_gas_limit(u64::MAX)
+            .with_gas_limit(0xfffffffffff)
             .with_nonce(0x42)
             .with_extra_data(Bytes::from_static(b"tempo-genesis"))
             .with_coinbase(Address::ZERO);


### PR DESCRIPTION
I didn't do a deepdive on this issue, but Reth does not support `u64::MAX` as it's gas limit