### PR TITLE
feat: add `SpecId` to `TempoHardfork` conversion method

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -77,6 +77,11 @@ impl From<TempoHardfork> for SpecId {
 }
 
 impl From<SpecId> for TempoHardfork {
+    /// Maps a [`SpecId`] to the *latest compatible* [`TempoHardfork`].
+    ///
+    /// Note: this is intentionally not a strict inverse of
+    /// `From<TempoHardfork> for SpecId`, because multiple Tempo
+    /// hardforks may share the same underlying EVM spec.
     fn from(spec: SpecId) -> Self {
         if spec.is_enabled_in(SpecId::from(Self::Moderato)) {
             Self::Moderato


### PR DESCRIPTION
This makes life a whole lot easier in Foundry as we can then rely on `into()`

If more hardforks are added the `else if` branch is to be expanded ranging from newest to oldest with fallback to the first

Required for: https://github.com/tempoxyz/tempo-foundry/pull/53