### PR TITLE
chore: rm consts from tip fee manager

### DIFF
--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -25,10 +25,6 @@ sol! {
             bool hasBeenSet;
         }
 
-        // Constants
-        function BASIS_POINTS() external pure returns (uint256);
-        function FEE_BPS() external pure returns (uint256);
-
         // User preferences
         function userTokens(address user) external view returns (address);
         function validatorTokens(address validator) external view returns (address);


### PR DESCRIPTION
these dont exist

https://github.com/tempoxyz/docs/blob/d73975cc8d72a274f69661d7183395b4061d2b1a/specs/src/FeeManager.sol

https://github.com/tempoxyz/docs/blob/d73975cc8d72a274f69661d7183395b4061d2b1a/specs/src/FeeAMM.sol

and are constants anyway

ref https://github.com/tempoxyz/tempo/pull/727