### PR TITLE
refactor(commonware-node): make execution driver cloneable and clean up handlers

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -149,7 +149,7 @@ where
             // TODO: pass in from the outside,
             fee_recipient: self.fee_recipient,
             mailbox_size: self.mailbox_size,
-            syncer_mailbox: syncer_mailbox.clone(),
+            syncer: syncer_mailbox.clone(),
             execution_node: self.execution_node,
             // chainspec: self.chainspec,
             // engine_handle: self.execution_engine,


### PR DESCRIPTION
Moves all channels and state-tracking fields of the execution driver into an `Inner` business logic that is cloneable.

This allows considerably cleaning up message handling by removing janky workarounds creating futures and attaching state to them. Especially `RunPropose::given_timestamp` was removed in favor of `Inner::handle_propose`.

Closes #195 