### PR TITLE
fix(precompiles): ensure `Orderbook`'s best tick is always up-to-date

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -4219,7 +4219,7 @@ mod tests {
 
     #[test]
     fn test_best_tick_updates_on_fill() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new(1).with_spec(TempoHardfork::Allegretto);
         let mut exchange = StablecoinExchange::new(&mut storage);
         exchange.initialize()?;
 
@@ -4303,7 +4303,7 @@ mod tests {
 
     #[test]
     fn test_best_tick_updates_on_cancel() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new(1).with_spec(TempoHardfork::Allegretto);
         let mut exchange = StablecoinExchange::new(&mut storage);
         exchange.initialize()?;
 


### PR DESCRIPTION
## Motivation

closes #1062 

## Solution

ensure that `best_tick` updated when:
- filling orders that consume all its liquidity
- cancelling an active order that represented all the liquidity at the best tick