### PR TITLE
refactor(chainspec): add is_moderato() helper method

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -33,6 +33,13 @@ hardfork!(
     }
 );
 
+impl TempoHardfork {
+    /// Returns `true` if this hardfork is Moderato or later.
+    pub fn is_moderato(self) -> bool {
+        self >= Self::Moderato
+    }
+}
+
 /// Trait for querying Tempo-specific hardfork activations.
 pub trait TempoHardforks: EthereumHardforks {
     /// Retrieves activation condition for a Tempo-specific hardfork
@@ -99,5 +106,12 @@ mod tests {
         // Deserialize from JSON
         let deserialized: TempoHardfork = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, fork);
+    }
+
+    #[test]
+    fn test_is_moderato() {
+        assert!(!TempoHardfork::Adagio.is_moderato());
+
+        assert!(TempoHardfork::Moderato.is_moderato());
     }
 }

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -8,7 +8,6 @@ use tempo_precompiles_macros::contract;
 
 use crate::{NONCE_PRECOMPILE_ADDRESS, error::Result, storage::PrecompileStorageProvider};
 use alloy::primitives::{Address, IntoLogData, U256};
-use tempo_chainspec::hardfork::TempoHardfork;
 
 /// NonceManager contract for managing 2D nonces as per the AA spec
 ///
@@ -99,7 +98,7 @@ impl<'a, S: PrecompileStorageProvider> NonceManager<'a, S> {
         self.sstore_active_key_count(account, new_count)?;
 
         // Emit ActiveKeyCountChanged event (only after Moderato hardfork)
-        if self.storage.spec() >= TempoHardfork::Moderato {
+        if self.storage.spec().is_moderato() {
             self.storage.emit_event(
                 self.address,
                 NonceEvent::ActiveKeyCountChanged(INonce::ActiveKeyCountChanged {
@@ -117,6 +116,7 @@ impl<'a, S: PrecompileStorageProvider> NonceManager<'a, S> {
 #[cfg(test)]
 mod tests {
     use crate::{error::TempoPrecompileError, storage::hashmap::HashMapStorageProvider};
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     use super::*;
     use alloy::primitives::address;

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -23,7 +23,6 @@ use alloy::{
 };
 use revm::state::Bytecode;
 use std::sync::LazyLock;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles_macros::contract;
 use tracing::trace;
 
@@ -795,7 +794,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
         }
 
         // Handle rewards (only after Moderato hardfork)
-        if self.storage.spec() >= TempoHardfork::Moderato {
+        if self.storage.spec().is_moderato() {
             // Accrue rewards up to current timestamp
             let current_timestamp = self.storage.timestamp();
             self.accrue(current_timestamp)?;
@@ -859,7 +858,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
         }
 
         // Handle rewards (only after Moderato hardfork)
-        if self.storage.spec() >= TempoHardfork::Moderato {
+        if self.storage.spec().is_moderato() {
             // Note: We assume that transferFeePreTx is always called first, so _accrue has already been called
             // Update rewards for the recipient and get their reward recipient
             let to_reward_recipient = self.update_rewards(to)?;
@@ -906,6 +905,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Token<'a, S> {
 #[cfg(test)]
 pub(crate) mod tests {
     use alloy::primitives::{Address, FixedBytes, U256};
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     use super::*;
     use crate::{

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use alloy::primitives::{Address, Bytes, IntoLogData, U256};
 use revm::state::Bytecode;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tracing::trace;
 
 #[contract]
@@ -59,7 +58,7 @@ impl<'a, S: PrecompileStorageProvider> TIP20Factory<'a, S> {
 
         // Ensure that the quote token is a valid TIP20 that is currently deployed.
         // Note that the token Id increments on each deployment.
-        if self.storage.spec() >= TempoHardfork::Moderato {
+        if self.storage.spec().is_moderato() {
             // Post-Moderato: Fixed validation - quote token id must be < current token_id (strictly less than).
             if !is_tip20(call.quoteToken)
                 || address_to_token_id_unchecked(call.quoteToken) >= token_id
@@ -128,6 +127,7 @@ mod tests {
         error::TempoPrecompileError, storage::hashmap::HashMapStorageProvider,
         tip20::tests::initialize_linking_usd,
     };
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
     fn test_create_token() {

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use alloy::{primitives::Address, sol_types::SolCall};
 use revm::precompile::{PrecompileError, PrecompileResult};
-use tempo_chainspec::hardfork::TempoHardfork;
 
 impl<'a, S: PrecompileStorageProvider> Precompile for TipFeeManager<'a, S> {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -96,7 +95,7 @@ impl<'a, S: PrecompileStorageProvider> Precompile for TipFeeManager<'a, S> {
             }
             ITIPFeeAMM::mintCall::SELECTOR => {
                 mutate::<ITIPFeeAMM::mintCall>(calldata, msg_sender, |s, call| {
-                    if self.storage.spec() >= TempoHardfork::Moderato {
+                    if self.storage.spec().is_moderato() {
                         Err(TempoPrecompileError::UnknownFunctionSelector)
                     } else {
                         self.mint(

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -18,7 +18,6 @@ use crate::{
 // Re-export PoolKey for backward compatibility with tests
 use alloy::primitives::{Address, Bytes, IntoLogData, U256, uint};
 use revm::state::Bytecode;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles_macros::contract;
 
 /// Helper type to easily interact with the `tokens_with_fees` array
@@ -111,7 +110,7 @@ impl<'a, S: PrecompileStorageProvider> TipFeeManager<'a, S> {
         }
 
         // Forbid setting LinkingUSD as the user's fee token (only after Moderato hardfork)
-        if self.storage.spec() >= TempoHardfork::Moderato && call.token == LINKING_USD_ADDRESS {
+        if self.storage.spec().is_moderato() && call.token == LINKING_USD_ADDRESS {
             return Err(FeeManagerError::invalid_token().into());
         }
 
@@ -338,6 +337,7 @@ impl<'a, S: PrecompileStorageProvider> TipFeeManager<'a, S> {
 
 #[cfg(test)]
 mod tests {
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP20Error;
 
     use super::*;


### PR DESCRIPTION
ref https://github.com/tempoxyz/tempo/pull/855#discussion_r2518688231

Adds `TempoHardfork::is_moderato()` helper method to replace verbose `>= TempoHardfork::Moderato` comparisons.
