### PR TITLE
chore(commonware-node): graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12535,6 +12535,7 @@ dependencies = [
  "tempo-eyre",
  "tempo-faucet",
  "tempo-node",
+ "tempo-telemetry-util",
  "tokio",
  "tokio-util",
  "tracing",

--- a/bin/tempo-commonware/Cargo.toml
+++ b/bin/tempo-commonware/Cargo.toml
@@ -14,6 +14,7 @@ tempo-commonware-node-config.workspace = true
 tempo-chainspec.workspace = true
 tempo-consensus.workspace = true
 tempo-faucet.workspace = true
+tempo-telemetry-util.workspace = true
 
 camino = { workspace = true, features = ["serde1"] }
 commonware-runtime.workspace = true


### PR DESCRIPTION
Closes #229 

Makes use of commonware's [`commonware_runtime::Spawner::stop`](https://docs.rs/commonware-runtime/0.0.62/commonware_runtime/trait.Spawner.html#tymethod.stop) and [`commonware_runtime::Spawner::stopped`](https://docs.rs/commonware-runtime/0.0.62/commonware_runtime/trait.Spawner.html#tymethod.stopped) to signal its tasks to shutdown (and listen for a shutdown signal).

Unfortunately the shutdown process is not as clean as I would like with some things inside commonware tripping, but I can confirm that after SIGINT / CTRL-C the node indeed shuts down:

```
^C2025-09-16T12:57:52.036317Z  INFO received shutdown signal
2025-09-16T12:57:52.038274Z  INFO Wrote network peers to file peers_file="/Users/janis/dev/tempo/tempo/cmwr_test/57be4a76328da0be3464f060b7e71ee9b947641335164812c44b74b1316dd4ba/reth_storage/known-peers.json"
2025-09-16T12:57:52.039564Z  INFO exit consensus thread: exiting consensus thread reason="received shutdown signal"
2025-09-16T12:57:52.039614Z  INFO exit consensus thread: signaling all consensus tasks to shut down deadline=5secs

thread 'tokio-runtime-worker' panicked at /Users/janis/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/future/future/shared.rs:263:39:
Shared future polled again after completion
2025-09-16T12:57:52.039948Z  INFO execution driver shutdown signal: received shutdown signal; exiting consensus stack value=0
stack backtrace:
2025-09-16T12:57:52.040098Z  INFO handler closed, shutting down
2025-09-16T12:57:52.040342Z ERROR orchestrator closed, shutting down
   0:        0x1012a4dbc - __mh_execute_header
   1:        0x100835ca8 - __mh_execute_header
   2:        0x10129f35c - __mh_execute_header
   3:        0x1012a4c7c - __mh_execute_header
   4:        0x1012a72fc - __mh_execute_header
   5:        0x1012a6fcc - __mh_execute_header
   6:        0x1012a7bac - __mh_execute_header
   7:        0x1012a77e8 - __mh_execute_header
   8:        0x1012a5248 - __mh_execute_header
   9:        0x1012a74ec - __mh_execute_header
  10:        0x102cbea98 - __mh_execute_header
  11:        0x102cbea78 - __mh_execute_header
  12:        0x10081f8d0 - __mh_execute_header
  13:        0x1022a3ce8 - __mh_execute_header
  14:        0x1025d00d4 - __mh_execute_header
  15:        0x1018fbab4 - __mh_execute_header
  16:        0x1020557cc - __mh_execute_header
  17:        0x1024a2b94 - __mh_execute_header
  18:        0x102ac6bec - __mh_execute_header
  19:        0x102ac611c - __mh_execute_header
  20:        0x102ab0ae0 - __mh_execute_header
  21:        0x102aa563c - __mh_execute_header
  22:        0x102ac59d0 - __mh_execute_header
  23:        0x102ab1bc8 - __mh_execute_header
  24:        0x102ab8398 - __mh_execute_header
  25:        0x102a9d848 - __mh_execute_header
  26:        0x102abd780 - __mh_execute_header
  27:        0x102ab2ffc - __mh_execute_header
  28:        0x102ab39d4 - __mh_execute_header
  29:        0x1012a9dd8 - __mh_execute_header
  30:        0x198de3c0c - __pthread_cond_wait
2025-09-16T12:57:52.042984Z ERROR task panicked err="Shared future polled again after completion"
2025-09-16T12:57:57.041778Z  WARN exit consensus thread: some consensus tasks are still alive past the designated deadline; they will die error=[timeout]
```