### PR TITLE
feat(node): Add endpoints and schema for `policy` JSON-RPC API

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDexApiServer, TempoEthApiBuilder, dex::TempoDex},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder, TempoPolicy, TempoPolicyApiServer},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -139,9 +139,11 @@ where
                 } = container;
 
                 let eth_api = registry.eth_api().clone();
-                let dex = TempoDex::new(eth_api);
+                let dex = TempoDex::new(eth_api.clone());
+                let policy = TempoPolicy::new(eth_api);
 
                 modules.merge_configured(dex.into_rpc())?;
+                modules.merge_configured(policy.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/node/src/rpc/dex/books.rs
+++ b/crates/node/src/rpc/dex/books.rs
@@ -1,20 +1,10 @@
-use crate::rpc::dex::{FilterRange, types::Tick};
+use crate::rpc::dex::{
+    FilterRange,
+    types::{FieldName, Tick},
+};
 use alloy_primitives::{Address, B256};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksParam {}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksResponse {
-    /// Cursor for next page, null if no more results
-    pub next_cursor: Option<String>,
-    /// Orderbooks that match the query
-    pub orderbooks: Vec<Orderbook>,
-}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,4 +36,10 @@ pub struct OrderbooksFilter {
     pub quote_token: Option<Address>,
     /// Spread in range (in ticks)
     pub spread: Option<FilterRange<Tick>>,
+}
+
+impl FieldName for Orderbook {
+    fn field_plural_camel_case() -> &'static str {
+        "orderbooks"
+    }
 }

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -6,8 +6,9 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
 
-mod books;
 pub mod types;
+
+mod books;
 
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -1,9 +1,7 @@
-pub use books::{Orderbook, OrderbooksFilter, OrderbooksParam, OrderbooksResponse};
-pub use types::{
-    FilterRange, Order, OrdersFilters, OrdersResponse, OrdersSort, OrdersSortOrder,
-    PaginationParams,
-};
+pub use books::{Orderbook, OrderbooksFilter};
+pub use types::{FilterRange, Order, OrdersFilters, OrdersSort, OrdersSortOrder, PaginationParams};
 
+use crate::rpc::dex::types::PaginationResponse;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
@@ -14,13 +12,16 @@ pub mod types;
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {
     #[method(name = "getOrders")]
-    async fn orders(&self, params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse>;
+    async fn orders(
+        &self,
+        params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>>;
 
     #[method(name = "getOrderbooks")]
     async fn orderbooks(
         &self,
         params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse>;
+    ) -> RpcResult<PaginationResponse<Orderbook>>;
 }
 
 /// The JSON-RPC handlers for the `dex_` namespace.
@@ -37,14 +38,17 @@ impl<EthApi> TempoDex<EthApi> {
 
 #[async_trait::async_trait]
 impl<EthApi: RpcNodeCore> TempoDexApiServer for TempoDex<EthApi> {
-    async fn orders(&self, _params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse> {
+    async fn orders(
+        &self,
+        _params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>> {
         Err(internal_rpc_err("unimplemented"))
     }
 
     async fn orderbooks(
         &self,
         _params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse> {
+    ) -> RpcResult<PaginationResponse<Orderbook>> {
         Err(internal_rpc_err("unimplemented"))
     }
 }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -2,7 +2,7 @@ pub mod dex;
 
 mod request;
 
-pub use dex::TempoDexApiServer;
+pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -1,8 +1,10 @@
 pub mod dex;
+pub mod policy;
 
 mod request;
 
 pub use dex::{TempoDex, TempoDexApiServer};
+pub use policy::{TempoPolicy, TempoPolicyApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};

--- a/crates/node/src/rpc/policy/addresses.rs
+++ b/crates/node/src/rpc/policy/addresses.rs
@@ -1,0 +1,36 @@
+use crate::rpc::dex::{PaginationParams, types::FieldName};
+use alloy_primitives::{Address, B256};
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressesParams {
+    /// Policy ID to query addresses for
+    pub policy_id: B256,
+    /// Determines what items should be yielded in the response.
+    #[serde(flatten)]
+    pub params: PaginationParams<AddressesFilters>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressesFilters {
+    /// Filter by authorization status (true = authorized, false = not authorized)
+    pub authorized: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyAddress {
+    /// Address in the policy
+    pub address: Address,
+    /// Whether address is authorized (depends on policy type)
+    pub authorized: bool,
+}
+
+impl FieldName for PolicyAddress {
+    fn field_plural_camel_case() -> &'static str {
+        "addresses"
+    }
+}

--- a/crates/node/src/rpc/policy/mod.rs
+++ b/crates/node/src/rpc/policy/mod.rs
@@ -1,0 +1,46 @@
+pub use addresses::{AddressesFilters, PolicyAddress};
+
+use crate::rpc::{dex::types::PaginationResponse, policy::addresses::AddressesParams};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_core::rpc::result::internal_rpc_err;
+use reth_rpc_eth_api::RpcNodeCore;
+
+pub mod addresses;
+
+#[rpc(server, namespace = "policy")]
+pub trait TempoPolicyApi {
+    #[method(name = "getAddresses")]
+    async fn addresses(
+        &self,
+        params: AddressesParams,
+    ) -> RpcResult<PaginationResponse<PolicyAddress>>;
+}
+
+/// The JSON-RPC handlers for the `policy_` namespace.
+#[derive(Debug, Clone, Default)]
+pub struct TempoPolicy<EthApi> {
+    eth_api: EthApi,
+}
+
+impl<EthApi> TempoPolicy<EthApi> {
+    pub fn new(eth_api: EthApi) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EthApi: RpcNodeCore> TempoPolicyApiServer for TempoPolicy<EthApi> {
+    async fn addresses(
+        &self,
+        _params: AddressesParams,
+    ) -> RpcResult<PaginationResponse<PolicyAddress>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}
+
+impl<EthApi: RpcNodeCore> TempoPolicy<EthApi> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &EthApi::Provider {
+        self.eth_api.provider()
+    }
+}


### PR DESCRIPTION
Part of #549

Adds a trait and an implementation for the `policy` endpoints with an accompanying schema.

Need your help with the proper types for the numeric fields as the spec doesn't have them.

https://tempo-docs-git-jxom-rpc-tempoxyz.vercel.app/rpc/policy_getAddresses
