### PR TITLE
fix(tip20): change startReward secs parameter from uint128 to uint32

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -92,7 +92,7 @@ sol! {
         }
 
         // Reward Functions
-        function startReward(uint256 amount, uint128 secs) external returns (uint64);
+        function startReward(uint256 amount, uint32 secs) external returns (uint64);
         function setRewardRecipient(address recipient) external;
         function cancelReward(uint64 id) external returns (uint256);
         function claimRewards() external returns (uint256);

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -96,7 +96,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
 
             let current_time = self.storage.timestamp().to::<u128>();
             let end_time = current_time
-                .checked_add(call.secs)
+                .checked_add(call.secs as u128)
                 .ok_or(TempoPrecompileError::under_overflow())?;
 
             RewardStream::new(
@@ -127,7 +127,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
                     funder: msg_sender,
                     id: stream_id,
                     amount: call.amount,
-                    durationSeconds: call.secs as u32,
+                    durationSeconds: call.secs,
                 })
                 .into_log_data(),
             )?;
@@ -1144,7 +1144,7 @@ mod tests {
             },
         )?;
 
-        let stream_duration = 10u128;
+        let stream_duration = 10u32;
         token.start_reward(
             admin,
             ITIP20::startRewardCall {
@@ -1153,7 +1153,7 @@ mod tests {
             },
         )?;
 
-        let end_time = current_time + stream_duration;
+        let end_time = current_time + stream_duration as u128;
 
         // Advance the timestamp to simulate time passing
         token.storage.set_timestamp(U256::from(end_time));


### PR DESCRIPTION
ref https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1762157514260509?thread_ts=1761930432.103249&cid=C09KCGR4LQ4

Changes `startReward` duration parameter from `uint128` to `uint32` to prevent overflow issues with large values.