### PR TITLE
chore: rm `#[rustfmt::skip]`

### DIFF
--- a/crates/precompiles/src/precompiles/tip20.rs
+++ b/crates/precompiles/src/precompiles/tip20.rs
@@ -9,10 +9,15 @@ use crate::{
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::{PrecompileError, PrecompileResult};
 
-#[rustfmt::skip]
 impl<'a, S: StorageProvider> Precompile for TIP20Token<'a, S> {
     fn call(&mut self, calldata: &[u8], msg_sender: &Address) -> PrecompileResult {
-        let selector: [u8; 4] = calldata.get(..4).ok_or_else(|| { PrecompileError::Other("Invalid input: missing function selector".to_string()) })?.try_into().unwrap();
+        let selector: [u8; 4] = calldata
+            .get(..4)
+            .ok_or_else(|| {
+                PrecompileError::Other("Invalid input: missing function selector".to_string())
+            })?
+            .try_into()
+            .unwrap();
 
         match selector {
             // Metadata
@@ -20,42 +25,143 @@ impl<'a, S: StorageProvider> Precompile for TIP20Token<'a, S> {
             ITIP20::symbolCall::SELECTOR => metadata::<ITIP20::symbolCall>(self.symbol()),
             ITIP20::decimalsCall::SELECTOR => metadata::<ITIP20::decimalsCall>(self.decimals()),
             ITIP20::currencyCall::SELECTOR => metadata::<ITIP20::currencyCall>(self.currency()),
-            ITIP20::totalSupplyCall::SELECTOR => metadata::<ITIP20::totalSupplyCall>(self.total_supply()),
+            ITIP20::totalSupplyCall::SELECTOR => {
+                metadata::<ITIP20::totalSupplyCall>(self.total_supply())
+            }
             ITIP20::supplyCapCall::SELECTOR => metadata::<ITIP20::supplyCapCall>(self.supply_cap()),
-            ITIP20::transferPolicyIdCall::SELECTOR => metadata::<ITIP20::transferPolicyIdCall>(self.transfer_policy_id()),
-            ITIP20::pausedCall::SELECTOR => metadata::<ITIP20::pausedCall>( self.paused()),
+            ITIP20::transferPolicyIdCall::SELECTOR => {
+                metadata::<ITIP20::transferPolicyIdCall>(self.transfer_policy_id())
+            }
+            ITIP20::pausedCall::SELECTOR => metadata::<ITIP20::pausedCall>(self.paused()),
 
             // View functions
-            ITIP20::balanceOfCall::SELECTOR => view::<ITIP20::balanceOfCall>(calldata, |call| self.balance_of(call)),
-            ITIP20::allowanceCall::SELECTOR => view::<ITIP20::allowanceCall>(calldata, |call| self.allowance(call)),
-            ITIP20::noncesCall::SELECTOR => view::<ITIP20::noncesCall>(calldata, |call| self.nonces(call)),
-            ITIP20::saltsCall::SELECTOR => view::<ITIP20::saltsCall>(calldata, |call| self.salts(call)),
+            ITIP20::balanceOfCall::SELECTOR => {
+                view::<ITIP20::balanceOfCall>(calldata, |call| self.balance_of(call))
+            }
+            ITIP20::allowanceCall::SELECTOR => {
+                view::<ITIP20::allowanceCall>(calldata, |call| self.allowance(call))
+            }
+            ITIP20::noncesCall::SELECTOR => {
+                view::<ITIP20::noncesCall>(calldata, |call| self.nonces(call))
+            }
+            ITIP20::saltsCall::SELECTOR => {
+                view::<ITIP20::saltsCall>(calldata, |call| self.salts(call))
+            }
 
             // State changing functions
-            ITIP20::transferFromCall::SELECTOR => mutate::<ITIP20::transferFromCall, TIP20Error>(calldata, msg_sender, |s, call| self.transfer_from(s, call)),
-            ITIP20::transferCall::SELECTOR => mutate::<ITIP20::transferCall, TIP20Error>(calldata, msg_sender, |s, call| self.transfer(s, call)),
-            ITIP20::approveCall::SELECTOR => mutate::<ITIP20::approveCall, TIP20Error>(calldata, msg_sender, |s, call| self.approve(s, call)),
-            ITIP20::permitCall::SELECTOR => mutate_void::<ITIP20::permitCall, TIP20Error>(calldata, msg_sender, |s, call| self.permit(s, call)),
-            ITIP20::changeTransferPolicyIdCall::SELECTOR => mutate_void::<ITIP20::changeTransferPolicyIdCall, TIP20Error>(calldata, msg_sender, |s, call| self.change_transfer_policy_id(s, call)),
-            ITIP20::setSupplyCapCall::SELECTOR => mutate_void::<ITIP20::setSupplyCapCall, TIP20Error>(calldata, msg_sender, |s, call| self.set_supply_cap(s, call)),
-            ITIP20::pauseCall::SELECTOR => mutate_void::<ITIP20::pauseCall, TIP20Error>(calldata, msg_sender, |s, call| self.pause(s, call)),
-            ITIP20::unpauseCall::SELECTOR => mutate_void::<ITIP20::unpauseCall, TIP20Error>(calldata, msg_sender, |s, call| self.unpause(s, call)),
-            ITIP20::mintCall::SELECTOR => mutate_void::<ITIP20::mintCall, _>(calldata, msg_sender, |s, call| self.mint(s, call)),
-            ITIP20::burnCall::SELECTOR => mutate_void::<ITIP20::burnCall, TIP20Error>(calldata, msg_sender, |s, call| self.burn(s, call)),
-            ITIP20::burnBlockedCall::SELECTOR => mutate_void::<ITIP20::burnBlockedCall, TIP20Error>(calldata, msg_sender, |s, call| self.burn_blocked(s, call)),
-            ITIP20::transferWithMemoCall::SELECTOR => mutate_void::<ITIP20::transferWithMemoCall, TIP20Error>(calldata, msg_sender, |s, call| self.transfer_with_memo(s, call)),
+            ITIP20::transferFromCall::SELECTOR => {
+                mutate::<ITIP20::transferFromCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.transfer_from(s, call)
+                })
+            }
+            ITIP20::transferCall::SELECTOR => {
+                mutate::<ITIP20::transferCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.transfer(s, call)
+                })
+            }
+            ITIP20::approveCall::SELECTOR => {
+                mutate::<ITIP20::approveCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.approve(s, call)
+                })
+            }
+            ITIP20::permitCall::SELECTOR => {
+                mutate_void::<ITIP20::permitCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.permit(s, call)
+                })
+            }
+            ITIP20::changeTransferPolicyIdCall::SELECTOR => {
+                mutate_void::<ITIP20::changeTransferPolicyIdCall, TIP20Error>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.change_transfer_policy_id(s, call),
+                )
+            }
+            ITIP20::setSupplyCapCall::SELECTOR => {
+                mutate_void::<ITIP20::setSupplyCapCall, TIP20Error>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.set_supply_cap(s, call),
+                )
+            }
+            ITIP20::pauseCall::SELECTOR => {
+                mutate_void::<ITIP20::pauseCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.pause(s, call)
+                })
+            }
+            ITIP20::unpauseCall::SELECTOR => {
+                mutate_void::<ITIP20::unpauseCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.unpause(s, call)
+                })
+            }
+            ITIP20::mintCall::SELECTOR => {
+                mutate_void::<ITIP20::mintCall, _>(calldata, msg_sender, |s, call| {
+                    self.mint(s, call)
+                })
+            }
+            ITIP20::burnCall::SELECTOR => {
+                mutate_void::<ITIP20::burnCall, TIP20Error>(calldata, msg_sender, |s, call| {
+                    self.burn(s, call)
+                })
+            }
+            ITIP20::burnBlockedCall::SELECTOR => {
+                mutate_void::<ITIP20::burnBlockedCall, TIP20Error>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.burn_blocked(s, call),
+                )
+            }
+            ITIP20::transferWithMemoCall::SELECTOR => {
+                mutate_void::<ITIP20::transferWithMemoCall, TIP20Error>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.transfer_with_memo(s, call),
+                )
+            }
 
             // RolesAuth functions
