### PR TITLE
fix: ensure executor task is aborted with application

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -718,6 +718,9 @@ impl Inner<Uninit> {
         }
         .build(context.with_label("executor"));
 
+        let executor_mailbox = executor.mailbox().clone();
+        let executor_handle = executor.start();
+
         let initialized = Inner {
             fee_recipient: self.fee_recipient,
             epoch_length: self.epoch_length,
@@ -729,13 +732,12 @@ impl Inner<Uninit> {
             state: Init {
                 latest_proposed_block: Arc::new(RwLock::new(None)),
                 dkg_manager,
-                executor_mailbox: executor.mailbox().clone(),
+                executor_mailbox,
+                _executor_handle: AbortOnDrop(executor_handle).into(),
             },
             subblocks: self.subblocks,
             scheme_provider: self.scheme_provider,
         };
-
-        executor.start();
 
         Ok(initialized)
     }
@@ -750,7 +752,13 @@ pub(in crate::consensus) struct Uninit(());
 struct Init {
     latest_proposed_block: Arc<RwLock<Option<Block>>>,
     dkg_manager: crate::dkg::manager::Mailbox,
+    /// The communication channel to the [`executor::Executor`] task.
     executor_mailbox: ExecutorMailbox,
+    /// The handle to the spawned executor task.
+    ///
+    /// If the last instance of this is dropped (the application task is aborted),
+    /// this ensures that the task is aborted as well.
+    _executor_handle: Arc<AbortOnDrop>,
 }
 
 /// Verifies `block` given its `parent` against the execution layer.
@@ -871,4 +879,19 @@ fn report_verification_result(
         }
     }
     Ok(())
+}
+
+/// Ensures the task associated with the [`Handle`] is aborted [`Handle::abort`] when this instance is dropped.
+struct AbortOnDrop(Handle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl std::fmt::Debug for AbortOnDrop {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AbortOnDrop").finish_non_exhaustive()
+    }
 }


### PR DESCRIPTION
the executor task is spawned into the void and doesn't get terminated when the `engine.start` or the application task terminates because the executor has a full channel that never closes

https://github.com/tempoxyz/tempo/blob/d567097a1e4152eab949085e732eb0c53f38b050/crates/commonware-node/src/consensus/application/executor.rs#L149-L158

this is fine because it is intended to run for the entire program but makes it difficult to do shutdown+restart tests