### PR TITLE
feat: `TempoEngineValidator`

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -15,7 +15,7 @@ tempo-chainspec.workspace = true
 reth-malachite.workspace = true
 reth-cli-commands.workspace = true
 reth-ethereum-engine-primitives.workspace = true
-reth-ethereum = { workspace = true, features = ["rpc"] }
+reth-ethereum = { workspace = true, features = ["node", "rpc"] }
 reth-ethereum-primitives.workspace = true
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
 reth-node-builder.workspace = true

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,0 +1,73 @@
+use alloy_rpc_types_engine::ExecutionData;
+use reth_ethereum::{Block, engine::EthPayloadAttributes, primitives::Header};
+use reth_node_api::{
+    EngineApiMessageVersion, EngineApiValidator, EngineObjectValidationError,
+    InvalidPayloadAttributesError, NewPayloadError, PayloadOrAttributes, PayloadValidator,
+};
+use reth_node_ethereum::{EthEngineTypes, EthereumEngineValidator};
+use reth_primitives_traits::RecoveredBlock;
+use std::sync::Arc;
+use tempo_chainspec::spec::TempoChainSpec;
+
+/// Type encapsulating Tempo engine validation logic. Wraps an inner [`EthereumEngineValidator`].
+pub struct TempoEngineValidator {
+    inner: EthereumEngineValidator<TempoChainSpec>,
+}
+
+impl TempoEngineValidator {
+    /// Creates a new [`TempoEngineValidator`] with the given chain spec.
+    pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
+        Self {
+            inner: EthereumEngineValidator::new(chain_spec),
+        }
+    }
+}
+
+impl PayloadValidator<EthEngineTypes> for TempoEngineValidator {
+    type Block = Block;
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: ExecutionData,
+    ) -> Result<RecoveredBlock<Block>, NewPayloadError> {
+        PayloadValidator::<EthEngineTypes>::ensure_well_formed_payload(&self.inner, payload)
+    }
+
+    fn validate_payload_attributes_against_header(
+        &self,
+        attr: &EthPayloadAttributes,
+        header: &Header,
+    ) -> Result<(), InvalidPayloadAttributesError> {
+        // Ensure that payload attributes timestamp is not in the past
+        if attr.timestamp < header.timestamp {
+            return Err(InvalidPayloadAttributesError::InvalidTimestamp);
+        }
+        Ok(())
+    }
+}
+
+impl EngineApiValidator<EthEngineTypes> for TempoEngineValidator {
+    fn validate_version_specific_fields(
+        &self,
+        version: EngineApiMessageVersion,
+        payload_or_attrs: PayloadOrAttributes<'_, ExecutionData, EthPayloadAttributes>,
+    ) -> Result<(), EngineObjectValidationError> {
+        EngineApiValidator::<EthEngineTypes>::validate_version_specific_fields(
+            &self.inner,
+            version,
+            payload_or_attrs,
+        )
+    }
+
+    fn ensure_well_formed_attributes(
+        &self,
+        version: EngineApiMessageVersion,
+        attributes: &EthPayloadAttributes,
+    ) -> Result<(), EngineObjectValidationError> {
+        EngineApiValidator::<EthEngineTypes>::ensure_well_formed_attributes(
+            &self.inner,
+            version,
+            attributes,
+        )
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,5 +1,6 @@
 //! Tempo Node types config.
 
 pub mod args;
+pub mod engine;
 pub mod node;
 pub mod rpc;


### PR DESCRIPTION
Closes #139 

Introduces `TempoEngineValidator` that relaxes timestamp check and delegates all other logic to inner `EthereumEngineValidator`