### PR TITLE
fix!(stablecoin-exchange): round up quote amounts (Moderato+)

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -33,9 +33,7 @@ pub const MIN_ORDER_AMOUNT: u128 = 10_000_000;
 /// Pre-Moderato behavior
 fn calculate_quote_amount_floor(amount: u128, tick: i16) -> Option<u128> {
     let price = tick_to_price(tick) as u128;
-    let scale = PRICE_SCALE as u128;
-    let product = amount.checked_mul(price)?;
-    product.checked_div(scale)
+    amount.checked_mul(price)?.checked_div(PRICE_SCALE as u128)
 }
 
 /// Calculate quote amount using ceiling division (rounds up)


### PR DESCRIPTION
Closes #929

Fixes a bug where `calculate_quote_amount()` used floor division (rounding down), which favored users over the exchange. Post-Moderato hardfork, the function now uses ceiling division (rounds up).