### PR TITLE
feat(node): Add endpoints and schema for `token` JSON-RPC API

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDexApiServer, TempoEthApiBuilder, dex::TempoDex},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder, TempoToken, TempoTokenApiServer},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -139,9 +139,11 @@ where
                 } = container;
 
                 let eth_api = registry.eth_api().clone();
-                let dex = TempoDex::new(eth_api);
+                let dex = TempoDex::new(eth_api.clone());
+                let token = TempoToken::new(eth_api);
 
                 modules.merge_configured(dex.into_rpc())?;
+                modules.merge_configured(token.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/node/src/rpc/dex/books.rs
+++ b/crates/node/src/rpc/dex/books.rs
@@ -1,20 +1,10 @@
-use crate::rpc::dex::{FilterRange, types::Tick};
+use crate::rpc::dex::{
+    FilterRange,
+    types::{FieldName, Tick},
+};
 use alloy_primitives::{Address, B256};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksParam {}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksResponse {
-    /// Cursor for next page, null if no more results
-    pub next_cursor: Option<String>,
-    /// Orderbooks that match the query
-    pub orderbooks: Vec<Orderbook>,
-}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,4 +36,10 @@ pub struct OrderbooksFilter {
     pub quote_token: Option<Address>,
     /// Spread in range (in ticks)
     pub spread: Option<FilterRange<Tick>>,
+}
+
+impl FieldName for Orderbook {
+    fn field_plural_camel_case() -> &'static str {
+        "orderbooks"
+    }
 }

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -1,9 +1,7 @@
-pub use books::{Orderbook, OrderbooksFilter, OrderbooksParam, OrderbooksResponse};
-pub use types::{
-    FilterRange, Order, OrdersFilters, OrdersResponse, OrdersSort, OrdersSortOrder,
-    PaginationParams,
-};
+pub use books::{Orderbook, OrderbooksFilter};
+pub use types::{FilterRange, Order, OrdersFilters, OrdersSort, OrdersSortOrder, PaginationParams};
 
