### PR TITLE
fix: remove commented code

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -84,7 +84,7 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, chain_id: u64)
         } else if *address == TIP403_REGISTRY_ADDRESS {
             Some(TIP403RegistryPrecompile::create(chain_id))
         } else if *address == TIP4217_REGISTRY_ADDRESS {
-            Some(TIP4217RegistryPrecompile::create())
+            Some(TIP4217RegistryPrecompile::create(chain_id))
         } else if *address == TIP_FEE_MANAGER_ADDRESS {
             Some(TipFeeManagerPrecompile::create(chain_id))
         } else if *address == TIP_ACCOUNT_REGISTRAR {
@@ -145,8 +145,10 @@ impl TipAccountRegistrarPrecompile {
 
 pub struct TIP4217RegistryPrecompile;
 impl TIP4217RegistryPrecompile {
-    pub fn create() -> DynPrecompile {
-        tempo_precompile!("TIP4217Registry", |input| TIP4217Registry::default())
+    pub fn create(chain_id: u64) -> DynPrecompile {
+        tempo_precompile!("TIP4217Registry", |input| TIP4217Registry::new(
+            &mut EvmPrecompileStorageProvider::new(input.internals, input.gas, chain_id)
+        ))
     }
 }
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -102,7 +102,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
 
     pub fn decimals(&mut self) -> Result<u8, TempoPrecompileError> {
         let currency = self.currency()?;
-        Ok(TIP4217Registry::default()
+        Ok(TIP4217Registry::new(self.storage)
             .get_currency_decimals(ITIP4217Registry::getCurrencyDecimalsCall { currency }))
     }
 

--- a/crates/precompiles/src/tip4217_registry/dispatch.rs
+++ b/crates/precompiles/src/tip4217_registry/dispatch.rs
@@ -1,14 +1,14 @@
-use crate::{Precompile, view};
+use crate::{Precompile, input_cost, storage::PrecompileStorageProvider, view};
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::{PrecompileError, PrecompileResult};
 
 use crate::tip4217_registry::{ITIP4217Registry, TIP4217Registry};
 
-impl Precompile for TIP4217Registry {
+impl<'a, S: PrecompileStorageProvider> Precompile for TIP4217Registry<'a, S> {
     fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
-        // self.storage
-        //     .deduct_gas(input_cost(calldata.len()))
-        //     .map_err(|_| PrecompileError::OutOfGas)?;
+        self.storage
+            .deduct_gas(input_cost(calldata.len()))
+            .map_err(|_| PrecompileError::OutOfGas)?;
 
         let selector: [u8; 4] = calldata
             .get(..4)
@@ -18,7 +18,7 @@ impl Precompile for TIP4217Registry {
             .try_into()
             .unwrap();
 
-        match selector {
+        let result = match selector {
             ITIP4217Registry::getCurrencyDecimalsCall::SELECTOR => {
                 view::<ITIP4217Registry::getCurrencyDecimalsCall>(calldata, |call| {
                     Ok(self.get_currency_decimals(call))
@@ -27,6 +27,11 @@ impl Precompile for TIP4217Registry {
             _ => Err(PrecompileError::Other(
                 "Unknown function selector".to_string(),
             )),
-        }
+        };
+
+        result.map(|mut res| {
+            res.gas_used = self.storage.gas_remaining();
+            res
+        })
     }
 }


### PR DESCRIPTION
propagates precompile storage to `TIP4217Registry` and correctly accounts for the input cost