### PR TITLE
chore: remove unused functions

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -338,7 +338,7 @@ async fn test_eth_estimate_gas() -> eyre::Result<()> {
         .input(TransactionInput::new(calldata));
 
     let gas = provider.estimate_gas(tx).await?;
-    assert_eq!(gas, 23667);
+    assert_eq!(gas, 23697);
 
     Ok(())
 }


### PR DESCRIPTION
This PR removes unused functions from the `TIP20` interface.