### PR TITLE
ci: add snapshot re-execution workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Download snapshot
         run: cargo run --release --bin tempo download --datadir snap-rexec
       - name: Re-execute snapshot
-        run: cargo run --release --bin tempo re-execute --datadir snap-rexec/data
+        run: cargo run --release --bin tempo re-execute --datadir snap-rexec/data/tempo
 
   test-success:
     name: test success


### PR DESCRIPTION
Adds a new CI job that downloads a snapshot using `tempo download` and then re-executes it using `tempo re-execute` to verify historical sync correctness.


re-execute is still quite fast, but maybe this should run in --release and only mandatory for the mergify backports