### PR TITLE
fix(faucet): send transactions to node's rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11509,11 +11509,7 @@ dependencies = [
  "clap",
  "jsonrpsee",
  "reth-rpc-server-types",
- "reth-transaction-pool",
  "tempo-precompiles",
- "tempo-transaction-pool",
- "thiserror 2.0.17",
- "url",
 ]
 
 [[package]]

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -198,9 +198,7 @@ fn main() -> eyre::Result<()> {
             })
             .extend_rpc_modules(move |ctx| {
                 if faucet_args.enabled {
-                    let txpool = ctx.pool().clone();
                     let ext = TempoFaucetExt::new(
-                        txpool,
                         faucet_args.addresses(),
                         faucet_args.amount(),
                         faucet_args.provider(),

--- a/crates/faucet/Cargo.toml
+++ b/crates/faucet/Cargo.toml
@@ -13,8 +13,6 @@ workspace = true
 
 [dependencies]
 tempo-precompiles.workspace = true
-tempo-transaction-pool.workspace = true
-reth-transaction-pool.workspace = true
 reth-rpc-server-types.workspace = true
 alloy = { workspace = true, features = [
   "rpc-types",
@@ -26,5 +24,3 @@ alloy = { workspace = true, features = [
 async-trait.workspace = true
 jsonrpsee.workspace = true
 clap.workspace = true
-thiserror.workspace = true
-url = "2.5.4"

--- a/crates/faucet/src/faucet.rs
+++ b/crates/faucet/src/faucet.rs
@@ -1,26 +1,14 @@
 use alloy::{
-    consensus::{
-        TxEnvelope, crypto::RecoveryError, error::ValueError, transaction::SignerRecoverable,
-    },
-    network::Ethereum,
     primitives::{Address, B256, U256},
     providers::{
-        Provider,
+        DynProvider, Provider,
         fillers::{FillProvider, TxFiller},
     },
-    transports::{RpcError, TransportErrorKind},
 };
 use async_trait::async_trait;
-use jsonrpsee::{
-    core::RpcResult,
-    proc_macros::rpc,
-    types::error::{INTERNAL_ERROR_CODE, INVALID_REQUEST_CODE},
-};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::error::INTERNAL_ERROR_CODE};
 use reth_rpc_server_types::result::rpc_err;
-use reth_transaction_pool::{TransactionOrigin, TransactionPool, error::PoolError};
-use std::error::Error;
 use tempo_precompiles::tip20::ITIP20;
-use tempo_transaction_pool::transaction::TempoPooledTransaction;
 
 #[rpc(server, namespace = "tempo")]
 pub trait TempoFaucetExtApi {
@@ -28,104 +16,37 @@ pub trait TempoFaucetExtApi {
     async fn fund_address(&self, address: Address) -> RpcResult<Vec<B256>>;
 }
 
-pub struct TempoFaucetExt<Pool, P, F>
-where
-    P: Provider,
-    F: TxFiller<Ethereum>,
-{
-    pool: Pool,
+pub struct TempoFaucetExt {
     faucet_token_addresses: Vec<Address>,
     funding_amount: U256,
-    provider: FillProvider<F, P, Ethereum>,
+    provider: DynProvider,
 }
 
-impl<Pool, P, F> TempoFaucetExt<Pool, P, F>
-where
-    P: Provider,
-    F: TxFiller<Ethereum>,
-{
+impl TempoFaucetExt {
     pub fn new(
-        pool: Pool,
         faucet_token_addresses: Vec<Address>,
         funding_amount: U256,
-        provider: FillProvider<F, P, Ethereum>,
+        provider: FillProvider<impl TxFiller + 'static, impl Provider + 'static>,
     ) -> Self {
         Self {
-            pool,
             faucet_token_addresses,
             funding_amount,
-            provider,
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum FaucetError {
-    #[error(transparent)]
-    ParseUrlError(#[from] url::ParseError),
-    #[error(transparent)]
-    FillError(#[from] RpcError<TransportErrorKind>),
-    #[error(transparent)]
-    ConversionError(#[from] Box<dyn Error + Send + Sync + 'static>),
-    #[error(transparent)]
-    SignatureRecoveryError(#[from] RecoveryError),
-    #[error(transparent)]
-    TxPoolError(#[from] PoolError),
-}
-
-impl From<FaucetError> for jsonrpsee::types::ErrorObject<'static> {
-    fn from(err: FaucetError) -> Self {
-        match err {
-            FaucetError::ParseUrlError(e) => rpc_err(INTERNAL_ERROR_CODE, e.to_string(), None),
-            FaucetError::FillError(e) => rpc_err(INTERNAL_ERROR_CODE, e.to_string(), None),
-            FaucetError::ConversionError(e) => rpc_err(INTERNAL_ERROR_CODE, e.to_string(), None),
-            FaucetError::SignatureRecoveryError(e) => {
-                rpc_err(INTERNAL_ERROR_CODE, e.to_string(), None)
-            }
-            FaucetError::TxPoolError(e) => rpc_err(INVALID_REQUEST_CODE, e.to_string(), None),
+            provider: provider.erased(),
         }
     }
 }
 
 #[async_trait]
-impl<Pool, P, F> TempoFaucetExtApiServer for TempoFaucetExt<Pool, P, F>
-where
-    Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
-    P: Provider + Clone + 'static,
-    F: TxFiller<Ethereum> + Send + Sync + 'static,
-{
+impl TempoFaucetExtApiServer for TempoFaucetExt {
     async fn fund_address(&self, address: Address) -> RpcResult<Vec<B256>> {
-        let requests = self.faucet_token_addresses.iter().map(|token_address| {
-            ITIP20::new(*token_address, &self.provider)
-                .transfer(address, self.funding_amount)
-                .into_transaction_request()
-        });
-
         let mut tx_hashes = Vec::new();
-
-        for request in requests {
-            let filled_tx = self
-                .provider
-                .fill(request)
+        for token in &self.faucet_token_addresses {
+            let tx_hash = *ITIP20::new(*token, &self.provider)
+                .transfer(address, self.funding_amount)
+                .send()
                 .await
-                .map_err(FaucetError::FillError)?;
-
-            let tx: TxEnvelope = filled_tx
-                .try_into_envelope()
-                .map_err(|e| FaucetError::ConversionError(Box::new(e)))?;
-
-            let tx_hash = *tx.hash();
-
-            let tx = tx
-                .try_into_recovered()
-                .map_err(FaucetError::SignatureRecoveryError)?
-                .try_convert::<_, ValueError<TxEnvelope>>()
-                .map_err(|e| FaucetError::ConversionError(Box::new(e)))?;
-
-            self.pool
-                .add_consensus_transaction(tx, TransactionOrigin::Local)
-                .await
-                .map_err(FaucetError::TxPoolError)?;
+                .map_err(|err| rpc_err(INTERNAL_ERROR_CODE, err.to_string(), None))?
+                .tx_hash();
 
             tx_hashes.push(tx_hash);
         }


### PR DESCRIPTION
Changes faucet to send transactions directly to node's rpc so that we don't rely on p2p propagation for public nodes but use the configured tx forwarder, if any

Also generally simplifies the code to avoid generics