### PR TITLE
fix(consensus): backfill correct height to execution layer

### DIFF
--- a/crates/commonware-node/src/consensus/application/executor.rs
+++ b/crates/commonware-node/src/consensus/application/executor.rs
@@ -239,7 +239,7 @@ where
             );
             self.backfill(
                 latest_execution_block_number.saturating_add(1),
-                latest_execution_block_number,
+                finalized_consensus_height,
             )
             .await
             .wrap_err(


### PR DESCRIPTION
On startup, backfills the correct range from `on_execution + 1` to `on_consensus`. Before it was `on_execution+1` to `on_execution`, which is clearly wrong.