### PR TITLE
chore: forward common features

### DIFF
--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -49,42 +49,51 @@ asm-keccak = [
 ]
 
 otlp = [
-    "reth-ethereum-cli/otlp",
-	"reth-ethereum/otlp"
+	"reth-ethereum-cli/otlp",
+	"reth-ethereum/otlp",
+	"tempo-node/otlp"
 ]
 js-tracer = [
 	"reth-node-builder/js-tracer",
-	"reth-ethereum/js-tracer"
+	"reth-ethereum/js-tracer",
+	"tempo-node/js-tracer"
 ]
 
 jemalloc = [
 	"reth-cli-util/jemalloc",
 	"reth-ethereum-cli/jemalloc",
-	"reth-ethereum/jemalloc"
+	"reth-ethereum/jemalloc",
+	"tempo-node/jemalloc"
 ]
 jemalloc-prof = [
 	"reth-cli-util/jemalloc",
 	"reth-cli-util/jemalloc-prof",
-	"reth-ethereum-cli/jemalloc-prof"
+	"reth-ethereum-cli/jemalloc-prof",
+	"tempo-node/jemalloc-prof"
 ]
 
 min-error-logs = [
 	"tracing/release_max_level_error",
-	"reth-ethereum-cli/min-error-logs"
+	"reth-ethereum-cli/min-error-logs",
+	"tempo-node/min-error-logs"
 ]
 min-warn-logs = [
 	"tracing/release_max_level_warn",
-	"reth-ethereum-cli/min-warn-logs"
+	"reth-ethereum-cli/min-warn-logs",
+	"tempo-node/min-warn-logs"
 ]
 min-info-logs = [
 	"tracing/release_max_level_info",
-	"reth-ethereum-cli/min-info-logs"
+	"reth-ethereum-cli/min-info-logs",
+	"tempo-node/min-info-logs"
 ]
 min-debug-logs = [
 	"tracing/release_max_level_debug",
-	"reth-ethereum-cli/min-debug-logs"
+	"reth-ethereum-cli/min-debug-logs",
+	"tempo-node/min-debug-logs"
 ]
 min-trace-logs = [
-	"reth-ethereum-cli/min-trace-logs"
+	"reth-ethereum-cli/min-trace-logs",
+	"tempo-node/min-trace-logs"
 ]
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -94,3 +94,37 @@ asm-keccak = [
     "reth-node-ethereum/asm-keccak",
     "tempo-alloy/asm-keccak"
 ]
+otlp = [
+	"reth-ethereum/otlp",
+	"reth-node-core/otlp"
+]
+js-tracer = [
+	"reth-ethereum/js-tracer",
+	"reth-node-builder/js-tracer",
+	"reth-node-ethereum/js-tracer",
+	"reth-rpc/js-tracer",
+	"reth-rpc-eth-api/js-tracer",
+	"reth-rpc-eth-types/js-tracer"
+]
+jemalloc = [
+	"reth-ethereum/jemalloc",
+	"reth-node-core/jemalloc",
+	"reth-node-metrics/jemalloc"
+]
+jemalloc-prof = []
+
+min-error-logs = [
+	"reth-node-core/min-error-logs"
+]
+min-warn-logs = [
+	"reth-node-core/min-warn-logs"
+]
+min-info-logs = [
+	"reth-node-core/min-info-logs"
+]
+min-debug-logs = [
+	"reth-node-core/min-debug-logs"
+]
+min-trace-logs = [
+	"reth-node-core/min-trace-logs"
+]


### PR DESCRIPTION
forward more features, this mirrors the feature set of common reth crates

due to how CARGO_FEATURES env var behaves during build only the ones activated in the crate that has the build.rs are included.
we can fix this by adding a bunch of forwards