### PR TITLE
feat: Add an empty `tempo-order-book` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11750,6 +11750,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-order-book"
+version = "0.1.0"
+
+[[package]]
 name = "tempo-payload-builder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/evm",
   "crates/e2e",
   "crates/faucet",
+  "crates/order-book",
   "crates/node",
   "crates/payload/builder",
   "crates/payload/types",
@@ -103,6 +104,7 @@ tempo-faucet = { path = "crates/faucet" }
 tempo-evm = { path = "crates/evm" }
 tempo-eyre = { path = "crates/eyre" }
 tempo-revm = { path = "crates/revm" }
+tempo-order-book = { path = "crates/order-book" }
 tempo-payload-builder = { path = "crates/payload/builder" }
 tempo-payload-types = { path = "crates/payload/types" }
 tempo-precompiles = { path = "crates/precompiles" }

--- a/crates/order-book/Cargo.toml
+++ b/crates/order-book/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tempo-order-book"
+description = "Order book RPC module for browsing DEX"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/order-book/src/lib.rs
+++ b/crates/order-book/src/lib.rs
@@ -1,0 +1,4 @@
+//! Order book JSON-RPC API
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]


### PR DESCRIPTION
Part of #536 

Dedicated for JSON-RPC API of orders