### PR TITLE
feat(node): Add endpoints and schema for `amm` JSON-RPC API

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
+    rpc::{TempoAmm, TempoAmmApiServer, TempoDex, TempoDexApiServer, TempoEthApiBuilder},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -139,9 +139,11 @@ where
                 } = container;
 
                 let eth_api = registry.eth_api().clone();
-                let dex = TempoDex::new(eth_api);
+                let dex = TempoDex::new(eth_api.clone());
+                let amm = TempoAmm::new(eth_api);
 
                 modules.merge_configured(dex.into_rpc())?;
+                modules.merge_configured(amm.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDexApiServer, TempoEthApiBuilder, dex::TempoDex},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};

--- a/crates/node/src/rpc/amm/mod.rs
+++ b/crates/node/src/rpc/amm/mod.rs
@@ -1,0 +1,46 @@
+pub use pools::{Pool, PoolsFilters};
+
+use crate::rpc::dex::{PaginationParams, types::PaginationResponse};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_core::rpc::result::internal_rpc_err;
+use reth_rpc_eth_api::RpcNodeCore;
+
+pub mod pools;
+
+#[rpc(server, namespace = "amm")]
+pub trait TempoAmmApi {
+    #[method(name = "getPools")]
+    async fn pools(
+        &self,
+        params: PaginationParams<PoolsFilters>,
+    ) -> RpcResult<PaginationResponse<Pool>>;
+}
+
+/// The JSON-RPC handlers for the `amm_` namespace.
+#[derive(Debug, Clone, Default)]
+pub struct TempoAmm<EthApi> {
+    eth_api: EthApi,
+}
+
+impl<EthApi> TempoAmm<EthApi> {
+    pub fn new(eth_api: EthApi) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EthApi: RpcNodeCore> TempoAmmApiServer for TempoAmm<EthApi> {
+    async fn pools(
+        &self,
+        _params: PaginationParams<PoolsFilters>,
+    ) -> RpcResult<PaginationResponse<Pool>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}
+
+impl<EthApi: RpcNodeCore> TempoAmm<EthApi> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &EthApi::Provider {
+        self.eth_api.provider()
+    }
+}

--- a/crates/node/src/rpc/amm/pools.rs
+++ b/crates/node/src/rpc/amm/pools.rs
@@ -1,0 +1,48 @@
+use crate::rpc::dex::{FilterRange, types::FieldName};
+use alloy_primitives::{Address, U256};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolsFilters {
+    /// Effective validator reserve in range
+    pub effective_validator_reserve: Option<FilterRange<U256>>,
+    /// Pending fee swap input in range
+    pub pending_fee_swap_in: Option<FilterRange<U256>>,
+    /// Reserve user token in range
+    pub reserve_user_token: Option<FilterRange<U256>>,
+    /// Reserve validator token in range
+    pub reserve_validator_token: Option<FilterRange<U256>>,
+    /// Total supply (LP tokens) in range
+    pub total_supply: Option<FilterRange<U256>>,
+    /// Filter by user token address
+    pub user_token: Option<Address>,
+    /// Filter by validator token address
+    pub validator_token: Option<Address>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Pool {
+    /// Effective reserve of validator token after pending swaps
+    pub effective_reserve_validator_token: U256,
+    /// Pool ID (keccak256 of userToken and validatorToken)
+    pub pool_id: U256,
+    /// User token reserve
+    pub reserve_user_token: U256,
+    /// Validator token reserve
+    pub reserve_validator_token: U256,
+    /// Total LP token supply for this pool
+    pub total_supply: U256,
+    /// User token address
+    pub user_token: Address,
+    /// Validator token address
+    pub validator_token: Address,
+}
+
+impl FieldName for Pool {
+    fn field_plural_camel_case() -> &'static str {
+        "pools"
+    }
+}

--- a/crates/node/src/rpc/dex/books.rs
+++ b/crates/node/src/rpc/dex/books.rs
@@ -1,20 +1,10 @@
-use crate::rpc::dex::{FilterRange, types::Tick};
+use crate::rpc::dex::{
+    FilterRange,
+    types::{FieldName, Tick},
+};
 use alloy_primitives::{Address, B256};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksParam {}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksResponse {
-    /// Cursor for next page, null if no more results
-    pub next_cursor: Option<String>,
-    /// Orderbooks that match the query
-    pub orderbooks: Vec<Orderbook>,
-}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,4 +36,10 @@ pub struct OrderbooksFilter {
     pub quote_token: Option<Address>,
     /// Spread in range (in ticks)
     pub spread: Option<FilterRange<Tick>>,
+}
+
+impl FieldName for Orderbook {
+    fn field_plural_camel_case() -> &'static str {
+        "orderbooks"
+    }
 }

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -6,8 +6,9 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
 
-mod books;
 pub mod types;
+
+mod books;
 
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -1,9 +1,7 @@
-pub use books::{Orderbook, OrderbooksFilter, OrderbooksParam, OrderbooksResponse};
-pub use types::{
-    FilterRange, Order, OrdersFilters, OrdersResponse, OrdersSort, OrdersSortOrder,
-    PaginationParams,
-};
+pub use books::{Orderbook, OrderbooksFilter};
+pub use types::{FilterRange, Order, OrdersFilters, OrdersSort, OrdersSortOrder, PaginationParams};
 
+use crate::rpc::dex::types::PaginationResponse;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
@@ -14,13 +12,16 @@ pub mod types;
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {
     #[method(name = "getOrders")]
-    async fn orders(&self, params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse>;
+    async fn orders(
+        &self,
+        params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>>;
 
     #[method(name = "getOrderbooks")]
     async fn orderbooks(
         &self,
         params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse>;
+    ) -> RpcResult<PaginationResponse<Orderbook>>;
 }
 
 /// The JSON-RPC handlers for the `dex_` namespace.
@@ -37,14 +38,17 @@ impl<EthApi> TempoDex<EthApi> {
 
 #[async_trait::async_trait]
 impl<EthApi: RpcNodeCore> TempoDexApiServer for TempoDex<EthApi> {
-    async fn orders(&self, _params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse> {
+    async fn orders(
+        &self,
+        _params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>> {
         Err(internal_rpc_err("unimplemented"))
     }
 
     async fn orderbooks(
         &self,
         _params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse> {
+    ) -> RpcResult<PaginationResponse<Orderbook>> {
         Err(internal_rpc_err("unimplemented"))
     }
 }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -1,7 +1,9 @@
+pub mod amm;
 pub mod dex;
 
 mod request;
 
+pub use amm::{TempoAmm, TempoAmmApiServer};
 pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -2,7 +2,7 @@ pub mod dex;
 
 mod request;
 
-pub use dex::TempoDexApiServer;
+pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};


### PR DESCRIPTION
Part of #549

Adds a trait and an implementation for the `amm` endpoints with an accompanying schema.

Need your help with the proper types for the numeric fields as the spec doesn't have them.

https://tempo-docs-git-jxom-rpc-tempoxyz.vercel.app/rpc/amm_getLiquidityPools