+use crate::rpc::dex::types::PaginationResponse;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
@@ -14,13 +12,16 @@ pub mod types;
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {
     #[method(name = "getOrders")]
-    async fn orders(&self, params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse>;
+    async fn orders(
+        &self,
+        params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>>;
 
     #[method(name = "getOrderbooks")]
     async fn orderbooks(
         &self,
         params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse>;
+    ) -> RpcResult<PaginationResponse<Orderbook>>;
 }
 
 /// The JSON-RPC handlers for the `dex_` namespace.
@@ -37,14 +38,17 @@ impl<EthApi> TempoDex<EthApi> {
 
 #[async_trait::async_trait]
 impl<EthApi: RpcNodeCore> TempoDexApiServer for TempoDex<EthApi> {
-    async fn orders(&self, _params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse> {
+    async fn orders(
+        &self,
+        _params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>> {
         Err(internal_rpc_err("unimplemented"))
     }
 
     async fn orderbooks(
         &self,
         _params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse> {
+    ) -> RpcResult<PaginationResponse<Orderbook>> {
         Err(internal_rpc_err("unimplemented"))
     }
 }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -2,7 +2,7 @@ pub mod dex;
 
 mod request;
 
-pub use dex::TempoDexApiServer;
+pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -1,9 +1,11 @@
 pub mod dex;
+pub mod token;
 
 mod request;
 
 pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
+pub use token::{TempoToken, TempoTokenApiServer};
 
 use crate::{TempoNetwork, node::TempoNode};
 use alloy::{consensus::TxReceipt, primitives::U256};

--- a/crates/node/src/rpc/token/mod.rs
+++ b/crates/node/src/rpc/token/mod.rs
@@ -1,0 +1,79 @@
+use crate::rpc::{
+    dex::{PaginationParams, types::PaginationResponse},
+    token::{
+        role_history::{RoleChange, RoleHistoryFilters},
+        tokens::{Token, TokensFilters},
+        tokens_by_address::{AccountToken, TokensByAddressParams},
+    },
+};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_core::rpc::result::internal_rpc_err;
+use reth_rpc_eth_api::RpcNodeCore;
+
+pub mod role_history;
+pub mod tokens;
+pub mod tokens_by_address;
+
+#[rpc(server, namespace = "token")]
+pub trait TempoTokenApi {
+    #[method(name = "getRoleHistory")]
+    async fn role_history(
+        &self,
+        params: PaginationParams<RoleHistoryFilters>,
+    ) -> RpcResult<PaginationResponse<RoleChange>>;
+
+    #[method(name = "getTokens")]
+    async fn tokens(
+        &self,
+        params: PaginationParams<TokensFilters>,
+    ) -> RpcResult<PaginationResponse<Token>>;
+
+    #[method(name = "getTokensByAddress")]
+    async fn tokens_by_address(
+        &self,
+        params: TokensByAddressParams,
+    ) -> RpcResult<PaginationResponse<AccountToken>>;
+}
+
+/// The JSON-RPC handlers for the `token_` namespace.
+#[derive(Debug, Clone, Default)]
+pub struct TempoToken<EthApi> {
+    eth_api: EthApi,
+}
+
+impl<EthApi> TempoToken<EthApi> {
+    pub fn new(eth_api: EthApi) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EthApi: RpcNodeCore> TempoTokenApiServer for TempoToken<EthApi> {
+    async fn role_history(
+        &self,
+        _params: PaginationParams<RoleHistoryFilters>,
+    ) -> RpcResult<PaginationResponse<RoleChange>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+
+    async fn tokens(
+        &self,
+        _params: PaginationParams<TokensFilters>,
+    ) -> RpcResult<PaginationResponse<Token>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+
+    async fn tokens_by_address(
+        &self,
+        _params: TokensByAddressParams,
+    ) -> RpcResult<PaginationResponse<AccountToken>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}
+
+impl<EthApi: RpcNodeCore> TempoToken<EthApi> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &EthApi::Provider {
+        self.eth_api.provider()
+    }
+}

--- a/crates/node/src/rpc/token/role_history.rs
+++ b/crates/node/src/rpc/token/role_history.rs
@@ -1,0 +1,50 @@
+use crate::rpc::dex::{FilterRange, types::FieldName};
+use alloy_primitives::{Address, B256, BlockNumber, TxHash};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleHistoryFilters {
+    /// Filter by account address that received/lost role
+    pub account: Option<Address>,
+    /// Block number in range
+    pub block_number: Option<FilterRange<BlockNumber>>,
+    /// Filter by granted vs revoked (true = grants, false = revocations)
+    pub granted: Option<bool>,
+    /// Filter by specific role (32-byte hex)
+    pub role: Option<B256>,
+    /// Filter by address that made the change
+    pub sender: Option<Address>,
+    /// Timestamp (seconds) in range
+    pub timestamp: Option<FilterRange<u64>>,
+    /// Filter by token address
+    pub token: Option<Address>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleChange {
+    /// Account that received/lost the role
+    pub account: Address,
+    /// Block number where change occurred
+    pub block_number: BlockNumber,
+    /// Whether role was granted (true) or revoked (false)
+    pub granted: bool,
+    /// Role identifier (32-byte hex)
+    pub role: B256,
+    /// Address that made the change
+    pub sender: Address,
+    /// Timestamp of the change
+    pub timestamp: u64,
+    /// Token address
+    pub token: Address,
+    /// Transaction hash
+    pub transaction_hash: TxHash,
+}
+
+impl FieldName for RoleChange {
+    fn field_plural_camel_case() -> &'static str {
+        "roleChanges"
+    }
+}

--- a/crates/node/src/rpc/token/tokens.rs
+++ b/crates/node/src/rpc/token/tokens.rs
@@ -1,0 +1,64 @@
+use crate::rpc::dex::{FilterRange, types::FieldName};
+use alloy_primitives::{Address, B256, U256};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokensFilters {
+    /// Filter by currency code (e.g., "USD", "EUR", "JPY")
+    pub currency: Option<String>,
+    /// Filter by creator address
+    pub creator: Option<Address>,
+    /// Created timestamp (seconds) in range
+    pub created_at: Option<FilterRange<u64>>,
+    /// Filter by token name (case-insensitive)
+    pub name: Option<String>,
+    /// Filter by pause state
+    pub paused: Option<bool>,
+    /// Filter by quote token address
+    pub quote_token: Option<Address>,
+    /// Supply cap in range
+    pub supply_cap: Option<FilterRange<U256>>,
+    /// Filter by symbol
+    pub symbol: Option<String>,
+    /// Total supply in range
+    pub total_supply: Option<FilterRange<U256>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Token {
+    /// Token contract address (deterministic vanity address based on tokenId)
+    pub address: Address,
+    /// Timestamp when token was created
+    pub created_at: u64,
+    /// Address that created the token
+    pub creator: Address,
+    /// Currency code (e.g., "USD", "EUR")
+    pub currency: String,
+    /// Token decimals (from TIP-4217 registry based on currency)
+    pub decimals: u32,
+    /// Token name
+    pub name: String,
+    /// Whether token transfers are paused
+    pub paused: bool,
+    /// Quote token address for trading pairs
+    pub quote_token: Address,
+    /// Maximum token supply
+    pub supply_cap: B256,
+    /// Token symbol
+    pub symbol: String,
+    /// Unique token ID from factory
+    pub token_id: B256,
+    /// Current total supply
+    pub total_supply: B256,
+    /// Current transfer policy ID
+    pub transfer_policy_id: B256,
+}
+
+impl FieldName for Token {
+    fn field_plural_camel_case() -> &'static str {
+        "tokens"
+    }
+}

--- a/crates/node/src/rpc/token/tokens_by_address.rs
+++ b/crates/node/src/rpc/token/tokens_by_address.rs
@@ -1,0 +1,34 @@
+use crate::rpc::{
+    dex::{PaginationParams, types::FieldName},
+    token::tokens::{Token, TokensFilters},
+};
+use alloy_primitives::{Address, B256, U256};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokensByAddressParams {
+    /// Filter by account address that received/lost role.
+    pub address: Address,
+    /// Determines what items should be yielded in the response.
+    #[serde(flatten)]
+    pub params: PaginationParams<TokensFilters>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountToken {
+    /// Account's balance in this token
+    pub balance: U256,
+    /// Roles the account has for this token
+    pub roles: Vec<B256>,
+    /// Token details
+    pub token: Token,
+}
+
+impl FieldName for AccountToken {
+    fn field_plural_camel_case() -> &'static str {
+        "tokens"
+    }
+}


### PR DESCRIPTION
Part of #549

Adds a trait and an implementation for the `token` endpoints with an accompanying schema.

Need your help with the proper types for the numeric fields as the spec doesn't have them.

https://tempo-docs-git-jxom-rpc-tempoxyz.vercel.app/rpc/token_getRoleHistory
