### PR TITLE
chore(commonware-node): make most items crate-private

### DIFF
--- a/crates/commonware-node/src/config.rs
+++ b/crates/commonware-node/src/config.rs
@@ -13,31 +13,28 @@ use std::num::NonZeroU32;
 
 use governor::Quota;
 
-pub const TEMPO_CHAIN_ID: u64 = 2600;
-pub const TEMPO_CHAIN_NAME: &str = "tempo";
-
 // Hardcoded values to configure commonware's alto toy chain. These could be made into
 // configuration variables at some point.
-pub const PENDING_CHANNEL_IDENT: commonware_p2p::Channel = 0;
-pub const RECOVERED_CHANNEL_IDENT: commonware_p2p::Channel = 1;
-pub const RESOLVER_CHANNEL_IDENT: commonware_p2p::Channel = 2;
-pub const BROADCASTER_CHANNEL_IDENT: commonware_p2p::Channel = 3;
-pub const BACKFILL_BY_DIGEST_CHANNE_IDENTL: commonware_p2p::Channel = 4;
+pub(crate) const PENDING_CHANNEL_IDENT: commonware_p2p::Channel = 0;
+pub(crate) const RECOVERED_CHANNEL_IDENT: commonware_p2p::Channel = 1;
+pub(crate) const RESOLVER_CHANNEL_IDENT: commonware_p2p::Channel = 2;
+pub(crate) const BROADCASTER_CHANNEL_IDENT: commonware_p2p::Channel = 3;
+pub(crate) const BACKFILL_BY_DIGEST_CHANNE_IDENTL: commonware_p2p::Channel = 4;
 
-pub const NUMBER_CONCURRENT_FETCHES: usize = 4;
-pub const NUMBER_MAX_FETCHES: usize = 16;
+pub(crate) const NUMBER_CONCURRENT_FETCHES: usize = 4;
+pub(crate) const NUMBER_MAX_FETCHES: usize = 16;
 
-pub const BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB
-pub const FINALIZED_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB
+pub(crate) const BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB
 
-pub const BACKFILL_QUOTA: Quota = Quota::per_second(NonZeroU32::new(8).expect("value is not zero"));
-pub const BROADCASTER_LIMIT: Quota =
+pub(crate) const BACKFILL_QUOTA: Quota =
     Quota::per_second(NonZeroU32::new(8).expect("value is not zero"));
-pub const PENDING_LIMIT: Quota =
+pub(crate) const BROADCASTER_LIMIT: Quota =
+    Quota::per_second(NonZeroU32::new(8).expect("value is not zero"));
+pub(crate) const PENDING_LIMIT: Quota =
     Quota::per_second(NonZeroU32::new(128).expect("value is not zero"));
-pub const RECOVERED_LIMIT: Quota =
+pub(crate) const RECOVERED_LIMIT: Quota =
     Quota::per_second(NonZeroU32::new(128).expect("value is not zero"));
-pub const RESOLVER_LIMIT: Quota =
+pub(crate) const RESOLVER_LIMIT: Quota =
     Quota::per_second(NonZeroU32::new(128).expect("value is not zero"));
 
-pub const NAMESPACE: &[u8] = b"TEMPO";
+pub(crate) const NAMESPACE: &[u8] = b"TEMPO";

--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -20,32 +20,32 @@ use tempo_commonware_node_cryptography::Digest;
 // Sealed because of the frequent accesses to the hash.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct Block(SealedBlock<tempo_primitives::Block>);
