### PR TITLE
chore: enable osaka in genesis generator

### DIFF
--- a/xtask/src/genesis.rs
+++ b/xtask/src/genesis.rs
@@ -285,6 +285,7 @@ impl GenesisArgs {
             shanghai_time: Some(0),
             cancun_time: Some(0),
             prague_time: Some(0),
+            osaka_time: Some(0),
             terminal_total_difficulty: Some(U256::from(0)),
             terminal_total_difficulty_passed: true,
             deposit_contract_address: Some(address!("0x00000000219ab540356cBB839Cbe05303d7705Fa")),


### PR DESCRIPTION
Closes #591 

This PR adds the `osaka` hardfork to the `genesis.json` file.