### PR TITLE
fix: reject transactions with illiquid fee tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11757,6 +11757,7 @@ dependencies = [
  "reth-provider",
  "reth-storage-api",
  "reth-transaction-pool",
+ "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.17",

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 tempo-primitives = { workspace = true, features = ["serde", "reth-codec"] }
 tempo-revm = { workspace = true, features = ["reth"] }
+tempo-precompiles.workspace = true
 
 reth-transaction-pool.workspace = true
 reth-chainspec.workspace = true

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -73,6 +73,9 @@ pub enum TempoPoolTransactionError {
 
     #[error("No fee token preference configured")]
     MissingFeeToken,
+
+    #[error("Insufficient liquidity in FeeAMM pool for fee token swap")]
+    InsufficientLiquidity,
 }
 
 impl PoolTransactionError for TempoPoolTransactionError {
@@ -81,6 +84,7 @@ impl PoolTransactionError for TempoPoolTransactionError {
             Self::ExceedsNonPaymentLimit => false,
             Self::InvalidFeeToken(_) => false,
             Self::MissingFeeToken => false,
+            Self::InsufficientLiquidity => false,
         }
     }
 


### PR DESCRIPTION
Closes #507 

Adds AMM liquidity validation during transaction pool validation to prevent transactions with illiquid fee tokens from getting stuck in the mempool.