### PR TITLE
chore: replace tip20err macro with constructor calls

### DIFF
--- a/crates/precompiles/src/contracts/types.rs
+++ b/crates/precompiles/src/contracts/types.rs
@@ -235,11 +235,71 @@ sol! {
     }
 }
 
-#[macro_export]
-macro_rules! tip20_err {
-    ($err:ident) => {
-        $crate::contracts::types::TIP20Error::$err($crate::contracts::types::ITIP20::$err {})
-    };
+impl TIP20Error {
+    /// Creates an error for insufficient token balance.
+    pub const fn insufficient_balance() -> Self {
+        Self::InsufficientBalance(ITIP20::InsufficientBalance {})
+    }
+
+    /// Creates an error for insufficient spending allowance.
+    pub const fn insufficient_allowance() -> Self {
+        Self::InsufficientAllowance(ITIP20::InsufficientAllowance {})
+    }
+
+    /// Creates an error when minting would exceed supply cap.
+    pub const fn supply_cap_exceeded() -> Self {
+        Self::SupplyCapExceeded(ITIP20::SupplyCapExceeded {})
+    }
+
+    /// Creates an error for invalid cryptographic signature.
+    pub const fn invalid_signature() -> Self {
+        Self::InvalidSignature(ITIP20::InvalidSignature {})
+    }
+
+    /// Creates an error for invalid payload data.
+    pub const fn invalid_payload() -> Self {
+        Self::InvalidPayload(ITIP20::InvalidPayload {})
+    }
+
+    /// Creates an error for invalid or reused nonce.
+    pub const fn invalid_nonce() -> Self {
+        Self::InvalidNonce(ITIP20::InvalidNonce {})
+    }
+
+    /// Creates an error when string parameter exceeds maximum length.
+    pub const fn string_too_long() -> Self {
+        Self::StringTooLong(ITIP20::StringTooLong {})
+    }
+
+    /// Creates an error when transfer is forbidden by policy.
+    pub const fn policy_forbids() -> Self {
+        Self::PolicyForbids(ITIP20::PolicyForbids {})
+    }
+
+    /// Creates an error for invalid recipient address.
+    pub const fn invalid_recipient() -> Self {
+        Self::InvalidRecipient(ITIP20::InvalidRecipient {})
+    }
+
+    /// Creates an error when operation deadline has expired.
+    pub const fn expired() -> Self {
+        Self::Expired(ITIP20::Expired {})
+    }
+
+    /// Creates an error when salt has already been used.
+    pub const fn salt_already_used() -> Self {
+        Self::SaltAlreadyUsed(ITIP20::SaltAlreadyUsed {})
+    }
+
+    /// Creates an error when contract is paused.
+    pub const fn contract_paused() -> Self {
+        Self::ContractPaused(ITIP20::ContractPaused {})
+    }
+
+    /// Creates an error for invalid currency.
+    pub const fn invalid_currency() -> Self {
+        Self::InvalidCurrency(ITIP20::InvalidCurrency {})
+    }
 }
 
 #[macro_export]

--- a/crates/precompiles/src/precompiles/tip20.rs
+++ b/crates/precompiles/src/precompiles/tip20.rs
@@ -62,9 +62,11 @@ impl<'a, S: StorageProvider> Precompile for TIP20Token<'a, S> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        contracts::{HashMapStorageProvider, types::IRolesAuth},
+        contracts::{
+            HashMapStorageProvider,
+            types::{IRolesAuth, TIP20Error},
+        },
         precompiles::{METADATA_GAS, MUTATE_FUNC_GAS, VIEW_FUNC_GAS, expect_precompile_error},
-        tip20_err,
     };
     use alloy::{
         primitives::{U256, keccak256},
@@ -567,7 +569,7 @@ mod tests {
         let result = token.call(&Bytes::from(calldata), &admin);
 
         // Should fail due to supply cap
-        expect_precompile_error(&result, tip20_err!(SupplyCapExceeded));
+        expect_precompile_error(&result, TIP20Error::supply_cap_exceeded());
     }
 
     #[test]
@@ -622,7 +624,7 @@ mod tests {
         };
         let calldata = mint_call.abi_encode();
         let result = token.call(&Bytes::from(calldata.clone()), &unauthorized);
-        expect_precompile_error(&result, tip20_err!(PolicyForbids));
+        expect_precompile_error(&result, TIP20Error::policy_forbids());
 
         // Test authorized mint (should succeed)
         let result = token.call(&Bytes::from(calldata), &user1).unwrap();
@@ -742,6 +744,6 @@ mod tests {
         let change_policy_call = ITIP20::changeTransferPolicyIdCall { newPolicyId: 100 };
         let calldata = change_policy_call.abi_encode();
         let result = token.call(&Bytes::from(calldata), &non_admin);
-        expect_precompile_error(&result, tip20_err!(PolicyForbids));
+        expect_precompile_error(&result, TIP20Error::policy_forbids());
     }
 }

--- a/crates/precompiles/src/precompiles/tip20_factory.rs
+++ b/crates/precompiles/src/precompiles/tip20_factory.rs
@@ -30,9 +30,8 @@ impl<'a, S: StorageProvider> Precompile for TIP20Factory<'a, S> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        contracts::HashMapStorageProvider,
+        contracts::{HashMapStorageProvider, types::TIP20Error},
         precompiles::{MUTATE_FUNC_GAS, VIEW_FUNC_GAS, expect_precompile_error},
-        tip20_err,
     };
     use alloy::{
         primitives::{Bytes, U256},
@@ -120,7 +119,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &sender);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
 
         // Check counter increased again
         let counter_call = ITIP20Factory::tokenIdCounterCall {};
@@ -158,7 +157,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &admin2);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
 
         // Create token with different unsupported currency should fail
         let create_call = ITIP20Factory::createTokenCall {
@@ -169,7 +168,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &admin1);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
     }
 
     #[test]
@@ -187,7 +186,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &sender);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
     }
 
     #[test]
@@ -242,7 +241,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &caller2);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
 
         // Third caller creates a token with different admin and unsupported currency should fail
         let create_call = ITIP20Factory::createTokenCall {
@@ -253,7 +252,7 @@ mod tests {
         };
         let calldata = create_call.abi_encode();
         let result = factory.call(&Bytes::from(calldata), &caller3);
-        expect_precompile_error(&result, tip20_err!(InvalidCurrency));
+        expect_precompile_error(&result, TIP20Error::invalid_currency());
 
         // Verify only first token was created
         assert_eq!(token_id1, U256::ZERO);


### PR DESCRIPTION
I find this easier to read,

only did it for the tip20 errors, to keep diff smol
