### PR TITLE
deps: remove `reth-evm` as a dependency of `precompiles`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14020,8 +14020,8 @@ dependencies = [
  "criterion 0.7.0",
  "eyre",
  "rand 0.8.5",
- "reth-evm",
  "reth-storage-api",
+ "revm",
  "tempo-contracts",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b940d0a", feat
   "std",
   "optional-checks",
 ] }
+revm = "29"
 
 alloy = { version = "1.0.35", default-features = false }
 alloy-evm = "0.21.1"

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -11,10 +11,10 @@ workspace = true
 
 [dependencies]
 tempo-contracts.workspace = true
-reth-evm.workspace = true
 reth-storage-api.workspace = true
 alloy = { workspace = true, default-features = false }
 alloy-evm.workspace = true
+revm.workspace = true
 
 tracing.workspace = true
 

--- a/crates/precompiles/src/contracts/provider.rs
+++ b/crates/precompiles/src/contracts/provider.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, U256};
-use reth_evm::revm::{Database, interpreter::instructions::utility::IntoAddress};
 use reth_storage_api::{StateProvider, errors::ProviderResult};
+use revm::{Database, interpreter::instructions::utility::IntoAddress};
 
 use crate::{
     DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,

--- a/crates/precompiles/src/contracts/storage/evm.rs
+++ b/crates/precompiles/src/contracts/storage/evm.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, Log, LogData, U256};
 use alloy_evm::{EvmInternals, EvmInternalsError};
-use reth_evm::revm::state::Bytecode;
+use revm::state::Bytecode;
 
 use crate::contracts::storage::{AccountInfo, StorageProvider};
 
@@ -74,7 +74,7 @@ mod tests {
         EthEvmFactory, EvmEnv, EvmFactory, EvmInternals,
         revm::context::{ContextTr, Host},
     };
