### PR TITLE
fix(transaction-pool): enable serde and reth-codec features in primitives dep

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 tempo-precompiles = { workspace = true, features = ["reth"] }
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["serde", "reth-codec"] }
 
 reth-transaction-pool.workspace = true
 reth-chainspec.workspace = true


### PR DESCRIPTION
This PR adds `features = ["serde", "reth-codec"]` to the `tempo-primitives` dependency of `transaction-pool`.

Tests were failing like:

```
$ cargo test --package tempo-transaction-pool --lib test_validate_fee_token_liquidity_with_liquidity -- --nocapture
   Compiling tempo-primitives v0.2.0 (/home/home-link/workspace/paradigm/tempo/crates/primitives)
error[E0277]: the trait bound `TempoTxEnvelope: serde::Deserialize<'de>` is not satisfied
   --> crates/primitives/src/transaction/envelope.rs:297:52
    |
297 | impl reth_primitives_traits::SignedTransaction for TempoTxEnvelope {}
    |                                                    ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
help: the trait `for<'de> Deserialize<'de>` is not implemented for `TempoTxEnvelope`
   --> crates/primitives/src/transaction/envelope.rs:36:1
    |
 36 | pub enum TempoTxEnvelope {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `TempoTxEnvelope` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Deserialize<'de>`:
              `&'a Path` implements `Deserialize<'de>`
              `&'a [u8]` implements `Deserialize<'de>`
              `&'a serde_json::raw::RawValue` implements `Deserialize<'de>`
              `&'a str` implements `Deserialize<'de>`
              `&'de bitvec::slice::BitSlice<u8, O>` implements `Deserialize<'de>`
              `()` implements `Deserialize<'de>`
              `(T,)` implements `Deserialize<'de>`
              `(T0, T1)` implements `Deserialize<'de>`
            and 526 others
    = note: required for `TempoTxEnvelope` to implement `MaybeSerde`
note: required by a bound in `SignedTransaction`
   --> /home/home-link/.cargo/git/checkouts/reth-e231042ee7db3fb7/99fe175/crates/primitives-traits/src/transaction/signed.rs:45:7
    |
 31 | pub trait SignedTransaction:
    |           ----------------- required by a bound in this trait
...
 45 |     + MaybeSerde
    |       ^^^^^^^^^^ required by this bound in `SignedTransaction`

error[E0277]: the trait bound `TempoTxEnvelope: serde::Serialize` is not satisfied
   --> crates/primitives/src/transaction/envelope.rs:297:52
    |
297 | impl reth_primitives_traits::SignedTransaction for TempoTxEnvelope {}
    |                                                    ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
help: the trait `Serialize` is not implemented for `TempoTxEnvelope`
   --> crates/primitives/src/transaction/envelope.rs:36:1
    |
 36 | pub enum TempoTxEnvelope {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for local types consider adding `#[derive(serde::Serialize)]` to your `TempoTxEnvelope` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
            and 524 others
    = note: required for `TempoTxEnvelope` to implement `MaybeSerde`
note: required by a bound in `SignedTransaction`
   --> /home/home-link/.cargo/git/checkouts/reth-e231042ee7db3fb7/99fe175/crates/primitives-traits/src/transaction/signed.rs:45:7
    |
 31 | pub trait SignedTransaction:
    |           ----------------- required by a bound in this trait
...
 45 |     + MaybeSerde
    |       ^^^^^^^^^^ required by this bound in `SignedTransaction`

............................

```
