### PR TITLE
fix!(stablecoin-exchange): check maxIn/maxOut only on final swap amount

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -828,11 +828,6 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
             }
         }
 
-        // Post-Moderato: Check maxIn only on final amount after all orders filled
-        if self.storage.spec() >= TempoHardfork::Moderato && total_amount_in > max_amount_in {
-            return Err(StablecoinExchangeError::max_input_exceeded().into());
-        }
-
         Ok(total_amount_in)
     }
 
@@ -874,7 +869,8 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
             }
         }
 
-        if total_amount_out < min_amount_out {
+        // Pre-Moderato: Check min out after filling the full amount in
+        if self.storage.spec() < TempoHardfork::Moderato && total_amount_out < min_amount_out {
             return Err(StablecoinExchangeError::insufficient_output().into());
         }
 


### PR DESCRIPTION
from https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1762896791409559

```
if the swap is completely filled using the last order in the tick, the tick wont be advanced, and the next time a swap happens, _fillOrder(0, 0) will be called which emits confusing events and could potentially corrupt state if there was ever a book with bytes32(0)
in the spec we pass maxAmountIn/minAmountOut into the per-pair swap function and check the intermediate swaps against that limit, but it should only matter if the final input/output met the threshold, right?
```

only fixed `fill_orders_exact_out`, `fill_orders_exact_in` is already correct (only has final min_amount_out check)