### PR TITLE
fix(tempo): activate feature in binary

### DIFF
--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -19,10 +19,11 @@ tempo-commonware-node.workspace = true
 tempo-commonware-node-config.workspace = true
 tempo-chainspec.workspace = true
 tempo-consensus.workspace = true
+tempo-evm.workspace = true
 tempo-faucet.workspace = true
 
 camino = { workspace = true, features = ["serde1"] }
-commonware-runtime.workspace = true
+commonware-runtime = { workspace = true, features = ["external"] }
 futures = { workspace = true, features = ["executor"] }
 reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }
@@ -32,7 +33,6 @@ eyre.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
-tempo-evm.workspace = true
 
 [[bin]]
 name = "tempo"


### PR DESCRIPTION
This patch activates feature `"external"` of `commonware-runtime`, which is a direct dependency of the `tempo` binary.

Because the feature was not set on the direct dependency, it looks like cargo's resolver deactivated it on the `tempo-commonware-node/commonware-runtime` (i.e. the indirect dependency).