### PR TITLE
fix(genesis): add missing AlphaUSD-LinkingUSD liquidity pool and fix token order

### DIFF
--- a/xtask/src/genesis.rs
+++ b/xtask/src/genesis.rs
@@ -587,8 +587,8 @@ fn mint_pairwise_liquidity(
             .mint(
                 admin,
                 ITIPFeeAMM::mintCall {
-                    validatorToken: a_token,
-                    userToken: b_token_address,
+                    userToken: a_token,
+                    validatorToken: b_token_address,
                     amountUserToken: amount,
                     amountValidatorToken: amount,
                     to: admin,


### PR DESCRIPTION
Fixes two issues in genesis FeeAMM pool creation:

- missing AlphaUSD-LinkingUSD liquidity pool - without this, users with the default token (AlphaUSD) cannot pay fees to validators (who use LinkingUSD)

- incorrect token parameter order - pools were created with swapped userToken/validatorToken parameters, causing the pools to have backwards directionality (validatorToken -> userToken instead of userToken -> validatorToken)