### PR TITLE
chore: use uint! for consts

### DIFF
--- a/crates/precompiles/src/contracts/storage/slots.rs
+++ b/crates/precompiles/src/contracts/storage/slots.rs
@@ -1,11 +1,5 @@
 use alloy::primitives::{U256, keccak256};
 
-pub const fn to_u256(x: u64) -> U256 {
-    let mut limbs = [0; 4];
-    limbs[0] = x;
-    U256::from_limbs(limbs)
-}
-
 pub const fn pad_to_32(x: &[u8]) -> [u8; 32] {
     let mut buf = [0u8; 32];
     let mut i = 0;

--- a/crates/precompiles/src/contracts/tip20.rs
+++ b/crates/precompiles/src/contracts/tip20.rs
@@ -16,25 +16,24 @@ use crate::{
 };
 
 mod slots {
-    use crate::contracts::storage::slots::to_u256;
-    use alloy::primitives::U256;
+    use alloy::primitives::{U256, uint};
 
     // Variables
-    pub const NAME: U256 = to_u256(0);
-    pub const SYMBOL: U256 = to_u256(1);
-    pub const TOTAL_SUPPLY: U256 = to_u256(3);
-    pub const CURRENCY: U256 = to_u256(4);
-    pub const DOMAIN_SEPARATOR: U256 = to_u256(5);
-    pub const TRANSFER_POLICY_ID: U256 = to_u256(6);
-    pub const SUPPLY_CAP: U256 = to_u256(7);
-    pub const PAUSED: U256 = to_u256(8);
+    pub const NAME: U256 = uint!(0_U256);
+    pub const SYMBOL: U256 = uint!(1_U256);
+    pub const TOTAL_SUPPLY: U256 = uint!(3_U256);
+    pub const CURRENCY: U256 = uint!(4_U256);
+    pub const DOMAIN_SEPARATOR: U256 = uint!(5_U256);
+    pub const TRANSFER_POLICY_ID: U256 = uint!(6_U256);
+    pub const SUPPLY_CAP: U256 = uint!(7_U256);
+    pub const PAUSED: U256 = uint!(8_U256);
     // Mappings
-    pub const BALANCES: U256 = to_u256(10);
-    pub const ALLOWANCES: U256 = to_u256(11);
-    pub const NONCES: U256 = to_u256(12);
-    pub const SALTS: U256 = to_u256(13);
-    pub const ROLES_BASE_SLOT: U256 = to_u256(14); // via RolesAuthContract
-    pub const ROLE_ADMIN_BASE_SLOT: U256 = to_u256(15); // via RolesAuthContract
+    pub const BALANCES: U256 = uint!(10_U256);
+    pub const ALLOWANCES: U256 = uint!(11_U256);
+    pub const NONCES: U256 = uint!(12_U256);
+    pub const SALTS: U256 = uint!(13_U256);
+    pub const ROLES_BASE_SLOT: U256 = uint!(14_U256); // via RolesAuthContract
+    pub const ROLE_ADMIN_BASE_SLOT: U256 = uint!(15_U256); // via RolesAuthContract
 }
 
 #[derive(Debug)]

--- a/crates/precompiles/src/contracts/tip403_registry.rs
+++ b/crates/precompiles/src/contracts/tip403_registry.rs
@@ -11,12 +11,11 @@ use crate::{
 };
 
 mod slots {
-    use crate::contracts::storage::slots::to_u256;
-    use alloy::primitives::U256;
+    use alloy::primitives::{U256, uint};
 
-    pub const POLICY_ID_COUNTER: U256 = to_u256(0);
-    pub const POLICY_DATA: U256 = to_u256(1);
-    pub const POLICY_SET: U256 = to_u256(2);
+    pub const POLICY_ID_COUNTER: U256 = uint!(0_U256);
+    pub const POLICY_DATA: U256 = uint!(1_U256);
+    pub const POLICY_SET: U256 = uint!(2_U256);
 }
 
 #[derive(Debug)]

--- a/crates/precompiles/src/contracts/tip_fee_manager.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager.rs
@@ -10,16 +10,15 @@ use alloy::{
 use reth::revm::interpreter::instructions::utility::{IntoAddress, IntoU256};
 
 mod slots {
-    use crate::contracts::storage::slots::to_u256;
-    use alloy::primitives::U256;
+    use alloy::primitives::{U256, uint};
 
-    pub const POOLS: U256 = to_u256(0);
-    pub const POOL_EXISTS: U256 = to_u256(2);
-    pub const VALIDATOR_TOKENS: U256 = to_u256(4);
-    pub const USER_TOKENS: U256 = to_u256(5);
-    pub const COLLECTED_FEES: U256 = to_u256(6);
-    pub const TOKENS_WITH_FEES_LENGTH: U256 = to_u256(11);
-    pub const TOKEN_IN_FEES_ARRAY: U256 = to_u256(15);
+    pub const POOLS: U256 = uint!(0_U256);
+    pub const POOL_EXISTS: U256 = uint!(2_U256);
+    pub const VALIDATOR_TOKENS: U256 = uint!(4_U256);
+    pub const USER_TOKENS: U256 = uint!(5_U256);
+    pub const COLLECTED_FEES: U256 = uint!(6_U256);
+    pub const TOKENS_WITH_FEES_LENGTH: U256 = uint!(11_U256);
+    pub const TOKEN_IN_FEES_ARRAY: U256 = uint!(15_U256);
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
this is equivalent to the macro

e.g.

```
   pub const VALIDATOR_TOKENS: U256 = ::ruint::Uint::<
        256,
        4,
    >::from_limbs([
        0x0000000000000004_u64,
        0x0000000000000000_u64,
        0x0000000000000000_u64,
        0x0000000000000000_u64,
    ]);

```