### PR TITLE
fix: guard faucet transaction against duplicate nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12664,6 +12664,7 @@ dependencies = [
  "tempo-precompiles",
  "tempo-transaction-pool",
  "thiserror 2.0.16",
+ "tokio",
  "url",
 ]
 

--- a/crates/faucet/Cargo.toml
+++ b/crates/faucet/Cargo.toml
@@ -16,12 +16,15 @@ reth-transaction-pool.workspace = true
 reth-rpc-server-types.workspace = true
 alloy = { workspace = true, features = [
   "rpc-types",
+  "providers",
   "signers",
   "signer-local",
   "signer-mnemonic-all-languages",
+  "reqwest-rustls-tls" # TODO(mattsse): set this to just reqwest after https://github.com/alloy-rs/alloy/pull/2865
 ] }
 async-trait.workspace = true
 jsonrpsee.workspace = true
 clap.workspace = true
 thiserror.workspace = true
 url = "2.5.4"
+tokio.workspace = true


### PR DESCRIPTION
there's a race condition here if two faucet requests are performed at the same time because both transactions can end up with the same nonce