### PR TITLE
refactor: Replace custom `UnsupportedTxTypeEip4844` error by `UnsupportedTxType` error from `alloy`

### DIFF
--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -1,6 +1,6 @@
 use crate::rpc::TempoTransactionRequest;
 use alloy::{
-    consensus::{ReceiptWithBloom, TxType},
+    consensus::{ReceiptWithBloom, TxType, error::UnsupportedTransactionType},
     rpc::types::AccessList,
 };
 use alloy_network::{
@@ -9,8 +9,7 @@ use alloy_network::{
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use tempo_primitives::{
-    TempoHeader, TempoReceipt, TempoTxEnvelope, TempoTxType,
-    transaction::{TempoTypedTransaction, UnsupportedTransactionTypeEip4844},
+    TempoHeader, TempoReceipt, TempoTxEnvelope, TempoTxType, transaction::TempoTypedTransaction,
 };
 
 /// The Tempo specific configuration of [`Network`] schema and consensus primitives.
@@ -209,7 +208,7 @@ impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
                     return Err(UnbuiltTransactionError {
                         request: self,
                         error: TransactionBuilderError::Custom(Box::new(
-                            UnsupportedTransactionTypeEip4844,
+                            UnsupportedTransactionType::new(TxType::Eip4844),
                         )),
                     });
                 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,8 +1,7 @@
 use super::fee_token::TxFeeToken;
-use crate::transaction::UnsupportedTransactionTypeEip4844;
 use alloy_consensus::{
     EthereumTxEnvelope, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy, TxType,
-    error::ValueError,
+    error::{UnsupportedTransactionType, ValueError},
 };
 use alloy_primitives::{Address, B256, Signature, SignatureError, U256};
 use core::fmt;
@@ -48,21 +47,21 @@ pub enum TempoTxEnvelope {
 }
 
 impl TryFrom<TxType> for TempoTxType {
-    type Error = UnsupportedTransactionTypeEip4844;
+    type Error = UnsupportedTransactionType<TxType>;
 
     fn try_from(value: TxType) -> Result<Self, Self::Error> {
         Ok(match value {
             TxType::Legacy => Self::Legacy,
             TxType::Eip2930 => Self::Eip2930,
             TxType::Eip1559 => Self::Eip1559,
-            TxType::Eip4844 => return Err(UnsupportedTransactionTypeEip4844),
+            TxType::Eip4844 => return Err(UnsupportedTransactionType::new(TxType::Eip4844)),
             TxType::Eip7702 => Self::Eip7702,
         })
     }
 }
 
 impl TryFrom<TempoTxType> for TxType {
-    type Error = UnsupportedTransactionTypeEip4844;
+    type Error = UnsupportedTransactionType<TempoTxType>;
 
     fn try_from(value: TempoTxType) -> Result<Self, Self::Error> {
         Ok(match value {
@@ -70,7 +69,9 @@ impl TryFrom<TempoTxType> for TxType {
             TempoTxType::Eip2930 => Self::Eip2930,
             TempoTxType::Eip1559 => Self::Eip1559,
             TempoTxType::Eip7702 => Self::Eip7702,
-            TempoTxType::FeeToken => return Err(UnsupportedTransactionTypeEip4844),
+            TempoTxType::FeeToken => {
+                return Err(UnsupportedTransactionType::new(TempoTxType::FeeToken));
+            }
         })
     }
 }


### PR DESCRIPTION
Uses an `alloy` generic error for unsupported transaction types.

The current `UnsupportedTxTypeEip4844` is superseded by this. It was also sometimes returned for Fee Token type which does not make sense.
