### PR TITLE
chore: set caller and enable statediffs

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -153,6 +153,7 @@ async fn test_eth_trace_call() -> eyre::Result<()> {
     let recipient = Address::random();
     let calldata = token.transfer(recipient, mint_amount).calldata().clone();
     let tx = TransactionRequest::default()
+        .from(caller)
         .to(*token.address())
         .gas_price(0)
         .input(TransactionInput::new(calldata));
@@ -161,9 +162,7 @@ async fn test_eth_trace_call() -> eyre::Result<()> {
     let success = transferCall::abi_decode_returns(&res)?;
     assert!(success);
 
-    let trace_res = provider.trace_call(&tx).await?;
-
-    dbg!(&trace_res);
+    let trace_res = provider.trace_call(&tx).state_diff().await?;
 
     let success = transferCall::abi_decode_returns(&trace_res.output)?;
     assert!(success);


### PR DESCRIPTION
RPC endpoints are somewhat difficult to connect to with the installed wallet, hence the from field isnt auto configured.

it's not easy to get this behaviour quite right so the caller must be manually set

also used the state_diff call

though need to figure out why the feetoken isnt part of the statediff