### PR TITLE
chore(test): just ensure it had more than 0 pipeline runs

### DIFF
--- a/crates/e2e/src/tests/backfill.rs
+++ b/crates/e2e/src/tests/backfill.rs
@@ -65,8 +65,8 @@ async fn run_validator_late_join_test(
             "at least one backfill must have been triggered"
         );
     } else {
-        assert!(
-            actual_runs == 0,
+        assert_eq!(
+            0, actual_runs,
             "Expected no backfill, got {actual_runs} runs"
         );
     }


### PR DESCRIPTION
Backfill might be triggered more than once if chain progresses fast or the node is slow during tests.

https://github.com/tempoxyz/tempo/actions/runs/19080423872/job/54507240269
> thread 'tests::backfill::validator_can_join_later_with_pipeline_sync' (50171) panicked at crates/e2e/src/tests/backfill.rs:62:5:
    Expected 1 backfill runs, got 2