### PR TITLE
test(consensus): set peer set from inside the application

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -3,6 +3,7 @@
 //! [`alto`]: https://github.com/commonwarexyx/alto
 
 use std::{
+    net::SocketAddr,
     num::{NonZeroU64, NonZeroUsize},
     time::Duration,
 };
@@ -22,7 +23,7 @@ use commonware_p2p::{Blocker, Receiver, Sender};
 use commonware_runtime::{
     Clock, Handle, Metrics, Network, Pacer, Spawner, Storage, buffer::PoolRef,
 };
-use commonware_utils::set::Ordered;
+use commonware_utils::set::{Ordered, OrderedAssociated};
 use eyre::WrapErr as _;
 use futures::future::try_join_all;
 use rand::{CryptoRng, Rng};
@@ -77,6 +78,8 @@ pub struct Builder<
     pub blocker: TBlocker,
     pub peer_manager: TPeerManager,
 
+    pub unresolved_peers: OrderedAssociated<PublicKey, String>,
+
     pub partition_prefix: String,
     pub signer: PrivateKey,
     pub polynomial: Poly<<MinSig as Variant>::Public>,
@@ -109,7 +112,10 @@ where
         + Storage
         + Metrics
         + Network,
-    TPeerManager: commonware_p2p::Manager<PublicKey = PublicKey>,
+    TPeerManager: commonware_p2p::Manager<
+            PublicKey = PublicKey,
+            Peers = OrderedAssociated<PublicKey, SocketAddr>,
+        >,
 {
     pub async fn try_init(self) -> eyre::Result<Engine<TBlocker, TContext, TPeerManager>> {
         let (broadcast, broadcast_mailbox) = buffered::Engine::new(
@@ -131,7 +137,7 @@ where
         // https://github.com/commonwarexyz/monorepo/commit/92870f39b4a9e64a28434b3729ebff5aba67fb4e
         let resolver_config = commonware_consensus::marshal::resolver::p2p::Config {
             public_key: self.signer.public_key(),
-            manager: self.peer_manager,
+            manager: self.peer_manager.clone(),
             mailbox_size: self.mailbox_size,
             requester_config: commonware_p2p::utils::requester::Config {
                 me: Some(self.signer.public_key()),
@@ -233,6 +239,8 @@ where
                 namespace: crate::config::NAMESPACE.to_vec(),
                 me: self.signer.clone(),
                 partition_prefix: format!("{}_dkg_manager", self.partition_prefix),
+                peer_manager: self.peer_manager.clone(),
+                unresolved_peers: self.unresolved_peers,
             },
         )
         .await;
@@ -283,7 +291,7 @@ where
     broadcast: buffered::Engine<TContext, PublicKey, Block>,
     broadcast_mailbox: buffered::Mailbox<PublicKey, Block>,
 
-    dkg_manager: dkg::manager::Actor<TContext>,
+    dkg_manager: dkg::manager::Actor<TContext, TPeerManager>,
     dkg_manager_mailbox: dkg::manager::Mailbox,
 
     /// The core of the application, the glue between commonware-xyz consensus and reth-execution.
@@ -314,7 +322,10 @@ where
         + Pacer
         + Spawner
         + Storage,
-    TPeerManager: commonware_p2p::Manager<PublicKey = PublicKey>,
+    TPeerManager: commonware_p2p::Manager<
+            PublicKey = PublicKey,
+            Peers = OrderedAssociated<PublicKey, SocketAddr>,
+        >,
 {
     #[expect(
         clippy::too_many_arguments,

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -13,15 +13,11 @@ pub mod metrics;
 
 pub mod subblocks;
 
-use std::net::SocketAddr;
-
 use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
-use commonware_p2p::{Manager as _, authenticated::lookup};
+use commonware_p2p::authenticated::lookup;
 use commonware_runtime::Metrics as _;
-use commonware_utils::set::OrderedAssociated;
 use eyre::{WrapErr as _, eyre};
 use tempo_node::TempoFullNode;
-use tracing::info;
 
 use crate::config::{
     BOUNDARY_CERT_CHANNEL_IDENT, BOUNDARY_CERT_LIMIT, BROADCASTER_CHANNEL_IDENT, BROADCASTER_LIMIT,
@@ -35,15 +31,15 @@ pub async fn run_consensus_stack(
     config: &tempo_commonware_node_config::Config,
     execution_node: TempoFullNode,
 ) -> eyre::Result<()> {
-    let (mut network, mut oracle) = instantiate_network(context, config)
+    let (mut network, oracle) = instantiate_network(context, config)
         .await
         .wrap_err("failed to start network")?;
 
-    let all_resolved_peers = resolve_all_peers(&config.peers)
-        .await
-        .wrap_err("failed resolving peers")?;
+    // let all_resolved_peers = resolve_all_peers(&config.peers)
+    //     .await
+    //     .wrap_err("failed resolving peers")?;
 
-    oracle.update(0, all_resolved_peers).await;
+    // oracle.update(0, all_resolved_peers).await;
 
     let message_backlog = config.message_backlog;
     let pending = network.register(PENDING_CHANNEL_IDENT, PENDING_LIMIT, message_backlog);
@@ -71,6 +67,14 @@ pub async fn run_consensus_stack(
         execution_node,
         blocker: oracle.clone(),
         peer_manager: oracle.clone(),
+
+        unresolved_peers: config
+            .peers
+            .iter()
+            .map(|(key, val)| (key.clone(), val.clone()))
+            .collect::<Vec<(_, _)>>()
+            .into(),
+
         // TODO: Set this through config?
         partition_prefix: "engine".into(),
         signer: config.signer.clone(),
@@ -146,38 +150,4 @@ async fn instantiate_network(
     };
 
     Ok(lookup::Network::new(context.with_label("network"), p2p_cfg))
-}
-
-async fn resolve_all_peers(
-    peers: impl IntoIterator<Item = (&PublicKey, &String)>,
-) -> eyre::Result<OrderedAssociated<PublicKey, SocketAddr>> {
-    use futures::stream::{FuturesOrdered, TryStreamExt as _};
-    let resolve_all = peers
-        .into_iter()
-        .map(|(peer, name)| async move {
-            // XXX: collecting every single result isn't exactly efficient, but
-            // we only do it once at startup, so w/e.
-            let addrs = tokio::net::lookup_host(name)
-                .await
-                .wrap_err_with(|| {
-                    format!("failed looking up IP of peer `{peer}` for DNS name `{name}`")
-                })?
-                .collect::<Vec<_>>();
-            info!(
-                %peer,
-                name,
-                potential_addresses = ?addrs,
-                "resolved DNS name to IPs; taking the first one"
-            );
-            let addr = addrs.first().ok_or_else(|| {
-                eyre!("peer `{peer}` with DNS name `{name}` resolved to zero addresses")
-            })?;
-            Ok::<_, eyre::Report>((peer.clone(), *addr))
-        })
-        .collect::<FuturesOrdered<_>>();
-    let resolved = resolve_all
-        .try_collect::<Vec<(_, _)>>()
-        .await
-        .wrap_err("failed resolving at least one peer")?;
-    Ok(resolved.into())
 }


### PR DESCRIPTION
This patch does not add any externally visible feature. It merely demonstrates that a peer set can be set from inside the application without needing to wire up the p2p network beforehand.

The main change this requires is to wrap the `commonware_p2p::simulated::Oracle` so that we can implement `commonware_p2p::Manager` with the same associated peers as is used by `commonware_p2p::authenticated::lookup::Oracle` (namely `OrderedAssociated<PublicKey, SocketAddress>` instead of `Ordered<PublicKey>`).

This is a prep work for dynamic validator sets.