### PR TITLE
ci(test): run all tests without stopping on first failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: taiki-e/install-action@nextest
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run --no-fail-fast
 
   msrv:
     name: MSRV


### PR DESCRIPTION
for instance this build https://github.com/tempoxyz/tempo/actions/runs/18307597036/job/52128444273 stopped at first failure, while there were a few more failing tests