### PR TITLE
fix(payload): check `is_osaka` when checking sealed blocksize

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -309,7 +309,7 @@ where
         let sealed_block = Arc::new(block.sealed_block().clone());
         debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
-        if sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
+        if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
             return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
                 rlp_length: sealed_block.rlp_length(),
                 max_rlp_length: MAX_RLP_BLOCK_SIZE,


### PR DESCRIPTION
This PR updates the payload builder to check `is_osaka` when checking sealed block size. Here is the [reth implementation](https://github.com/paradigmxyz/reth/blob/4cc50f9799ecd4b02ab759f3b72348cb45b549ee/crates/ethereum/payload/src/lib.rs#L362) for reference.