### PR TITLE
poc(precompiles): thread local example with closures

### DIFF
--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -26,7 +26,7 @@ const MAX_CALL_DEPTH: usize = 64;
 
 thread_local! {
     /// Thread-local storage for the current storage provider pointer
-    static STORAGE: Cell<Option<*mut dyn PrecompileStorageProvider>> = const { Cell::new(None) };
+    pub(crate) static STORAGE: Cell<Option<*mut dyn PrecompileStorageProvider>> = const { Cell::new(None) };
 
     /// Thread-local stack of contract addresses for nested calls
     static ADDRESS_STACK: RefCell<Vec<Address>> = RefCell::new(Vec::new());
@@ -76,6 +76,7 @@ impl StorageGuard {
 
 impl Drop for StorageGuard {
     fn drop(&mut self) {
+        // Clean up thread-local state
         STORAGE.with(|s| s.set(None));
         ADDRESS_STACK.with(|s| s.borrow_mut().clear());
     }

--- a/crates/precompiles/src/thread_local_example/mod.rs
+++ b/crates/precompiles/src/thread_local_example/mod.rs
@@ -4,35 +4,45 @@ use crate::{
 };
 use alloy::primitives::{Address, U256};
 
-pub mod slots {
-    use alloy::primitives::U256;
-
-    pub const TOTAL_SUPPLY: U256 = U256::ZERO;
-    pub const BALANCES: U256 = U256::ONE;
-}
-
 pub struct ThreadLocalToken {
-    _address_guard: crate::storage::thread_local::AddressGuard,
     total_supply: Slot<U256>,
     balances: Mapping<Address, U256>,
 }
 
 impl ThreadLocalToken {
-    pub fn new(address: Address) -> Result<Self> {
-        // automatically creates and manages `AddressGuard`
-        let guard = AddressGuard::new(address)?;
-        Ok(Self {
-            _address_guard: guard,
-            total_supply: Slot::new(slots::TOTAL_SUPPLY),
-            balances: Mapping::new(slots::BALANCES),
-        })
+    // macro generated
+    pub fn _new() -> Self {
+        Self {
+            total_supply: Slot::new(U256::ZERO),
+            balances: Mapping::new(U256::ONE),
+        }
+    }
+
+    // macro generated
+    pub fn staticcall<F, R>(address: Address, f: F) -> Result<R>
+    where
+        F: for<'b> FnOnce(&Self) -> Result<R>,
+    {
+        let _guard = AddressGuard::new(address)?;
+        let instance = Self::_new();
+        f(&instance)
+    }
+
+    // macro generated
+    pub fn call_mut<F, R>(address: Address, f: F) -> Result<R>
+    where
+        F: for<'b> FnOnce(&mut Self) -> Result<R>,
+    {
+        let _guard = AddressGuard::new(address)?;
+        let mut instance = Self::_new();
+        f(&mut instance)
     }
 
     pub fn total_supply(&self) -> Result<U256> {
         self.total_supply.read_tl()
     }
 
-    fn set_total_supply(&self, value: U256) -> Result<()> {
+    fn set_total_supply(&mut self, value: U256) -> Result<()> {
         self.total_supply.write_tl(value)
     }
 
@@ -40,11 +50,11 @@ impl ThreadLocalToken {
         self.balances.at(account).read_tl()
     }
 
-    fn set_balance(&self, account: Address, balance: U256) -> Result<()> {
+    fn set_balance(&mut self, account: Address, balance: U256) -> Result<()> {
         self.balances.at(account).write_tl(balance)
     }
 
-    pub fn mint(&self, to: Address, amount: U256) -> Result<()> {
+    pub fn mint(&mut self, to: Address, amount: U256) -> Result<()> {
         let balance = self.balance_of(to)?;
         let supply = self.total_supply()?;
 
@@ -54,7 +64,7 @@ impl ThreadLocalToken {
         Ok(())
     }
 
-    pub fn transfer(&self, from: Address, to: Address, amount: U256) -> Result<()> {
+    pub fn transfer(&mut self, from: Address, to: Address, amount: U256) -> Result<()> {
         let from_balance = self.balance_of(from)?;
         let to_balance = self.balance_of(to)?;
 
@@ -63,32 +73,58 @@ impl ThreadLocalToken {
 
         Ok(())
     }
+
+    pub fn transfer_with_rewards(
+        &mut self,
+        from: Address,
+        to: Address,
+        amount: U256,
+    ) -> Result<()> {
+        self.transfer(from, to, amount)?;
+
+        ThreadLocalRewards::call_mut(REWARDS_ADDRESS, |rewards| rewards.distribute(amount))?;
+
+        Ok(())
+    }
 }
 
-pub mod rewards_slots {
-    use alloy::primitives::U256;
-    pub const REWARDS_POOL: U256 = U256::ZERO;
-}
+const REWARDS_ADDRESS: Address = Address::new([0xEE; 20]);
 
 pub struct ThreadLocalRewards {
-    _address_guard: AddressGuard,
     rewards_pool: Slot<U256>,
 }
 
 impl ThreadLocalRewards {
-    pub fn new(address: Address) -> Result<Self> {
-        // automatically creates and manages `AddressGuard`
-        let guard = AddressGuard::new(address)?;
-        Ok(Self {
-            _address_guard: guard,
-            rewards_pool: Slot::new(rewards_slots::REWARDS_POOL),
-        })
+    // macro generated
+    fn _new() -> Self {
+        Self {
+            rewards_pool: Slot::new(U256::ZERO),
+        }
     }
 
-    pub fn distribute(&self, transfer_amount: U256) -> Result<()> {
-        let pool = self.rewards_pool.read_tl()?;
-        let reward = transfer_amount / U256::from(100);
+    // macro generated
+    pub fn staticcall<F, R>(address: Address, f: F) -> Result<R>
+    where
+        F: for<'b> FnOnce(&Self) -> Result<R>,
+    {
+        let _guard = AddressGuard::new(address)?;
+        let instance = Self::_new();
+        f(&instance)
+    }
 
+    // macro generated
+    pub fn call_mut<F, R>(address: Address, f: F) -> Result<R>
+    where
+        F: for<'b> FnOnce(&mut Self) -> Result<R>,
+    {
+        let _guard = AddressGuard::new(address)?;
+        let mut instance = Self::_new();
+        f(&mut instance)
+    }
+
+    pub fn distribute(&mut self, transfer_amount: U256) -> Result<()> {
+        let reward = transfer_amount / U256::from(100);
+        let pool = self.rewards_pool.read_tl()?;
         self.rewards_pool.write_tl(pool + reward)?;
 
         Ok(())
@@ -96,25 +132,6 @@ impl ThreadLocalRewards {
 
     pub fn get_pool(&self) -> Result<U256> {
         self.rewards_pool.read_tl()
-    }
-}
-
-const REWARDS_ADDRESS: Address = Address::new([0xEE; 20]);
-
-impl ThreadLocalToken {
-    pub fn transfer_with_rewards(&self, from: Address, to: Address, amount: U256) -> Result<()> {
-        // uses token's address from self._address_guard
-        self.transfer(from, to, amount)?;
-
-        {
-            // uses rewards' address from `rewards._address_guard`
-            let rewards = ThreadLocalRewards::new(REWARDS_ADDRESS)?;
-            rewards.distribute(amount)?;
-        }
-
-        // once rewards is dropped, its guard is also dropped and we switch back to `token._address_guard`
-
-        Ok(())
     }
 }
 
@@ -126,54 +143,53 @@ mod tests {
     #[test]
     fn test_pure_thread_local() -> Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
-        // this would be set at the dispatcher (entry point)
         let _storage_guard = unsafe { StorageGuard::new(&mut storage) };
 
         let token_address = Address::new([0x01; 20]);
         let alice = Address::new([0xA1; 20]);
         let bob = Address::new([0xB0; 20]);
 
-        let token = ThreadLocalToken::new(token_address)?;
+        ThreadLocalToken::call_mut(token_address, |token| {
+            // mint
+            token.mint(alice, U256::from(1000))?;
+            assert_eq!(token.balance_of(alice)?, U256::from(1000));
+            assert_eq!(token.total_supply()?, U256::from(1000));
 
-        // mint
-        token.mint(alice, U256::from(1000))?;
-        assert_eq!(token.balance_of(alice)?, U256::from(1000));
-        assert_eq!(token.total_supply()?, U256::from(1000));
+            // transfer
+            token.transfer(alice, bob, U256::from(100))?;
+            assert_eq!(token.balance_of(alice)?, U256::from(900));
+            assert_eq!(token.balance_of(bob)?, U256::from(100));
 
-        // transfer
-        token.transfer(alice, bob, U256::from(100))?;
-        assert_eq!(token.balance_of(alice)?, U256::from(900));
-        assert_eq!(token.balance_of(bob)?, U256::from(100));
-
-        Ok(())
+            Ok(())
+        })
     }
 
     #[test]
     fn test_cross_contract_calls() -> Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
-        // this would be set at the dispatcher (entry point)
         let _storage_guard = unsafe { StorageGuard::new(&mut storage) };
 
         let token_address = Address::new([0x01; 20]);
         let alice = Address::new([0xA1; 20]);
         let bob = Address::new([0xB0; 20]);
 
-        let token = ThreadLocalToken::new(token_address)?;
-        token.mint(alice, U256::from(1000))?;
+        ThreadLocalToken::call_mut(token_address, |token| {
+            token.mint(alice, U256::from(1000))?;
 
-        // transfer with rewards
-        token.transfer_with_rewards(alice, bob, U256::from(100))?;
-        assert_eq!(token.balance_of(alice)?, U256::from(900));
-        assert_eq!(token.balance_of(bob)?, U256::from(100));
+            // transfer with rewards - demonstrates scoped cross-contract call
+            token.transfer_with_rewards(alice, bob, U256::from(100))?;
+            assert_eq!(token.balance_of(alice)?, U256::from(900));
+            assert_eq!(token.balance_of(bob)?, U256::from(100));
+
+            Ok(())
+        })?;
 
         // verify rewards were distributed
-        {
-            let rewards = ThreadLocalRewards::new(REWARDS_ADDRESS)?;
+        ThreadLocalRewards::staticcall(REWARDS_ADDRESS, |rewards| {
             let pool = rewards.get_pool()?;
             assert_eq!(pool, U256::from(1));
-        }
-
-        Ok(())
+            Ok(())
+        })
     }
 
     #[test]
@@ -187,26 +203,24 @@ mod tests {
 
         let _storage_guard = unsafe { StorageGuard::new(&mut storage) };
 
-        // demonstrate nested contract instantiation and automatic address switching
-        {
-            let _token1 = ThreadLocalToken::new(addr1)?;
+        // demonstrate nested contract calls with automatic address stack management
+        ThreadLocalToken::staticcall(addr1, |_token1| {
             assert_eq!(context::call_depth(), 1);
 
-            {
-                let _token2 = ThreadLocalToken::new(addr2)?;
+            ThreadLocalToken::staticcall(addr2, |_token2| {
                 assert_eq!(context::call_depth(), 2);
 
-                {
-                    let _token3 = ThreadLocalToken::new(addr3)?;
+                ThreadLocalToken::staticcall(addr3, |_token3| {
                     assert_eq!(context::call_depth(), 3);
-                }
+                    Ok(())
+                })?;
 
                 assert_eq!(context::call_depth(), 2);
-            }
+                Ok(())
+            })?;
 
             assert_eq!(context::call_depth(), 1);
-        }
-
-        Ok(())
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
## Motivation

POC to explore how a threadlocal impl to avoid passing storage around would look like

## Note

this is a prototype built on top of the current architecture, but obviously we would have to modify the existing traits/fns/APIs rather than having 2 impls that cohexist