### PR TITLE
fix(evm): Update `transact_raw` to check gas fee via `tx.max_balance_spending()`

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -347,7 +347,7 @@ mod tests {
         db::{CacheDB, EmptyDB},
         inspector::NoOpInspector,
     };
-    use reth_evm::{EvmEnv, EvmError, EvmFactory, EvmInternals, precompiles::PrecompilesMap};
+    use reth_evm::{EvmEnv, EvmFactory, EvmInternals, precompiles::PrecompilesMap};
     use reth_revm::DatabaseCommit;
     use tempo_precompiles::{
         TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,


### PR DESCRIPTION
This PR updates `TempoEvm::transact_raw` to check the transaction gas fee via `tx.max_balance_spending()` rather than calculating directly.