### PR TITLE
fix: don't use system time in Tip20

### DIFF
--- a/crates/precompiles/src/contracts/storage/evm.rs
+++ b/crates/precompiles/src/contracts/storage/evm.rs
@@ -31,6 +31,10 @@ impl<'a> StorageProvider for EvmStorageProvider<'a> {
         self.chain_id
     }
 
+    fn timestamp(&self) -> U256 {
+        self.internals.block_timestamp()
+    }
+
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), Self::Error> {
         self.ensure_loaded_account(address)?;
         self.internals.set_code(address, code);

--- a/crates/precompiles/src/contracts/storage/hashmap.rs
+++ b/crates/precompiles/src/contracts/storage/hashmap.rs
@@ -10,6 +10,7 @@ pub struct HashMapStorageProvider {
     accounts: HashMap<Address, AccountInfo>,
     pub events: HashMap<Address, Vec<LogData>>,
     chain_id: u64,
+    timestamp: U256,
 }
 
 impl HashMapStorageProvider {
@@ -19,6 +20,13 @@ impl HashMapStorageProvider {
             accounts: HashMap::new(),
             events: HashMap::new(),
             chain_id,
+            #[expect(clippy::disallowed_methods)]
+            timestamp: U256::from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            ),
         }
     }
     pub fn set_nonce(&mut self, address: Address, nonce: u64) {
@@ -32,6 +40,10 @@ impl StorageProvider for HashMapStorageProvider {
 
     fn chain_id(&self) -> u64 {
         self.chain_id
+    }
+
+    fn timestamp(&self) -> U256 {
+        self.timestamp
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), Self::Error> {

--- a/crates/precompiles/src/contracts/storage/mod.rs
+++ b/crates/precompiles/src/contracts/storage/mod.rs
@@ -11,6 +11,7 @@ pub trait StorageProvider {
     type Error: Debug;
 
     fn chain_id(&self) -> u64;
+    fn timestamp(&self) -> U256;
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), Self::Error>;
     fn get_account_info(&mut self, address: Address) -> Result<AccountInfo, Self::Error>;
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<(), Self::Error>;

--- a/crates/precompiles/src/contracts/tip20.rs
+++ b/crates/precompiles/src/contracts/tip20.rs
@@ -626,16 +626,7 @@ impl<'a, S: StorageProvider> TIP20Token<'a, S> {
         _msg_sender: &Address,
         call: ITIP20::permitCall,
     ) -> Result<(), TIP20Error> {
-        // TODO: this shouldn't use SystemTime due to non-determinism, see GH issue #446
-        #[allow(clippy::disallowed_methods)]
-        if U256::from(call.deadline)
-            < U256::from(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            )
-        {
+        if U256::from(call.deadline) < self.storage.timestamp() {
             return Err(TIP20Error::expired());
         }
 
@@ -1168,7 +1159,7 @@ mod tests {
         let spender = Address::from([2u8; 20]);
         let value = U256::from(12345u64);
 
-        #[allow(clippy::disallowed_methods)]
+        #[expect(clippy::disallowed_methods)]
         let deadline_u64 = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -1252,7 +1243,7 @@ mod tests {
         let spender = Address::from([3u8; 20]);
         let value = U256::from(777u64);
 
-        #[allow(clippy::disallowed_methods)]
+        #[expect(clippy::disallowed_methods)]
         let deadline_u64 = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()


### PR DESCRIPTION
Closes #446 

Propagates block timestamp via `StorageProvider` and uses it instead of system time