-            IRolesAuth::hasRoleCall::SELECTOR => view::<IRolesAuth::hasRoleCall>(calldata, |call| self.get_roles_contract().has_role(call)),
-            IRolesAuth::getRoleAdminCall::SELECTOR => view::<IRolesAuth::getRoleAdminCall>(calldata, |call| self.get_roles_contract().get_role_admin(call)),
-            IRolesAuth::grantRoleCall::SELECTOR => mutate_void::<IRolesAuth::grantRoleCall, RolesAuthError>(calldata, msg_sender, |s, call| self.get_roles_contract().grant_role(s, call)),
-            IRolesAuth::revokeRoleCall::SELECTOR => mutate_void::<IRolesAuth::revokeRoleCall, RolesAuthError>(calldata, msg_sender, |s, call| self.get_roles_contract().revoke_role(s, call)),
-            IRolesAuth::renounceRoleCall::SELECTOR => mutate_void::<IRolesAuth::renounceRoleCall, RolesAuthError>(calldata, msg_sender, |s, call| self.get_roles_contract().renounce_role(s, call)),
-            IRolesAuth::setRoleAdminCall::SELECTOR => mutate_void::<IRolesAuth::setRoleAdminCall, RolesAuthError>(calldata, msg_sender, |s, call| self.get_roles_contract().set_role_admin(s, call)),
+            IRolesAuth::hasRoleCall::SELECTOR => {
+                view::<IRolesAuth::hasRoleCall>(calldata, |call| {
+                    self.get_roles_contract().has_role(call)
+                })
+            }
+            IRolesAuth::getRoleAdminCall::SELECTOR => {
+                view::<IRolesAuth::getRoleAdminCall>(calldata, |call| {
+                    self.get_roles_contract().get_role_admin(call)
+                })
+            }
+            IRolesAuth::grantRoleCall::SELECTOR => {
+                mutate_void::<IRolesAuth::grantRoleCall, RolesAuthError>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.get_roles_contract().grant_role(s, call),
+                )
+            }
+            IRolesAuth::revokeRoleCall::SELECTOR => {
+                mutate_void::<IRolesAuth::revokeRoleCall, RolesAuthError>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.get_roles_contract().revoke_role(s, call),
+                )
+            }
+            IRolesAuth::renounceRoleCall::SELECTOR => {
+                mutate_void::<IRolesAuth::renounceRoleCall, RolesAuthError>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.get_roles_contract().renounce_role(s, call),
+                )
+            }
+            IRolesAuth::setRoleAdminCall::SELECTOR => {
+                mutate_void::<IRolesAuth::setRoleAdminCall, RolesAuthError>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.get_roles_contract().set_role_admin(s, call),
+                )
+            }
 
