### PR TITLE
deps: just use `alloy` meta crate in `precompiles`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14013,7 +14013,6 @@ name = "tempo-precompiles"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-consensus",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -13,10 +13,8 @@ workspace = true
 tempo-contracts.workspace = true
 reth-evm.workspace = true
 reth-storage-api.workspace = true
-alloy = { workspace = true, features = ["contract", "sol-types", "rpc"] }
+alloy = { workspace = true, default-features = false }
 alloy-evm.workspace = true
-alloy-consensus.workspace = true
-alloy-primitives.workspace = true
 
 tracing.workspace = true
 

--- a/crates/precompiles/benches/tempo_precompiles.rs
+++ b/crates/precompiles/benches/tempo_precompiles.rs
@@ -1,5 +1,4 @@
-use alloy::primitives::{Address, U256};
-use alloy_primitives::FixedBytes;
+use alloy::primitives::{Address, FixedBytes, U256};
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 use tempo_precompiles::contracts::{

--- a/crates/precompiles/src/contracts/provider.rs
+++ b/crates/precompiles/src/contracts/provider.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy::primitives::{Address, U256};
 use reth_evm::revm::{Database, interpreter::instructions::utility::IntoAddress};
 use reth_storage_api::{StateProvider, errors::ProviderResult};
 

--- a/crates/precompiles/src/contracts/roles.rs
+++ b/crates/precompiles/src/contracts/roles.rs
@@ -213,8 +213,7 @@ impl<'a, S: StorageProvider> RolesAuthContract<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::keccak256;
-    use alloy_primitives::address;
+    use alloy::primitives::{address, keccak256};
 
     use super::*;
     use crate::contracts::storage::hashmap::HashMapStorageProvider;

--- a/crates/precompiles/src/contracts/storage/evm.rs
+++ b/crates/precompiles/src/contracts/storage/evm.rs
@@ -69,11 +69,11 @@ impl<'a> StorageProvider for EvmStorageProvider<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::{address, b256, bytes};
     use alloy_evm::{
         EthEvmFactory, EvmEnv, EvmFactory, EvmInternals,
         revm::context::{ContextTr, Host},
     };
-    use alloy_primitives::{address, b256, bytes};
     use reth_evm::revm::{
         database::{CacheDB, EmptyDB},
         interpreter::StateLoad,

--- a/crates/precompiles/src/contracts/tip20.rs
+++ b/crates/precompiles/src/contracts/tip20.rs
@@ -11,9 +11,10 @@ use crate::{
         types::{TIP20Error, TIP20Event},
     },
 };
-use alloy::primitives::{Address, B256, IntoLogData, Signature as EthSignature, U256, keccak256};
-use alloy_consensus::crypto::secp256k1 as eth_secp256k1;
-use alloy_primitives::Bytes;
+use alloy::{
+    consensus::crypto::secp256k1 as eth_secp256k1,
+    primitives::{Address, B256, Bytes, IntoLogData, Signature as EthSignature, U256, keccak256},
+};
 use reth_evm::revm::state::Bytecode;
 use tracing::trace;
 
@@ -953,8 +954,7 @@ impl<'a, S: StorageProvider> TIP20Token<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, U256, keccak256};
-    use alloy_primitives::FixedBytes;
+    use alloy::primitives::{Address, FixedBytes, U256, keccak256};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
 

--- a/crates/precompiles/src/contracts/tip20_factory.rs
+++ b/crates/precompiles/src/contracts/tip20_factory.rs
@@ -7,8 +7,7 @@ use crate::{
         types::{ITIP20Factory, TIP20Error, TIP20FactoryEvent},
     },
 };
-use alloy::primitives::{Address, IntoLogData, U256};
-use alloy_primitives::Bytes;
+use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use reth_evm::revm::state::Bytecode;
 use tracing::trace;
 

--- a/crates/precompiles/src/contracts/tip403_registry.rs
+++ b/crates/precompiles/src/contracts/tip403_registry.rs
@@ -7,9 +7,8 @@ use crate::{
     },
     tip403_err,
 };
