### PR TITLE
chore: simplify EVM generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12007,7 +12007,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
- "reth-revm",
+ "reth-evm",
  "tempo-precompiles",
  "tracing",
 ]

--- a/bin/tempo-bench/src/cmd/genesis.rs
+++ b/bin/tempo-bench/src/cmd/genesis.rs
@@ -9,9 +9,9 @@ use rayon::prelude::*;
 use reth::revm::{
     context::ContextTr,
     db::{CacheDB, EmptyDB},
-    inspector::{JournalExt, NoOpInspector},
+    inspector::JournalExt,
 };
-use reth_evm::{Evm, EvmEnv, EvmFactory, EvmInternals, precompiles::PrecompilesMap};
+use reth_evm::{Evm, EvmEnv, EvmFactory, EvmInternals};
 use simple_tqdm::{ParTqdm, Tqdm};
 use std::{collections::BTreeMap, fs, path::PathBuf};
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
@@ -185,7 +185,7 @@ impl GenesisArgs {
     }
 }
 
-fn setup_tempo_evm() -> TempoEvm<CacheDB<EmptyDB>, NoOpInspector, PrecompilesMap> {
+fn setup_tempo_evm() -> TempoEvm<CacheDB<EmptyDB>> {
     let db = CacheDB::default();
     let env = EvmEnv::default();
     let factory = TempoEvmFactory::default();
@@ -199,7 +199,7 @@ fn create_and_mint_token(
     currency: &str,
     admin: Address,
     mint_amount: U256,
-    evm: &mut TempoEvm<CacheDB<EmptyDB>, NoOpInspector, PrecompilesMap>,
+    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
 ) -> eyre::Result<u64> {
     let chain_id = evm.chain_id();
     let block = evm.block.clone();

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-reth-revm.workspace = true
+reth-evm.workspace = true
 alloy-primitives.workspace = true
 tempo-precompiles.workspace = true
 

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1,67 +1,124 @@
-use reth_revm::{
-    Database, Inspector,
-    context::{ContextError, ContextSetters, ContextTr, Evm, FrameStack},
-    handler::{
-        EthFrame, EthPrecompiles, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult,
-        PrecompileProvider,
-        instructions::{EthInstructions, InstructionProvider},
+use reth_evm::{
+    Database,
+    precompiles::PrecompilesMap,
+    revm::{
+        Context, Inspector,
+        context::{BlockEnv, CfgEnv, ContextError, Evm, FrameStack, TxEnv},
+        handler::{
+            EthFrame, EthPrecompiles, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult,
+            instructions::EthInstructions,
+        },
+        inspector::InspectorEvmTr,
+        interpreter::interpreter::EthInterpreter,
     },
-    inspector::{InspectorEvmTr, JournalExt},
-    interpreter::{InterpreterResult, interpreter::EthInterpreter},
 };
 
+/// The Tempo EVM context type.
+pub type TempoContext<DB> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
+
 /// TempoEvm extends the Evm with Tempo specific types and logic.
-#[derive(Debug, Clone)]
-pub struct TempoEvm<
-    CTX,
-    INSP,
-    I = EthInstructions<EthInterpreter, CTX>,
-    // TODO: Tempo Precompiles
-    P = EthPrecompiles,
-    F = EthFrame<EthInterpreter>,
->(
+#[derive(Debug)]
+#[expect(clippy::type_complexity)]
+pub struct TempoEvm<DB: Database, I>(
     /// Inner EVM type.
-    pub Evm<CTX, INSP, I, P, F>,
+    pub  Evm<
+        TempoContext<DB>,
+        I,
+        EthInstructions<EthInterpreter, TempoContext<DB>>,
+        PrecompilesMap,
+        EthFrame<EthInterpreter>,
+    >,
 );
 
-impl<CTX: ContextTr, INSP> TempoEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>> {
+impl<DB: Database, I> TempoEvm<DB, I> {
     /// Create a new Optimism EVM.
-    pub fn new(ctx: CTX, inspector: INSP) -> Self {
+    pub fn new(ctx: TempoContext<DB>, inspector: I) -> Self {
         Self(Evm {
             ctx,
             inspector,
             instruction: EthInstructions::new_mainnet(),
-            precompiles: EthPrecompiles::default(),
+            precompiles: PrecompilesMap::from_static(EthPrecompiles::default().precompiles),
             frame_stack: FrameStack::new(),
         })
     }
 }
 
-impl<CTX, INSP, I, P> TempoEvm<CTX, INSP, I, P> {
+impl<DB: Database, I> TempoEvm<DB, I> {
     /// Consumed self and returns a new Evm type with given Inspector.
-    pub fn with_inspector<OINSP>(self, inspector: OINSP) -> TempoEvm<CTX, OINSP, I, P> {
+    pub fn with_inspector<OINSP>(self, inspector: OINSP) -> TempoEvm<DB, OINSP> {
         TempoEvm(self.0.with_inspector(inspector))
     }
 
     /// Consumes self and returns a new Evm type with given Precompiles.
-    pub fn with_precompiles<OP>(self, precompiles: OP) -> TempoEvm<CTX, INSP, I, OP> {
+    pub fn with_precompiles(self, precompiles: PrecompilesMap) -> Self {
         TempoEvm(self.0.with_precompiles(precompiles))
     }
 
     /// Consumes self and returns the inner Inspector.
-    pub fn into_inspector(self) -> INSP {
+    pub fn into_inspector(self) -> I {
         self.0.into_inspector()
     }
 }
 
-impl<CTX, INSP, I, P> InspectorEvmTr for TempoEvm<CTX, INSP, I, P>
+impl<DB, I> EvmTr for TempoEvm<DB, I>
 where
-    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
-    I: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
-    P: PrecompileProvider<CTX, Output = InterpreterResult>,
-    INSP: Inspector<CTX, I::InterpreterTypes>,
+    DB: Database,
 {
-    type Inspector = INSP;
+    type Context = TempoContext<DB>;
+    type Instructions = EthInstructions<EthInterpreter, TempoContext<DB>>;
+    type Precompiles = PrecompilesMap;
+    type Frame = EthFrame<EthInterpreter>;
+
+    fn ctx(&mut self) -> &mut Self::Context {
+        &mut self.0.ctx
+    }
+
+    fn ctx_ref(&self) -> &Self::Context {
+        &self.0.ctx
+    }
+
+    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
+        (&mut self.0.ctx, &mut self.0.instruction)
+    }
+
+    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
+        (&mut self.0.ctx, &mut self.0.precompiles)
+    }
+
+    fn frame_stack(&mut self) -> &mut FrameStack<Self::Frame> {
+        &mut self.0.frame_stack
+    }
+
+    fn frame_init(
+        &mut self,
+        frame_input: <Self::Frame as FrameTr>::FrameInit,
+    ) -> Result<
+        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
+        ContextError<DB::Error>,
+    > {
+        self.0.frame_init(frame_input)
+    }
+
+    fn frame_run(&mut self) -> Result<FrameInitOrResult<Self::Frame>, ContextError<DB::Error>> {
+        self.0.frame_run()
+    }
+
+    #[doc = " Returns the result of the frame to the caller. Frame is popped from the frame stack."]
+    #[doc = " Consumes the frame result or returns it if there is more frames to run."]
+    fn frame_return_result(
+        &mut self,
+        result: <Self::Frame as FrameTr>::FrameResult,
+    ) -> Result<Option<<Self::Frame as FrameTr>::FrameResult>, ContextError<DB::Error>> {
+        self.0.frame_return_result(result)
+    }
+}
+
+impl<DB, I> InspectorEvmTr for TempoEvm<DB, I>
+where
+    DB: Database,
+    I: Inspector<TempoContext<DB>>,
+{
+    type Inspector = I;
 
     fn inspector(&mut self) -> &mut Self::Inspector {
         &mut self.0.inspector
@@ -95,68 +152,5 @@ where
             self.0.frame_stack.get(),
             &mut self.0.instruction,
         )
-    }
-}
-
-impl<CTX, INSP, I, P> EvmTr for TempoEvm<CTX, INSP, I, P, EthFrame<EthInterpreter>>
-where
-    CTX: ContextTr,
-    I: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
-    P: PrecompileProvider<CTX, Output = InterpreterResult>,
-{
-    type Context = CTX;
-    type Instructions = I;
-    type Precompiles = P;
-    type Frame = EthFrame<EthInterpreter>;
-
-    fn ctx(&mut self) -> &mut Self::Context {
-        &mut self.0.ctx
-    }
-
-    fn ctx_ref(&self) -> &Self::Context {
-        &self.0.ctx
-    }
-
-    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
-        (&mut self.0.ctx, &mut self.0.instruction)
-    }
-
-    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
-        (&mut self.0.ctx, &mut self.0.precompiles)
-    }
-
-    fn frame_stack(&mut self) -> &mut FrameStack<Self::Frame> {
-        &mut self.0.frame_stack
-    }
-
-    fn frame_init(
-        &mut self,
-        frame_input: <Self::Frame as FrameTr>::FrameInit,
-    ) -> Result<
-        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_init(frame_input)
-    }
-
-    fn frame_run(
-        &mut self,
-    ) -> Result<
-        FrameInitOrResult<Self::Frame>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_run()
-    }
-
-    #[doc = " Returns the result of the frame to the caller. Frame is popped from the frame stack."]
-    #[doc = " Consumes the frame result or returns it if there is more frames to run."]
-    fn frame_return_result(
-        &mut self,
-        result: <Self::Frame as FrameTr>::FrameResult,
-    ) -> Result<
-        Option<<Self::Frame as FrameTr>::FrameResult>,
-        ContextError<<<Self::Context as ContextTr>::Db as Database>::Error>,
-    > {
-        self.0.frame_return_result(result)
     }
 }


### PR DESCRIPTION
There's no need for `TempoEvm` to be generic over precompiles/instruction providers because we're only going to use it with single generic value. This PR changes types to only be generic over database and inspector, simplifying things a bit and making types easier to reason about