### PR TITLE
deps: bump reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e7f93a60ef3d867c93d43442ef3f2d8a1095450131c3d4e16bbbbf2166b9bd"
+checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -7318,8 +7318,8 @@ checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
 name = "reth"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7364,8 +7364,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7388,8 +7388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7419,8 +7419,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7439,8 +7439,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7453,8 +7453,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7534,8 +7534,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7544,8 +7544,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7562,8 +7562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7582,8 +7582,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7592,8 +7592,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7607,8 +7607,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7620,8 +7620,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7632,8 +7632,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7658,8 +7658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7684,8 +7684,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7712,8 +7712,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7742,8 +7742,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7757,8 +7757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7782,8 +7782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7806,8 +7806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7830,8 +7830,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7865,8 +7865,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7923,8 +7923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7954,8 +7954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7976,8 +7976,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8001,8 +8001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "futures",
  "pin-project",
@@ -8023,8 +8023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8078,8 +8078,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8106,8 +8106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8122,8 +8122,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8137,8 +8137,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8159,8 +8159,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8170,8 +8170,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8199,8 +8199,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8223,8 +8223,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8264,8 +8264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "clap",
  "eyre",
@@ -8288,8 +8288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8304,8 +8304,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8322,8 +8322,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8336,8 +8336,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8365,8 +8365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8385,8 +8385,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8395,8 +8395,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8418,8 +8418,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8440,8 +8440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8453,8 +8453,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8471,8 +8471,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8509,8 +8509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8523,8 +8523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "serde",
  "serde_json",
@@ -8533,8 +8533,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8561,8 +8561,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "bytes",
  "futures",
@@ -8581,8 +8581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8597,8 +8597,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8606,8 +8606,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "futures",
  "metrics",
@@ -8618,16 +8618,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8640,8 +8640,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8695,8 +8695,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8720,8 +8720,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,8 +8743,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8758,8 +8758,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8772,8 +8772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -8789,8 +8789,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8813,8 +8813,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8881,8 +8881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8933,8 +8933,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8971,8 +8971,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8995,8 +8995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9019,8 +9019,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "eyre",
  "http",
@@ -9041,8 +9041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9053,8 +9053,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9073,8 +9073,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9094,8 +9094,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9106,8 +9106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9126,8 +9126,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9136,8 +9136,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9149,8 +9149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9182,8 +9182,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9226,8 +9226,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9252,8 +9252,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9267,8 +9267,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9286,8 +9286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9313,8 +9313,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9326,8 +9326,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9405,8 +9405,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9433,8 +9433,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9472,8 +9472,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -9493,8 +9493,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9523,8 +9523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9567,8 +9567,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9614,8 +9614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9628,8 +9628,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9644,8 +9644,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9692,8 +9692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9719,8 +9719,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9733,8 +9733,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9753,8 +9753,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9765,8 +9765,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9784,12 +9784,13 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm-database",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9804,8 +9805,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9822,8 +9823,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9838,8 +9839,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9848,8 +9849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "clap",
  "eyre",
@@ -9865,8 +9866,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "clap",
  "eyre",
@@ -9882,8 +9883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9923,8 +9924,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9948,8 +9949,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9975,8 +9976,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9988,8 +9989,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10013,8 +10014,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10032,8 +10033,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10050,8 +10051,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.4"
-source = "git+https://github.com/paradigmxyz/reth?rev=1cd5b50#1cd5b50aaf77de6ebe1d65cd7d4fd1939f45635b"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=99fe175#99fe17582343828b5b1b8e346a11c0a8c83196aa"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,60 +113,60 @@ tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175" }
 
 alloy-network = { version = "1.0.41" }
 alloy-rpc-types-eth = { version = "1.0.41" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1cd5b50", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "99fe175", features = [
   "std",
   "optional-checks",
 ] }
@@ -177,7 +177,7 @@ alloy-evm = "0.23.0"
 alloy-consensus = "1.0.41"
 alloy-eips = "1.0.41"
 alloy-genesis = "1.0.41"
-alloy-hardforks = "0.4.3"
+alloy-hardforks = "0.4.4"
 alloy-primitives = "1.4.1"
 alloy-provider = { version = "1.0.41", default-features = false }
 alloy-sol-types = "1.4.1"


### PR DESCRIPTION
Bump Reth to https://github.com/paradigmxyz/reth/commit/99fe17582343828b5b1b8e346a11c0a8c83196aa to get new Engine metrics.

Not bumping to latest main, because it includes a bunch of static file changes that we want to test more before using.