### PR TITLE
fix: more precise block size control during block building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11522,6 +11522,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "reth-consensus-common",
  "reth-evm",
  "reth-node-builder",
  "reth-node-core",

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -16,6 +16,7 @@ tempo-node.workspace = true
 tempo-primitives.workspace = true
 tempo-payload-types.workspace = true
 
+reth-consensus-common.workspace = true
 reth-evm.workspace = true
 reth-revm.workspace = true
 

--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -30,6 +30,7 @@ use eyre::{Context, OptionExt};
 use futures::{StreamExt, channel::mpsc};
 use indexmap::IndexMap;
 use parking_lot::Mutex;
+use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
 use reth_evm::{Evm, revm::database::State};
 use reth_node_builder::ConfigureEvm;
 use reth_primitives_traits::Recovered;
@@ -610,6 +611,20 @@ async fn validate_subblock(
         scheme.participants().iter().any(|p| p == &sender),
         "sender is not a validator"
     );
+
+    // Bound subblock size at a value proportional to `TEMPO_SHARED_GAS_DIVISOR`.
+    //
+    // This ensures we never collect too many subblocks to fit into a new proposal.
+    let max_size = MAX_RLP_BLOCK_SIZE
+        / TEMPO_SHARED_GAS_DIVISOR as usize
+        / scheme.participants().len() as usize;
+    if subblock.total_tx_size() > max_size {
+        warn!(
+            size = subblock.total_tx_size(),
+            max_size, "subblock is too large, skipping"
+        );
+        return Ok(());
+    }
 
     for tx in subblock.transactions_recovered() {
         if let Err(err) = evm.transact_commit(tx) {

--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -115,6 +115,11 @@ impl SubBlock {
             transactions: Decodable::decode(buf)?,
         })
     }
+
+    /// Returns the total length of the transactions in the subblock.
+    pub fn total_tx_size(&self) -> usize {
+        self.transactions.iter().map(|tx| tx.length()).sum()
+    }
 }
 
 impl Encodable for SubBlock {


### PR DESCRIPTION
Based on https://github.com/tempoxyz/tempo/pull/581

Changes block building to correctly account for subblocks and system transactions sizes when ensuring that total block size does not exceed the EIP-7934 limit
