### PR TITLE
fix(test): fix flaky 2d nonce pool test race condition

### DIFF
--- a/crates/node/tests/it/account_abstraction.rs
+++ b/crates/node/tests/it/account_abstraction.rs
@@ -1359,10 +1359,14 @@ async fn test_aa_2d_nonce_pool_comprehensive() -> eyre::Result<()> {
         println!("  ✓ Both nonce=1 and nonce=2 included");
     }
 
-    // Assert that all transactions are removed from the pool
+    // Assert that included transactions are removed from the pool
     assert!(!setup.node.inner.pool.contains(&pending));
-    assert!(!setup.node.inner.pool.contains(&queued));
     assert!(!setup.node.inner.pool.contains(&new_pending));
+    // Only assert queued tx is removed if it was actually included in the block
+    // (due to the known limitation with auto-promotion of queued transactions)
+    if nonce_key_3_txs_after.contains(&2) {
+        assert!(!setup.node.inner.pool.contains(&queued));
+    }
 
     println!("\n=== All Scenarios Passed ===");
     println!("✅ Pool routing works correctly");


### PR DESCRIPTION
The test was failing intermittently like here https://github.com/tempoxyz/tempo/actions/runs/19713975993/job/56483269334?pr=1084 because it unconditionally asserted that a queued transaction was removed from the pool after mining a block. Due to a known limitation with auto-promotion of queued transactions, the transaction may not always be included. 

The fix makes this assertion conditional on whether the transaction was actually included in the block