### PR TITLE
fix(node): activate external feature for runtime

### DIFF
--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -32,7 +32,7 @@ commonware-cryptography.workspace = true
 commonware-macros.workspace = true
 commonware-p2p.workspace = true
 commonware-resolver.workspace = true
-commonware-runtime.workspace = true
+commonware-runtime = { workspace = true, features = ["external"] }
 commonware-utils.workspace = true
 
 eyre.workspace = true


### PR DESCRIPTION
This patch adds the `external` feature to `commonware-runtime`. For some reason (probably workspace-wide dependency resolution and unifiication) it passed CI but fails to compile locally.