### PR TITLE
feat(cli): add download defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11404,6 +11404,7 @@ dependencies = [
  "commonware-runtime",
  "eyre",
  "futures",
+ "reth-cli-commands",
  "reth-cli-util",
  "reth-ethereum",
  "reth-node-builder",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -25,6 +25,7 @@ tempo-faucet.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 commonware-runtime = { workspace = true, features = ["external"] }
 futures = { workspace = true, features = ["executor"] }
+reth-cli-commands.workspace = true
 reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }
 reth-node-builder.workspace = true

--- a/bin/tempo/src/download.rs
+++ b/bin/tempo/src/download.rs
@@ -1,0 +1,20 @@
+use std::borrow::Cow;
+
+use reth_cli_commands::download::DownloadDefaults;
+
+pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42426";
+
+pub(crate) fn init_download_urls() {
+    let download_defaults = DownloadDefaults {
+        available_snapshots: vec![
+            Cow::Borrowed("https://snapshots.tempoxyz.dev/42426 (andante-1)"),
+            Cow::Borrowed("https://snapshots.tempoxyz.dev/42427 (andantino-1)"),
+        ],
+        default_base_url: Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
+        long_help: None,
+    };
+
+    download_defaults
+        .try_init()
+        .expect("failed to initialize download URLs");
+}

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+mod download;
+
 use clap::Parser;
 use commonware_runtime::{Metrics, Runner};
 use eyre::WrapErr as _;
@@ -70,6 +72,7 @@ fn main() -> eyre::Result<()> {
     }
 
     tempo_node::init_version_metadata();
+    download::init_download_urls();
 
     let cli = Cli::<TempoChainSpecParser, TempoArgs>::parse();
     let is_node = matches!(cli.command, Commands::Node(_));


### PR DESCRIPTION
adds our snapshot server as the default download source. we should switch this to andantino, once it's liev