### PR TITLE
feat: generate abis for precompiles

### DIFF
--- a/crates/contracts/src/precompiles/nonce.rs
+++ b/crates/contracts/src/precompiles/nonce.rs
@@ -9,7 +9,7 @@ sol! {
     /// are handled directly by account state. Each account can have multiple
     /// independent nonce sequences identified by a nonce key.
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface INonce {
         /// Get the current nonce for a specific account and nonce key
         /// @param account The account address

--- a/crates/contracts/src/precompiles/stablecoin_exchange.rs
+++ b/crates/contracts/src/precompiles/stablecoin_exchange.rs
@@ -17,7 +17,7 @@ sol! {
     /// The exchange operates on pairs between base tokens and their designated quote tokens,
     /// using a tick-based pricing system for precise order matching.
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface IStablecoinExchange {
         // Structs
         struct Order {

--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -4,7 +4,7 @@ use alloy::sol;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface IRolesAuth {
         function hasRole(address account, bytes32 role) external view returns (bool);
         function getRoleAdmin(bytes32 role) external view returns (bytes32);
@@ -32,7 +32,7 @@ sol! {
     /// The interface supports both standard token operations and administrative functions
     /// for managing token behavior and compliance requirements.
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     #[allow(clippy::too_many_arguments)]
     interface ITIP20 {
         // Standard token functions

--- a/crates/contracts/src/precompiles/tip20_factory.rs
+++ b/crates/contracts/src/precompiles/tip20_factory.rs
@@ -3,7 +3,7 @@ use alloy::sol;
 
 sol! {
   #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface ITIP20Factory {
         event TokenCreated(address indexed token, uint256 indexed tokenId, string name, string symbol, string currency, address admin);
 

--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -6,7 +6,7 @@ pub use ITIP403Registry::{
 
 sol! {
    #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface ITIP403Registry {
         // Enums
         enum PolicyType {

--- a/crates/contracts/src/precompiles/tip4217_registry.rs
+++ b/crates/contracts/src/precompiles/tip4217_registry.rs
@@ -2,6 +2,7 @@ use alloy::sol;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
     interface ITIP4217Registry {
         function getCurrencyDecimals(string currency) external view returns (uint8);
     }

--- a/crates/contracts/src/precompiles/tip_account_registrar.rs
+++ b/crates/contracts/src/precompiles/tip_account_registrar.rs
@@ -3,7 +3,7 @@ use alloy::sol;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface ITipAccountRegistrar {
         function delegateToDefault(bytes32 hash, bytes signature) external returns (address authority);
         function getDelegationMessage() external pure returns (string memory);

--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -17,7 +17,7 @@ sol! {
     /// - Slots 0-3: TIPFeeAMM storage (pools, pool exists, liquidity data)
     /// - Slots 4+: FeeManager-specific storage (validator tokens, user tokens, collected fees, etc.)
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface IFeeManager {
         // Structs
         struct FeeInfo {


### PR DESCRIPTION
Generate ABIs for precompiled contracts, this enables us to easily integrate trace decoding for precompiles in the current Foundry fork with Tempo support.