### PR TITLE
chore!: clean up unused Permit struct / permit / DOMAIN_SEPARATOR in TIP20 interface definition

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -70,19 +70,6 @@ sol! {
         function updateQuoteToken(address newQuoteToken) external;
         function finalizeQuoteTokenUpdate() external;
 
-        // EIP-712 Permit
-        struct Permit {
-            address owner;
-            address spender;
-            uint256 value;
-            uint256 nonce;
-            uint256 deadline;
-        }
-        function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
-        function DOMAIN_SEPARATOR() external view returns (bytes32);
-
-
-
         struct RewardStream {
             address funder;
             uint64 startTime;


### PR DESCRIPTION
Per: https://github.com/tempoxyz/docs/pull/130