### PR TITLE
fix: check codehash empty instead bytecode

### DIFF
--- a/crates/precompiles/src/contracts/tip_account_registrar.rs
+++ b/crates/precompiles/src/contracts/tip_account_registrar.rs
@@ -47,9 +47,7 @@ impl<'a, S: StorageProvider> TipAccountRegistrar<'a, S> {
             ));
         }
 
-        let code = account_info.code.unwrap_or_default();
-
-        if !code.is_empty() {
+        if !account_info.is_empty_code_hash() {
             return Err(TipAccountRegistrarError::CodeNotEmpty(
                 ITipAccountRegistrar::CodeNotEmpty {},
             ));
@@ -221,6 +219,6 @@ mod tests {
         let account_info_after = storage
             .get_account_info(expected_address)
             .expect("Failed to get account info");
-        assert_eq!(account_info_after.code, None);
+        assert!(account_info_after.is_empty_code_hash());
     }
 }


### PR DESCRIPTION
there's a nuance here that bytecode is empty in the default impl (unsure why really)

but we must check the codehash instead