### PR TITLE
feat: separate TIPFeeAMM from FeeManager

### DIFF
--- a/crates/precompiles/src/contracts/mod.rs
+++ b/crates/precompiles/src/contracts/mod.rs
@@ -1,12 +1,12 @@
 pub mod provider;
 pub mod roles;
-pub mod stable_amm;
 pub mod storage;
 pub mod tip20;
 pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip4217_registry;
 pub mod tip_account_registrar;
+pub mod tip_fee_amm;
 pub mod tip_fee_manager;
 pub mod types;
 

--- a/crates/precompiles/src/contracts/tip_fee_amm.rs
+++ b/crates/precompiles/src/contracts/tip_fee_amm.rs
@@ -1,17 +1,17 @@
 use crate::contracts::{
     storage::{StorageProvider, slots::mapping_slot},
-    types::IStableAMM,
+    types::ITIPFeeAMM,
 };
 use alloy::{
     primitives::{Address, B256, U256, keccak256},
     sol_types::SolValue,
 };
 
-/// Storage slots for StableAMM
+/// Storage slots for TIPFeeAMM
 ///
-/// IMPORTANT: These slots are shared with FeeManager when it inherits from StableAMM.
+/// IMPORTANT: These slots are shared with FeeManager when it inherits from TIPFeeAMM.
 /// FeeManager uses the same slots (0-3) for AMM functionality and adds its own slots (4+).