+pub(crate) struct Block(SealedBlock<tempo_primitives::Block>);
 
 impl Block {
-    pub fn from_execution_block(block: SealedBlock<tempo_primitives::Block>) -> Self {
+    pub(crate) fn from_execution_block(block: SealedBlock<tempo_primitives::Block>) -> Self {
         Self(block)
     }
 
-    pub fn into_inner(self) -> SealedBlock<tempo_primitives::Block> {
+    pub(crate) fn into_inner(self) -> SealedBlock<tempo_primitives::Block> {
         self.0
     }
 
     /// Returns the (eth) hash of the wrapped block.
-    pub fn block_hash(&self) -> B256 {
+    pub(crate) fn block_hash(&self) -> B256 {
         self.0.hash()
     }
 
     /// Returns the hash of the wrapped block as a commonware [`Digest`].
-    pub fn digest(&self) -> Digest {
+    pub(crate) fn digest(&self) -> Digest {
         Digest(self.hash())
     }
 
-    pub fn parent_digest(&self) -> Digest {
+    pub(crate) fn parent_digest(&self) -> Digest {
         Digest(self.0.parent_hash())
     }
 
-    pub fn timestamp(&self) -> u64 {
+    pub(crate) fn timestamp(&self) -> u64 {
         self.0.timestamp()
     }
 }
@@ -139,7 +139,7 @@ impl commonware_consensus::Block for Block {
 // /// A notarized [`Block`].
 // // XXX: Not used right now but will be used once an indexer is implemented.
 // #[derive(Clone, Debug, PartialEq, Eq)]
-// pub struct Notarized {
+// pub(crate) struct Notarized {
 //     proof: Notarization,
 //     block: Block,
 // }
@@ -148,14 +148,14 @@ impl commonware_consensus::Block for Block {
 // #[error(
 //     "invalid notarized block: proof proposal `{proposal}` does not match block digest `{digest}`"
 // )]
-// pub struct NotarizationProofNotForBlock {
+// pub(crate) struct NotarizationProofNotForBlock {
 //     proposal: Digest,
 //     digest: Digest,
 // }
 
 // impl Notarized {
 //     /// Constructs a new [`Notarized`] block.
-//     pub fn try_new(
+//     pub(crate) fn try_new(
 //         proof: Notarization,
 //         block: Block,
 //     ) -> Result<Self, NotarizationProofNotForBlock> {
@@ -168,19 +168,19 @@ impl commonware_consensus::Block for Block {
 //         Ok(Self { proof, block })
 //     }
 
-//     pub fn block(&self) -> &Block {
+//     pub(crate) fn block(&self) -> &Block {
 //         &self.block
 //     }
 
 //     /// Breaks up [`Notarized`] into its constituent parts.
-//     pub fn into_parts(self) -> (Notarization, Block) {
+//     pub(crate) fn into_parts(self) -> (Notarization, Block) {
 //         (self.proof, self.block)
 //     }
 
 //     /// Verifies the notarized block against `namespace` and `identity`.
 //     ///
 //     // XXX: But why does this ignore the block entirely??
-//     pub fn verify(&self, namespace: &[u8], identity: &BlsPublicKey) -> bool {
+//     pub(crate) fn verify(&self, namespace: &[u8], identity: &BlsPublicKey) -> bool {
 //         self.proof.verify(namespace, identity)
 //     }
 // }
@@ -219,7 +219,7 @@ impl commonware_consensus::Block for Block {
 // //
 // // XXX: Not used right now but will be used once an indexer is implemented.
 // #[derive(Clone, Debug, PartialEq, Eq)]
-// pub struct Finalized {
+// pub(crate) struct Finalized {
 //     proof: Finalization,
 //     block: Block,
 // }
@@ -228,14 +228,14 @@ impl commonware_consensus::Block for Block {
 // #[error(
 //     "invalid finalized block: proof proposal `{proposal}` does not match block digest `{digest}`"
 // )]
-// pub struct FinalizationProofNotForBlock {
+// pub(crate) struct FinalizationProofNotForBlock {
 //     proposal: Digest,
 //     digest: Digest,
 // }
 
 // impl Finalized {
 //     /// Constructs a new [`Finalized`] block.
-//     pub fn try_new(
+//     pub(crate) fn try_new(
 //         proof: Finalization,
 //         block: Block,
 //     ) -> Result<Self, FinalizationProofNotForBlock> {
@@ -248,19 +248,19 @@ impl commonware_consensus::Block for Block {
 //         Ok(Self { proof, block })
 //     }
 
-//     pub fn block(&self) -> &Block {
+//     pub(crate) fn block(&self) -> &Block {
 //         &self.block
 //     }
 
 //     /// Breaks up [`Finalized`] into its constituent parts.
-//     pub fn into_parts(self) -> (Finalization, Block) {
+//     pub(crate) fn into_parts(self) -> (Finalization, Block) {
 //         (self.proof, self.block)
 //     }
 
 //     /// Verifies the notarized block against `namespace` and `identity`.
 //     ///
 //     // XXX: But why does this ignore the block entirely??
-//     pub fn verify(&self, namespace: &[u8], identity: &BlsPublicKey) -> bool {
+//     pub(crate) fn verify(&self, namespace: &[u8], identity: &BlsPublicKey) -> bool {
 //         self.proof.verify(namespace, identity)
 //     }
 // }

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -45,46 +45,45 @@ const MAX_REPAIR: u64 = 20;
 ///
 // XXX: Mostly a one-to-one copy of alto for now. We also put the context in here
 // because there doesn't really seem to be a point putting it into an extra initializer.
-pub struct Builder<
+pub(crate) struct Builder<
     TBlocker,
     TContext,
     // TODO: add the indexer. It's part of alto and we have skipped it, for now.
     // TIndexer,
 > {
     /// The contextg
-    pub context: TContext,
+    pub(crate) context: TContext,
 
-    pub fee_recipient: alloy_primitives::Address,
+    pub(crate) fee_recipient: alloy_primitives::Address,
 
-    pub execution_node: TempoFullNode,
+    pub(crate) execution_node: TempoFullNode,
 
-    // pub chainspec: Arc<TempoChainSpec>,
-    // pub execution_engine: ConsensusEngineHandle<TNodeTypes::Payload>,
-    // pub execution_payload_builder: PayloadBuilderHandle<TNodeTypes::Payload>,
+    // pub(crate) chainspec: Arc<TempoChainSpec>,
+    // pub(crate) execution_engine: ConsensusEngineHandle<TNodeTypes::Payload>,
+    // pub(crate) execution_payload_builder: PayloadBuilderHandle<TNodeTypes::Payload>,
     /// A handle to the reth execution node so that consensus can drive execution.
     //
-    pub blocker: TBlocker,
-    pub partition_prefix: String,
-    pub blocks_freezer_table_initial_size: u32,
-    pub finalized_freezer_table_initial_size: u32,
-    pub signer: PrivateKey,
-    pub polynomial: PublicPolynomial,
-    pub share: GroupShare,
-    pub participants: Vec<PublicKey>,
-    pub mailbox_size: usize,
-    pub backfill_quota: Quota,
-    pub deque_size: usize,
+    pub(crate) blocker: TBlocker,
+    pub(crate) partition_prefix: String,
+    pub(crate) blocks_freezer_table_initial_size: u32,
+    pub(crate) signer: PrivateKey,
+    pub(crate) polynomial: PublicPolynomial,
+    pub(crate) share: GroupShare,
+    pub(crate) participants: Vec<PublicKey>,
+    pub(crate) mailbox_size: usize,
+    pub(crate) backfill_quota: Quota,
+    pub(crate) deque_size: usize,
 
-    pub leader_timeout: Duration,
-    pub notarization_timeout: Duration,
-    pub nullify_retry: Duration,
-    pub fetch_timeout: Duration,
-    pub activity_timeout: u64,
-    pub skip_timeout: u64,
-    pub new_payload_wait_time: Duration,
-    pub max_fetch_count: usize,
-    pub fetch_concurrent: usize,
-    pub fetch_rate_per_peer: Quota,
+    pub(crate) leader_timeout: Duration,
+    pub(crate) notarization_timeout: Duration,
+    pub(crate) nullify_retry: Duration,
+    pub(crate) fetch_timeout: Duration,
+    pub(crate) activity_timeout: u64,
+    pub(crate) skip_timeout: u64,
+    pub(crate) new_payload_wait_time: Duration,
+    pub(crate) max_fetch_count: usize,
+    pub(crate) fetch_concurrent: usize,
+    pub(crate) fetch_rate_per_peer: Quota,
     // pub indexer: Option<TIndexer>,
 }
 
@@ -93,7 +92,7 @@ where
     TBlocker: Blocker<PublicKey = PublicKey>,
     TContext: Clock + governor::clock::Clock + Rng + CryptoRng + Spawner + Storage + Metrics,
 {
-    pub async fn try_init(self) -> eyre::Result<Engine<TBlocker, TContext>> {
+    pub(crate) async fn try_init(self) -> eyre::Result<Engine<TBlocker, TContext>> {
         let supervisor = Supervisor::new(
             self.polynomial.clone(),
             self.participants.clone(),
@@ -206,7 +205,7 @@ where
     }
 }
 
-pub struct Engine<TBlocker, TContext>
+pub(crate) struct Engine<TBlocker, TContext>
 where
     TBlocker: Blocker<PublicKey = PublicKey>,
     TContext: Clock + governor::clock::Clock + Rng + CryptoRng + Spawner + Storage + Metrics,
@@ -243,7 +242,7 @@ where
     TBlocker: Blocker<PublicKey = PublicKey>,
     TContext: Clock + governor::clock::Clock + Rng + CryptoRng + Spawner + Storage + Metrics,
 {
-    pub fn start(
+    pub(crate) fn start(
         self,
         pending_network: (
             impl Sender<PublicKey = PublicKey>,

--- a/crates/commonware-node/src/consensus/mod.rs
+++ b/crates/commonware-node/src/consensus/mod.rs
@@ -1,14 +1,12 @@
 //! Mainly aliases to define consensus within tempo.
 
-pub mod block;
-pub mod engine;
-pub mod execution_driver;
+pub(crate) mod block;
+pub(crate) mod engine;
+pub(crate) mod execution_driver;
 mod supervisor;
 
-pub use engine::Engine;
-
 use commonware_consensus::marshal;
-pub use supervisor::Supervisor;
+pub(crate) use supervisor::Supervisor;
 
 use tempo_commonware_node_cryptography::{BlsScheme, Digest, PrivateKey};
 

--- a/crates/commonware-node/src/consensus/supervisor.rs
+++ b/crates/commonware-node/src/consensus/supervisor.rs
@@ -20,7 +20,7 @@ use tempo_commonware_node_cryptography::{
 ///
 /// Implementation of `[commonware_consensus::Supervisor]`.
 #[derive(Clone)]
-pub struct Supervisor {
+pub(crate) struct Supervisor {
     identity: Identity,
     polynomial: Vec<Identity>,
     participants: Vec<ed25519::PublicKey>,
@@ -31,7 +31,7 @@ pub struct Supervisor {
 
 impl Supervisor {
     /// Create a new [Supervisor].
-    pub fn new(
+    pub(crate) fn new(
         polynomial: PublicPolynomial,
         mut participants: Vec<ed25519::PublicKey>,
         share: GroupShare,

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -3,15 +3,15 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-pub mod config;
-pub mod consensus;
+pub(crate) mod config;
+pub(crate) mod consensus;
 pub mod metrics;
 
 use std::net::SocketAddr;
 
 use commonware_cryptography::Signer;
 use commonware_p2p::authenticated::discovery;
-use commonware_runtime::{Handle, Metrics as _};
+use commonware_runtime::Metrics as _;
 use eyre::{WrapErr as _, bail, eyre};
 use indexmap::IndexMap;
 use tempo_node::TempoFullNode;
@@ -19,16 +19,11 @@ use tracing::info;
 
 use crate::config::{
     BACKFILL_BY_DIGEST_CHANNE_IDENTL, BACKFILL_QUOTA, BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES,
-    BROADCASTER_CHANNEL_IDENT, BROADCASTER_LIMIT, FINALIZED_FREEZER_TABLE_INITIAL_SIZE_BYTES,
-    NUMBER_CONCURRENT_FETCHES, NUMBER_MAX_FETCHES, PENDING_CHANNEL_IDENT, PENDING_LIMIT,
-    RECOVERED_CHANNEL_IDENT, RECOVERED_LIMIT, RESOLVER_CHANNEL_IDENT, RESOLVER_LIMIT,
+    BROADCASTER_CHANNEL_IDENT, BROADCASTER_LIMIT, NUMBER_CONCURRENT_FETCHES, NUMBER_MAX_FETCHES,
+    PENDING_CHANNEL_IDENT, PENDING_LIMIT, RECOVERED_CHANNEL_IDENT, RECOVERED_LIMIT,
+    RESOLVER_CHANNEL_IDENT, RESOLVER_LIMIT,
 };
 use tempo_commonware_node_cryptography::{PrivateKey, PublicKey};
-
-pub struct ConsensusStack {
-    pub network: Handle<()>,
-    pub consensus_engine: Handle<eyre::Result<()>>,
-}
 
 pub async fn run_consensus_stack(
     context: &commonware_runtime::tokio::Context,
@@ -67,7 +62,6 @@ pub async fn run_consensus_stack(
         // TODO: Set this through config?
         partition_prefix: "engine".into(),
         blocks_freezer_table_initial_size: BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES,
-        finalized_freezer_table_initial_size: FINALIZED_FREEZER_TABLE_INITIAL_SIZE_BYTES,
         signer: config.signer.clone(),
         polynomial: config.polynomial.clone(),
         share: config.share.clone(),


### PR DESCRIPTION
It's not necessary to have so many items in the commonware-node crate be public.

The only relevant entry points are `run_consensus_stack` and `metrics::install`. Everything else can be kept crate-private.

This already revealed a couple of items that were not used anywhere.