### PR TITLE
chore(e2e): tweak timeouts

### DIFF
--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -256,7 +256,7 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
             ..DatadirArgs::default()
         })
         .with_payload_builder(PayloadBuilderArgs {
-            interval: Duration::from_millis(50),
+            interval: Duration::from_millis(100),
             ..Default::default()
         })
         .apply(|mut c| {

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -292,7 +292,7 @@ pub async fn setup_validators(
             time_for_peer_response: Duration::from_secs(2),
             views_to_track: 10,
             views_until_leader_skip: 5,
-            new_payload_wait_time: Duration::from_millis(100),
+            new_payload_wait_time: Duration::from_millis(200),
             time_to_build_subblock: Duration::from_millis(100),
         };
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -381,8 +381,6 @@ where
             attributes.subblocks()
         };
 
-        println!("subblocks: {}", subblocks.len());
-
         subblocks.retain(|subblock| {
             // Edge case: remove subblocks with expired transactions
             //


### PR DESCRIPTION
Right now in e2e tests `new_payload_wait_time` is set to 100ms
https://github.com/tempoxyz/tempo/blob/a3983a82ac4a28065b05299b0308fc1b7795cc96/crates/e2e/src/lib.rs#L295

With interval set to 100ms as well it effectively means that we never get more than 1 attempt at building a payload. For subblocks this means that some of the subblocks might be lost because validators start sending them around the same time proposer starts building a new block

This should fix CI failures like https://github.com/tempoxyz/tempo/actions/runs/19598480215/job/56126559188?pr=1001