-    use reth_evm::revm::{
+    use revm::{
         database::{CacheDB, EmptyDB},
         interpreter::StateLoad,
     };

--- a/crates/precompiles/src/contracts/storage/hashmap.rs
+++ b/crates/precompiles/src/contracts/storage/hashmap.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use alloy::primitives::{Address, LogData, U256};
-use reth_evm::revm::state::{AccountInfo, Bytecode};
+use revm::state::{AccountInfo, Bytecode};
 
 use crate::contracts::storage::StorageProvider;
 

--- a/crates/precompiles/src/contracts/storage/mod.rs
+++ b/crates/precompiles/src/contracts/storage/mod.rs
@@ -5,7 +5,7 @@ pub mod slots;
 use std::fmt::Debug;
 
 use alloy::primitives::{Address, LogData, U256};
-use reth_evm::revm::state::{AccountInfo, Bytecode};
+use revm::state::{AccountInfo, Bytecode};
 
 pub trait StorageProvider {
     type Error: Debug;

--- a/crates/precompiles/src/contracts/tip20.rs
+++ b/crates/precompiles/src/contracts/tip20.rs
@@ -15,7 +15,7 @@ use alloy::{
     consensus::crypto::secp256k1 as eth_secp256k1,
     primitives::{Address, B256, Bytes, IntoLogData, Signature as EthSignature, U256, keccak256},
 };
-use reth_evm::revm::state::Bytecode;
+use revm::state::Bytecode;
 use tracing::trace;
 
 pub mod slots {

--- a/crates/precompiles/src/contracts/tip20_factory.rs
+++ b/crates/precompiles/src/contracts/tip20_factory.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use alloy::primitives::{Address, Bytes, IntoLogData, U256};
-use reth_evm::revm::state::Bytecode;
+use revm::state::Bytecode;
 use tracing::trace;
 
 mod slots {

--- a/crates/precompiles/src/contracts/tip403_registry.rs
+++ b/crates/precompiles/src/contracts/tip403_registry.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use alloy_evm::revm::interpreter::instructions::utility::{IntoAddress, IntoU256};
-use reth_evm::revm::state::Bytecode;
+use revm::state::Bytecode;
 
 mod slots {
     use alloy::primitives::{U256, uint};

--- a/crates/precompiles/src/contracts/tip_account_registrar.rs
+++ b/crates/precompiles/src/contracts/tip_account_registrar.rs
@@ -2,7 +2,7 @@ use alloy::{
     eips::eip7702::constants::SECP256K1N_HALF,
     primitives::{Address, B512, U256},
 };
-use reth_evm::revm::{precompile::secp256k1::ecrecover, state::Bytecode};
+use revm::{precompile::secp256k1::ecrecover, state::Bytecode};
 use tempo_contracts::DEFAULT_7702_DELEGATE_ADDRESS;
 
 use crate::contracts::{

--- a/crates/precompiles/src/contracts/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/contracts/tip_fee_manager/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 // Re-export PoolKey for backward compatibility with tests
 use alloy::primitives::{Address, Bytes, IntoLogData, U256, uint};
-use reth_evm::revm::{
+use revm::{
     interpreter::instructions::utility::{IntoAddress, IntoU256},
     state::Bytecode,
 };

--- a/crates/precompiles/src/precompiles/mod.rs
+++ b/crates/precompiles/src/precompiles/mod.rs
@@ -3,12 +3,10 @@ use alloy::{
     sol,
     sol_types::{SolCall, SolError, SolInterface},
 };
-use reth_evm::{
-    precompiles::{DynPrecompile, PrecompilesMap},
-    revm::{
-        context::Block,
-        precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult},
-    },
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use revm::{
+    context::Block,
+    precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult},
 };
 
 pub mod tip20;
@@ -217,13 +215,13 @@ mod tests {
     use super::*;
     use crate::precompiles::Precompile;
     use alloy::primitives::{Address, Bytes, U256};
-    use alloy_evm::{EthEvmFactory, EvmEnv, EvmFactory, EvmInternals};
-    use reth_evm::{
+    use alloy_evm::{
+        EthEvmFactory, EvmEnv, EvmFactory, EvmInternals,
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
-        revm::{
-            context::ContextTr,
-            database::{CacheDB, EmptyDB},
-        },
+    };
+    use revm::{
+        context::ContextTr,
+        database::{CacheDB, EmptyDB},
     };
 
     #[test]

--- a/crates/precompiles/src/precompiles/tip20.rs
+++ b/crates/precompiles/src/precompiles/tip20.rs
@@ -7,7 +7,7 @@ use crate::{
     precompiles::{Precompile, metadata, mutate, mutate_void, view},
 };
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 #[rustfmt::skip]
 impl<'a, S: StorageProvider> Precompile for TIP20Token<'a, S> {

--- a/crates/precompiles/src/precompiles/tip20_factory.rs
+++ b/crates/precompiles/src/precompiles/tip20_factory.rs
@@ -1,6 +1,6 @@
 use crate::precompiles::{Precompile, mutate, view};
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 use crate::contracts::{
     storage::StorageProvider, tip20_factory::TIP20Factory, types::ITIP20Factory,

--- a/crates/precompiles/src/precompiles/tip403_registry.rs
+++ b/crates/precompiles/src/precompiles/tip403_registry.rs
@@ -1,6 +1,6 @@
 use crate::precompiles::{Precompile, mutate, mutate_void, view};
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 use crate::contracts::{
     storage::StorageProvider,
@@ -423,7 +423,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(reth_evm::revm::precompile::PrecompileError::Other(_))
+            Err(revm::precompile::PrecompileError::Other(_))
         ));
 
         // Test with insufficient data

--- a/crates/precompiles/src/precompiles/tip4217_registry.rs
+++ b/crates/precompiles/src/precompiles/tip4217_registry.rs
@@ -1,6 +1,6 @@
 use crate::precompiles::{Precompile, view};
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 use crate::contracts::{tip4217_registry::TIP4217Registry, types::ITIP4217Registry};
 

--- a/crates/precompiles/src/precompiles/tip_account_registrar.rs
+++ b/crates/precompiles/src/precompiles/tip_account_registrar.rs
@@ -1,6 +1,6 @@
 use crate::precompiles::{Precompile, mutate};
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 use crate::contracts::{StorageProvider, TipAccountRegistrar, types::ITipAccountRegistrar};
 

--- a/crates/precompiles/src/precompiles/tip_fee_manager.rs
+++ b/crates/precompiles/src/precompiles/tip_fee_manager.rs
@@ -7,7 +7,7 @@ use crate::{
     precompiles::{Precompile, mutate, mutate_void, view},
 };
 use alloy::{primitives::Address, sol_types::SolCall};
-use reth_evm::revm::precompile::{PrecompileError, PrecompileResult};
+use revm::precompile::{PrecompileError, PrecompileResult};
 
 #[rustfmt::skip]
 impl<'a, S: StorageProvider> Precompile for TipFeeManager<'a, S> {
@@ -28,7 +28,7 @@ impl<'a, S: StorageProvider> Precompile for TipFeeManager<'a, S> {
             ITIPFeeAMM::poolsCall::SELECTOR => view::<ITIPFeeAMM::poolsCall>(calldata, |call| self.pools(call)),
             ITIPFeeAMM::totalSupplyCall::SELECTOR => view::<ITIPFeeAMM::totalSupplyCall>(calldata, |call| self.total_supply(call)),
             ITIPFeeAMM::liquidityBalancesCall::SELECTOR => view::<ITIPFeeAMM::liquidityBalancesCall>(calldata, |call| self.liquidity_balances(call)),
-            
+
             // State changing functions
             IFeeManager::setValidatorTokenCall::SELECTOR => mutate_void::<IFeeManager::setValidatorTokenCall, IFeeManager::IFeeManagerErrors>(calldata, msg_sender, |s, call| self.set_validator_token(s, call)),
             IFeeManager::setUserTokenCall::SELECTOR => mutate_void::<IFeeManager::setUserTokenCall, IFeeManager::IFeeManagerErrors>(calldata, msg_sender, |s, call| self.set_user_token(s, call)),


### PR DESCRIPTION
This dependency was mostly used for `reth_evm::revm`, but we can pull in `revm` directly to make the crate graph leaner. This matters for an eventual Foundry integration where we would not want to depend on
a lot of Reth internals.

The solution is to use `revm` directly instead of
the `revm` re-exports in `reth_evm`, and `alloy_evm` instead of the `alloy_evm` re-exports in `reth_evm`.

Some of the reth internals still remain in the crate graph for `precompiles`, but this is due to `reth-storage-api`. For a leaner Foundry integration, we should consider feature gating this.

~On top of #383 for now, will rebase once merged.~