### PR TITLE
chore: set `view` on `getStream` + `totalRewardPerSecond`

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -93,8 +93,8 @@ sol! {
         function setRewardRecipient(address recipient) external;
         function cancelReward(uint64 id) external returns (uint256);
         function finalizeStreams() external;
-        function getStream(uint64 id) external returns (RewardStream);
-        function totalRewardPerSecond() external returns (uint256);
+        function getStream(uint64 id) external view returns (RewardStream);
+        function totalRewardPerSecond() external view returns (uint256);
 
         // Events
         event Transfer(address indexed from, address indexed to, uint256 amount);


### PR DESCRIPTION
Sets `view` on `getStream` and `totalRewardPerSecond` solidity interfaces. 