### PR TITLE
chore(deps): update commonware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "paste",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "blake3",
  "blst",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "futures",
  "proc-macro2",
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bimap",
  "bytes",
@@ -2486,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "async-lock",
  "axum",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "0.0.62"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=0320f5c8985ae767d7da75b61025ad47732354ab#0320f5c8985ae767d7da75b61025ad47732354ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=a68f75ec78bab93e551637f4799acc7b539f4f1a#a68f75ec78bab93e551637f4799acc7b539f4f1a"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,11 +241,12 @@ vergen = "9"
 vergen-git2 = "1"
 
 [patch.crates-io]
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "0320f5c8985ae767d7da75b61025ad47732354ab" }
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "a68f75ec78bab93e551637f4799acc7b539f4f1a" }
+

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -111,7 +111,7 @@ async fn instantiate_network(
     config: &tempo_commonware_node_config::Config,
 ) -> eyre::Result<(
     discovery::Network<commonware_runtime::tokio::Context, PrivateKey>,
-    discovery::Oracle<commonware_runtime::tokio::Context, PublicKey>,
+    discovery::Oracle<PublicKey>,
 )> {
     use commonware_p2p::authenticated::discovery;
     use std::net::Ipv4Addr;
@@ -145,7 +145,7 @@ async fn instantiate_network(
     let p2p_namespace = commonware_utils::union_unique(crate::config::NAMESPACE, b"_P2P");
     let p2p_cfg = discovery::Config {
         mailbox_size: config.mailbox_size,
-        ..discovery::Config::aggressive(
+        ..discovery::Config::local(
             config.signer.clone(),
             &p2p_namespace,
             // TODO: should the listen addr be restricted to ipv4?


### PR DESCRIPTION
Commonware changed how they set up their async runtime contexts, removing `spawn_ref` in favor of `ContextCell`s.  Our in-flight PR https://github.com/tempoxyz/tempo/pull/433 to add e2e testing using their deterministic runtime requires some of commonware's in-flight changes in https://github.com/commonwarexyz/monorepo/pull/1848.

This patch bumps our commonware dependencies to the same parent as https://github.com/commonwarexyz/monorepo/pull/1848.