### PR TITLE
chore(precompiles): update stable exchange swap function names

### DIFF
--- a/crates/contracts/src/precompiles.rs
+++ b/crates/contracts/src/precompiles.rs
@@ -348,8 +348,8 @@ sol! {
 
         // View functions
         function balanceOf(address user, address token) external view returns (uint128);
-        function quoteBuy(address tokenIn, address tokenOut, uint128 amountOut) external view returns (uint128 amountIn);
-        function quoteSell(address tokenIn, address tokenOut, uint128 amountIn) external view returns (uint128 amountOut);
+        function quoteSwapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut) external view returns (uint128 amountIn);
+        function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) external view returns (uint128 amountOut);
         function pairKey(address tokenA, address tokenB) external pure returns (bytes32 key);
         function getPriceLevel(address base, int16 tick, bool isBid) external view returns (PriceLevel memory level);
         function activeOrderId() external view returns (uint128);
@@ -360,8 +360,8 @@ sol! {
         function createPair(address base) external returns (bytes32 key);
 
         // Taker functions
-        function sell(address tokenIn, address tokenOut, uint128 amountIn, uint128 minAmountOut) external returns (uint128 amountOut);
-        function buy(address tokenIn, address tokenOut, uint128 amountOut, uint128 maxAmountIn) external returns (uint128 amountIn);
+        function swapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn, uint128 minAmountOut) external returns (uint128 amountOut);
+        function swapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut, uint128 maxAmountIn) external returns (uint128 amountIn);
 
         // Maker functions
         function place(address token, uint128 amount, bool isBid, int16 tick) external returns (uint128 orderId);

