### PR TITLE
fix(consensus): ensure that finalized is always the forkchoice floor

### DIFF
--- a/crates/commonware-node/src/consensus/application/executor.rs
+++ b/crates/commonware-node/src/consensus/application/executor.rs
@@ -107,7 +107,11 @@ impl LastCanonicalized {
             this.forkchoice.safe_block_hash = hash;
             this.forkchoice.finalized_block_hash = hash;
         }
-        this.update_head(height, hash)
+        if height >= this.head_height {
+            this.head_height = height;
+            this.forkchoice.head_block_hash = hash;
+        }
+        this
     }
 
     /// Updates the head height and head block hash to `height` and `hash`.


### PR DESCRIPTION
This patch ensures that for cases `finalized >= head` we actually update the head.

The previous condition inadvertantly skipped this, so we'd end up sending `finalized = n` and `head = 0`.