### PR TITLE
chore: move all sol! invocations to contracts

### DIFF
--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -5,6 +5,8 @@
 
 use alloy::primitives::{Address, address};
 
+pub mod precompiles;
+
 pub const MULTICALL_ADDRESS: Address = alloy::providers::MULTICALL3_ADDRESS;
 pub const CREATEX_ADDRESS: Address = address!("0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed");
 pub const PERMIT2_ADDRESS: Address = address!("0x000000000022d473030f116ddee9f6b43ac78ba3");

--- a/crates/contracts/src/precompiles.rs
+++ b/crates/contracts/src/precompiles.rs
@@ -481,8 +481,8 @@ impl TIP20Error {
 #[macro_export]
 macro_rules! tip403_err {
     ($err:ident) => {
-        $crate::contracts::types::TIP403RegistryError::$err(
-            $crate::contracts::types::ITIP403Registry::$err {},
+        $crate::precompiles::TIP403RegistryError::$err(
+            $crate::precompiles::ITIP403Registry::$err {},
         )
     };
 }
@@ -490,8 +490,8 @@ macro_rules! tip403_err {
 #[macro_export]
 macro_rules! fee_manager_err {
     ($err:ident) => {
-        $crate::contracts::types::IFeeManager::IFeeManagerErrors::$err(
-            $crate::contracts::types::IFeeManager::$err {},
+        $crate::precompiles::IFeeManager::IFeeManagerErrors::$err(
+            $crate::precompiles::IFeeManager::$err {},
         )
     };
 }

--- a/crates/precompiles/src/contracts/mod.rs
+++ b/crates/precompiles/src/contracts/mod.rs
@@ -7,7 +7,11 @@ pub mod tip403_registry;
 pub mod tip4217_registry;
 pub mod tip_account_registrar;
 pub mod tip_fee_manager;
-pub mod types;
+
+pub mod types {
+    pub use tempo_contracts::precompiles::*;
+}
+pub use tempo_contracts::{fee_manager_err, tip403_err};
 
 use crate::TIP20_TOKEN_PREFIX;
 use alloy::primitives::Address;

--- a/crates/precompiles/src/contracts/tip403_registry.rs
+++ b/crates/precompiles/src/contracts/tip403_registry.rs
@@ -3,9 +3,9 @@ use crate::{
     contracts::{
         ITIP403Registry, StorageProvider,
         storage::slots::{double_mapping_slot, mapping_slot},
+        tip403_err,
         types::{TIP403RegistryError, TIP403RegistryEvent},
     },
-    tip403_err,
 };
 use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use alloy_evm::revm::interpreter::instructions::utility::{IntoAddress, IntoU256};

--- a/crates/precompiles/src/precompiles/tip_fee_manager.rs
+++ b/crates/precompiles/src/precompiles/tip_fee_manager.rs
@@ -107,12 +107,11 @@ mod tests {
     use crate::{
         TIP_FEE_MANAGER_ADDRESS,
         contracts::{
-            HashMapStorageProvider, TIP20Token, address_to_token_id_unchecked,
+            HashMapStorageProvider, TIP20Token, address_to_token_id_unchecked, fee_manager_err,
             tip_fee_manager::amm::PoolKey,
             token_id_to_address,
             types::{IFeeManager, ITIP20, ITIPFeeAMM, TIPFeeAMMError},
         },
-        fee_manager_err,
         precompiles::{MUTATE_FUNC_GAS, VIEW_FUNC_GAS, expect_precompile_error},
     };
     use alloy::{


### PR DESCRIPTION
Proc macros are not incrementally cached so preferably they're all in a separate crate that is not touched much to avoid re-running and compiling a bunch of generated code.