### PR TITLE
fix: validate system transactions fields

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -207,12 +207,7 @@ impl Consensus<Block> for TempoConsensus {
         let transactions = &block.body().transactions;
 
         if let Some(tx) = transactions.iter().find(|&tx| {
-            tx.is_system_tx()
-                && (tx.max_fee_per_gas() != 0
-                    || tx.gas_limit() != 0
-                    || !tx.value().is_zero()
-                    || tx.chain_id() != Some(self.inner.chain_spec().chain().id())
-                    || tx.nonce() != 0)
+            tx.is_system_tx() && !tx.is_valid_system_tx(self.inner.chain_spec().chain().id())
         }) {
             return Err(ConsensusError::Other(format!(
                 "Invalid system transaction: {}",

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -2,7 +2,7 @@ use crate::subblock::PartialValidatorKey;
 
 use super::{aa_signed::AASigned, fee_token::TxFeeToken};
 use alloy_consensus::{
-    EthereumTxEnvelope, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy, TxType,
+    EthereumTxEnvelope, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, TxType,
     TypedTransaction,
     error::{UnsupportedTransactionType, ValueError},
 };
@@ -162,6 +162,15 @@ impl TempoTxEnvelope {
     /// Returns true if this is a Tempo system transaction
     pub fn is_system_tx(&self) -> bool {
         matches!(self, Self::Legacy(tx) if tx.signature() == &TEMPO_SYSTEM_TX_SIGNATURE)
+    }
+
+    /// Returns true if this is a valid Tempo system transaction, i.e all gas fields and nonce are zero.
+    pub fn is_valid_system_tx(&self, chain_id: u64) -> bool {
+        self.max_fee_per_gas() == 0
+            && self.gas_limit() == 0
+            && self.value().is_zero()
+            && self.chain_id() == Some(chain_id)
+            && self.nonce() == 0
     }
 
     /// Classify a transaction as payment or non-payment.


### PR DESCRIPTION
Enforces that system transactions have zero values for `gas_limit`, `gas_price`, `value` and `nonce` fields, and correct `chain_id` set.

This shouldn't really be important and can be set to any values by block builder but enforcing it doesn't hurt