### PR TITLE
feat(node): Launch node with `TempoDex` RPC module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11704,6 +11704,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "async-trait",
  "base64 0.22.1",
  "clap",
  "eyre",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -47,6 +47,7 @@ alloy.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 
+async-trait.workspace = true
 clap.workspace = true
 eyre.workspace = true
 tokio.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,5 +1,8 @@
 use crate::{
-    TempoPayloadTypes, args::TempoArgs, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
+    TempoPayloadTypes,
+    args::TempoArgs,
+    engine::TempoEngineValidator,
+    rpc::{TempoDexApiServer, TempoEthApiBuilder, dex::TempoDex},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -128,11 +131,21 @@ where
 {
     type Handle = <RpcAddOns<N, EthB, PVB, NoopEngineApiBuilder, EVB> as NodeAddOns<N>>::Handle;
 
-    async fn launch_add_ons(
-        self,
-        ctx: reth_node_api::AddOnsContext<'_, N>,
-    ) -> eyre::Result<Self::Handle> {
-        self.inner.launch_add_ons(ctx).await
+    async fn launch_add_ons(self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
+        self.inner
+            .launch_add_ons_with(ctx, move |container| {
+                let reth_node_builder::rpc::RpcModuleContainer {
+                    modules, registry, ..
+                } = container;
+
+                let eth_api = registry.eth_api().clone();
+                let dex = TempoDex::new(eth_api);
+
+                modules.merge_configured(dex.into_rpc())?;
+
+                Ok(())
+            })
+            .await
     }
 }
 

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -3,6 +3,8 @@ pub use types::{
 };
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_core::rpc::result::internal_rpc_err;
+use reth_rpc_eth_api::RpcNodeCore;
 
 pub mod types;
 
@@ -10,4 +12,30 @@ pub mod types;
 pub trait TempoDexApi {
     #[method(name = "getOrders")]
     async fn orders(&self, params: Vec<OrdersParams>) -> RpcResult<OrdersResponse>;
+}
+
+/// The JSON-RPC handlers for the `dex_` namespace.
+#[derive(Debug, Clone, Default)]
+pub struct TempoDex<EthApi> {
+    eth_api: EthApi,
+}
+
+impl<EthApi> TempoDex<EthApi> {
+    pub fn new(eth_api: EthApi) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EthApi: RpcNodeCore> TempoDexApiServer for TempoDex<EthApi> {
+    async fn orders(&self, _params: Vec<OrdersParams>) -> RpcResult<OrdersResponse> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}
+
+impl<EthApi: RpcNodeCore> TempoDex<EthApi> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &EthApi::Provider {
+        self.eth_api.provider()
+    }
 }


### PR DESCRIPTION
Part of #536 

Adds a placeholder implementation of the generated jsonrpsee API trait.

Registers this implementation during node launch.
