### PR TITLE
refactor(commonware-node): remove generics from consensus block

### DIFF
--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -20,20 +20,14 @@ use tempo_commonware_node_cryptography::Digest;
 // Sealed because of the frequent accesses to the hash.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-// TODO: Can there be a reasonable default for TBlock?
-pub struct Block<TBlock>(SealedBlock<TBlock>)
-where
-    TBlock: reth_primitives_traits::Block;
+pub struct Block(SealedBlock<tempo_primitives::Block>);
 
-impl<TBlock> Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block,
-{
-    pub fn from_execution_block(block: SealedBlock<TBlock>) -> Self {
+impl Block {
+    pub fn from_execution_block(block: SealedBlock<tempo_primitives::Block>) -> Self {
         Self(block)
     }
 
-    pub fn into_inner(self) -> SealedBlock<TBlock> {
+    pub fn into_inner(self) -> SealedBlock<tempo_primitives::Block> {
         self.0
     }
 
@@ -56,31 +50,22 @@ where
     }
 }
 
-impl<TBlock> std::ops::Deref for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block,
-{
-    type Target = SealedBlock<TBlock>;
+impl std::ops::Deref for Block {
+    type Target = SealedBlock<tempo_primitives::Block>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<TBlock> Write for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block,
-{
+impl Write for Block {
     fn write(&self, buf: &mut impl BufMut) {
         use alloy_rlp::Encodable as _;
         self.0.encode(buf);
     }
 }
 
-impl<TBlock> Read for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block,
-{
+impl Read for Block {
     // TODO: Figure out what this is for/when to use it. This is () for both alto and summit.
     type Cfg = ();
 
@@ -113,20 +98,14 @@ where
     }
 }
 
-impl<TBlock> EncodeSize for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block,
-{
+impl EncodeSize for Block {
     fn encode_size(&self) -> usize {
         use alloy_rlp::Encodable as _;
         self.0.length()
     }
 }
 
-impl<TBlock> Committable for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block + 'static,
-{
+impl Committable for Block {
     type Commitment = Digest;
 
     fn commitment(&self) -> Self::Commitment {
@@ -134,10 +113,7 @@ where
     }
 }
 
-impl<TBlock> Digestible for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block + 'static,
-{
+impl Digestible for Block {
     type Digest = Digest;
 
     fn digest(&self) -> Self::Digest {
@@ -145,10 +121,7 @@ where
     }
 }
 
-impl<TBlock> commonware_consensus::Block for Block<TBlock>
-where
-    TBlock: reth_primitives_traits::Block + 'static,
-{
+impl commonware_consensus::Block for Block {
     fn parent(&self) -> Digest {
         self.parent_digest()
     }

--- a/crates/commonware-node/src/consensus/mod.rs
+++ b/crates/commonware-node/src/consensus/mod.rs
@@ -19,8 +19,8 @@ pub type Consensus<TContext, TBlocker> = commonware_consensus::threshold_simplex
     TBlocker,
     BlsScheme,
     Digest,
-    crate::consensus::execution_driver::Mailbox<tempo_primitives::Block>,
-    crate::consensus::execution_driver::Mailbox<tempo_primitives::Block>,
+    crate::consensus::execution_driver::Mailbox,
+    crate::consensus::execution_driver::Mailbox,
     Reporter,
     Supervisor,
 >;
@@ -36,6 +36,6 @@ pub type Notarization =
 // This seems to be the reporter that the marshal "syncer" is talking to.
 // Alto actually has 2 reporters, this "marshal mailbox" and a custom indexer::Pusher;
 // we skip the latter for now.
-pub type Reporter = marshal::Mailbox<BlsScheme, block::Block<tempo_primitives::Block>>;
+pub type Reporter = marshal::Mailbox<BlsScheme, block::Block>;
 
 pub type View = commonware_consensus::threshold_simplex::types::View;


### PR DESCRIPTION
With https://github.com/tempoxyz/tempo/pull/246 the `TBlock: reth_primitives_traits::Block` generic on the consensus block is no longer necessary.

This patch removes all generic parameters on `consensus::Block` in favor of `tempo_primitives::Block`.