### PR TITLE
chore!(contracts): remove `delegationMessage()` from TIPAccountRegistrar interface

### DIFF
--- a/crates/contracts/src/precompiles/tip_account_registrar.rs
+++ b/crates/contracts/src/precompiles/tip_account_registrar.rs
@@ -6,7 +6,6 @@ sol! {
     #[sol(rpc, abi)]
     interface ITipAccountRegistrar {
         function delegateToDefault(bytes32 hash, bytes calldata signature) external returns (address authority);
-        function getDelegationMessage() external pure returns (string memory);
 
         // Errors
         error InvalidSignature();


### PR DESCRIPTION
Ref #727 

This PR removes the `delegationMessage()` from the `TIPAccountRegsitrar` interface.

The [spec mentions](https://github.com/tempoxyz/docs/blob/d73975cc8d72a274f69661d7183395b4061d2b1a/pages/protocol/accounts.mdx#2-defaultaccountregistrar-precompile) that any 32 bytes string can be used as a message when signing a delegation. This change removes the `delegationMessage()` to reflect this.


