### PR TITLE
refactor: don't use re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11600,6 +11600,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-eth-api",
+ "revm",
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-payload-types",
@@ -11792,12 +11793,14 @@ name = "tempo-revm"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "derive_more",
  "eyre",
  "reth-evm",
  "reth-rpc-convert",
+ "revm",
  "tempo-contracts",
  "tempo-precompiles",
  "tempo-primitives",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -36,5 +36,8 @@ derive_more.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+revm.workspace = true
+
 [features]
 rpc = ["dep:reth-rpc-eth-api"]

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -1,11 +1,8 @@
 use crate::{
     TempoEvmConfig, TempoEvmFactory, block::TempoReceiptBuilder, context::TempoBlockExecutionCtx,
 };
-use reth_evm::{
-    block::BlockExecutionError,
-    eth::EthBlockExecutorFactory,
-    execute::{BlockAssembler, BlockAssemblerInput},
-};
+use alloy_evm::{block::BlockExecutionError, eth::EthBlockExecutorFactory};
+use reth_evm::execute::{BlockAssembler, BlockAssemblerInput};
 use reth_evm_ethereum::EthBlockAssembler;
 use reth_primitives_traits::SealedHeader;
 use std::sync::Arc;

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1,18 +1,18 @@
 use crate::{TempoBlockExecutionCtx, evm::TempoEvm};
 use alloy_consensus::{Transaction, transaction::TxHashRef};
