### PR TITLE
chore: fix missing feature

### DIFF
--- a/crates/faucet/Cargo.toml
+++ b/crates/faucet/Cargo.toml
@@ -19,6 +19,7 @@ alloy = { workspace = true, features = [
   "signers",
   "signer-local",
   "signer-mnemonic-all-languages",
+  "reqwest-rustls-tls" # TODO(mattsse): set this to just reqwest after https://github.com/alloy-rs/alloy/pull/2865
 ] }
 async-trait.workspace = true
 jsonrpsee.workspace = true


### PR DESCRIPTION
this crate currently doesnt compile we removed it because this was activating openssl 

