### PR TITLE
fix: remove incorrect check

### DIFF
--- a/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
@@ -205,12 +205,6 @@ impl<'a, S: StorageProvider> TIPFeeAMM<'a, S> {
             .checked_sub(amount_out)
             .ok_or(TIPFeeAMMError::invalid_amount())?;
 
-        // Ensure rebalancing doesn't create invalid reserves where user token < validator token
-        // This prevents rebalancing in the wrong direction
-        if pool.reserve_user_token < pool.reserve_validator_token {
-            return Err(TIPFeeAMMError::invalid_new_reserves());
-        }
-
         if !self.can_support_pending_swaps(&pool_id, U256::from(pool.reserve_validator_token)) {
             return Err(TIPFeeAMMError::insufficient_liquidity_for_pending());
         }


### PR DESCRIPTION
This removes an incorrectly added check. In the new asymmetric and fixed-price design of the fee AMM, where fee swaps only go in one direction (from user token to validator token), the balance in the user token is allowed (and expected and encouraged) to go to 0.