### PR TITLE
chore(ci): add concurrency and cancel in progress flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: build-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: lint-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clippy:
     name: clippy


### PR DESCRIPTION
This will make CI get canceled if a commit gets pushed to a PR branch while another run is already in progress.