### PR TITLE
nit: explicitly refer to generic `multicall` as `multicall3` in `contracts`

### DIFF
--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -5,7 +5,7 @@
 
 use alloy::primitives::{Address, address};
 
-pub const MULTICALL_ADDRESS: Address = alloy::providers::MULTICALL3_ADDRESS;
+pub const MULTICALL3_ADDRESS: Address = alloy::providers::MULTICALL3_ADDRESS;
 pub const CREATEX_ADDRESS: Address = address!("0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed");
 pub const SAFE_DEPLOYER_ADDRESS: Address = address!("0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7");
 pub const PERMIT2_ADDRESS: Address = address!("0x000000000022d473030f116ddee9f6b43ac78ba3");

--- a/xtask/src/genesis.rs
+++ b/xtask/src/genesis.rs
@@ -21,7 +21,7 @@ use std::{collections::BTreeMap, fs, path::PathBuf};
 use tempo_chainspec::spec::TEMPO_BASE_FEE;
 use tempo_contracts::{
     ARACHNID_CREATE2_FACTORY_ADDRESS, CREATEX_ADDRESS, DEFAULT_7702_DELEGATE_ADDRESS,
-    MULTICALL_ADDRESS, PERMIT2_ADDRESS, SAFE_DEPLOYER_ADDRESS,
+    MULTICALL3_ADDRESS, PERMIT2_ADDRESS, SAFE_DEPLOYER_ADDRESS,
     contracts::ARACHNID_CREATE2_FACTORY_BYTECODE,
 };
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
@@ -216,7 +216,7 @@ impl GenesisArgs {
             .collect();
 
         genesis_alloc.insert(
-            MULTICALL_ADDRESS,
+            MULTICALL3_ADDRESS,
             GenesisAccount {
                 code: Some(tempo_contracts::Multicall::DEPLOYED_BYTECODE.clone()),
                 nonce: Some(1),


### PR DESCRIPTION
nit, noticed this when syncing the names for `tempo-std`