-            _ => Err(PrecompileError::Other("Unknown function selector".to_string()))
+            _ => Err(PrecompileError::Other(
+                "Unknown function selector".to_string(),
+            )),
         }
-
     }
 }
 

--- a/crates/precompiles/src/precompiles/tip20_factory.rs
+++ b/crates/precompiles/src/precompiles/tip20_factory.rs
@@ -6,23 +6,28 @@ use crate::contracts::{
     storage::StorageProvider, tip20_factory::TIP20Factory, types::ITIP20Factory,
 };
 
-#[rustfmt::skip]
 impl<'a, S: StorageProvider> Precompile for TIP20Factory<'a, S> {
     fn call(&mut self, calldata: &[u8], msg_sender: &Address) -> PrecompileResult {
-        let selector: [u8; 4] = calldata.get(..4).ok_or_else(|| {
-            PrecompileError::Other("Invalid input: missing function selector".to_string())
-        })?.try_into().map_err(|_| {
-            PrecompileError::Other("Invalid function selector length".to_string())
-        })?;
+        let selector: [u8; 4] = calldata
+            .get(..4)
+            .ok_or_else(|| {
+                PrecompileError::Other("Invalid input: missing function selector".to_string())
+            })?
+            .try_into()
+            .map_err(|_| PrecompileError::Other("Invalid function selector length".to_string()))?;
 
         match selector {
             ITIP20Factory::tokenIdCounterCall::SELECTOR => {
                 view::<ITIP20Factory::tokenIdCounterCall>(calldata, |_call| self.token_id_counter())
-            },
+            }
             ITIP20Factory::createTokenCall::SELECTOR => {
-                mutate::<ITIP20Factory::createTokenCall, _>(calldata, msg_sender, |s, call| self.create_token(s, call))
-            },
-            _ => Err(PrecompileError::Other("Unknown function selector".to_string()))
+                mutate::<ITIP20Factory::createTokenCall, _>(calldata, msg_sender, |s, call| {
+                    self.create_token(s, call)
+                })
+            }
+            _ => Err(PrecompileError::Other(
+                "Unknown function selector".to_string(),
+            )),
         }
     }
 }

