### PR TITLE
fix(commonware-node): finalized even if syncing

### DIFF
--- a/crates/commonware-node/src/consensus/execution_driver/finalizer.rs
+++ b/crates/commonware-node/src/consensus/execution_driver/finalizer.rs
@@ -77,8 +77,8 @@ impl Finalizer {
             )?;
 
         ensure!(
-            payload_status.is_valid(),
-            "payload status of block-to-be-finalized not valid: \
+            payload_status.is_valid() || payload_status.is_syncing(),
+            "payload status of block-to-be-finalized was neither valid nor syncing: \
             `{payload_status}`"
         );
 
@@ -102,12 +102,16 @@ impl Finalizer {
             )?;
 
         ensure!(
-            fcu_response.is_valid(),
-            "payload status of forkchoice update response valid: `{}`",
+            fcu_response.is_valid() || fcu_response.is_syncing(),
+            "payload status of forkchoice update response was neither valid nor syncing: `{}`",
             fcu_response.payload_status,
         );
 
         // Acknowledge that the block was finalized.
+        //
+        // TODO(janis): try to understand what this means for the marshaller. If we
+        // don't send the response here the marshaller will stall finalizations to
+        // the application until it receives an ack.
         if let Err(()) = response.send(()) {
             warn!("tried acknowledging finalization but channel was already closed");
         }

--- a/crates/commonware-node/src/consensus/execution_driver/mod.rs
+++ b/crates/commonware-node/src/consensus/execution_driver/mod.rs
@@ -553,7 +553,7 @@ async fn verify_block(
             // FIXME: is this error message correct?
             bail!(
                 "failed validating block because payload is still syncing, \
-                this means the parent block was available to the consensus
+                this means the parent block was available to the consensus \
                 layer but not the execution layer"
             )
         }


### PR DESCRIPTION
This patch relaxes the condition under which a finalization succeeds: where before finalizations only went through if and only both payload and forkchoice-update were reported as "valid", finalizations now also succeed when payload and/or forkchoice-update report "syncing".

This is a requirement to have a node catch up in the event that it falls behind or is restarted after an outage: the "marshal" actor will eventually forward new finalized blocks to the execution driver. But since the execution layer is behind there is no guarantee that the node will actually treat the forwarded block as "valid" (since it potentially doesn't have its parent yet). So to get the execution layer up to tip we need to bump its `finalization_hash` so it starts a sync with its peers.