### PR TITLE
fix!(stablecoin-exchange): validate base token is TIP20 in createPair

### DIFF
--- a/crates/contracts/src/precompiles/stablecoin_exchange.rs
+++ b/crates/contracts/src/precompiles/stablecoin_exchange.rs
@@ -105,6 +105,7 @@ sol! {
         error InsufficientOutput();
         error MaxInputExceeded();
         error BelowMinimumOrderSize(uint128 amount);
+        error InvalidBaseToken();
     }
 }
 
@@ -172,5 +173,10 @@ impl StablecoinExchangeError {
     /// Creates an error for order amount below minimum.
     pub const fn below_minimum_order_size(amount: u128) -> Self {
         Self::BelowMinimumOrderSize(IStablecoinExchange::BelowMinimumOrderSize { amount })
+    }
+
+    /// Creates an error for invalid base token.
+    pub const fn invalid_base_token() -> Self {
+        Self::InvalidBaseToken(IStablecoinExchange::InvalidBaseToken {})
     }
 }

--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -140,7 +140,6 @@ sol! {
         error ContractPaused();
         error InvalidCurrency();
         error InvalidQuoteToken();
-        error InvalidBaseToken();
         error TransfersDisabled();
         error InvalidAmount();
         error NotStreamFunder();
@@ -196,11 +195,6 @@ impl TIP20Error {
     /// Creates an error for invalid quote token.
     pub const fn invalid_quote_token() -> Self {
         Self::InvalidQuoteToken(ITIP20::InvalidQuoteToken {})
-    }
-
-    /// Creates an error for invalid base token.
-    pub const fn invalid_base_token() -> Self {
-        Self::InvalidBaseToken(ITIP20::InvalidBaseToken {})
     }
 
     /// Creates an error when string parameter exceeds maximum length.

--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     linking_usd::LinkingUSD,
     stablecoin_exchange::orderbook::compute_book_key,
     storage::{PrecompileStorageProvider, Slot, Storable, VecSlotExt},
-    tip20::{ITIP20, TIP20Error, TIP20Token, is_tip20, validate_usd_currency},
+    tip20::{ITIP20, TIP20Token, is_tip20, validate_usd_currency},
 };
 use alloy::primitives::{Address, B256, Bytes, IntoLogData, U256};
 use revm::state::Bytecode;
@@ -338,7 +338,7 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
     pub fn create_pair(&mut self, base: Address) -> Result<B256> {
         // Validate that base is a TIP20 token (only after Moderato hardfork)
         if self.storage.spec() >= TempoHardfork::Moderato && !is_tip20(base) {
-            return Err(TIP20Error::invalid_base_token().into());
+            return Err(StablecoinExchangeError::invalid_base_token().into());
         }
 
         let quote = TIP20Token::from_address(base, self.storage).quote_token()?;
@@ -3316,7 +3316,9 @@ mod tests {
         let result = exchange.create_pair(non_tip20_address);
         assert!(matches!(
             result,
-            Err(TempoPrecompileError::TIP20(TIP20Error::InvalidBaseToken(_)))
+            Err(TempoPrecompileError::StablecoinExchange(
+                StablecoinExchangeError::InvalidBaseToken(_)
+            ))
         ));
 
         Ok(())


### PR DESCRIPTION
from https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1762839136406689

```
https://github.com/tempoxyz/docs/blob/a4a5b5bf9c0b296b9d7b54b12ec2688bf1930c9b/specs/src/StablecoinExchange.sol#L155-L163
https://github.com/tempoxyz/tempo/blob/13a3f1f6826b6490caa7099ea06450a4d9997541/crates/precompiles/src/stablecoin_exchange/mod.rs#L337-L342
this should validate that the base token is a tip20
```

breaking, changes error message and gas consumption in receipt