### PR TITLE
fix!: correct off-by-one in TIP20Factory quote token validation, gate behind Moderato

### DIFF
--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -57,14 +57,23 @@ impl<'a, S: PrecompileStorageProvider> TIP20Factory<'a, S> {
 
         trace!(%sender, %token_id, ?call, "Create token");
 
-        // Ensure that the quote token is a valid TIP20 that is currently deployed (only after Moderato hardfork).
-        // Note that the token Id increments on each deployment which ensures that the quote
-        // token id must always be < the current token_id (strictly less than, not less than or equal).
-        if self.storage.spec() >= TempoHardfork::Moderato
-            && (!is_tip20(call.quoteToken)
-                || address_to_token_id_unchecked(call.quoteToken) >= token_id)
-        {
-            return Err(TIP20Error::invalid_quote_token().into());
+        // Ensure that the quote token is a valid TIP20 that is currently deployed.
+        // Note that the token Id increments on each deployment.
+        if self.storage.spec() >= TempoHardfork::Moderato {
+            // Post-Moderato: Fixed validation - quote token id must be < current token_id (strictly less than).
+            if !is_tip20(call.quoteToken)
+                || address_to_token_id_unchecked(call.quoteToken) >= token_id
+            {
+                return Err(TIP20Error::invalid_quote_token().into());
+            }
+        } else {
+            // Pre-Moderato: Original validation with off-by-one bug for consensus compatibility.
+            // The buggy check allowed quote_token_id == token_id to pass.
+            if !is_tip20(call.quoteToken)
+                || address_to_token_id_unchecked(call.quoteToken) > token_id
+            {
+                return Err(TIP20Error::invalid_quote_token().into());
+            }
         }
 
         TIP20Token::new(token_id, self.storage).initialize(
@@ -266,6 +275,50 @@ mod tests {
     }
 
     #[test]
+    fn test_create_token_future_quote_token_pre_moderato() {
+        // Test that pre-Moderato SHOULD still validate that quote tokens exist
+        // Using a TIP20 address with ID > current token_id should fail (not yet created)
+        let mut storage = HashMapStorageProvider::new(1).with_spec(TempoHardfork::Adagio);
+        let sender = Address::random();
+        initialize_linking_usd(&mut storage, sender).unwrap();
+
+        let mut factory = TIP20Factory::new(&mut storage);
+        factory
+            .initialize()
+            .expect("Factory initialization should succeed");
+
+        // Current token_id should be 1
+        assert_eq!(factory.token_id_counter().unwrap(), U256::from(1));
+
+        // Try to use token ID 5 as quote token (doesn't exist yet)
+        // This should fail factory validation even pre-Moderato
+        let future_quote_token = token_id_to_address(5);
+        let call = ITIP20Factory::createTokenCall {
+            name: "Test Token".to_string(),
+            symbol: "TEST".to_string(),
+            currency: "EUR".to_string(), // Use non-USD to avoid TIP20Token::initialize validation
+            quoteToken: future_quote_token,
+            admin: sender,
+        };
+
+        let result = factory.create_token(sender, call);
+
+        // This should fail with InvalidQuoteToken from factory validation
+        // Currently this test will PASS (not fail) because factory validation is skipped pre-Moderato
+        assert!(
+            result.is_err(),
+            "Should fail when using a not-yet-created token as quote token"
+        );
+        if let Err(e) = result {
+            assert_eq!(
+                e,
+                TempoPrecompileError::TIP20(TIP20Error::invalid_quote_token()),
+                "Should fail with InvalidQuoteToken from factory validation"
+            );
+        }
+    }
+
+    #[test]
     fn test_create_token_off_by_one_allowed_pre_moderato() {
         // Test the off-by-one bug: using token_id as quote token is allowed pre-Moderato (buggy behavior)
         let mut storage = HashMapStorageProvider::new(1).with_spec(TempoHardfork::Adagio);
@@ -282,7 +335,7 @@ mod tests {
         assert_eq!(current_token_id, U256::from(1));
 
         // Try to use token_id 1 (the token being created) as the quote token
-        // Pre-Moderato, the off-by-one bug allows this to pass the validation check
+        // Pre-Moderato, the old buggy validation (> instead of >=) allows this to pass
         let same_id_quote_token = token_id_to_address(1);
         let call = ITIP20Factory::createTokenCall {
             name: "Test Token".to_string(),
@@ -294,22 +347,21 @@ mod tests {
 
         let result = factory.create_token(sender, call);
 
-        // Pre-Moderato: the validation is skipped, so the operation may succeed or fail
-        // with a different error. The key is that it should NOT fail with InvalidQuoteToken
-        // from the validation check we're gating behind Moderato.
+        // Pre-Moderato: the old buggy validation (> token_id) allows quote_token_id == token_id
+        // The operation may succeed or fail with a different error later, but it should NOT
+        // fail with InvalidQuoteToken from validation
         match result {
             Ok(_) => {
-                // Operation succeeded due to buggy pre-Moderato behavior
-                // This is allowed (though incorrect) in pre-Moderato
+                // Operation succeeded - the buggy validation allowed it through
             }
             Err(e) => {
-                // If it fails, it should NOT be due to the InvalidQuoteToken validation
+                // If it fails, it should NOT be due to InvalidQuoteToken validation
                 assert!(
                     !matches!(
                         e,
                         TempoPrecompileError::TIP20(TIP20Error::InvalidQuoteToken(_))
                     ),
-                    "Pre-Moderato should not reject with InvalidQuoteToken from validation"
+                    "Pre-Moderato should not reject with InvalidQuoteToken when quote_token_id == token_id (buggy > logic)"
                 );
             }
         }


### PR DESCRIPTION
from https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1762839136406689

```
no changes needed in tempo, we already have https://github.com/tempoxyz/tempo/blob/main/crates/precompiles/src/tip20_factory/mod.rs#L62
this conditional is off-by-one, token_id is the id of the to be deployed token, so it should be >=
```