--- a/crates/node/tests/it/stablecoin_exchange.rs
+++ b/crates/node/tests/it/stablecoin_exchange.rs
@@ -115,7 +115,7 @@ async fn test_bids() -> eyre::Result<()> {
     let fill_amount = (num_orders * order_amount) - (order_amount / 2);
 
     let amount_in = exchange
-        .quoteSell(*base.address(), *quote.address(), fill_amount)
+        .quoteSwapExactAmountIn(*base.address(), *quote.address(), fill_amount)
         .call()
         .await?;
 
@@ -123,9 +123,9 @@ async fn test_bids() -> eyre::Result<()> {
     let pending = base.mint(caller, U256::from(amount_in)).send().await?;
     pending.get_receipt().await?;
 
-    //  Execute sell and assert orders are filled
+    //  Execute swap and assert orders are filled
     let tx = exchange
-        .sell(*base.address(), *quote.address(), amount_in, 0)
+        .swapExactAmountIn(*base.address(), *quote.address(), amount_in, 0)
         .send()
         .await?;
     tx.get_receipt().await?;
@@ -265,7 +265,7 @@ async fn test_asks() -> eyre::Result<()> {
     let fill_amount = (num_orders * order_amount) - (order_amount / 2);
 
     let amount_in = exchange
-        .quoteBuy(*quote.address(), *base.address(), fill_amount)
+        .quoteSwapExactAmountOut(*quote.address(), *base.address(), fill_amount)
         .call()
         .await?;
 
@@ -280,9 +280,9 @@ async fn test_asks() -> eyre::Result<()> {
         .await?;
     pending.get_receipt().await?;
 
-    //  Execute buy and assert orders are filled
+    //  Execute swap and assert orders are filled
     let tx = exchange
-        .buy(*quote.address(), *base.address(), fill_amount, u128::MAX)
+        .swapExactAmountOut(*quote.address(), *base.address(), fill_amount, u128::MAX)
         .send()
         .await?;
     tx.get_receipt().await?;

--- a/crates/precompiles/src/precompiles/stablecoin_exchange.rs
+++ b/crates/precompiles/src/precompiles/stablecoin_exchange.rs
@@ -95,12 +95,12 @@ impl<'a, S: StorageProvider> Precompile for StablecoinExchange<'a, S> {
                     IStablecoinExchange::IStablecoinExchangeErrors,
                 >(calldata, msg_sender, |s, call| self.cancel(s, call.orderId))
             }
-            IStablecoinExchange::sellCall::SELECTOR => {
+            IStablecoinExchange::swapExactAmountInCall::SELECTOR => {
                 mutate::<
-                    IStablecoinExchange::sellCall,
+                    IStablecoinExchange::swapExactAmountInCall,
                     IStablecoinExchange::IStablecoinExchangeErrors,
                 >(calldata, msg_sender, |s, call| {
-                    self.sell(
+                    self.swap_exact_amount_in(
                         s,
                         call.tokenIn,
                         call.tokenOut,
@@ -109,33 +109,35 @@ impl<'a, S: StorageProvider> Precompile for StablecoinExchange<'a, S> {
                     )
                 })
             }
-            IStablecoinExchange::buyCall::SELECTOR => {
-                mutate::<IStablecoinExchange::buyCall, IStablecoinExchange::IStablecoinExchangeErrors>(
-                    calldata,
-                    msg_sender,
-                    |s, call| {
-                        self.buy(
-                            s,
-                            call.tokenIn,
-                            call.tokenOut,
-                            call.amountOut,
-                            call.maxAmountIn,
-                        )
-                    },
-                )
+            IStablecoinExchange::swapExactAmountOutCall::SELECTOR => {
+                mutate::<
+                    IStablecoinExchange::swapExactAmountOutCall,
+                    IStablecoinExchange::IStablecoinExchangeErrors,
+                >(calldata, msg_sender, |s, call| {
+                    self.swap_exact_amount_out(
+                        s,
+                        call.tokenIn,
+                        call.tokenOut,
+                        call.amountOut,
+                        call.maxAmountIn,
+                    )
+                })
             }
-            IStablecoinExchange::quoteSellCall::SELECTOR => view_result::<
-                IStablecoinExchange::quoteSellCall,
+            IStablecoinExchange::quoteSwapExactAmountInCall::SELECTOR => view_result::<
+                IStablecoinExchange::quoteSwapExactAmountInCall,
                 IStablecoinExchange::IStablecoinExchangeErrors,
-            >(calldata, |call| {
-                self.quote_sell(call.tokenIn, call.tokenOut, call.amountIn)
-            }),
-            IStablecoinExchange::quoteBuyCall::SELECTOR => view_result::<
-                IStablecoinExchange::quoteBuyCall,
-                IStablecoinExchange::IStablecoinExchangeErrors,
-            >(calldata, |call| {
-                self.quote_buy(call.tokenIn, call.tokenOut, call.amountOut)
-            }),
+            >(
+                calldata,
+                |call| self.quote_swap_exact_amount_in(call.tokenIn, call.tokenOut, call.amountIn),
+            ),
+            IStablecoinExchange::quoteSwapExactAmountOutCall::SELECTOR => {
+                view_result::<
+                    IStablecoinExchange::quoteSwapExactAmountOutCall,
+                    IStablecoinExchange::IStablecoinExchangeErrors,
+                >(calldata, |call| {
+                    self.quote_swap_exact_amount_out(call.tokenIn, call.tokenOut, call.amountOut)
+                })
+            }
             IStablecoinExchange::executeBlockCall::SELECTOR => {
                 mutate_void::<
                     IStablecoinExchange::executeBlockCall,
@@ -186,22 +188,22 @@ mod tests {
     }
 
     #[test]
-    fn test_sell_call() {
+    fn test_swap_exact_amount_in_call() {
         // TODO:
     }
 
     #[test]
-    fn test_buy_call() {
+    fn test_swap_exact_amount_out_call() {
         // TODO:
     }
 
     #[test]
-    fn test_quote_sell_call() {
+    fn test_quote_swap_exact_amount_in_call() {
         // TODO:
     }
 
     #[test]
-    fn test_quote_buy_call() {
+    fn test_quote_swap_exact_amount_out_call() {
         // TODO:
     }
 


### PR DESCRIPTION
This PR updates the stablecoin exchange `buy`/`sell` functions to `swapExactAmountOut`, `swapExactAmountIn`.

Ref tempoxyz/docs#64