### PR TITLE
fix!(precompiles): update `TIP20` interface to pass `timestamp` to `finalizeStreams`

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -105,7 +105,7 @@ sol! {
         function setRewardRecipient(address recipient) external;
         function cancelReward(uint64 id) external returns (uint256);
         function claimRewards() external returns (uint256);
-        function finalizeStreams() external;
+        function finalizeStreams(uint64 timestamp) external;
         function getStream(uint64 id) external view returns (RewardStream memory);
         function totalRewardPerSecond() external view returns (uint256);
         function optedInSupply() external view returns (uint128);

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -166,9 +166,8 @@ impl<'a, S: PrecompileStorageProvider> Precompile for TIP20Token<'a, S> {
             }
 
             ITIP20::finalizeStreamsCall::SELECTOR => {
-                mutate_void::<ITIP20::finalizeStreamsCall>(calldata, msg_sender, |sender, _call| {
-                    let current_time = self.storage.timestamp().to::<u128>();
-                    self.finalize_streams(sender, current_time)
+                mutate_void::<ITIP20::finalizeStreamsCall>(calldata, msg_sender, |sender, call| {
+                    self.finalize_streams(sender, call.timestamp as u128)
                 })
             }
 


### PR DESCRIPTION
This PR updates the `TIP20` interface to specify the `timestamp` when calling `finalizeStreams`.