### PR TITLE
fix(precompiles): Update `rebalance_swap` insufficient funds check

### DIFF
--- a/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
@@ -940,7 +940,7 @@ mod tests {
         let pool = amm.get_pool(&pool_id);
         assert_eq!(pool.reserve_user_token, pool.reserve_validator_token,);
 
-        let msg_sender = Address::random(); // Random address with no token balance
+        let msg_sender = Address::random();
         let to = Address::random();
         let result = amm.rebalance_swap(
             msg_sender,


### PR DESCRIPTION
This PR updates `rebalance_swap` to enforce that the `amountOut` does not exceed the reserves balance.