### PR TITLE
chore(deny): apply `MIT OR Apache-2.0` license to crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.5.2"
 edition = "2024"
 rust-version = "1.88"
-license = ""
+license = "MIT OR Apache-2.0"
 publish = false
 
 [workspace]


### PR DESCRIPTION
This was raised by a review from `cargo deny` indicating the crates were missing their license