### PR TITLE
fix: explicit error for non-zero value

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -78,7 +78,7 @@ pub enum TempoPoolTransactionError {
     Keychain(&'static str),
 
     #[error(
-        "native transfers not supported, if you were trying to transfer a stablecoin, please call TIP20::Transfer"
+        "Native transfers are not supported, if you were trying to transfer a stablecoin, please call TIP20::Transfer"
     )]
     NonZeroValue,
 }

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -366,7 +366,7 @@ mod tests {
         if let TransactionValidationOutcome::Invalid(_, err) = outcome {
             assert!(
                 err.to_string()
-                    .contains("native token transfers are not supported")
+                    .contains("Native transfers are not supported")
             );
         } else {
             panic!("Expected Invalid outcome with InsufficientFunds error");


### PR DESCRIPTION
Changes error returned when there's a non-zero value set from `InvalidTxType` to a custom error with explicit error message