### PR TITLE
chore: xtask -> tempo-xtask in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ build binary extra_args="":
 [group('localnet')]
 [doc('Generates a genesis file')]
 genesis accounts="1000" output="genesis.json" profile="maxperf":
-    cargo run --bin xtask --profile {{profile}} -- generate-genesis --output {{output}} -a {{accounts}}
+    cargo run -p tempo-xtask --profile {{profile}} -- generate-genesis --output {{output}} -a {{accounts}}
 
 [group('localnet')]
 [doc('Deletes local network data and launches a new localnet')]


### PR DESCRIPTION
Was failing on `main`
```console
❯ just localnet
This will wipe your data directory (unless you have reset=false) - please confirm before proceeding (y/n): y
cargo run --bin xtask --profile maxperf -- generate-genesis --output ./localnet/genesis.json -a 1000
error: no bin target named `xtask` in default-run packages
help: available bin targets:
    tempo
    tempo-bench
    tempo-sidecar
    tempo-xtask
```