### PR TITLE
chore(primitives): remove deref of tempo header to eth header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11595,7 +11595,6 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "derive_more",
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -65,7 +65,7 @@ impl HeaderValidator<TempoHeader> for TempoConsensus {
         if let Some(blob_params) = self
             .inner
             .chain_spec()
-            .blob_params_at_timestamp(header.timestamp)
+            .blob_params_at_timestamp(header.timestamp())
         {
             validate_against_parent_4844(header.header(), parent.header(), blob_params)?;
         }

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -27,9 +27,11 @@ impl reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv<TempoHeader>
     for TempoNextBlockEnvAttributes
 {
     fn build_pending_env(parent: &crate::SealedHeader<TempoHeader>) -> Self {
+        use alloy_consensus::BlockHeader as _;
+
         Self {
             inner: NextBlockEnvAttributes::build_pending_env(parent),
-            general_gas_limit: parent.gas_limit / tempo_consensus::TEMPO_GENERAL_GAS_DIVISOR,
+            general_gas_limit: parent.gas_limit() / tempo_consensus::TEMPO_GENERAL_GAS_DIVISOR,
         }
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod assemble;
+use alloy_consensus::BlockHeader as _;
 pub use assemble::TempoBlockAssembler;
 mod block;
 mod context;
@@ -118,7 +119,8 @@ impl ConfigureEvm for TempoEvmConfig {
             header,
             self.chain_spec(),
             self.chain_spec().chain().id(),
-            self.chain_spec().blob_params_at_timestamp(header.timestamp),
+            self.chain_spec()
+                .blob_params_at_timestamp(header.timestamp()),
         ))
     }
 
@@ -151,8 +153,8 @@ impl ConfigureEvm for TempoEvmConfig {
     ) -> Result<TempoBlockExecutionCtx<'a>, Self::Error> {
         Ok(TempoBlockExecutionCtx {
             inner: EthBlockExecutionCtx {
-                parent_hash: block.header().parent_hash,
-                parent_beacon_block_root: block.header().parent_beacon_block_root,
+                parent_hash: block.header().parent_hash(),
+                parent_beacon_block_root: block.header().parent_beacon_block_root(),
                 // no ommers in tempo
                 ommers: &[],
                 withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::{TempoExecutionData, TempoPayloadTypes};
 use reth_ethereum::engine::EthPayloadAttributes;
 use reth_node_api::{InvalidPayloadAttributesError, NewPayloadError, PayloadValidator};
-use reth_primitives_traits::RecoveredBlock;
+use reth_primitives_traits::{AlloyBlockHeader as _, RecoveredBlock};
 use tempo_primitives::{Block, TempoHeader};
 
 /// Type encapsulating Tempo engine validation logic.
@@ -35,7 +35,7 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
         header: &TempoHeader,
     ) -> Result<(), InvalidPayloadAttributesError> {
         // Ensure that payload attributes timestamp is not in the past
-        if attr.timestamp < header.timestamp {
+        if attr.timestamp < header.timestamp() {
             return Err(InvalidPayloadAttributesError::InvalidTimestamp);
         }
         Ok(())

--- a/crates/node/tests/it/backfill.rs
+++ b/crates/node/tests/it/backfill.rs
@@ -7,6 +7,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
 use reth_node_api::EngineApiMessageVersion;
+use reth_primitives_traits::AlloyBlockHeader as _;
 
 /// Test that verifies backfill sync works correctly.
 ///
@@ -73,7 +74,7 @@ async fn test_backfill_sync() -> eyre::Result<()> {
 
         // Verify the transaction was included
         let block_hash = payload.block().hash();
-        let block_number = payload.block().number;
+        let block_number = payload.block().number();
         node1
             .assert_new_block(tx_hash, block_hash, block_number)
             .await?;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod metrics;
 
-use alloy_consensus::{Signed, Transaction, TxLegacy};
+use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::U256;
 use alloy_rlp::Encodable;
 use alloy_sol_types::SolCall;
@@ -154,7 +154,7 @@ where
         skip_all,
         fields(
             id = %args.config.attributes.payload_id(),
-            parent_number = %args.config.parent_header.number,
+            parent_number = %args.config.parent_header.number(),
             parent_hash = %args.config.parent_header.hash()
         )
     )]
@@ -186,7 +186,7 @@ where
             .with_bundle_update()
             .build();
 
-        let general_gas_limit = parent_header.gas_limit / TEMPO_GENERAL_GAS_DIVISOR;
+        let general_gas_limit = parent_header.gas_limit() / TEMPO_GENERAL_GAS_DIVISOR;
 
         let mut builder = self
             .evm_config
@@ -198,7 +198,7 @@ where
                         timestamp: attributes.timestamp(),
                         suggested_fee_recipient: attributes.suggested_fee_recipient(),
                         prev_randao: attributes.prev_randao(),
-                        gas_limit: parent_header.gas_limit,
+                        gas_limit: parent_header.gas_limit(),
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: Some(attributes.withdrawals().clone()),
                     },

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::attrs::{InterruptHandle, TempoPayloadBuilderAttributes};
 use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_node_api::{ExecutionPayload, PayloadBuilderAttributes, PayloadTypes};
-use reth_primitives_traits::SealedBlock;
+use reth_primitives_traits::{AlloyBlockHeader as _, SealedBlock};
 use serde::{Deserialize, Serialize};
 use tempo_primitives::{Block, TempoPrimitives};
 
@@ -25,7 +25,7 @@ pub struct TempoExecutionData(pub SealedBlock<Block>);
 
 impl ExecutionPayload for TempoExecutionData {
     fn parent_hash(&self) -> alloy_primitives::B256 {
-        self.0.parent_hash
+        self.0.parent_hash()
     }
 
     fn block_hash(&self) -> alloy_primitives::B256 {
@@ -33,7 +33,7 @@ impl ExecutionPayload for TempoExecutionData {
     }
 
     fn block_number(&self) -> u64 {
-        self.0.number
+        self.0.number()
     }
 
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
@@ -45,15 +45,15 @@ impl ExecutionPayload for TempoExecutionData {
     }
 
     fn parent_beacon_block_root(&self) -> Option<alloy_primitives::B256> {
-        self.0.parent_beacon_block_root
+        self.0.parent_beacon_block_root()
     }
 
     fn timestamp(&self) -> u64 {
-        self.0.timestamp
+        self.0.timestamp()
     }
 
     fn gas_used(&self) -> u64 {
-        self.0.gas_used
+        self.0.gas_used()
     }
 }
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -32,7 +32,6 @@ alloy-network = { workspace = true, optional = true }
 
 # Utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }
-derive_more.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 modular-bitfield = { version = "0.11.2", optional = true }
 

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -8,19 +8,7 @@ use reth_primitives_traits::{InMemorySize, serde_bincode_compat::RlpBincode};
 ///
 /// Encoded as `rlp([inner, general_gas_limit])` meaning that any new
 /// fields added to the inner header will only affect the first list element.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    derive_more::Deref,
-    derive_more::DerefMut,
-    RlpEncodable,
-    RlpDecodable,
-    Compact,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable, Compact)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -31,8 +19,6 @@ pub struct TempoHeader {
     pub general_gas_limit: u64,
 
     /// Inner Ethereum [`Header`].
-    #[deref]
-    #[deref_mut]
     #[cfg_attr(feature = "serde", serde(flatten))]
     pub inner: Header,
 }


### PR DESCRIPTION
Removes the `Deref<Target = Header> for TempoHeader` impl. I found this to be a footgun, where depending whether or not `alloy_primitives::Sealable` was imported, I would get the result of `Sealable::hash_slow(&tempo_header)` or the inherent `Header::hash_slow` due to deref.

This not only happens when one hold a `TempoHeader`, but even if one holds a `Block`: because of `Deref<Target = H> for Block<H>`, auto-deref will go `Block -> TempoHeader -> Header`.