### PR TITLE
fix: skip fee token validity for eth_calls without fees

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -102,7 +102,9 @@ impl<DB: alloy_evm::Database, I> TempoEvmHandler<DB, I> {
         evm: &mut TempoEvm<DB, I>,
     ) -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
         self.fee_token = get_fee_token(evm.ctx_mut())?;
-        if !evm.ctx.tx.max_balance_spending()?.is_zero() {
+
+        // Skip fee token validity check for cases when the transaction is free and is not a part of subblock.
+        if !evm.ctx.tx.max_balance_spending()?.is_zero() || evm.ctx.tx.is_subblock_transaction() {
             validate_fee_token(evm.ctx_mut(), self.fee_token)?;
         }
         self.fee_payer = evm.ctx().tx().fee_payer()?;

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -74,6 +74,13 @@ impl TempoTxEnv {
             Ok(self.caller())
         }
     }
+
+    /// Returns true if the transaction is a subblock transaction.
+    pub fn is_subblock_transaction(&self) -> bool {
+        self.aa_tx_env
+            .as_ref()
+            .is_some_and(|aa| aa.subblock_transaction)
+    }
 }
 
 impl From<TxEnv> for TempoTxEnv {


### PR DESCRIPTION
Skips validating a fee token if `TempoTxEnv` has zero fees and is not a part of subblock.

Idea is that basic `eth_call`s should not be affected by the fee token validation