### PR TITLE
chore(precompiles): feature gate reth dependencies

### DIFF
--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 tempo-contracts.workspace = true
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, optional = true }
 alloy = { workspace = true, default-features = false }
 alloy-evm.workspace = true
 revm.workspace = true
@@ -27,6 +27,9 @@ alloy-signer-local.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 eyre.workspace = true
 rand.workspace = true
+
+[features]
+reth = ["dep:reth-storage-api"]
 
 [[bench]]
 name = "tempo_precompiles"

--- a/crates/precompiles/src/contracts/provider.rs
+++ b/crates/precompiles/src/contracts/provider.rs
@@ -1,4 +1,5 @@
 use alloy::primitives::{Address, U256};
+#[cfg(feature = "reth")]
 use reth_storage_api::{StateProvider, errors::ProviderResult};
 use revm::{Database, interpreter::instructions::utility::IntoAddress};
 
@@ -12,6 +13,7 @@ use crate::{
 };
 
 /// Trait to provide [`StateProvider`] access to TIPFeeManager storage to fetch fee token data and balances
+#[cfg(feature = "reth")]
 pub trait TIPFeeStateProviderExt: StateProvider {
     /// Get fee token balance for a user.
     ///
@@ -49,6 +51,7 @@ pub trait TIPFeeStateProviderExt: StateProvider {
     }
 }
 
+#[cfg(feature = "reth")]
 impl<T: StateProvider> TIPFeeStateProviderExt for T {}
 
 /// Trait to provide [`Database`] access to TIPFeeManager storage to fetch fee token data and balances

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -12,7 +12,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["reth"] }
 tempo-primitives.workspace = true
 
 reth-transaction-pool.workspace = true


### PR DESCRIPTION
Similar to https://github.com/tempoxyz/tempo/pull/384 in motivation, we want to slim `tempo-precompiles` to a degree where we can integrate it into Foundry without pulling in unnecessary dependencies. Foundry does not (as of now) depend on any Reth crates.

This feature gates the `TIPFeeStateProviderExt` trait on a new feature, `reth`.