### PR TITLE
fix(ci): temporarily disable consensus in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,49 +45,50 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
 
-  consensus-e2e-tests:
-    name: Consensus E2E Tests
-    runs-on: depot-ubuntu-latest-4
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq curl
-
-      - name: Build tempo-commonware Docker image
-        run: |
-          docker build -t tempo-commonware:latest .
-
-      - name: Make test scripts executable
-        run: |
-          chmod +x scripts/consensus/*.sh
-
-      - name: Run partial network failure test
-        run: |
-          ./scripts/consensus/test-partial-network-failure.sh
-          sleep 5
-
-      - name: Run network halt and recovery test
-        run: |
-          ./scripts/consensus/test-network-halt-and-recovery.sh
-          sleep 5
-
-      - name: Run full network failure and recovery test
-        run: |
-          ./scripts/consensus/test-full-network-failure-and-recovery.sh
-          sleep 5
-
-      # Cleanup
-      - name: Cleanup containers
-        if: always()
-        run: |
-          cd scripts/consensus
-          ./stop-network.sh || true
-          docker container prune -f || true
-          docker network prune -f || true
+  # FIXME: Consensus tests are flaky in CI. Temporarily disabling them to avoid blocking PR merges.
+  # consensus-e2e-tests:
+  #   name: Consensus E2E Tests
+  #   runs-on: depot-ubuntu-latest-4
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Install test dependencies
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y jq curl
+  #
+  #     - name: Build tempo-commonware Docker image
+  #       run: |
+  #         docker build -t tempo-commonware:latest .
+  #
+  #     - name: Make test scripts executable
+  #       run: |
+  #         chmod +x scripts/consensus/*.sh
+  #
+  #     - name: Run partial network failure test
+  #       run: |
+  #         ./scripts/consensus/test-partial-network-failure.sh
+  #         sleep 5
+  #
+  #     - name: Run network halt and recovery test
+  #       run: |
+  #         ./scripts/consensus/test-network-halt-and-recovery.sh
+  #         sleep 5
+  #
+  #     - name: Run full network failure and recovery test
+  #       run: |
+  #         ./scripts/consensus/test-full-network-failure-and-recovery.sh
+  #         sleep 5
+  #
+  #     # Cleanup
+  #     - name: Cleanup containers
+  #       if: always()
+  #       run: |
+  #         cd scripts/consensus
+  #         ./stop-network.sh || true
+  #         docker container prune -f || true
+  #         docker network prune -f || true
 
   test-success:
     name: test success
@@ -96,7 +97,7 @@ jobs:
     needs:
       - test
       - msrv
-      - consensus-e2e-tests
+      # - consensus-e2e-tests
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
Consensus tests are flaky in CI. Temporarily disabling them to avoid blocking PR merges.
