### PR TITLE
feat(tempo-sidecar): simplify arb bot, use polling interval

### DIFF
--- a/bin/tempo-sidecar/src/cmd/simple_arb.rs
+++ b/bin/tempo-sidecar/src/cmd/simple_arb.rs
@@ -17,7 +17,7 @@ use tempo_precompiles::{
     },
 };
 use tempo_telemetry_util::error_field;
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -30,7 +30,7 @@ pub struct SimpleArbArgs {
     #[arg(short, long, required = true)]
     private_key: String,
 
-    /// Interval between checking pools for rebalancing
+    /// Interval between checking pools for rebalancing. This should be set to the block time.
     #[arg(long, default_value_t = 2)]
     poll_interval: u64,
 }
@@ -127,8 +127,10 @@ impl SimpleArbArgs {
                         format!("failed to fetch pool for tokens {:?}, {:?}", pair.0, pair.1)
                     })?;
 
-                if pool.reserveUserToken > 0
-                    && let Err(e) = fee_amm
+                if pool.reserveUserToken > 0 {
+                    let mut pending_txs = vec![];
+
+                    match fee_amm
                         .rebalanceSwap(
                             pair.0,
                             pair.1,
@@ -137,18 +139,46 @@ impl SimpleArbArgs {
                         )
                         .send()
                         .await
-                {
-                    error!(
-                        token_a = %pair.0,
-                        token_b = %pair.1,
-                        amount = %pool.reserveUserToken,
-                        err = error_field(&e),
-                        "Failed to send rebalance transaction"
-                    );
+                    {
+                        Ok(tx) => {
+                            pending_txs.push(tx);
+                        }
+
+                        Err(e) => {
+                            error!(
+                                token_a = %pair.0,
+                                token_b = %pair.1,
+                                amount = %pool.reserveUserToken,
+                                err = error_field(&e),
+                                "Failed to send rebalance transaction"
+                            );
+                        }
+                    }
+
+                    // Await all receipts with timeout
+                    for tx in pending_txs {
+                        match tokio::time::timeout(
+                            Duration::from_secs(self.poll_interval * 2),
+                            tx.get_receipt(),
+                        )
+                        .await
+                        {
+                            Ok(Ok(_)) => {
+                                debug!("Tx receipt received successfully");
+                            }
+                            Ok(Err(e)) => {
+                                error!(err = error_field(&e), "Failed to get tx receipt");
+                            }
+                            Err(_) => {
+                                error!("Timeout waiting for tx receipt");
+                            }
+                        }
+                    }
                 }
             }
 
             tokio::time::sleep(Duration::from_secs(self.poll_interval)).await;
+            debug!("Polling interval elapsed, checking pools for rebalancing");
         }
     }
 }


### PR DESCRIPTION
This PR updates the arb bot to check receipts and rebalance pools every `n` seconds rather than every block.