### PR TITLE
fix: init TIP403_REGISTRY separately

### DIFF
--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -25,6 +25,9 @@ pub struct TIP20Factory<'a, S: PrecompileStorageProvider> {
 
 // Precompile functions
 impl<'a, S: PrecompileStorageProvider> TIP20Factory<'a, S> {
+    /// Creates an instance of the factory account.
+    ///
+    /// Caution: This does not initialize the account, see [`Self::initialize`].
     pub fn new(storage: &'a mut S) -> Self {
         Self { storage }
     }

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use alloy_evm::revm::interpreter::instructions::utility::{IntoAddress, IntoU256};
 use revm::state::Bytecode;
+use tempo_contracts::precompiles::TIP20Error;
 
 mod slots {
     use alloy::primitives::{U256, uint};
@@ -33,15 +34,23 @@ pub struct PolicyData {
 }
 
 impl<'a, S: PrecompileStorageProvider> TIP403Registry<'a, S> {
-    pub fn new(storage: &'a mut S) -> Self {
-        storage
+    /// Creates an instance of the precompile.
+    ///
+    /// Caution: This does not initialize the account, see [`Self::initialize`].
+    pub const fn new(storage: &'a mut S) -> Self {
+        Self { storage }
+    }
+
+    /// Initializes the registry contract.
+    pub fn initialize(&mut self) -> Result<(), TIP20Error> {
+        self.storage
             .set_code(
                 TIP403_REGISTRY_ADDRESS,
                 Bytecode::new_legacy(Bytes::from_static(&[0xef])),
             )
             .expect("TODO: handle error");
 
-        Self { storage }
+        Ok(())
     }
 
     // View functions


### PR DESCRIPTION
we incorrectly always set the code of TIP403Registry when we created an instance

this is problematic because this is tracked in the evm journal internally as a codechange entry.

if a tx then reverts, this triggers cleanup:

https://github.com/bluealloy/revm/blob/ce68f93c9acb77444f7f077d4cdcd7217714e645/crates/context/interface/src/journaled_state/entry.rs#L403-L407

this fixes it by doing init separately when we generate the genesis:

```
    "0x403c000000000000000000000000000000000000": {
      "nonce": "0x0",
      "balance": "0x0",
      "code": "0xef"
    },
```

this issue can be triggered on adante by sending a dex `place` call that reverts.

this reverting tx then results in an invalid transition during the evm's revert cleanup.

