### PR TITLE
fix(precompiles): add insufficient liquidity error to `swap_exact_amount_in` post `Moderato` hardfork

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -992,6 +992,9 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
                     level = new_level;
                     order = new_order;
                 } else {
+                    if amount_in > 0 {
+                        return Err(StablecoinExchangeError::insufficient_liquidity().into());
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
This PR updates `StablecoinExchange::swap_exact_amount_in()` to return an insufficient liquidity error if there are no more orders and `amount_in > 0`.