### PR TITLE
test: adjust P256 batch test funding to match regenerated genesis balances

### DIFF
--- a/crates/node/tests/it/account_abstraction.rs
+++ b/crates/node/tests/it/account_abstraction.rs
@@ -1239,7 +1239,7 @@ async fn test_aa_p256_call_batching() -> eyre::Result<()> {
 
     reth_tracing::init_test_tracing();
 
-    let initial_funding_amount = U256::from(100u64) * U256::from(10).pow(U256::from(18)); // 100 tokens with 18 decimals
+    let initial_funding_amount = U256::from(20u64) * U256::from(10).pow(U256::from(18)); // 20 tokens with 18 decimals
     let (
         mut setup,
         provider,


### PR DESCRIPTION
Fixes `test_aa_p256_call_batching` by reducing funding amount from 100 to 20 tokens to match the regenerated genesis file balances from #764.

The regenerated genesis version allocates ~37 tokens per account. 20 tokens is sufficient for the batch transfers (15 total) plus gas fees.
