### PR TITLE
fix: bumps reth to 2a16222

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7403,7 +7403,7 @@ checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7583,7 +7583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7621,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7782,7 +7782,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7870,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7992,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "futures",
  "pin-project",
@@ -8061,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8209,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8303,7 +8303,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "clap",
  "eyre",
@@ -8325,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8359,7 +8359,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8373,7 +8373,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8422,7 +8422,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8432,7 +8432,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8546,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8598,7 +8598,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "bytes",
  "futures",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8643,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "futures",
  "metrics",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8678,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8733,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8758,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8796,7 +8796,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8810,7 +8810,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9060,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "eyre",
  "http",
@@ -9082,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9094,7 +9094,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9135,7 +9135,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9491,7 +9491,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9520,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9564,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9625,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9689,7 +9689,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9802,7 +9802,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9820,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "clap",
  "eyre",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "clap",
  "eyre",
@@ -9880,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9921,7 +9921,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.9.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=63409fe#63409fe650c99fc4bc9e4a60cb6cc863c216ce05"
+source = "git+https://github.com/paradigmxyz/reth?rev=2a16222#2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,59 +115,59 @@ tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222" }
 
 alloy-network = { version = "1.0.41" }
 alloy-rpc-types-eth = { version = "1.0.41" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "63409fe", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2a16222", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
bumps reth to https://github.com/paradigmxyz/reth/commit/2a16222ea1cd473eaaf15fb2714d4ebd5a19a4b7 which includes the [persistence fix](https://github.com/paradigmxyz/reth/pull/19803)

on top of https://github.com/tempoxyz/tempo/pull/947