### PR TITLE
perf: introduce and propagate `asm-keccak` feature

### DIFF
--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -31,3 +31,9 @@ tracing.workspace = true
 [[bin]]
 name = "tempo"
 path = "src/main.rs"
+
+[features]
+default = []
+asm-keccak = [
+	"tempo-node/asm-keccak"
+]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -74,3 +74,12 @@ test-case.workspace = true
 [build-dependencies]
 vergen.workspace = true
 vergen-git2.workspace = true
+
+[features]
+default = []
+asm-keccak = [
+	"alloy/asm-keccak",
+	"alloy-primitives/asm-keccak",
+	"reth-node-core/asm-keccak",
+	"reth-node-ethereum/asm-keccak"
+]


### PR DESCRIPTION
It's not enabled by default in Reth dependencies