### PR TITLE
refactor: remove `Handler` trait

### DIFF
--- a/crates/precompiles-macros/src/storable.rs
+++ b/crates/precompiles-macros/src/storable.rs
@@ -167,9 +167,6 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
             // delete uses default implementation from trait
         }
-
-        // Structs use the default MaybePackable implementation (returns error)
-        impl #impl_generics crate::storage::MaybePackable for #strukt #ty_generics #where_clause {}
     };
 
     // Generate array implementations if requested

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -17,7 +17,7 @@ use tempo_precompiles_macros;
 
 use crate::{
     error::Result,
-    storage::{Handler, LayoutCtx, Storable, StorableType, packing, types::Slot},
+    storage::{LayoutCtx, Storable, StorableType, packing, types::Slot},
 };
 
 // fixed-size arrays: [T; N] for primitive types T and sizes 1-32
@@ -158,30 +158,6 @@ where
         };
 
         Some(T::handle(base_slot, layout_ctx, Rc::clone(&self.address)))
-    }
-}
-
-impl<T, const N: usize> Handler<[T; N]> for ArrayHandler<T, N>
-where
-    T: StorableType,
-    [T; N]: Storable,
-{
-    /// Reads the entire array from storage.
-    #[inline]
-    fn read(&self) -> Result<[T; N]> {
-        self.as_slot().read()
-    }
-
-    /// Writes the entire array to storage.
-    #[inline]
-    fn write(&mut self, value: [T; N]) -> Result<()> {
-        self.as_slot().write(value)
-    }
-
-    /// Deletes the entire array from storage (clears all elements).
-    #[inline]
-    fn delete(&mut self) -> Result<()> {
-        self.as_slot().delete()
     }
 }
 

--- a/crates/precompiles/src/storage/types/bytes_like.rs
+++ b/crates/precompiles/src/storage/types/bytes_like.rs
@@ -92,9 +92,6 @@ impl Storable for Bytes {
     }
 }
 
-// Bytes uses the default MaybePackable implementation (returns error)
-impl MaybePackable for Bytes {}
-
 impl Storable for String {
     #[inline]
     fn load<S: StorageOps>(storage: &S, slot: U256, ctx: LayoutCtx) -> Result<Self> {
@@ -119,9 +116,6 @@ impl Storable for String {
         delete_bytes_like(storage, slot)
     }
 }
-
-// String uses the default MaybePackable implementation (returns error)
-impl MaybePackable for String {}
 
 // -- HELPER FUNCTIONS ---------------------------------------------------------
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -10,10 +10,7 @@ pub mod vec;
 mod bytes_like;
 mod primitives;
 
-use crate::{
-    error::{Result, TempoPrecompileError},
-    storage::StorageOps,
-};
+use crate::{error::Result, storage::StorageOps};
 use alloy::primitives::{Address, U256};
 use std::rc::Rc;
 
@@ -202,47 +199,6 @@ pub trait Storable: StorableType + Sized {
                 storage.sstore(slot, cleared)
             }
         }
-    }
-}
-
-/// Trait for single-word encoding/decoding, required for packed storage in `Vec<T>`.
-///
-/// When storing elements in [`Vec<T>`], packed storage requires casting values to/from a
-/// U256 word. However, not all [`Storable`] types can be packed based on EVM storage rules.
-///
-/// By separating this into its own trait with default error implementations, we can:
-/// 1. Require the trait bound on `Vec<T>` to enable packed storage
-/// 2. Allow non-packable types to satisfy the bound while failing at runtime if
-///    packing is actually attempted (which would be a bug in the storage logic)
-///
-/// # Implementations
-///
-/// - **Primitives** (`bool`, `Address`, integers, `FixedBytes`): Implement meaningful
-///   conversions via [`Encodable<1>`].
-/// - **Non-packable types** (`Bytes`, `String`, `Vec<T>`, structs, arrays): Use the
-///   default implementation which returns an error.
-///
-/// # Relationship to `IS_PACKABLE`
-///
-/// - Types where [`StorableType::IS_PACKABLE`] is `true` provide working implementations.
-/// - Types where [`StorableType::IS_PACKABLE`] is `false` use the default error.
-pub trait MaybePackable: StorableType + Sized {
-    /// Encode this value to a single U256 word for packing.
-    ///
-    /// Returns an error for non-packable types.
-    fn to_word(&self) -> Result<U256> {
-        Err(TempoPrecompileError::Fatal(
-            "to_word called on non-packable type".to_string(),
-        ))
-    }
-
-    /// Decode this type from a single U256 word.
-    ///
-    /// Returns an error for non-packable types.
-    fn from_word(_word: U256) -> Result<Self> {
-        Err(TempoPrecompileError::Fatal(
-            "from_word called on non-packable type".to_string(),
-        ))
     }
 }
 

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -152,18 +152,6 @@ pub trait StorableType {
     fn handle(slot: U256, ctx: LayoutCtx, address: Rc<Address>) -> Self::Handler;
 }
 
-/// Abstracts reading, writing, and deleting values for [`Storable`] types.
-pub trait Handler<T: Storable> {
-    /// Reads the value from storage.
-    fn read(&self) -> Result<T>;
-
-    /// Writes the value to storage.
-    fn write(&mut self, value: T) -> Result<()>;
-
-    /// Deletes the value from storage (sets to zero).
-    fn delete(&mut self) -> Result<()>;
-}
-
 /// High-level storage operations for storable types.
 ///
 /// This trait provides storage I/O operations: load, store, delete.

--- a/crates/precompiles/src/storage/types/primitives.rs
+++ b/crates/precompiles/src/storage/types/primitives.rs
@@ -104,18 +104,6 @@ impl Storable for bool {
     // delete uses default implementation from trait
 }
 
