### PR TITLE
feat(bin): Add version information to `tempo-commonware`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12458,8 +12458,6 @@ dependencies = [
  "tempo-node",
  "tokio",
  "tracing",
- "vergen",
- "vergen-git2",
 ]
 
 [[package]]
@@ -12711,6 +12709,8 @@ dependencies = [
  "tempo-precompiles",
  "tempo-transaction-pool",
  "tokio",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/bin/tempo-commonware/src/main.rs
+++ b/bin/tempo-commonware/src/main.rs
@@ -64,6 +64,8 @@ fn main() -> eyre::Result<()> {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
     }
 
+    tempo_node::init_version_metadata();
+
     let (args_and_node_handle_tx, args_and_node_handle_rx) =
         oneshot::channel::<(TempoFullNode, TempoArgs)>();
     let (consensus_dead_tx, mut consensus_dead_rx) = oneshot::channel();

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -28,10 +28,6 @@ eyre.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
-[build-dependencies]
-vergen.workspace = true
-vergen-git2.workspace = true
-
 [[bin]]
 name = "tempo"
 path = "src/main.rs"

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -12,12 +12,8 @@
 //!
 //! Configuration can be provided via command-line arguments or configuration files.
 
-mod version;
-
 use clap::Parser;
-use reth_ethereum::{
-    chainspec::EthChainSpec, cli::Cli, node::core::version::try_init_version_metadata,
-};
+use reth_ethereum::{chainspec::EthChainSpec, cli::Cli};
 use reth_malachite::{
     app::{Config, Genesis, State, ValidatorInfo},
     cli::MalachiteArgs,
@@ -46,8 +42,7 @@ fn main() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
     }
 
-    try_init_version_metadata(version::tempo())
-        .expect("Version metadata should be generated in `build.rs`");
+    tempo_node::init_version_metadata();
 
     let components = |spec: Arc<TempoChainSpec>| {
         (

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -23,6 +23,7 @@ reth-ethereum = { workspace = true, features = ["node", "rpc"] }
 reth-ethereum-primitives.workspace = true
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
 reth-node-builder.workspace = true
+reth-node-core.workspace = true
 reth-tracing.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true
@@ -52,10 +53,14 @@ serde_json.workspace = true
 tempo-contracts.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 alloy = { workspace = true, features = [
-  "full",
-  "providers",
-  "signers",
-  "signer-mnemonic-all-languages",
+    "full",
+    "providers",
+    "signers",
+    "signer-mnemonic-all-languages",
 ] }
 rand = "0.9.2"
 futures = "0.3"
+
+[build-dependencies]
+vergen.workspace = true
+vergen-git2.workspace = true

--- a/crates/node/build.rs
+++ b/crates/node/build.rs
@@ -49,14 +49,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Set formatted version strings
     let pkg_version = env!("CARGO_PKG_VERSION");
 
-    // The short version information for reth.
+    // The short version information for tempo.
     // - The latest version from Cargo.toml
     // - The short SHA of the latest commit.
     // Example: 0.1.0 (defa64b2)
     println!("cargo:rustc-env=RETH_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
 
     // LONG_VERSION
-    // The long version information for reth.
+    // The long version information for tempo.
     //
     // - The latest version from Cargo.toml + version suffix (if any)
     // - The full SHA of the latest commit
@@ -85,15 +85,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
     println!("cargo:rustc-env=RETH_LONG_VERSION_4=Build Profile: {profile}");
 
-    // The version information for reth formatted for P2P (devp2p).
+    // The version information for tempo formatted for P2P (devp2p).
     // - The latest version from Cargo.toml
     // - The target triple
     //
-    // Example: reth/v0.1.0-alpha.1-428a6dc2f/aarch64-apple-darwin
+    // Example: tempo/v0.1.0-alpha.1-428a6dc2f/aarch64-apple-darwin
     println!(
         "cargo:rustc-env=RETH_P2P_CLIENT_VERSION={}",
         format_args!(
-            "reth/v{pkg_version}-{sha_short}/{}",
+            "tempo/v{pkg_version}-{sha_short}/{}",
             env::var("VERGEN_CARGO_TARGET_TRIPLE")?
         )
     );

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+pub use version::{init_version_metadata, version_metadata};
+
 use crate::node::{TempoAddOns, TempoNode};
 use reth_ethereum::provider::db::DatabaseEnv;
 use reth_node_builder::{FullNode, NodeAdapter, RethFullAdapter};
@@ -12,6 +14,8 @@ pub mod args;
 pub mod engine;
 pub mod node;
 pub mod rpc;
+
+mod version;
 
 type TempoNodeAdapter = NodeAdapter<RethFullAdapter<Arc<DatabaseEnv>, TempoNode>>;
 

--- a/crates/node/src/version.rs
+++ b/crates/node/src/version.rs
@@ -1,9 +1,19 @@
 use reth_ethereum::node::core::version::RethCliVersionConsts;
-use std::borrow::Cow;
+use reth_node_core::version::try_init_version_metadata;
+use std::{borrow::Cow, env};
 
-pub(crate) fn tempo() -> RethCliVersionConsts {
+/// Sets version information for Tempo globally.
+///
+/// The version information is read by the CLI.
+pub fn init_version_metadata() {
+    try_init_version_metadata(version_metadata())
+        .expect("Version metadata should be generated in `build.rs`");
+}
+
+/// The version information for Tempo.
+pub fn version_metadata() -> RethCliVersionConsts {
     RethCliVersionConsts {
-        name_client: Cow::Borrowed("Reth"),
+        name_client: Cow::Borrowed("Tempo"),
         cargo_pkg_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
         vergen_git_sha_long: Cow::Borrowed(env!("VERGEN_GIT_SHA")),
         vergen_git_sha: Cow::Borrowed(env!("VERGEN_GIT_SHA_SHORT")),
@@ -27,9 +37,5 @@ pub(crate) fn tempo() -> RethCliVersionConsts {
 }
 
 fn extra_data() -> String {
-    format!(
-        "reth/v{}/{}",
-        env!("CARGO_PKG_VERSION"),
-        std::env::consts::OS
-    )
+    format!("tempo/v{}/{}", env!("CARGO_PKG_VERSION"), env::consts::OS)
 }


### PR DESCRIPTION
Part of #161 
Follow-up to #219 

* Adds the same version information to `tempo-commonware` crate as the one in `tempo`.
* Puts the version information generator to shared `tempo-node` crate.
* Replaces the client name from `reth` to `tempo`.

The environment variables are still prefixed with `RETH_` but that should not leaked somewhere.
