### PR TITLE
feat(alloy): re-export `tempo-primitives`

### DIFF
--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -38,3 +38,6 @@ mod network;
 pub use network::*;
 
 pub mod rpc;
+
+#[doc(inline)]
+pub use tempo_primitives as primitives;


### PR DESCRIPTION
The `TempoNetwork` struct uses a lot of the primitives in its `Network` impl, so we should probably re-export the primitives crate