### PR TITLE
test: unify test node setup patterns across integration tests

### DIFF
--- a/crates/node/tests/it/liquidity.rs
+++ b/crates/node/tests/it/liquidity.rs
@@ -5,10 +5,10 @@ use alloy::{primitives::U256, providers::ProviderBuilder, signers::local::Mnemon
 async fn test_block_building_insufficient_fee_amm_liquidity() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let source = crate::utils::NodeSource::LocalNode(
-        include_str!("../assets/test-genesis.json").to_string(),
-    );
-    let (http_url, _local_node) = crate::utils::setup_test_node(source).await?;
+    let setup = crate::utils::TestNodeBuilder::new()
+        .build_http_only()
+        .await?;
+    let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC)
         .index(0)?

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -14,7 +14,10 @@ use alloy::{
     sol_types::SolEvent,
     transports::http::reqwest::Url,
 };
+use alloy_rpc_types_engine::PayloadAttributes;
+use reth_e2e_test_utils::setup;
 use reth_ethereum::tasks::TaskManager;
+use reth_ethereum_engine_primitives::EthPayloadBuilderAttributes;
 use reth_node_api::FullNodeComponents;
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns};
 use reth_node_core::args::RpcServerArgs;
@@ -22,6 +25,7 @@ use reth_rpc_builder::RpcModuleSelection;
 use std::sync::Arc;
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_node::node::TempoNode;
+use tempo_payload_types::TempoPayloadBuilderAttributes;
 use tempo_precompiles::{
     TIP20_FACTORY_ADDRESS,
     contracts::{
@@ -90,47 +94,22 @@ where
 pub(crate) async fn setup_test_node(
     source: NodeSource,
 ) -> eyre::Result<(Url, Option<LocalTestNode>)> {
-    match source {
-        NodeSource::ExternalRpc(url) => Ok((url, None)),
-        NodeSource::LocalNode(genesis_content) => {
-            let tasks = TaskManager::current();
-            let chain_spec = TempoChainSpec::from_genesis(serde_json::from_str(&genesis_content)?);
-
-            let mut node_config = NodeConfig::new(Arc::new(chain_spec))
-                .with_unused_ports()
-                .dev()
-                .with_rpc(
-                    RpcServerArgs::default()
-                        .with_unused_ports()
-                        .with_http()
-                        .with_http_api(RpcModuleSelection::All),
-                );
-            node_config.txpool.max_account_slots = usize::MAX;
-
-            // Configure random non-zero validator address
-            let validator = Address::random();
-
-            let node_handle = NodeBuilder::new(node_config.clone())
-                .testing_node(tasks.executor())
-                .node(TempoNode::default())
-                .launch_with_debug_capabilities()
-                .map_debug_payload_attributes(move |mut attributes| {
-                    attributes.suggested_fee_recipient = validator;
-                    attributes
-                })
-                .await?;
-
-            let http_url = node_handle
-                .node
-                .rpc_server_handle()
-                .http_url()
-                .unwrap()
-                .parse()
-                .unwrap();
-
-            Ok((http_url, Some((Box::new(node_handle), tasks))))
+    let setup = match source {
+        NodeSource::ExternalRpc(url) => {
+            TestNodeBuilder::new()
+                .with_external_rpc(url)
+                .build_http_only()
+                .await?
         }
-    }
+        NodeSource::LocalNode(genesis_content) => {
+            TestNodeBuilder::new()
+                .with_genesis(genesis_content)
+                .build_http_only()
+                .await?
+        }
+    };
+
+    Ok((setup.http_url, setup.local_node))
 }
 
 pub(crate) async fn await_receipts(
@@ -142,4 +121,217 @@ pub(crate) async fn await_receipts(
     }
 
     Ok(())
+}
+
+/// Result type for single node setup
+pub(crate) struct SingleNodeSetup {
+    /// The node handle for direct manipulation (inject_tx, advance_block, etc.)
+    pub node: reth_e2e_test_utils::NodeHelperType<TempoNode>,
+    /// Task manager that must be kept alive for the node to function
+    _tasks: TaskManager,
+}
+
+/// Result type for multi-node setup
+pub(crate) struct MultiNodeSetup {
+    /// Node handles for direct manipulation
+    pub nodes: Vec<reth_e2e_test_utils::NodeHelperType<TempoNode>>,
+    /// Task manager that must be kept alive for nodes to function
+    _tasks: TaskManager,
+}
+
+/// Result type for HTTP-only setup (no direct node access)
+pub(crate) struct HttpOnlySetup {
+    /// HTTP RPC URL for provider connections
+    pub http_url: Url,
+    /// Optional local node and task manager (None if using external RPC)
+    pub local_node: Option<LocalTestNode>,
+}
+
+/// Builder for creating test nodes
+pub(crate) struct TestNodeBuilder {
+    genesis_content: String,
+    custom_gas_limit: Option<String>,
+    node_count: usize,
+    is_dev: bool,
+    external_rpc: Option<Url>,
+}
+
+impl TestNodeBuilder {
+    /// Create a new builder with default test genesis
+    pub(crate) fn new() -> Self {
+        Self {
+            genesis_content: include_str!("../assets/test-genesis.json").to_string(),
+            custom_gas_limit: None,
+            node_count: 1,
+            is_dev: true,
+            external_rpc: None,
+        }
+    }
+
+    /// Use custom genesis JSON content
+    pub(crate) fn with_genesis(mut self, genesis_content: String) -> Self {
+        self.genesis_content = genesis_content;
+        self
+    }
+
+    /// Set custom gas limit (overrides genesis value)
+    pub(crate) fn with_gas_limit(mut self, gas_limit: &str) -> Self {
+        self.custom_gas_limit = Some(gas_limit.to_string());
+        self
+    }
+
+    /// Set number of nodes to create for multi-node scenarios
+    pub(crate) fn with_node_count(mut self, count: usize) -> Self {
+        self.node_count = count;
+        self
+    }
+
+    /// Use external RPC instead of local node
+    pub(crate) fn with_external_rpc(mut self, url: Url) -> Self {
+        self.external_rpc = Some(url);
+        self
+    }
+
+    /// Build a single node with direct access (NodeHelperType)
+    pub(crate) async fn build_with_node_access(self) -> eyre::Result<SingleNodeSetup> {
+        if self.node_count != 1 {
+            return Err(eyre::eyre!(
+                "build_with_node_access requires node_count=1, use build_multi_node for multiple nodes"
+            ));
+        }
+
+        if self.external_rpc.is_some() {
+            return Err(eyre::eyre!(
+                "build_with_node_access cannot be used with external RPC"
+            ));
+        }
+
+        let chain_spec = self.build_chain_spec()?;
+
+        let (mut nodes, tasks, _wallet) = setup::<TempoNode>(
+            1,
+            Arc::new(chain_spec),
+            self.is_dev,
+            default_attributes_generator,
+        )
+        .await?;
+
+        let node = nodes.remove(0);
+
+        Ok(SingleNodeSetup {
+            node,
+            _tasks: tasks,
+        })
+    }
+
+    /// Build multiple nodes with direct access
+    pub(crate) async fn build_multi_node(self) -> eyre::Result<MultiNodeSetup> {
+        if self.node_count < 2 {
+            return Err(eyre::eyre!(
+                "build_multi_node requires node_count >= 2, use build_with_node_access for single node"
+            ));
+        }
+
+        if self.external_rpc.is_some() {
+            return Err(eyre::eyre!(
+                "build_multi_node cannot be used with external RPC"
+            ));
+        }
+
+        let chain_spec = self.build_chain_spec()?;
+
+        let (nodes, tasks, _wallet) = setup::<TempoNode>(
+            self.node_count,
+            Arc::new(chain_spec),
+            self.is_dev,
+            default_attributes_generator,
+        )
+        .await?;
+
+        Ok(MultiNodeSetup {
+            nodes,
+            _tasks: tasks,
+        })
+    }
+
+    /// Build HTTP-only setup
+    pub(crate) async fn build_http_only(self) -> eyre::Result<HttpOnlySetup> {
+        if let Some(url) = self.external_rpc {
+            return Ok(HttpOnlySetup {
+                http_url: url,
+                local_node: None,
+            });
+        }
+
+        let tasks = TaskManager::current();
+        let chain_spec = self.build_chain_spec()?;
+
+        let mut node_config = NodeConfig::new(Arc::new(chain_spec))
+            .with_unused_ports()
+            .dev()
+            .with_rpc(
+                RpcServerArgs::default()
+                    .with_unused_ports()
+                    .with_http()
+                    .with_http_api(RpcModuleSelection::All),
+            );
+        node_config.txpool.max_account_slots = usize::MAX;
+
+        // Configure random non-zero validator address
+        let validator = Address::random();
+
+        let node_handle = NodeBuilder::new(node_config.clone())
+            .testing_node(tasks.executor())
+            .node(TempoNode::default())
+            .launch_with_debug_capabilities()
+            .map_debug_payload_attributes(move |mut attributes| {
+                attributes.suggested_fee_recipient = validator;
+                attributes
+            })
+            .await?;
+
+        let http_url = node_handle
+            .node
+            .rpc_server_handle()
+            .http_url()
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        Ok(HttpOnlySetup {
+            http_url,
+            local_node: Some((Box::new(node_handle), tasks)),
+        })
+    }
+
+    /// Helper to build chain spec from genesis
+    fn build_chain_spec(&self) -> eyre::Result<TempoChainSpec> {
+        if let Some(gas_limit) = &self.custom_gas_limit {
+            let mut genesis: serde_json::Value = serde_json::from_str(&self.genesis_content)?;
+            genesis["gasLimit"] = serde_json::json!(gas_limit);
+            Ok(TempoChainSpec::from_genesis(serde_json::from_value(
+                genesis,
+            )?))
+        } else {
+            Ok(TempoChainSpec::from_genesis(serde_json::from_str(
+                &self.genesis_content,
+            )?))
+        }
+    }
+}
+
+/// Default attributes generator for payload building
+fn default_attributes_generator(timestamp: u64) -> TempoPayloadBuilderAttributes {
+    let attributes = PayloadAttributes {
+        timestamp,
+        prev_randao: alloy::primitives::B256::ZERO,
+        suggested_fee_recipient: alloy::primitives::Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(alloy::primitives::B256::ZERO),
+    };
+
+    TempoPayloadBuilderAttributes::new(EthPayloadBuilderAttributes::new(
+        alloy::primitives::B256::ZERO,
+        attributes,
+    ))
 }


### PR DESCRIPTION
Closes #382 
ref https://github.com/tempoxyz/tempo/pull/362#discussion_r2399250275

Unifies 3 inconsistent test node setup patterns into a single `TestNodeBuilder` API:

  - `build_with_node_access()` - Single node with direct manipulation (inject_tx, advance_block)
  - `build_multi_node()` - Multiple connected nodes for backfill/sync tests
  - `build_http_only()` - HTTP-only access for backwards compatibility

