### PR TITLE
feat(transaction-pool): add payment transaction classification with TIP20 prefix check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12799,7 +12799,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc-convert",
  "serde",
- "tempo-chainspec",
  "tempo-precompiles",
  "test-fuzz",
 ]

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -4,4 +4,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod spec;
-pub use spec::{PAYMENT_CLASSIFIER_ID, TempoChainSpec};
+pub use spec::TempoChainSpec;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -14,9 +14,6 @@ use tempo_contracts::DEFAULT_7702_DELEGATE_ADDRESS;
 
 pub const TEMPO_BASE_FEE: u64 = 44;
 
-/// Classifier ID for payment transaction classification rules
-pub const PAYMENT_CLASSIFIER_ID: u8 = 1;
-
 /// Tempo chain specification parser.
 #[derive(Debug, Clone, Default)]
 pub struct TempoChainSpecParser;

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
 tempo-precompiles.workspace = true
 
 # Alloy

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -4,7 +4,6 @@ use alloy_consensus::{
 };
 use alloy_primitives::{Address, B256, Signature, U256};
 use reth_primitives_traits::InMemorySize;
-use tempo_chainspec::PAYMENT_CLASSIFIER_ID;
 use tempo_precompiles::TIP20_PAYMENT_PREFIX;
 
 /// Fake signature for Tempo system transactions.
@@ -83,23 +82,16 @@ impl TempoTxEnvelope {
         matches!(self, Self::Legacy(tx) if tx.signature() == &TEMPO_SYSTEM_TX_SIGNATURE)
     }
 
-    /// Classify a transaction as payment or non-payment based on the current classifier.
+    /// Classify a transaction as payment or non-payment.
     ///
-    /// The ClassifierID selects which classification rules to use.
-    /// Classifier v1: transaction is a payment if the `to` address has the TIP20 prefix.
+    /// Currently uses classifier v1: transaction is a payment if the `to` address has the TIP20 prefix.
     pub fn is_payment(&self) -> bool {
         use alloy_consensus::Transaction;
 
-        match PAYMENT_CLASSIFIER_ID {
-            1 => {
-                // Classifier v1: Check if the transaction has a `to` address with TIP20 prefix
-                if let Some(to) = self.to() {
-                    return to.as_slice().starts_with(&TIP20_PAYMENT_PREFIX);
-                }
-                false
-            }
-            _ => false, // Unknown classifier versions default to non-payment
+        if let Some(to) = self.to() {
+            return to.as_slice().starts_with(&TIP20_PAYMENT_PREFIX);
         }
+        false
     }
 }
 


### PR DESCRIPTION
Closes #274 

Implements payment transaction classification in the transaction pool to support the PaymentLane specification. Transactions are classified once when entering the pool, with the result stored as a boolean field for instant lookups during block building.

- add `PAYMENT_CLASSIFIER_ID` and `TIP20_PAYMENT_PREFIX` constants to chainspec
- add `is_payment` boolean field to `TempoPooledTransaction` for caching classification
- implement classifier v1: transactions with `to` addresses having the TIP20 prefix (`0x20c000000...`) are marked as payments
- add `is_payment()` method for classification lookup during block building
- tests