### PR TITLE
fix(consensus): don't check block timestamp at consensus level

### DIFF
--- a/crates/commonware-node/src/consensus/execution_driver/mod.rs
+++ b/crates/commonware-node/src/consensus/execution_driver/mod.rs
@@ -650,11 +650,6 @@ async fn verify_block<TContext: Pacer>(
         info!("block's height must be +1 that of the parent but isn't");
         return Ok(false);
     }
-    if block.timestamp() <= parent.timestamp() {
-        info!("block's timestamp must exceed parent's timestamp but doesn't");
-        return Ok(false);
-    }
-
     let block = block.clone().into_inner();
     let payload_status = engine
         .new_payload(TempoExecutionData(block))


### PR DESCRIPTION
Removes the `parent.timestamp() < child.timestamp()` check in the consensus layer. This is the domain of the execution layer.