-impl MaybePackable for bool {
-    #[inline]
-    fn to_word(&self) -> Result<U256> {
-        Ok(<Self as Encodable<1>>::to_evm_words(self)?[0])
-    }
-
-    #[inline]
-    fn from_word(word: U256) -> Result<Self> {
-        <Self as Encodable<1>>::from_evm_words([word])
-    }
-}
-
 impl Storable for Address {
     #[inline]
     fn load<S: StorageOps>(storage: &S, base_slot: U256, ctx: LayoutCtx) -> Result<Self> {
@@ -143,18 +131,6 @@ impl Storable for Address {
     }
 
     // delete uses default implementation from trait
-}
-
-impl MaybePackable for Address {
-    #[inline]
-    fn to_word(&self) -> Result<U256> {
-        Ok(<Self as Encodable<1>>::to_evm_words(self)?[0])
-    }
-
-    #[inline]
-    fn from_word(word: U256) -> Result<Self> {
-        <Self as Encodable<1>>::from_evm_words([word])
-    }
 }
 
 #[cfg(test)]

--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -3,9 +3,7 @@ use std::{marker::PhantomData, rc::Rc};
 
 use crate::{
     error::Result,
-    storage::{
-        FieldLocation, Handler, LayoutCtx, Storable, StorableType, StorageAccessor, StorageOps,
-    },
+    storage::{FieldLocation, LayoutCtx, Storable, StorableType, StorageAccessor, StorageOps},
 };
 
 /// Type-safe wrapper for a single EVM storage slot.
@@ -122,7 +120,7 @@ impl<T> Slot<T> {
     }
 }
 
-impl<T: Storable> Handler<T> for Slot<T> {
+impl<T: Storable> Slot<T> {
     /// Reads a value from storage at this slot.
     ///
     /// This method delegates to the `Storable::load` implementation,
@@ -137,7 +135,7 @@ impl<T: Storable> Handler<T> for Slot<T> {
     /// let name = name_slot.read().unwrap();
     /// ```
     #[inline]
-    fn read(&self) -> Result<T> {
+    pub fn read(&self) -> Result<T> {
         T::load(self, self.slot, self.ctx)
     }
 
@@ -155,7 +153,7 @@ impl<T: Storable> Handler<T> for Slot<T> {
     /// name_slot.write("MyToken".to_string()).unwrap();
     /// ```
     #[inline]
-    fn write(&mut self, value: T) -> Result<()> {
+    pub fn write(&mut self, value: T) -> Result<()> {
         value.store(self, self.slot, self.ctx)
     }
 
@@ -173,7 +171,7 @@ impl<T: Storable> Handler<T> for Slot<T> {
     /// name_slot.delete().unwrap();
     /// ```
     #[inline]
-    fn delete(&mut self) -> Result<()> {
+    pub fn delete(&mut self) -> Result<()> {
         T::delete(self, self.slot, self.ctx)
     }
 }

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -174,6 +174,12 @@ impl<T: StorableType> VecHandler<T> {
         }
     }
 
+    /// Returns a `Slot` accessor for full-vector operations.
+    #[inline]
+    fn as_slot(&self) -> Slot<Vec<T>> {
+        Slot::new(self.len_slot, Rc::clone(&self.address))
+    }
+
     /// Returns the slot that stores the length of the dynamic array.
     #[inline]
     pub fn len_slot(&self) -> ::alloy::primitives::U256 {
@@ -224,6 +230,33 @@ impl<T: StorableType> VecHandler<T> {
     pub fn at(&self, index: usize) -> T::Handler {
         let (base_slot, layout_ctx) = self.location_of(index);
         T::handle(base_slot, layout_ctx, Rc::clone(&self.address))
+    }
+
+    /// Reads the entire vector from storage.
+    #[inline]
+    pub fn read(&self) -> Result<Vec<T>>
+    where
+        T: Storable,
+    {
+        self.as_slot().read()
+    }
+
+    /// Writes the entire vector to storage.
+    #[inline]
+    pub fn write(&mut self, value: Vec<T>) -> Result<()>
+    where
+        T: Storable,
+    {
+        self.as_slot().write(value)
+    }
+
+    /// Deletes the entire vector from storage (clears length and all elements).
+    #[inline]
+    pub fn delete(&mut self) -> Result<()>
+    where
+        T: Storable,
+    {
+        self.as_slot().delete()
     }
 
     /// Pushes a new element to the end of the vector.

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -174,12 +174,6 @@ impl<T: StorableType> VecHandler<T> {
         }
     }
 
-    /// Returns a `Slot` accessor for full-vector operations.
-    #[inline]
-    fn as_slot(&self) -> Slot<Vec<T>> {
-        Slot::new(self.len_slot, Rc::clone(&self.address))
-    }
-
     /// Returns the slot that stores the length of the dynamic array.
     #[inline]
     pub fn len_slot(&self) -> ::alloy::primitives::U256 {
@@ -193,6 +187,12 @@ impl<T: StorableType> VecHandler<T> {
     #[inline]
     pub fn data_slot(&self) -> ::alloy::primitives::U256 {
         calc_data_slot(self.len_slot)
+    }
+
+    /// Returns a `Slot` accessor for full-vector operations.
+    #[inline]
+    fn as_slot(&self) -> Slot<Vec<T>> {
+        Slot::new(self.len_slot, Rc::clone(&self.address))
     }
 
     /// Returns the length of the vector.


### PR DESCRIPTION
Removes `Handler` trait in favor of relying on `Slot` and `Storable` impls in `VecHandler`