### PR TITLE
docs(tempo-alloy): add some crate docs

### DIFF
--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,4 +1,35 @@
 //! Tempo types for Alloy.
+//!
+//! # Getting Started
+//!
+//! To use `tempo-alloy`, add the crate as a dependency in your `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+//! ```
+//!
+//! # Development Status
+//!
+//! `tempo-alloy` is currently in development and is not yet ready for production use.
+//!
+//! # Usage
+//!
+//! To get started, instantiate a provider with [`TempoNetwork`]:
+//!
+//! ```rust
+//! use alloy::{
+//!     providers::{Provider, ProviderBuilder},
+//!     transports::TransportError
+//! };
+//! use tempo_alloy::TempoNetwork;
+//!
+//! async fn build_provider() -> Result<impl Provider<TempoNetwork>, TransportError> {
+//!     ProviderBuilder::new_with_network::<TempoNetwork>()
+//!         .connect("https://rpc.testnet.tempo.xyz")
+//!         .await
+//! }
+//! ```
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/alloy/src/rpc/mod.rs
+++ b/crates/alloy/src/rpc/mod.rs
@@ -1,3 +1,5 @@
+//! Tempo RPC types.
+
 mod header;
 pub use header::TempoHeaderResponse;
 


### PR DESCRIPTION
Adds some basic crate level docs for `tempo-alloy`.

<img width="1274" height="1341" alt="image" src="https://github.com/user-attachments/assets/4ee2e4a2-01e7-45f2-b0d0-3402e49603ab" />
