### PR TITLE
feat(bin): Replace reth with tempo specific version constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12458,6 +12458,8 @@ dependencies = [
  "tempo-node",
  "tokio",
  "tracing",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,3 +240,7 @@ toml = "0.8"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 criterion = "0.7.0"
+
+# build deps
+vergen = "9"
+vergen-git2 = "1"

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -28,6 +28,10 @@ eyre.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+[build-dependencies]
+vergen.workspace = true
+vergen-git2.workspace = true
+
 [[bin]]
 name = "tempo"
 path = "src/main.rs"

--- a/bin/tempo/build.rs
+++ b/bin/tempo/build.rs
@@ -1,0 +1,102 @@
+#![allow(missing_docs)]
+
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default()
+        .features(true)
+        .target_triple(true)
+        .build()?;
+
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder = Git2Builder::default()
+        .describe(false, true, None)
+        .dirty(true)
+        .sha(false)
+        .build()?;
+
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag: v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
+    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    println!("cargo:rustc-env=RETH_VERSION_SUFFIX={version_suffix}");
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    // Set the build profile
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    println!("cargo:rustc-env=RETH_BUILD_PROFILE={profile}");
+
+    // Set formatted version strings
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // The short version information for reth.
+    // - The latest version from Cargo.toml
+    // - The short SHA of the latest commit.
+    // Example: 0.1.0 (defa64b2)
+    println!("cargo:rustc-env=RETH_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
+
+    // LONG_VERSION
+    // The long version information for reth.
+    //
+    // - The latest version from Cargo.toml + version suffix (if any)
+    // - The full SHA of the latest commit
+    // - The build datetime
+    // - The build features
+    // - The build profile
+    //
+    // Example:
+    //
+    // ```text
+    // Version: 0.1.0
+    // Commit SHA: defa64b2
+    // Build Timestamp: 2023-05-19T01:47:19.815651705Z
+    // Build Features: jemalloc
+    // Build Profile: maxperf
+    // ```
+    println!("cargo:rustc-env=RETH_LONG_VERSION_0=Version: {pkg_version}{version_suffix}");
+    println!("cargo:rustc-env=RETH_LONG_VERSION_1=Commit SHA: {sha}");
+    println!(
+        "cargo:rustc-env=RETH_LONG_VERSION_2=Build Timestamp: {}",
+        env::var("VERGEN_BUILD_TIMESTAMP")?
+    );
+    println!(
+        "cargo:rustc-env=RETH_LONG_VERSION_3=Build Features: {}",
+        env::var("VERGEN_CARGO_FEATURES")?
+    );
+    println!("cargo:rustc-env=RETH_LONG_VERSION_4=Build Profile: {profile}");
+
+    // The version information for reth formatted for P2P (devp2p).
+    // - The latest version from Cargo.toml
+    // - The target triple
+    //
+    // Example: reth/v0.1.0-alpha.1-428a6dc2f/aarch64-apple-darwin
+    println!(
+        "cargo:rustc-env=RETH_P2P_CLIENT_VERSION={}",
+        format_args!(
+            "reth/v{pkg_version}-{sha_short}/{}",
+            env::var("VERGEN_CARGO_TARGET_TRIPLE")?
+        )
+    );
+
+    Ok(())
+}

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -12,8 +12,12 @@
 //!
 //! Configuration can be provided via command-line arguments or configuration files.
 
+mod version;
+
 use clap::Parser;
-use reth_ethereum::{chainspec::EthChainSpec, cli::Cli};
+use reth_ethereum::{
+    chainspec::EthChainSpec, cli::Cli, node::core::version::try_init_version_metadata,
+};
 use reth_malachite::{
     app::{Config, Genesis, State, ValidatorInfo},
     cli::MalachiteArgs,
@@ -41,6 +45,9 @@ fn main() {
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
     }
+
+    try_init_version_metadata(version::tempo())
+        .expect("Version metadata should be generated in `build.rs`");
 
     let components = |spec: Arc<TempoChainSpec>| {
         (

--- a/bin/tempo/src/version.rs
+++ b/bin/tempo/src/version.rs
@@ -1,0 +1,35 @@
+use reth_ethereum::node::core::version::RethCliVersionConsts;
+use std::borrow::Cow;
+
+pub(crate) fn tempo() -> RethCliVersionConsts {
+    RethCliVersionConsts {
+        name_client: Cow::Borrowed("Reth"),
+        cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+        vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
+        vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
+        vergen_build_timestamp: Cow::Borrowed(env!("VERGEN_BUILD_TIMESTAMP")),
+        vergen_cargo_target_triple: Cow::Borrowed(env!("VERGEN_CARGO_TARGET_TRIPLE")),
+        vergen_cargo_features: Cow::Borrowed(env!("VERGEN_CARGO_FEATURES")),
+        short_version: Cow::Borrowed(env!("RETH_SHORT_VERSION")),
+        long_version: Cow::Owned(format!(
+            "{}\n{}\n{}\n{}\n{}",
+            env!("RETH_LONG_VERSION_0"),
+            env!("RETH_LONG_VERSION_1"),
+            env!("RETH_LONG_VERSION_2"),
+            env!("RETH_LONG_VERSION_3"),
+            env!("RETH_LONG_VERSION_4"),
+        )),
+
+        build_profile_name: Cow::Borrowed(env!("RETH_BUILD_PROFILE")),
+        p2p_client_version: Cow::Borrowed(env!("RETH_P2P_CLIENT_VERSION")),
+        extra_data: Cow::Owned(extra_data()),
+    }
+}
+
+fn extra_data() -> String {
+    format!(
+        "reth/v{}/{}",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS
+    )
+}


### PR DESCRIPTION
Closes #161 

Tells the Reth CLI to use version constants generated based on Tempo.