--- a/crates/precompiles/src/precompiles/tip_fee_manager.rs
+++ b/crates/precompiles/src/precompiles/tip_fee_manager.rs
@@ -9,37 +9,94 @@ use crate::{
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::{PrecompileError, PrecompileResult};
 
-#[rustfmt::skip]
 impl<'a, S: StorageProvider> Precompile for TipFeeManager<'a, S> {
     fn call(&mut self, calldata: &[u8], msg_sender: &Address) -> PrecompileResult {
-        let selector: [u8; 4] = calldata.get(..4).ok_or_else(|| {
-            PrecompileError::Other("Invalid input: missing function selector".to_string())
-        })?.try_into().map_err(|_| {
-            PrecompileError::Other("Invalid function selector length".to_string())
-        })?;
+        let selector: [u8; 4] = calldata
+            .get(..4)
+            .ok_or_else(|| {
+                PrecompileError::Other("Invalid input: missing function selector".to_string())
+            })?
+            .try_into()
+            .map_err(|_| PrecompileError::Other("Invalid function selector length".to_string()))?;
 
         match selector {
             // View functions
-            IFeeManager::userTokensCall::SELECTOR => view::<IFeeManager::userTokensCall>(calldata, |call| self.user_tokens(call)),
-            IFeeManager::validatorTokensCall::SELECTOR => view::<IFeeManager::validatorTokensCall>(calldata, |call| self.validator_tokens(call)),
-            IFeeManager::getFeeTokenBalanceCall::SELECTOR => view::<IFeeManager::getFeeTokenBalanceCall>(calldata, |call| self.get_fee_token_balance(call)),
-            ITIPFeeAMM::getPoolIdCall::SELECTOR => view::<ITIPFeeAMM::getPoolIdCall>(calldata, |call| self.get_pool_id(call)),
-            ITIPFeeAMM::getPoolCall::SELECTOR => view::<ITIPFeeAMM::getPoolCall>(calldata, |call| self.get_pool(call)),
-            ITIPFeeAMM::poolsCall::SELECTOR => view::<ITIPFeeAMM::poolsCall>(calldata, |call| self.pools(call)),
-            ITIPFeeAMM::totalSupplyCall::SELECTOR => view::<ITIPFeeAMM::totalSupplyCall>(calldata, |call| self.total_supply(call)),
-            ITIPFeeAMM::liquidityBalancesCall::SELECTOR => view::<ITIPFeeAMM::liquidityBalancesCall>(calldata, |call| self.liquidity_balances(call)),
+            IFeeManager::userTokensCall::SELECTOR => {
+                view::<IFeeManager::userTokensCall>(calldata, |call| self.user_tokens(call))
+            }
+            IFeeManager::validatorTokensCall::SELECTOR => {
+                view::<IFeeManager::validatorTokensCall>(calldata, |call| {
+                    self.validator_tokens(call)
+                })
+            }
+            IFeeManager::getFeeTokenBalanceCall::SELECTOR => {
+                view::<IFeeManager::getFeeTokenBalanceCall>(calldata, |call| {
+                    self.get_fee_token_balance(call)
+                })
+            }
+            ITIPFeeAMM::getPoolIdCall::SELECTOR => {
+                view::<ITIPFeeAMM::getPoolIdCall>(calldata, |call| self.get_pool_id(call))
+            }
+            ITIPFeeAMM::getPoolCall::SELECTOR => {
+                view::<ITIPFeeAMM::getPoolCall>(calldata, |call| self.get_pool(call))
+            }
+            ITIPFeeAMM::poolsCall::SELECTOR => {
+                view::<ITIPFeeAMM::poolsCall>(calldata, |call| self.pools(call))
+            }
+            ITIPFeeAMM::totalSupplyCall::SELECTOR => {
+                view::<ITIPFeeAMM::totalSupplyCall>(calldata, |call| self.total_supply(call))
+            }
+            ITIPFeeAMM::liquidityBalancesCall::SELECTOR => {
+                view::<ITIPFeeAMM::liquidityBalancesCall>(calldata, |call| {
+                    self.liquidity_balances(call)
+                })
+            }
 
             // State changing functions
-            IFeeManager::setValidatorTokenCall::SELECTOR => mutate_void::<IFeeManager::setValidatorTokenCall, IFeeManager::IFeeManagerErrors>(calldata, msg_sender, |s, call| self.set_validator_token(s, call)),
-            IFeeManager::setUserTokenCall::SELECTOR => mutate_void::<IFeeManager::setUserTokenCall, IFeeManager::IFeeManagerErrors>(calldata, msg_sender, |s, call| self.set_user_token(s, call)),
-            IFeeManager::executeBlockCall::SELECTOR => {
-                mutate_void::<IFeeManager::executeBlockCall, IFeeManager::IFeeManagerErrors>(calldata, msg_sender, |s, _call| self.execute_block(s))
+            IFeeManager::setValidatorTokenCall::SELECTOR => {
+                mutate_void::<IFeeManager::setValidatorTokenCall, IFeeManager::IFeeManagerErrors>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.set_validator_token(s, call),
+                )
             }
-            ITIPFeeAMM::mintCall::SELECTOR => mutate::<ITIPFeeAMM::mintCall, ITIPFeeAMM::ITIPFeeAMMErrors>(calldata, msg_sender, |s, call| self.mint(*s, call)),
-            ITIPFeeAMM::burnCall::SELECTOR => mutate::<ITIPFeeAMM::burnCall, ITIPFeeAMM::ITIPFeeAMMErrors>(calldata, msg_sender, |s, call| self.burn(*s, call)),
-            ITIPFeeAMM::rebalanceSwapCall::SELECTOR => mutate::<ITIPFeeAMM::rebalanceSwapCall, ITIPFeeAMM::ITIPFeeAMMErrors>(calldata, msg_sender, |s, call| self.rebalance_swap(*s, call)),
+            IFeeManager::setUserTokenCall::SELECTOR => {
+                mutate_void::<IFeeManager::setUserTokenCall, IFeeManager::IFeeManagerErrors>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.set_user_token(s, call),
+                )
+            }
+            IFeeManager::executeBlockCall::SELECTOR => {
+                mutate_void::<IFeeManager::executeBlockCall, IFeeManager::IFeeManagerErrors>(
+                    calldata,
+                    msg_sender,
+                    |s, _call| self.execute_block(s),
+                )
+            }
+            ITIPFeeAMM::mintCall::SELECTOR => mutate::<
+                ITIPFeeAMM::mintCall,
+                ITIPFeeAMM::ITIPFeeAMMErrors,
+            >(calldata, msg_sender, |s, call| {
+                self.mint(*s, call)
+            }),
+            ITIPFeeAMM::burnCall::SELECTOR => mutate::<
+                ITIPFeeAMM::burnCall,
+                ITIPFeeAMM::ITIPFeeAMMErrors,
+            >(calldata, msg_sender, |s, call| {
+                self.burn(*s, call)
+            }),
+            ITIPFeeAMM::rebalanceSwapCall::SELECTOR => {
+                mutate::<ITIPFeeAMM::rebalanceSwapCall, ITIPFeeAMM::ITIPFeeAMMErrors>(
+                    calldata,
+                    msg_sender,
+                    |s, call| self.rebalance_swap(*s, call),
+                )
+            }
 
-            _ => Err(PrecompileError::Other("Unknown function selector".to_string()))
+            _ => Err(PrecompileError::Other(
+                "Unknown function selector".to_string(),
+            )),
         }
     }
 }


### PR DESCRIPTION
While doing #395 I noticed that we have `#[rustfmt::skip]` in the precompiles crate. I couldn't find an original motivation, so if there is one, feel free to close. Otherwise, this PR removes those annotations and formats the code.