### PR TITLE
fix: missing rpc / abi generation for `TIP20_REWARDS_REGISTRY` and `VALIDATOR_CONFIG` precompiles

### DIFF
--- a/crates/contracts/src/precompiles/tip20_rewards_registry.rs
+++ b/crates/contracts/src/precompiles/tip20_rewards_registry.rs
@@ -3,6 +3,7 @@ use alloy::sol;
 
 sol! {
     #[derive(Debug, PartialEq, Eq)]
+    #[sol(rpc, abi)]
     interface ITIP20RewardsRegistry {
         /// Finalize streams for all tokens ending at the current timestamp
         function finalizeStreams() external;

--- a/crates/contracts/src/precompiles/validator_config.rs
+++ b/crates/contracts/src/precompiles/validator_config.rs
@@ -9,7 +9,7 @@ sol! {
     /// Validators can update their own information, rotate their identity to a new address,
     /// and the owner can manage validator status.
     #[derive(Debug, PartialEq, Eq)]
-    #[sol(rpc)]
+    #[sol(rpc, abi)]
     interface IValidatorConfig {
         /// Validator information
         struct Validator {


### PR DESCRIPTION
This is required for Foundry