-use alloy::primitives::{Address, IntoLogData, U256};
+use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use alloy_evm::revm::interpreter::instructions::utility::{IntoAddress, IntoU256};
-use alloy_primitives::Bytes;
 use reth_evm::revm::state::Bytecode;
 
 mod slots {

--- a/crates/precompiles/src/contracts/tip_account_registrar.rs
+++ b/crates/precompiles/src/contracts/tip_account_registrar.rs
@@ -1,5 +1,7 @@
-use alloy::eips::eip7702::constants::SECP256K1N_HALF;
-use alloy_primitives::{Address, B512, U256};
+use alloy::{
+    eips::eip7702::constants::SECP256K1N_HALF,
+    primitives::{Address, B512, U256},
+};
 use reth_evm::revm::{precompile::secp256k1::ecrecover, state::Bytecode};
 use tempo_contracts::DEFAULT_7702_DELEGATE_ADDRESS;
 
@@ -103,7 +105,7 @@ fn validate_signature(signature: &[u8]) -> Result<(B512, u8), TipAccountRegistra
 mod tests {
     use super::*;
     use crate::contracts::{HashMapStorageProvider, types::ITipAccountRegistrar};
-    use alloy_primitives::keccak256;
+    use alloy::primitives::keccak256;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
 

--- a/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager/amm.rs
@@ -5,10 +5,9 @@ use crate::contracts::{
     types::{ITIP20, ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent},
 };
 use alloy::{
-    primitives::{Address, B256, U256, keccak256, uint},
+    primitives::{Address, B256, IntoLogData, U256, keccak256, uint},
     sol_types::SolValue,
 };
-use alloy_primitives::IntoLogData;
 
 /// Constants from the Solidity reference implementation
 pub const M: U256 = uint!(9970_U256); // m = 0.9970 (scaled by 10000)
@@ -59,8 +58,7 @@ impl PoolKey {
 /// Storage slots for FeeAMM
 pub mod slots {
     use crate::contracts::storage::slots::{double_mapping_slot, mapping_slot};
-    use alloy::primitives::{U256, uint};
-    use alloy_primitives::{Address, B256};
+    use alloy::primitives::{Address, B256, U256, uint};
 
     // FeeAMM storage slots
     pub const POOLS: U256 = uint!(0_U256);

--- a/crates/precompiles/src/contracts/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager/mod.rs
@@ -14,8 +14,7 @@ use crate::{
 };
 
 // Re-export PoolKey for backward compatibility with tests
-use alloy::primitives::{Address, IntoLogData, U256, uint};
-use alloy_primitives::Bytes;
+use alloy::primitives::{Address, Bytes, IntoLogData, U256, uint};
 use reth_evm::revm::{
     interpreter::instructions::utility::{IntoAddress, IntoU256},
     state::Bytecode,
@@ -30,8 +29,7 @@ use reth_evm::revm::{
 /// This shared storage layout means that FeeManager can directly access and modify
 /// AMM pool data using the same storage slots that TIPFeeAMM would use.
 pub mod slots {
-    use alloy::primitives::{U256, uint};
-    use alloy_primitives::Address;
+    use alloy::primitives::{Address, U256, uint};
 
     use crate::contracts::storage::slots::mapping_slot;
 

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use alloy_primitives::{Address, address, hex};
+use alloy::primitives::{Address, address, hex};
 
 pub mod contracts;
 pub mod precompiles;

--- a/crates/precompiles/src/precompiles/mod.rs
+++ b/crates/precompiles/src/precompiles/mod.rs
@@ -1,9 +1,8 @@
 use alloy::{
-    primitives::Address,
+    primitives::{Address, Bytes},
     sol,
     sol_types::{SolCall, SolError, SolInterface},
 };
-use alloy_primitives::Bytes;
 use reth_evm::{
     precompiles::{DynPrecompile, PrecompilesMap},
     revm::{
@@ -202,7 +201,7 @@ where
 {
     match result {
         Err(PrecompileError::Other(hex_string)) => {
-            let bytes = alloy_primitives::hex::decode(hex_string)
+            let bytes = alloy::primitives::hex::decode(hex_string)
                 .expect("invalid hex string in PrecompileError::Other");
             let decoded: E = E::abi_decode(&bytes)
                 .expect("failed to decode precompile error as expected interface error");
@@ -217,8 +216,8 @@ where
 mod tests {
     use super::*;
     use crate::precompiles::Precompile;
+    use alloy::primitives::{Address, Bytes, U256};
     use alloy_evm::{EthEvmFactory, EvmEnv, EvmFactory, EvmInternals};
-    use alloy_primitives::{Address, Bytes, U256};
     use reth_evm::{
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
         revm::{

--- a/crates/precompiles/src/precompiles/tip20.rs
+++ b/crates/precompiles/src/precompiles/tip20.rs
@@ -69,10 +69,9 @@ mod tests {
         precompiles::{METADATA_GAS, MUTATE_FUNC_GAS, VIEW_FUNC_GAS, expect_precompile_error},
     };
     use alloy::{
-        primitives::{U256, keccak256},
+        primitives::{Bytes, U256, keccak256},
         sol_types::SolValue,
     };
-    use alloy_primitives::Bytes;
 
     use super::*;
 


### PR DESCRIPTION
The precompiles crate depends on both the `alloy` meta crate (with unused features) and individual crates like `alloy-primitives`. This PR settles for the meta crate make code completion more enjoyable and group imports.