### PR TITLE
feat(rpc): implement reusable cursor-based pagination with sorting for policy_getAddresses

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -10,7 +10,7 @@ mod pagination;
 pub use amm::{TempoAmm, TempoAmmApiServer};
 pub use dex::{TempoDex, api::TempoDexApiServer};
 pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
-pub use pagination::{FilterRange, PaginationParams};
+pub use pagination::{FilterRange, PaginatedResult, PaginationParams, Sort, SortOrder, paginate};
 pub use policy::{TempoPolicy, TempoPolicyApiServer};
 pub use tempo_alloy::rpc::TempoTransactionRequest;
 pub use token::{TempoToken, TempoTokenApiServer};

--- a/crates/node/src/rpc/pagination.rs
+++ b/crates/node/src/rpc/pagination.rs
@@ -1,14 +1,14 @@
-use crate::rpc::dex::OrdersSort;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PaginationParams<Filters> {
+pub struct PaginationParams<Filters, Sort = crate::rpc::dex::OrdersSort> {
     /// Cursor for pagination.
     ///
     /// The cursor format depends on the endpoint:
     /// - `dex_getOrders`: Order ID (u128 encoded as string)
     /// - `dex_getOrderbooks`: Book Key (B256 encoded as hex string)
+    /// - `policy_getAddresses`: Address (hex string)
     ///
     /// Defaults to first entry based on the sort and filter configuration.
     /// Use the `nextCursor` in response to get the next set of results.
@@ -19,7 +19,7 @@ pub struct PaginationParams<Filters> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Filters>,
 
-    /// Maximum number of orders to return.
+    /// Maximum number of items to return.
     ///
     /// Defaults to 10.
     /// Maximum is 100.
@@ -28,7 +28,28 @@ pub struct PaginationParams<Filters> {
 
     /// Determines the order of the items yielded in the response.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort: Option<OrdersSort>,
+    pub sort: Option<Sort>,
+}
+
+/// Generic sort configuration
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Sort {
+    /// Field to sort by
+    pub on: String,
+    /// Sort direction
+    pub order: SortOrder,
+}
+
+/// Sort order direction
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SortOrder {
+    /// Ascending order
+    Asc,
+    /// Descending order
+    #[default]
+    Desc,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -51,4 +72,58 @@ impl<T: PartialOrd> FilterRange<T> {
 
         true
     }
+}
+
+/// Result of pagination operation
+pub struct PaginatedResult<T> {
+    /// The page of items
+    pub items: Vec<T>,
+    /// Cursor for next page, None if no more results
+    pub next_cursor: Option<String>,
+}
+
+/// Apply cursor-based pagination to a collection of items
+pub fn paginate<T, C>(
+    mut items: Vec<T>,
+    cursor: Option<&String>,
+    limit: Option<usize>,
+    get_cursor_value: impl Fn(&T) -> C,
+) -> Result<PaginatedResult<T>, String>
+where
+    C: std::str::FromStr + PartialOrd + std::fmt::Display,
+    <C as std::str::FromStr>::Err: std::fmt::Display,
+{
+    // Find start index based on cursor
+    let start_index = if let Some(cursor_str) = cursor {
+        let cursor_value = cursor_str
+            .parse::<C>()
+            .map_err(|e| format!("Invalid cursor format: {e}"))?;
+
+        // Find position after cursor
+        items
+            .iter()
+            .position(|item| get_cursor_value(item) > cursor_value)
+            .unwrap_or(items.len())
+    } else {
+        0
+    };
+
+    // Apply limit
+    let limit = limit.unwrap_or(10).min(100);
+    let end_index = (start_index + limit).min(items.len());
+
+    // Slice to current page
+    let page = items.drain(start_index..end_index).collect::<Vec<_>>();
+
+    // Generate next cursor
+    let next_cursor = if end_index < items.len() + end_index - start_index {
+        page.last().map(|item| get_cursor_value(item).to_string())
+    } else {
+        None
+    };
+
+    Ok(PaginatedResult {
+        items: page,
+        next_cursor,
+    })
 }

--- a/crates/node/src/rpc/policy/addresses.rs
+++ b/crates/node/src/rpc/policy/addresses.rs
@@ -1,4 +1,4 @@
-use crate::rpc::pagination::PaginationParams;
+use crate::rpc::pagination::{PaginationParams, Sort};
 use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ pub struct AddressesParams {
     pub policy_id: u64,
     /// Determines what items should be yielded in the response.
     #[serde(flatten)]
-    pub params: PaginationParams<AddressesFilters>,
+    pub params: PaginationParams<AddressesFilters, Sort>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -6,6 +6,7 @@ mod eip7702_delegation;
 mod eth_call;
 mod liquidity;
 mod payment_lane;
+mod policy;
 mod pool;
 mod stablecoin_exchange;
 mod tip20;

--- a/crates/node/tests/it/policy.rs
+++ b/crates/node/tests/it/policy.rs
@@ -1,0 +1,360 @@
+use alloy::{
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
+    signers::local::MnemonicBuilder,
+};
+use std::env;
+use tempo_contracts::precompiles::ITIP403Registry;
+use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
+
+/// Test that pagination respects the limit parameter
+///
+/// Scenario: Add 5 addresses, request with limit=2
+/// Expected: Should return only 2 addresses and provide a nextCursor
+#[tokio::test(flavor = "multi_thread")]
+async fn test_policy_get_addresses_pagination_limit() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let source = if let Ok(rpc_url) = env::var("RPC_URL") {
+        crate::utils::NodeSource::ExternalRpc(rpc_url.parse()?)
+    } else {
+        crate::utils::NodeSource::LocalNode(include_str!("../assets/test-genesis.json").to_string())
+    };
+    let (http_url, _local_node) = crate::utils::setup_test_node(source).await?;
+
+    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+    let caller = wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(http_url.clone());
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider.clone());
+
+    // Create a whitelist policy
+    let admin = caller;
+    let policy_type = ITIP403Registry::PolicyType::WHITELIST;
+    let tx = registry.createPolicy(admin, policy_type).send().await?;
+    let receipt = tx.get_receipt().await?;
+    let policy_id = receipt.logs()[0]
+        .log_decode::<ITIP403Registry::PolicyCreated>()?
+        .inner
+        .data
+        .policyId;
+
+    // Add 5 addresses
+    for i in 1..=5 {
+        let addr = Address::from([i; 20]);
+        registry
+            .modifyPolicyWhitelist(policy_id, addr, true)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+    }
+
+    // Request with limit=2
+    let result: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "limit": 2,
+            })],
+        )
+        .await?;
+
+    let addresses = result["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+
+    // Should return exactly 2 addresses (respecting limit)
+    assert_eq!(
+        addresses.len(),
+        2,
+        "Should return only 2 addresses when limit=2. Got: {}",
+        addresses.len()
+    );
+
+    // Should have a nextCursor since there are more results
+    let next_cursor = result.get("nextCursor");
+    assert!(
+        next_cursor.is_some() && !next_cursor.unwrap().is_null(),
+        "Should return a nextCursor when more results are available. Got: {next_cursor:?}"
+    );
+
+    Ok(())
+}
+
+/// Test that cursor allows navigating to the next page
+///
+/// Scenario: Add 5 addresses, get first page (limit=2), use cursor to get next page
+/// Expected: Second page should return different addresses (the next 2)
+#[tokio::test(flavor = "multi_thread")]
+async fn test_policy_get_addresses_cursor_navigation() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let source = if let Ok(rpc_url) = env::var("RPC_URL") {
+        crate::utils::NodeSource::ExternalRpc(rpc_url.parse()?)
+    } else {
+        crate::utils::NodeSource::LocalNode(include_str!("../assets/test-genesis.json").to_string())
+    };
+    let (http_url, _local_node) = crate::utils::setup_test_node(source).await?;
+
+    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+    let caller = wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(http_url.clone());
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider.clone());
+
+    // Create a whitelist policy
+    let admin = caller;
+    let policy_type = ITIP403Registry::PolicyType::WHITELIST;
+    let tx = registry.createPolicy(admin, policy_type).send().await?;
+    let receipt = tx.get_receipt().await?;
+    let policy_id = receipt.logs()[0]
+        .log_decode::<ITIP403Registry::PolicyCreated>()?
+        .inner
+        .data
+        .policyId;
+
+    // Add 5 addresses
+    for i in 1..=5 {
+        let addr = Address::from([i; 20]);
+        registry
+            .modifyPolicyWhitelist(policy_id, addr, true)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+    }
+
+    // First page: limit=2
+    let page1: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "limit": 2,
+            })],
+        )
+        .await?;
+
+    let page1_addresses = page1["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+    assert_eq!(
+        page1_addresses.len(),
+        2,
+        "First page should have 2 addresses"
+    );
+
+    let cursor = page1["nextCursor"]
+        .as_str()
+        .expect("nextCursor should be present");
+
+    // Second page: use cursor
+    let page2: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "cursor": cursor,
+                "limit": 2,
+            })],
+        )
+        .await?;
+
+    let page2_addresses = page2["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+    assert_eq!(
+        page2_addresses.len(),
+        2,
+        "Second page should have 2 addresses"
+    );
+
+    // Pages should have different addresses
+    let page1_addr0 = page1_addresses[0]["address"].as_str().unwrap();
+    let page2_addr0 = page2_addresses[0]["address"].as_str().unwrap();
+    assert_ne!(
+        page1_addr0, page2_addr0,
+        "Second page should have different addresses than first page. Page1: {page1_addr0}, Page2: {page2_addr0}"
+    );
+
+    // Third page: should have 1 address
+    let cursor2 = page2["nextCursor"]
+        .as_str()
+        .expect("nextCursor should be present");
+    let page3: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "cursor": cursor2,
+                "limit": 2,
+            })],
+        )
+        .await?;
+
+    let page3_addresses = page3["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+    assert_eq!(
+        page3_addresses.len(),
+        1,
+        "Third page should have 1 address (last one)"
+    );
+
+    // Should be no more results
+    assert!(
+        page3["nextCursor"].is_null(),
+        "nextCursor should be null on last page"
+    );
+
+    Ok(())
+}
+
+/// Test that addresses can be sorted ascending and descending
+///
+/// Scenario: Add 3 addresses in random order
+/// Expected: Can retrieve them sorted asc or desc by address
+#[tokio::test(flavor = "multi_thread")]
+async fn test_policy_get_addresses_sorting() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let source = if let Ok(rpc_url) = env::var("RPC_URL") {
+        crate::utils::NodeSource::ExternalRpc(rpc_url.parse()?)
+    } else {
+        crate::utils::NodeSource::LocalNode(include_str!("../assets/test-genesis.json").to_string())
+    };
+    let (http_url, _local_node) = crate::utils::setup_test_node(source).await?;
+
+    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+    let caller = wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(http_url.clone());
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider.clone());
+
+    // Create a whitelist policy
+    let admin = caller;
+    let policy_type = ITIP403Registry::PolicyType::WHITELIST;
+    let tx = registry.createPolicy(admin, policy_type).send().await?;
+    let receipt = tx.get_receipt().await?;
+    let policy_id = receipt.logs()[0]
+        .log_decode::<ITIP403Registry::PolicyCreated>()?
+        .inner
+        .data
+        .policyId;
+
+    // Add addresses in non-sorted order (using sequential values like pagination test)
+    for i in [3u8, 1, 4, 2] {
+        let addr = Address::from([i; 20]);
+        registry
+            .modifyPolicyWhitelist(policy_id, addr, true)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+    }
+
+    // Get addresses sorted ascending
+    let result_asc: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "sort": {
+                    "on": "address",
+                    "order": "asc"
+                }
+            })],
+        )
+        .await?;
+
+    let addresses_asc = result_asc["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+
+    // We expect at least 2 addresses to test sorting
+    assert!(
+        addresses_asc.len() >= 2,
+        "Need at least 2 addresses to test sorting, got {}",
+        addresses_asc.len()
+    );
+
+    // Verify ascending order (check all consecutive pairs)
+    for i in 0..addresses_asc.len() - 1 {
+        let addr_i = addresses_asc[i]["address"].as_str().unwrap();
+        let addr_next = addresses_asc[i + 1]["address"].as_str().unwrap();
+        assert!(
+            addr_i < addr_next,
+            "Addresses should be sorted ascending: addr[{}]={} >= addr[{}]={}",
+            i,
+            addr_i,
+            i + 1,
+            addr_next
+        );
+    }
+
+    // Get addresses sorted descending
+    let result_desc: serde_json::Value = provider
+        .raw_request(
+            "policy_getAddresses".into(),
+            vec![serde_json::json!({
+                "policyId": policy_id,
+                "sort": {
+                    "on": "address",
+                    "order": "desc"
+                }
+            })],
+        )
+        .await?;
+
+    let addresses_desc = result_desc["addresses"]
+        .as_array()
+        .expect("addresses should be an array");
+    assert_eq!(
+        addresses_desc.len(),
+        addresses_asc.len(),
+        "Desc and asc should return same number of addresses"
+    );
+
+    // Verify descending order (check all consecutive pairs)
+    for i in 0..addresses_desc.len() - 1 {
+        let addr_i = addresses_desc[i]["address"].as_str().unwrap();
+        let addr_next = addresses_desc[i + 1]["address"].as_str().unwrap();
+        assert!(
+            addr_i > addr_next,
+            "Addresses should be sorted descending: addr[{}]={} <= addr[{}]={}",
+            i,
+            addr_i,
+            i + 1,
+            addr_next
+        );
+    }
+
+    // First in desc should equal last in asc, and vice versa
+    let addr_first_asc = addresses_asc[0]["address"].as_str().unwrap();
+    let addr_last_asc = addresses_asc[addresses_asc.len() - 1]["address"]
+        .as_str()
+        .unwrap();
+    let addr_first_desc = addresses_desc[0]["address"].as_str().unwrap();
+    let addr_last_desc = addresses_desc[addresses_desc.len() - 1]["address"]
+        .as_str()
+        .unwrap();
+
+    assert_eq!(
+        addr_first_desc, addr_last_asc,
+        "First in desc should be last in asc"
+    );
+    assert_eq!(
+        addr_last_desc, addr_first_asc,
+        "Last in desc should be first in asc"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
- added reusable `paginate()` helper function for cursor-based pagination
- added generic `Sort` and `SortOrder` types to `PaginationParams`
- implemented pagination and sorting for `policy_getAddresses`