### PR TITLE
feat(node): Add endpoints and schema for `eth` extension JSON-RPC API

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDexApiServer, TempoEthApiBuilder, dex::TempoDex},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2,7 +2,7 @@ use crate::{
     TempoPayloadTypes,
     args::TempoArgs,
     engine::TempoEngineValidator,
-    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder},
+    rpc::{TempoDex, TempoDexApiServer, TempoEthApiBuilder, TempoEthExt, TempoEthExtApiServer},
 };
 use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
@@ -139,9 +139,11 @@ where
                 } = container;
 
                 let eth_api = registry.eth_api().clone();
-                let dex = TempoDex::new(eth_api);
+                let dex = TempoDex::new(eth_api.clone());
+                let eth_ext = TempoEthExt::new(eth_api);
 
                 modules.merge_configured(dex.into_rpc())?;
+                modules.merge_configured(eth_ext.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/node/src/rpc/dex/books.rs
+++ b/crates/node/src/rpc/dex/books.rs
@@ -1,20 +1,10 @@
-use crate::rpc::dex::{FilterRange, types::Tick};
+use crate::rpc::dex::{
+    FilterRange,
+    types::{FieldName, Tick},
+};
 use alloy_primitives::{Address, B256};
 use jsonrpsee::core::Serialize;
 use serde::Deserialize;
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksParam {}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OrderbooksResponse {
-    /// Cursor for next page, null if no more results
-    pub next_cursor: Option<String>,
-    /// Orderbooks that match the query
-    pub orderbooks: Vec<Orderbook>,
-}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,4 +36,10 @@ pub struct OrderbooksFilter {
     pub quote_token: Option<Address>,
     /// Spread in range (in ticks)
     pub spread: Option<FilterRange<Tick>>,
+}
+
+impl FieldName for Orderbook {
+    fn field_plural_camel_case() -> &'static str {
+        "orderbooks"
+    }
 }

--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -1,9 +1,7 @@
-pub use books::{Orderbook, OrderbooksFilter, OrderbooksParam, OrderbooksResponse};
-pub use types::{
-    FilterRange, Order, OrdersFilters, OrdersResponse, OrdersSort, OrdersSortOrder,
-    PaginationParams,
-};
+pub use books::{Orderbook, OrderbooksFilter};
+pub use types::{FilterRange, Order, OrdersFilters, OrdersSort, OrdersSortOrder, PaginationParams};
 
+use crate::rpc::dex::types::PaginationResponse;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
@@ -14,13 +12,16 @@ pub mod types;
 #[rpc(server, namespace = "dex")]
 pub trait TempoDexApi {
     #[method(name = "getOrders")]
-    async fn orders(&self, params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse>;
+    async fn orders(
+        &self,
+        params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>>;
 
     #[method(name = "getOrderbooks")]
     async fn orderbooks(
         &self,
         params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse>;
+    ) -> RpcResult<PaginationResponse<Orderbook>>;
 }
 
 /// The JSON-RPC handlers for the `dex_` namespace.
@@ -37,14 +38,17 @@ impl<EthApi> TempoDex<EthApi> {
 
 #[async_trait::async_trait]
 impl<EthApi: RpcNodeCore> TempoDexApiServer for TempoDex<EthApi> {
-    async fn orders(&self, _params: PaginationParams<OrdersFilters>) -> RpcResult<OrdersResponse> {
+    async fn orders(
+        &self,
+        _params: PaginationParams<OrdersFilters>,
+    ) -> RpcResult<PaginationResponse<Order>> {
         Err(internal_rpc_err("unimplemented"))
     }
 
     async fn orderbooks(
         &self,
         _params: PaginationParams<OrderbooksFilter>,
-    ) -> RpcResult<OrderbooksResponse> {
+    ) -> RpcResult<PaginationResponse<Orderbook>> {
         Err(internal_rpc_err("unimplemented"))
     }
 }

--- a/crates/node/src/rpc/eth_ext/mod.rs
+++ b/crates/node/src/rpc/eth_ext/mod.rs
@@ -1,0 +1,49 @@
+pub use transactions::TransactionsFilter;
+
+use crate::rpc::{
+    dex::{PaginationParams, types::PaginationResponse},
+    eth_ext::transactions::Transaction,
+};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_core::rpc::result::internal_rpc_err;
+use reth_rpc_eth_api::RpcNodeCore;
+
+pub mod transactions;
+
+#[rpc(server, namespace = "eth")]
+pub trait TempoEthExtApi {
+    #[method(name = "getTransactions")]
+    async fn transactions(
+        &self,
+        params: PaginationParams<TransactionsFilter>,
+    ) -> RpcResult<PaginationResponse<Transaction>>;
+}
+
+/// The JSON-RPC handlers for the `dex_` namespace.
+#[derive(Debug, Clone, Default)]
+pub struct TempoEthExt<EthApi> {
+    eth_api: EthApi,
+}
+
+impl<EthApi> TempoEthExt<EthApi> {
+    pub fn new(eth_api: EthApi) -> Self {
+        Self { eth_api }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EthApi: RpcNodeCore> TempoEthExtApiServer for TempoEthExt<EthApi> {
+    async fn transactions(
+        &self,
+        _params: PaginationParams<TransactionsFilter>,
+    ) -> RpcResult<PaginationResponse<Transaction>> {
+        Err(internal_rpc_err("unimplemented"))
+    }
+}
+
+impl<EthApi: RpcNodeCore> TempoEthExt<EthApi> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &EthApi::Provider {
+        self.eth_api.provider()
+    }
+}

--- a/crates/node/src/rpc/eth_ext/transactions.rs
+++ b/crates/node/src/rpc/eth_ext/transactions.rs
@@ -1,0 +1,25 @@
+use crate::rpc::dex::types::FieldName;
+use alloy_primitives::Address;
+use jsonrpsee::core::Serialize;
+use serde::Deserialize;
+use tempo_primitives::{TempoTxEnvelope, TempoTxType};
+
+pub type Transaction = alloy_rpc_types_eth::Transaction<TempoTxEnvelope>;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionsFilter {
+    /// Filter by sender address (from)
+    from: Option<Address>,
+    /// Filter by recipient address (to)
+    to: Option<Address>,
+    /// Transaction type
+    #[serde(rename = "type")]
+    type_: Option<TempoTxType>,
+}
+
+impl FieldName for Transaction {
+    fn field_plural_camel_case() -> &'static str {
+        "transactions"
+    }
+}

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -2,7 +2,7 @@ pub mod dex;
 
 mod request;
 
-pub use dex::TempoDexApiServer;
+pub use dex::{TempoDex, TempoDexApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -1,8 +1,10 @@
 pub mod dex;
+pub mod eth_ext;
 
 mod request;
 
 pub use dex::{TempoDex, TempoDexApiServer};
+pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
 pub use request::TempoTransactionRequest;
 
 use crate::{TempoNetwork, node::TempoNode};


### PR DESCRIPTION
Part of #549

Adds a trait and an implementation for the `eth` extension endpoints with an accompanying schema.

https://tempo-docs-git-jxom-rpc-tempoxyz.vercel.app/rpc/eth_getTransactions
