### PR TITLE
feat: add `books` function to `StablecoinExchange` public interface

### DIFF
--- a/crates/contracts/src/precompiles/stablecoin_exchange.rs
+++ b/crates/contracts/src/precompiles/stablecoin_exchange.rs
@@ -71,6 +71,7 @@ sol! {
         function pairKey(address tokenA, address tokenB) external view returns (bytes32);
         function activeOrderId() external view returns (uint128);
         function pendingOrderId() external view returns (uint128);
+        function books(bytes32 pairKey) external view returns (Orderbook memory);
 
         // Events
         event PairCreated(bytes32 indexed key, address indexed base, address indexed quote);

--- a/crates/precompiles/src/stablecoin_exchange/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_exchange/dispatch.rs
@@ -72,6 +72,13 @@ impl<'a, S: PrecompileStorageProvider> Precompile for StablecoinExchange<'a, S> 
                     self.pair_key(call.tokenA, call.tokenB)
                 })
             }
+
+            IStablecoinExchange::booksCall::SELECTOR => {
+                view::<IStablecoinExchange::booksCall>(calldata, |call| {
+                    self.books(call.pairKey).into()
+                })
+            }
+
             IStablecoinExchange::createPairCall::SELECTOR => {
                 mutate::<
                     IStablecoinExchange::createPairCall,

--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -347,6 +347,11 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
             .to::<u128>())
     }
 
+    /// Get orderbook by pair key
+    pub fn books(&mut self, pair_key: B256) -> Orderbook {
+        Orderbook::from_storage(pair_key, self.storage, self.address)
+    }
+
     pub fn create_pair(&mut self, base: &Address) -> Result<B256, StablecoinExchangeError> {
         let quote =
             TIP20Token::new(address_to_token_id_unchecked(base), self.storage).quote_token();

--- a/crates/precompiles/src/stablecoin_exchange/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_exchange/orderbook.rs
@@ -435,6 +435,17 @@ impl Orderbook {
     }
 }
 
+impl From<Orderbook> for IStablecoinExchange::Orderbook {
+    fn from(value: Orderbook) -> Self {
+        Self {
+            base: value.base,
+            quote: value.quote,
+            bestBidTick: value.best_bid_tick,
+            bestAskTick: value.best_ask_tick,
+        }
+    }
+}
+
 /// Tick bitmap manager for efficient price discovery
 pub struct TickBitmap<'a, S: PrecompileStorageProvider> {
     storage: &'a mut S,


### PR DESCRIPTION
This PR  updates the `StablecoinExchange` public interface to add the `books` function to get orderbooks by `pairKey`.