### PR TITLE
telemetry(node): prefix all consensus metrics

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -115,7 +115,7 @@ fn main() -> eyre::Result<()> {
                 // Ensure all consensus metrics are prefixed. Shadow `ctx` to
                 // not forget.
                 let ctx = ctx.with_label("consensus");
-                
+
                 let mut metrics_server = match consensus_config
                     .metrics_port {
                     Some(port) => {


### PR DESCRIPTION
Immediately creates an intermediate context labelled `consensus`. This is to ensure that all metrics related to the (commonware) consensus mechanism are prefixed by `consensus_` and can be easily identified.