### PR TITLE
fix(stablecoin-exchange): gate tick checks behind allegretto hardfork

### DIFF
--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -9,6 +9,7 @@ use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_rpc_eth_api::{RpcNodeCore, helpers::SpawnBlocking};
 use reth_rpc_eth_types::{EthApiError, error::FromEthApiError};
 use tempo_alloy::rpc::pagination::PaginationParams;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoEvmConfig;
 use tempo_precompiles::{
     stablecoin_exchange::{
@@ -503,8 +504,13 @@ impl<'a, 'b> BookIterator<'a, 'b> {
     /// Get the next initialized tick after the given tick
     /// Returns None if there are no more ticks
     pub fn get_next_tick(&mut self, tick: i16) -> Option<i16> {
-        let (next_tick, more_ticks) =
-            PrecompileOrderbook::next_initialized_tick(self, self.book_key, self.bids, tick);
+        let (next_tick, more_ticks) = PrecompileOrderbook::next_initialized_tick(
+            self,
+            self.book_key,
+            self.bids,
+            tick,
+            TempoHardfork::default(),
+        );
 
         if more_ticks { Some(next_tick) } else { None }
     }

--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -835,8 +835,13 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
             Orderbook::clear_tick_bit(self, order.book_key(), order.tick(), order.is_bid())
                 .expect("Tick is valid");
 
-            let (tick, has_liquidity) =
-                Orderbook::next_initialized_tick(self, book_key, order.is_bid(), order.tick());
+            let (tick, has_liquidity) = Orderbook::next_initialized_tick(
+                self,
+                book_key,
+                order.is_bid(),
+                order.tick(),
+                self.storage.spec(),
+            );
 
             if self.storage.spec().is_allegretto() {
                 // Update best_tick when tick is exhausted
@@ -1294,6 +1299,7 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
                         order.book_key(),
                         order.is_bid(),
                         order.tick(),
+                        self.storage.spec(),
                     );
 
                     if order.is_bid() {
@@ -1362,7 +1368,9 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
             orderbook.best_ask_tick
         };
         // Check for no liquidity: i16::MIN means no bids, i16::MAX means no asks
-        if current_tick == i16::MIN || current_tick == i16::MAX {
+        if current_tick == i16::MIN
+            || self.storage.spec().is_allegretto() && current_tick == i16::MAX
+        {
             return Err(StablecoinExchangeError::insufficient_liquidity().into());
         }
 
@@ -1371,8 +1379,13 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
 
             // If no liquidity at this level, move to next tick
             if level.total_liquidity == 0 {
-                let (next_tick, initialized) =
-                    Orderbook::next_initialized_tick(self, book_key, is_bid, current_tick);
+                let (next_tick, initialized) = Orderbook::next_initialized_tick(
+                    self,
+                    book_key,
+                    is_bid,
+                    current_tick,
+                    self.storage.spec(),
+                );
 
                 if !initialized {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1427,8 +1440,13 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
 
             // If we exhausted this level or filled our requirement, move to next tick
             if fill_amount == level.total_liquidity {
-                let (next_tick, initialized) =
-                    Orderbook::next_initialized_tick(self, book_key, is_bid, current_tick);
+                let (next_tick, initialized) = Orderbook::next_initialized_tick(
+                    self,
+                    book_key,
+                    is_bid,
+                    current_tick,
+                    self.storage.spec(),
+                );
 
                 if !initialized && remaining_out > 0 {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1558,7 +1576,9 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
         };
 
         // Check for no liquidity: i16::MIN means no bids, i16::MAX means no asks
-        if current_tick == i16::MIN || current_tick == i16::MAX {
+        if current_tick == i16::MIN
+            || self.storage.spec().is_allegretto() && current_tick == i16::MAX
+        {
             return Err(StablecoinExchangeError::insufficient_liquidity().into());
         }
 
@@ -1567,8 +1587,13 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
 
             // If no liquidity at this level, move to next tick
             if level.total_liquidity == 0 {
-                let (next_tick, initialized) =
-                    Orderbook::next_initialized_tick(self, book_key, is_bid, current_tick);
+                let (next_tick, initialized) = Orderbook::next_initialized_tick(
+                    self,
+                    book_key,
+                    is_bid,
+                    current_tick,
+                    self.storage.spec(),
+                );
 
                 if !initialized {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1598,8 +1623,13 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
 
             // If we exhausted this level, move to next tick
             if fill_amount == level.total_liquidity {
-                let (next_tick, initialized) =
-                    Orderbook::next_initialized_tick(self, book_key, is_bid, current_tick);
+                let (next_tick, initialized) = Orderbook::next_initialized_tick(
+                    self,
+                    book_key,
+                    is_bid,
+                    current_tick,
+                    self.storage.spec(),
+                );
 
                 if !initialized && remaining_in > 0 {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());


### PR DESCRIPTION
This PR updates the tick checks introduced in #1124 to be gated behind the allegretto hardfork.