### PR TITLE
ci: copy .git folder for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY bin/ ./bin/
 COPY crates/ ./crates/
 COPY xtask/ ./xtask/
+COPY .git/ ./git/
 
 ARG RUST_BINARY
 ARG RUST_PROFILE


### PR DESCRIPTION
idk if this is best solution but vergen pulls the sha from the git repo

and we want to know the sha in web3_clientVersion

closes #673