### PR TITLE
feat: specify coinbase when generating genesis

### DIFF
--- a/bin/tempo-bench/src/cmd/genesis.rs
+++ b/bin/tempo-bench/src/cmd/genesis.rs
@@ -51,7 +51,7 @@ pub struct GenesisArgs {
     #[arg(long, short, default_value = "1337")]
     pub chain_id: u64,
 
-    #[arg(long, short)]
+    #[arg(long)]
     pub coinbase: Option<Address>,
 }
 


### PR DESCRIPTION
This PR adds a `--coinbase` flag to `tempo-bench generate-genesis` to allow you to specify the coinbase in the `genesis.json`.