### PR TITLE
test(tip20): migrate `TIP20` tests to new precompile abstractions

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -2160,46 +2160,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_transfer_fee_pre_tx_handles_rewards_post_moderato() -> eyre::Result<()> {
-        // Test with Moderato hardfork (rewards should be handled)
-        let (mut storage, admin) = setup_storage();
-        storage.set_spec(TempoHardfork::Moderato);
-
-        StorageContext::enter(&mut storage, || {
-            let user = Address::random();
-
-            let mint_amount = U256::from(1000e18);
-            let reward_amount = U256::from(100e18);
-
-            // Setup token with rewards enabled
-            let (token_id, initial_opted_in) =
-                setup_token_with_rewards(admin, user, mint_amount, reward_amount)?;
-
-            // Transfer fee from user
-            let fee_amount = U256::from(100e18);
-            let mut token = TIP20Token::new(token_id);
-            token.transfer_fee_pre_tx(user, fee_amount)?;
-
-            // After transfer_fee_pre_tx, the opted-in supply should be decreased
-            let final_opted_in = token.get_opted_in_supply()?;
-            assert_eq!(
-                final_opted_in,
-                initial_opted_in - fee_amount.to::<u128>(),
-                "opted-in supply should decrease by fee amount"
-            );
-
-            // User should have accumulated rewards (verify rewards were updated)
-            let user_info = token.get_user_reward_info(user)?;
-            assert!(
-                user_info.reward_balance > U256::ZERO,
-                "user should have accumulated rewards"
-            );
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_transfer_fee_pre_tx_no_rewards_pre_moderato() -> eyre::Result<()> {
         let (mut storage, admin) = setup_storage();
         storage.set_spec(TempoHardfork::Adagio);


### PR DESCRIPTION
This PR migrates TIP20 unit tests to use the new abstractions introduced in #1177.