### PR TITLE
chore(commonware): bump commonware to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
  "paste",
@@ -2661,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2686,12 +2686,13 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "blake3",
  "blst",
  "bytes",
  "cfg-if",
+ "chacha20poly1305",
  "commonware-codec",
  "commonware-utils",
  "ed25519-consensus",
@@ -2703,13 +2704,14 @@ dependencies = [
  "rayon",
  "sha2 0.10.9",
  "thiserror 2.0.16",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "commonware-macros"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "futures",
  "proc-macro2",
@@ -2722,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2734,6 +2736,10 @@ dependencies = [
  "either",
  "futures",
  "governor",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
  "prometheus-client 0.22.3",
  "rand 0.8.5",
  "rand_distr",
@@ -2744,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bimap",
  "bytes",
@@ -2766,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "async-lock",
  "axum",
@@ -2797,9 +2803,10 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
+ "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -2818,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -2828,8 +2835,8 @@ dependencies = [
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "hkdf",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "thiserror 2.0.16",
  "x25519-dalek",
  "zeroize",
@@ -2838,12 +2845,17 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=4afebae1534acd3f2787d1f9471cc78e8f0e4752#4afebae1534acd3f2787d1f9471cc78e8f0e4752"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
 dependencies = [
  "bytes",
+ "cfg-if",
  "commonware-codec",
  "futures",
  "getrandom 0.2.16",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
  "rand 0.8.5",
  "thiserror 2.0.16",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,11 +254,11 @@ vergen = "9"
 vergen-git2 = "1"
 
 [patch.crates-io]
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "4afebae1534acd3f2787d1f9471cc78e8f0e4752" }
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -114,16 +114,30 @@ where
         // Create the buffer pool
         let buffer_pool = PoolRef::new(BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
 
+        // XXX: All hard-coded values here are the same as prior to commonware
+        // making the resolver configurable in
+        // https://github.com/commonwarexyz/monorepo/commit/92870f39b4a9e64a28434b3729ebff5aba67fb4e
+        let resolver_config = commonware_consensus::marshal::resolver::p2p::Config {
+            public_key: self.signer.public_key(),
+            coordinator: supervisor.clone(),
+            mailbox_size: self.mailbox_size,
+            requester_config: commonware_p2p::utils::requester::Config {
+                public_key: self.signer.public_key(),
+                rate_limit: self.backfill_quota,
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+            },
+            fetch_retry_timeout: Duration::from_millis(100),
+            priority_requests: false,
+            priority_responses: false,
+        };
         let (syncer, syncer_mailbox): (_, marshal::Mailbox<BlsScheme, Block>) =
             marshal::Actor::init(
                 self.context.with_label("sync"),
                 marshal::Config {
-                    public_key: self.signer.public_key(),
                     identity: *self.polynomial.constant(),
-                    coordinator: supervisor.clone(),
                     partition_prefix: self.partition_prefix.clone(),
                     mailbox_size: self.mailbox_size,
-                    backfill_quota: self.backfill_quota,
                     view_retention_timeout: self
                         .activity_timeout
                         .saturating_mul(SYNCER_ACTIVITY_TIMEOUT_MULTIPLIER),
@@ -165,6 +179,8 @@ where
         let consensus = threshold_simplex::Engine::new(
             self.context.with_label("consensus"),
             threshold_simplex::Config {
+                // TODO(janis): make configuration epoch aware.
+                epoch: 0,
                 namespace: crate::config::NAMESPACE.to_vec(),
                 crypto: self.signer,
                 automaton: execution_driver.mailbox().clone(),
@@ -199,6 +215,7 @@ where
             execution_driver,
             execution_driver_mailbox,
 
+            resolver_config,
             syncer,
 
             consensus,
@@ -225,15 +242,12 @@ where
     execution_driver: crate::consensus::execution_driver::ExecutionDriver<TContext>,
     execution_driver_mailbox: crate::consensus::execution_driver::ExecutionDriverMailbox,
 
-    /// Responsible for syncing(?) messages from/to other nodes.
-    // FIXME: This is a complex beast, interacting with very many parts of the system. At
-    // its core it seems to be responsible for maintaining an ordered history of the chain,
-    // which means tracking the chain, finalizing blocks after getting a finalization signal
-    // from consensus, writign finalized blocks to the filesystem, backfilling missing blocks from
-    // its peers...
-    //
-    // Alto calls this `marshal`, we opt to call it `syncer` which seems marginally more expressive.
-    syncer: marshal::Actor<Block, TContext, BlsScheme, PublicKey, Supervisor>,
+    /// Resolver config that will be passed to the marshal actor upon start.
+    resolver_config: marshal::resolver::p2p::Config<PublicKey, Supervisor>,
+
+    /// Listens to consensus events and syncs blocks from the network to the
+    /// local node.
+    syncer: marshal::Actor<Block, TContext, BlsScheme>,
 
     consensus: crate::consensus::Consensus<TContext, TBlocker>,
 }
@@ -305,10 +319,13 @@ where
     ) -> eyre::Result<()> {
         let broadcast = self.broadcast.start(broadcast_network);
         let execution_driver = self.execution_driver.start();
+
+        let resolver =
+            marshal::resolver::p2p::init(&self.context, self.resolver_config, backfill_network);
         let syncer = self.syncer.start(
             self.execution_driver_mailbox,
             self.broadcast_mailbox,
-            backfill_network,
+            resolver,
         );
 
         let simplex = self

--- a/crates/commonware-node/src/consensus/mod.rs
+++ b/crates/commonware-node/src/consensus/mod.rs
@@ -24,11 +24,7 @@ type Consensus<TContext, TBlocker> = commonware_consensus::threshold_simplex::En
     Supervisor,
 >;
 
-type Context = commonware_consensus::threshold_simplex::types::Context<Digest>;
-
 // This seems to be the reporter that the marshal "syncer" is talking to.
 // Alto actually has 2 reporters, this "marshal mailbox" and a custom indexer::Pusher;
 // we skip the latter for now.
 type Reporter = marshal::Mailbox<BlsScheme, block::Block>;
-
-type View = commonware_consensus::threshold_simplex::types::View;

--- a/crates/commonware-node/src/consensus/supervisor.rs
+++ b/crates/commonware-node/src/consensus/supervisor.rs
@@ -6,11 +6,10 @@
 // Will this require some feedback mechanism between execution layer and consensus layer
 // (i.e. reth becoming aware of consensus and allowing to update peers)?
 
+use commonware_consensus::types::View;
 use commonware_cryptography::ed25519;
 use commonware_resolver::p2p;
 use std::collections::HashMap;
-
-use crate::consensus::View;
 
 use tempo_commonware_node_cryptography::{
     BlsScheme, BlsSignature, GroupShare, Identity, PublicKey, PublicPolynomial,


### PR DESCRIPTION
This patch puts the commonware node back on the main branch of the commonware repo. Following PR https://github.com/tempoxyz/tempo/pull/281 that made use of an experimental feature, commonware refined and merged the API in https://github.com/commonwarexyz/monorepo/pull/1695 and https://github.com/commonwarexyz/monorepo/pull/1726.

Main changes

1. updated the automaton implementation for the execution driver mailbox to be aware of epochs now (we are not actually doing anything with them, just reporting them)
2. hardcoded epoch in the consensus engine to be 0 (that's a todo to make it epoch aware once we are introduce network reconfiguration, staking, etc)
3. updated the marshaller since it now takes an externally initialized p2p resolver.