### PR TITLE
feat: impl `RecommendedFillers` for `TempoNetwork`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11428,6 +11428,7 @@ dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-rpc-types-eth",
  "reth-evm",
  "reth-rpc-convert",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ alloy-eips = "1.0.41"
 alloy-genesis = "1.0.41"
 alloy-hardforks = "0.4.3"
 alloy-primitives = "1.4.1"
+alloy-provider = { version = "1.0.41", default-features = false }
 alloy-sol-types = "1.4.1"
 alloy-rlp = "0.3.12"
 alloy-rpc-types-engine = "1.0.41"

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -19,6 +19,7 @@ alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
+alloy-provider.workspace = true
 alloy-rpc-types-eth.workspace = true
 
 reth-evm = { workspace = true, optional = true }

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -6,6 +6,9 @@ use alloy_network::{
     UnbuiltTransactionError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
+use alloy_provider::fillers::{
+    ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers,
+};
 use alloy_rpc_types_eth::AccessList;
 use tempo_primitives::{
     TempoHeader, TempoReceipt, TempoTxEnvelope, TempoTxType, transaction::TempoTypedTransaction,
@@ -272,6 +275,14 @@ impl TempoTransactionRequest {
         } else {
             Err(fields)
         }
+    }
+}
+
+impl RecommendedFillers for TempoNetwork {
+    type RecommendedFillers = JoinFill<GasFiller, JoinFill<NonceFiller, ChainIdFiller>>;
+
+    fn recommended_fillers() -> Self::RecommendedFillers {
+        Default::default()
     }
 }
 


### PR DESCRIPTION
Implements `RecommendedFillers` for `TempoNetwork`, which is required for `ProviderBuilder::new_with_network` in Alloy. The alternative is that consumers would have to use Alloy without any transaction fillers, which is poor UX.

I chose the recommended fillers based on what we did for `op-alloy`.