### PR TITLE
fix(precompiles): update TIP20 default suppy cap

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -22,7 +22,7 @@ use alloy::{
     primitives::{Address, B256, Bytes, IntoLogData, U256, keccak256, uint},
 };
 use revm::state::Bytecode;
-use std::{sync::LazyLock, u128};
+use std::sync::LazyLock;
 use tempo_precompiles_macros::contract;
 use tracing::trace;
 


### PR DESCRIPTION
Closes #904 

This PR updates the default supply cap from `U256::MAX` to `u128::MAX` to match the spec implementation.