-/// This allows FeeManager to operate as a full StableAMM while extending it with fee capabilities.
+/// This allows FeeManager to operate as a full TIPFeeAMM while extending it with fee capabilities.
 pub mod slots {
     use alloy::primitives::{U256, uint};
 
@@ -29,7 +29,7 @@ pub struct Pool {
     pub reserve1: u128,
 }
 
-impl From<Pool> for IStableAMM::Pool {
+impl From<Pool> for ITIPFeeAMM::Pool {
     fn from(pool: Pool) -> Self {
         Self {
             reserve0: pool.reserve0,
@@ -61,7 +61,7 @@ impl PoolKey {
     }
 }
 
-impl From<PoolKey> for IStableAMM::PoolKey {
+impl From<PoolKey> for ITIPFeeAMM::PoolKey {
     fn from(key: PoolKey) -> Self {
         Self {
             token0: key.token0,
@@ -70,31 +70,31 @@ impl From<PoolKey> for IStableAMM::PoolKey {
     }
 }
 
-impl From<IStableAMM::PoolKey> for PoolKey {
-    fn from(key: IStableAMM::PoolKey) -> Self {
+impl From<ITIPFeeAMM::PoolKey> for PoolKey {
+    fn from(key: ITIPFeeAMM::PoolKey) -> Self {
         Self::new(key.token0, key.token1)
     }
 }
 
-/// StableAMM implementation - Base AMM contract for stablecoin pools.
+/// TIPFeeAMM implementation - Base AMM contract for stablecoin pools.
 ///
 /// INHERITANCE MODEL:
-/// - StableAMM serves as the base contract providing core AMM functionality
-/// - FeeManager inherits from StableAMM, extending it with fee management capabilities
+/// - TIPFeeAMM serves as the base contract providing core AMM functionality
+/// - FeeManager inherits from TIPFeeAMM, extending it with fee management capabilities
 /// - Both contracts share the same storage space when FeeManager is deployed
 ///
 /// STORAGE SHARING:
-/// - When FeeManager creates a StableAMM instance, it passes its own contract address
-/// - This means both FeeManager and StableAMM operate on the same storage slots
-/// - StableAMM uses slots 0-3, FeeManager extends with slots 4+
+/// - When FeeManager creates a TIPFeeAMM instance, it passes its own contract address
+/// - This means both FeeManager and TIPFeeAMM operate on the same storage slots
+/// - TIPFeeAMM uses slots 0-3, FeeManager extends with slots 4+
 ///
 /// This design allows FeeManager to be a full-featured AMM while adding fee-specific logic.
-pub struct StableAMM<'a, S: StorageProvider> {
+pub struct TIPFeeAMM<'a, S: StorageProvider> {
     pub contract_address: Address,
     pub storage: &'a mut S,
 }
 
-impl<'a, S: StorageProvider> StableAMM<'a, S> {
+impl<'a, S: StorageProvider> TIPFeeAMM<'a, S> {
     pub fn new(contract_address: Address, storage: &'a mut S) -> Self {
         Self {
             contract_address,
@@ -114,17 +114,17 @@ impl<'a, S: StorageProvider> StableAMM<'a, S> {
     /// Create a new liquidity pool
     pub fn create_pool(
         &mut self,
-        call: IStableAMM::createPoolCall,
-    ) -> Result<(), IStableAMM::IStableAMMErrors> {
+        call: ITIPFeeAMM::createPoolCall,
+    ) -> Result<(), ITIPFeeAMM::ITIPFeeAMMErrors> {
         if call.tokenA == call.tokenB {
-            return Err(IStableAMM::IStableAMMErrors::IdenticalAddresses(
-                IStableAMM::IdenticalAddresses {},
+            return Err(ITIPFeeAMM::ITIPFeeAMMErrors::IdenticalAddresses(
+                ITIPFeeAMM::IdenticalAddresses {},
             ));
         }
 
         if call.tokenA == Address::ZERO || call.tokenB == Address::ZERO {
-            return Err(IStableAMM::IStableAMMErrors::InvalidToken(
-                IStableAMM::InvalidToken {},
+            return Err(ITIPFeeAMM::ITIPFeeAMMErrors::InvalidToken(
+                ITIPFeeAMM::InvalidToken {},
             ));
         }
 
@@ -139,8 +139,8 @@ impl<'a, S: StorageProvider> StableAMM<'a, S> {
             .expect("TODO: handle error")
             != U256::ZERO
         {
-            return Err(IStableAMM::IStableAMMErrors::PoolExists(
-                IStableAMM::PoolExists {},
+            return Err(ITIPFeeAMM::ITIPFeeAMMErrors::PoolExists(
+                ITIPFeeAMM::PoolExists {},
             ));
         }
 
@@ -161,13 +161,13 @@ impl<'a, S: StorageProvider> StableAMM<'a, S> {
     }
 
     /// Get pool ID for a given key
-    pub fn get_pool_id(&mut self, call: IStableAMM::getPoolIdCall) -> B256 {
+    pub fn get_pool_id(&mut self, call: ITIPFeeAMM::getPoolIdCall) -> B256 {
         let pool_key = PoolKey::from(call.key);
         pool_key.get_id()
     }
 
     /// Get pool data
-    pub fn get_pool(&mut self, call: IStableAMM::getPoolCall) -> IStableAMM::Pool {
+    pub fn get_pool(&mut self, call: ITIPFeeAMM::getPoolCall) -> ITIPFeeAMM::Pool {
         let pool_key = PoolKey::from(call.key);
         let pool_id = pool_key.get_id();
         let pool_slot = self.get_pool_slot(&pool_id);
@@ -181,11 +181,11 @@ impl<'a, S: StorageProvider> StableAMM<'a, S> {
         let reserve0 = (pool_value & U256::from(u128::MAX)).to::<u128>();
         let reserve1 = pool_value.wrapping_shr(128).to::<u128>();
 
-        IStableAMM::Pool { reserve0, reserve1 }
+        ITIPFeeAMM::Pool { reserve0, reserve1 }
     }
 
     /// Get pool data by ID
-    pub fn pools(&mut self, call: IStableAMM::poolsCall) -> IStableAMM::Pool {
+    pub fn pools(&mut self, call: ITIPFeeAMM::poolsCall) -> ITIPFeeAMM::Pool {
         let pool_slot = self.get_pool_slot(&call.poolId);
         let combined = self
             .storage
@@ -201,11 +201,11 @@ impl<'a, S: StorageProvider> StableAMM<'a, S> {
             .map(u128::from_be_bytes)
             .expect("TODO: handle error");
 
-        IStableAMM::Pool { reserve0, reserve1 }
+        ITIPFeeAMM::Pool { reserve0, reserve1 }
     }
 
     /// Check if pool exists
-    pub fn pool_exists(&mut self, call: IStableAMM::poolExistsCall) -> bool {
+    pub fn pool_exists(&mut self, call: ITIPFeeAMM::poolExistsCall) -> bool {
         let exists_slot = self.get_pool_exists_slot(&call.poolId);
         self.storage
             .sload(self.contract_address, exists_slot)
@@ -263,12 +263,12 @@ mod tests {
     fn test_create_pool() {
         let mut storage = HashMapStorageProvider::new(1);
         let contract_address = Address::random();
-        let mut amm = StableAMM::new(contract_address, &mut storage);
+        let mut amm = TIPFeeAMM::new(contract_address, &mut storage);
 
         let token_a = Address::random();
         let token_b = Address::random();
 
-        let call = IStableAMM::createPoolCall {
+        let call = ITIPFeeAMM::createPoolCall {
             tokenA: token_a,
             tokenB: token_b,
         };
@@ -278,7 +278,7 @@ mod tests {
         // Verify pool exists
         let pool_key = PoolKey::new(token_a, token_b);
         let pool_id = pool_key.get_id();
-        let exists_call = IStableAMM::poolExistsCall { poolId: pool_id };
+        let exists_call = ITIPFeeAMM::poolExistsCall { poolId: pool_id };
         assert!(amm.pool_exists(exists_call));
     }
 }

--- a/crates/precompiles/src/contracts/types.rs
+++ b/crates/precompiles/src/contracts/types.rs
@@ -152,16 +152,16 @@ sol! {
         error NonceNotZero();
     }
 
-    /// StableAMM interface defining the base AMM functionality for stablecoin pools.
+    /// TIPFeeAMM interface defining the base AMM functionality for stablecoin pools.
     /// This interface provides core liquidity pool management and swap operations.
     ///
-    /// NOTE: The FeeManager contract inherits from StableAMM and shares the same storage layout.
-    /// When FeeManager is deployed, it effectively "is" a StableAMM with additional fee management
+    /// NOTE: The FeeManager contract inherits from TIPFeeAMM and shares the same storage layout.
+    /// When FeeManager is deployed, it effectively "is" a TIPFeeAMM with additional fee management
     /// capabilities layered on top. Both contracts operate on the same storage slots.
     #[derive(Debug, PartialEq, Eq)]
     #[sol(rpc)]
     #[allow(clippy::too_many_arguments)]
-    interface IStableAMM {
+    interface ITIPFeeAMM {
         // Structs
         struct Pool {
             uint128 reserve0;
@@ -238,15 +238,15 @@ sol! {
 
     /// FeeManager interface for managing gas fee collection and distribution.
     ///
-    /// IMPORTANT: FeeManager inherits from StableAMM and shares the same storage layout.
+    /// IMPORTANT: FeeManager inherits from TIPFeeAMM and shares the same storage layout.
     /// This means:
-    /// - FeeManager has all the functionality of StableAMM (pool management, swaps, liquidity operations)
+    /// - FeeManager has all the functionality of TIPFeeAMM (pool management, swaps, liquidity operations)
     /// - Both contracts use the same storage slots for AMM data (pools, reserves, liquidity balances)
-    /// - FeeManager extends StableAMM with additional storage slots (4-15) for fee-specific data
-    /// - When deployed, FeeManager IS a StableAMM with additional fee management capabilities
+    /// - FeeManager extends TIPFeeAMM with additional storage slots (4-15) for fee-specific data
+    /// - When deployed, FeeManager IS a TIPFeeAMM with additional fee management capabilities
     ///
     /// Storage layout:
-    /// - Slots 0-3: StableAMM storage (pools, pool exists, liquidity data)
+    /// - Slots 0-3: TIPFeeAMM storage (pools, pool exists, liquidity data)
     /// - Slots 4+: FeeManager-specific storage (validator tokens, user tokens, collected fees, etc.)
     #[derive(Debug, PartialEq, Eq)]
     #[sol(rpc)]
@@ -374,10 +374,10 @@ macro_rules! fee_manager_err {
 }
 
 #[macro_export]
-macro_rules! stable_amm_err {
+macro_rules! tip_fee_amm_err {
     ($err:ident) => {
-        $crate::contracts::types::IStableAMM::IStableAMMErrors::$err(
-            $crate::contracts::types::IStableAMM::$err {},
+        $crate::contracts::types::ITIPFeeAMM::ITIPFeeAMMErrors::$err(
+            $crate::contracts::types::ITIPFeeAMM::$err {},
         )
     };
 }
@@ -385,10 +385,10 @@ macro_rules! stable_amm_err {
 // Use the auto-generated error and event enums
 pub use IFeeManager::{IFeeManagerErrors as FeeManagerError, IFeeManagerEvents as FeeManagerEvent};
 pub use IRolesAuth::{IRolesAuthErrors as RolesAuthError, IRolesAuthEvents as RolesAuthEvent};
-pub use IStableAMM::{IStableAMMErrors as StableAMMError, IStableAMMEvents as StableAMMEvent};
 pub use ITIP20::{ITIP20Errors as TIP20Error, ITIP20Events as TIP20Event};
 pub use ITIP20Factory::ITIP20FactoryEvents as TIP20FactoryEvent;
 pub use ITIP403Registry::{
     ITIP403RegistryErrors as TIP403RegistryError, ITIP403RegistryEvents as TIP403RegistryEvent,
 };
+pub use ITIPFeeAMM::{ITIPFeeAMMErrors as TIPFeeAMMError, ITIPFeeAMMEvents as TIPFeeAMMEvent};
 pub use ITipAccountRegistrar::ITipAccountRegistrarErrors as TipAccountRegistrarError;


### PR DESCRIPTION
Closes #187 

defines new `IStableAMM` interface and updates `IFeeManager` to remove AMM logic.

- added `IStableAMM` interface
- moved AMM-related functions from `IFeeManager` to `IStableAMM`
- created bindings for `StableAMM`
- created `stable_amm` module with `StableAMM` implementation, delegating AMM operations from `TipFeeManager`

still using the same functions as we have in `IFeeManager` and not fully aligned with https://github.com/tempoxyz/specs/pull/12/files#diff-2c518d4b0f105548ed2a16579c768ed2dabf7a1818d1859a648d70bae105a539
