### PR TITLE
fix(ci): use new `cargo docs` alias

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
-      - run: RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options" cargo doc -p tempo-alloy
+      - run: RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options" cargo docs
       - uses: actions/upload-pages-artifact@v3
         id: deployment
         with:


### PR DESCRIPTION
Uses the alias in https://github.com/tempoxyz/tempo/pull/908 to build docs for all crates in the crate building workflow