### PR TITLE
feat(precompiles): emit order filled events

### DIFF
--- a/crates/contracts/src/precompiles.rs
+++ b/crates/contracts/src/precompiles.rs
@@ -379,7 +379,7 @@ sol! {
         event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick);
         event FlipOrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, int16 flipTick);
         event OrderCancelled(uint128 indexed orderId);
-        event OrderFilled(uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill);
+        event OrderFilled(uint128 indexed orderId, address indexed maker, uint128 amountFilled, bool partialFill);
 
         // Errors
         error OrderDoesNotExist();

--- a/crates/precompiles/src/contracts/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/contracts/stablecoin_exchange/mod.rs
@@ -621,7 +621,19 @@ impl<'a, S: StorageProvider> StablecoinExchange<'a, S> {
             level.total_liquidity - fill_amount,
         );
 
-        // TODO: emit partial fill event
+        // Emit OrderFilled event for partial fill
+        self.storage
+            .emit_event(
+                self.address,
+                StablecoinExchangeEvents::OrderFilled(IStablecoinExchange::OrderFilled {
+                    orderId: order.order_id(),
+                    maker: order.maker(),
+                    amountFilled: fill_amount,
+                    partialFill: true,
+                })
+                .into_log_data(),
+            )
+            .expect("Event emission failed");
 
         Ok(amount_out)
     }
@@ -652,6 +664,20 @@ impl<'a, S: StorageProvider> StablecoinExchange<'a, S> {
 
             fill_amount
         };
+
+        // Emit OrderFilled event for complete fill
+        self.storage
+            .emit_event(
+                self.address,
+                StablecoinExchangeEvents::OrderFilled(IStablecoinExchange::OrderFilled {
+                    orderId: order.order_id(),
+                    maker: order.maker(),
+                    amountFilled: fill_amount,
+                    partialFill: false,
+                })
+                .into_log_data(),
+            )
+            .expect("Event emission failed");
 
         if order.is_flip() {
             // Create a new flip order with flipped side and swapped ticks


### PR DESCRIPTION
This PR introduces logic to emit events once orders are filled in the stablecoin exchange. Currently we do not have robust error handling for within precompiles for `StorageProvider` errors. This will be updated when precompiles are refactored to properly handle all errors.