### PR TITLE
feat(genesis): add `TRANSFER_ROLE` for linking USD during genesis generation

### DIFF
--- a/xtask/src/genesis.rs
+++ b/xtask/src/genesis.rs
@@ -25,7 +25,7 @@ use tempo_contracts::{
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
 use tempo_precompiles::{
     LINKING_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    linking_usd::LinkingUSD,
+    linking_usd::{LinkingUSD, TRANSFER_ROLE},
     stablecoin_exchange::StablecoinExchange,
     storage::evm::EvmPrecompileStorageProvider,
     tip_fee_manager::{IFeeManager, ITIPFeeAMM, TipFeeManager},
@@ -364,6 +364,7 @@ fn initialize_linking_usd(
         .expect("LinkingUSD initialization should succeed");
     let mut roles = linking_usd.get_roles_contract();
     roles.grant_role_internal(&admin, *ISSUER_ROLE)?;
+    roles.grant_role_internal(&admin, *TRANSFER_ROLE)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR updates the genesis generation tool to add the `TRANSFER_ROLE` for the specified `admin` when initializing `LinkingUSD`. This will allow the faucet to fund addresses with `LinkingUSD` in addition to other tokens.