-use alloy_primitives::Bytes;
-use alloy_sol_types::SolCall;
-use reth_evm::{
-    Database, Evm, OnStateHook,
+use alloy_evm::{
+    Database, Evm,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
-        ExecutableTx,
+        ExecutableTx, OnStateHook,
     },
     eth::{
         EthBlockExecutor,
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolCall;
 use reth_revm::{Inspector, State, context::result::ResultAndState};
 use tempo_chainspec::TempoChainSpec;
 use tempo_precompiles::{
@@ -136,7 +136,7 @@ where
     type Receipt = TempoReceipt;
     type Evm = TempoEvm<&'a mut State<DB>, I>;
 
-    fn apply_pre_execution_changes(&mut self) -> Result<(), reth_evm::block::BlockExecutionError> {
+    fn apply_pre_execution_changes(&mut self) -> Result<(), alloy_evm::block::BlockExecutionError> {
         self.inner.apply_pre_execution_changes()
     }
 

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -1,4 +1,5 @@
-use reth_evm::{NextBlockEnvAttributes, eth::EthBlockExecutionCtx};
+use alloy_evm::eth::EthBlockExecutionCtx;
+use reth_evm::NextBlockEnvAttributes;
 #[cfg(feature = "rpc")]
 use tempo_primitives::TempoHeader;
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -227,8 +227,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use reth_evm::revm::{context::TxEnv, database::EmptyDB};
     use reth_revm::context::BlockEnv;
+    use revm::{context::TxEnv, database::EmptyDB};
 
     use super::*;
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -14,16 +14,17 @@ pub use error::TempoEvmError;
 pub mod evm;
 use std::{borrow::Cow, sync::Arc};
 
-use alloy_evm::eth::NextEvmEnvAttributes;
+use alloy_evm::{
+    self, Database, EvmEnv,
+    block::{BlockExecutorFactory, BlockExecutorFor},
+    eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
+    revm::{Inspector, database::State},
+};
 use alloy_primitives::Bytes;
 pub use evm::TempoEvmFactory;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
-    self, ConfigureEngineEvm, ConfigureEvm, Database, EvmEnv, EvmEnvFor, ExecutableTxIterator,
-    ExecutionCtxFor,
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    eth::EthBlockExecutionCtx,
-    revm::{Inspector, database::State},
+    self, ConfigureEngineEvm, ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor,
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader, SignedTransaction};
 use tempo_payload_types::TempoExecutionData;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -18,6 +18,9 @@ tempo-contracts.workspace = true
 reth-evm.workspace = true
 reth-rpc-convert = { workspace = true, optional = true }
 
+revm.workspace = true
+
+alloy-evm.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-eth = { workspace = true, optional = true }

--- a/crates/revm/src/block.rs
+++ b/crates/revm/src/block.rs
@@ -1,10 +1,8 @@
+use alloy_evm::env::BlockEnvironment;
 use alloy_primitives::{Address, B256, U256, uint};
-use reth_evm::{
-    env::BlockEnvironment,
-    revm::{
-        context::{Block, BlockEnv},
-        context_interface::block::BlobExcessGasAndPrice,
-    },
+use revm::{
+    context::{Block, BlockEnv},
+    context_interface::block::BlobExcessGasAndPrice,
 };
 
 /// Tempo block environment.

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -1,10 +1,8 @@
 //! Tempo-specific transaction validation errors.
 
+use alloy_evm::error::InvalidTxError;
 use alloy_primitives::U256;
-use reth_evm::{
-    InvalidTxError,
-    revm::context::result::{EVMError, InvalidHeader, InvalidTransaction},
-};
+use revm::context::result::{EVMError, InvalidHeader, InvalidTransaction};
 
 /// Tempo-specific invalid transaction errors.
 ///

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1,17 +1,14 @@
 use crate::{TempoBlockEnv, TempoTxEnv, instructions};
-use reth_evm::{
-    Database,
-    precompiles::PrecompilesMap,
-    revm::{
-        Context, Inspector,
-        context::{CfgEnv, ContextError, Evm, FrameStack},
-        handler::{
-            EthFrame, EthPrecompiles, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult,
-            instructions::EthInstructions,
-        },
-        inspector::InspectorEvmTr,
-        interpreter::interpreter::EthInterpreter,
+use alloy_evm::{Database, precompiles::PrecompilesMap};
+use revm::{
+    Context, Inspector,
+    context::{CfgEnv, ContextError, Evm, FrameStack},
+    handler::{
+        EthFrame, EthPrecompiles, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult,
+        instructions::EthInstructions,
     },
+    inspector::InspectorEvmTr,
+    interpreter::interpreter::EthInterpreter,
 };
 
 /// The Tempo EVM context type.
@@ -156,7 +153,7 @@ where
 mod tests {
     use super::*;
     use alloy_primitives::{Address, U256, bytes};
-    use reth_evm::revm::{
+    use revm::{
         ExecuteEvm,
         context::{ContextTr, TxEnv},
         database::{CacheDB, EmptyDB},

--- a/crates/revm/src/exec.rs
+++ b/crates/revm/src/exec.rs
@@ -3,25 +3,21 @@ use crate::{
     evm::{TempoContext, TempoEvm},
     handler::TempoEvmHandler,
 };
-use reth_evm::{
-    Database,
-    revm::{
-        DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
-        context::{
-            ContextSetters, TxEnv,
-            result::{ExecResultAndState, HaltReason},
-        },
-        context_interface::{
-            ContextTr, JournalTr,
-            result::{EVMError, ExecutionResult},
-        },
-        handler::{Handler, SystemCallTx, system_call::SystemCallEvm},
-        inspector::{
-            InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler,
-        },
-        primitives::{Address, Bytes},
-        state::EvmState,
+use alloy_evm::Database;
+use revm::{
+    DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
+    context::{
+        ContextSetters, TxEnv,
+        result::{ExecResultAndState, HaltReason},
     },
+    context_interface::{
+        ContextTr, JournalTr,
+        result::{EVMError, ExecutionResult},
+    },
+    handler::{Handler, SystemCallTx, system_call::SystemCallEvm},
+    inspector::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler},
+    primitives::{Address, Bytes},
+    state::EvmState,
 };
 
 impl<DB, I> ExecuteEvm for TempoEvm<DB, I>

--- a/crates/revm/src/instructions.rs
+++ b/crates/revm/src/instructions.rs
@@ -1,10 +1,8 @@
 use crate::evm::TempoContext;
-use reth_evm::{
-    Database,
-    revm::{
-        handler::instructions::EthInstructions,
-        interpreter::{Instruction, InstructionContext, interpreter::EthInterpreter, push},
-    },
+use alloy_evm::Database;
+use revm::{
+    handler::instructions::EthInstructions,
+    interpreter::{Instruction, InstructionContext, interpreter::EthInterpreter, push},
 };
 
 /// Instruction ID for opcode returning milliseconds timestamp.

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -1,15 +1,13 @@
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844, Typed2718, crypto::secp256k1};
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
-use reth_evm::{
-    FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, TransactionEnv,
-    revm::context::{
-        Transaction, TxEnv,
-        either::Either,
-        result::InvalidTransaction,
-        transaction::{
-            AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization,
-            SignedAuthorization,
-        },
+use reth_evm::TransactionEnv;
+use revm::context::{
+    Transaction, TxEnv,
+    either::Either,
+    result::InvalidTransaction,
+    transaction::{
+        AccessList, AccessListItem, RecoveredAuthority, RecoveredAuthorization, SignedAuthorization,
     },
 };
 use tempo_primitives::{
@@ -357,8 +355,8 @@ impl reth_rpc_convert::transaction::TryIntoTxEnv<TempoTxEnv>
 
     fn try_into_tx_env<Spec>(
         self,
-        cfg_env: &reth_evm::revm::context::CfgEnv<Spec>,
-        block_env: &reth_evm::revm::context::BlockEnv,
+        cfg_env: &revm::context::CfgEnv<Spec>,
+        block_env: &revm::context::BlockEnv,
     ) -> Result<TempoTxEnv, Self::Err> {
         Ok(TempoTxEnv {
             inner: self.try_into_tx_env(cfg_env, block_env)?,


### PR DESCRIPTION
If we depend on the crate directly we should not use re-exports, but rather import the necessary types and functions directly.

This is because re-exports can lead to confusion and make it harder to understand the dependencies of a crate.

For example, this highlights that we only depend on `reth_evm` for the `TransactionEnv` trait in `tempo_revm`.