### PR TITLE
test(pathUSD): migrate `pathUSD` tests to new precompile abstractions

### DIFF
--- a/crates/precompiles/src/path_usd/mod.rs
+++ b/crates/precompiles/src/path_usd/mod.rs
@@ -363,977 +363,1015 @@ mod tests {
         })
     }
 
-    // #[test]
-    // fn test_transfer_with_memo_reverts() {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let (mut path_usd, _admin) = transfer_test_setup(&mut storage);
-
-    //     let result = path_usd.transfer_with_memo(
-    //         Address::random(),
-    //         ITIP20::transferWithMemoCall {
-    //             to: Address::random(),
-    //             amount: U256::from(100),
-    //             memo: [0u8; 32].into(),
-    //         },
-    //     );
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
-    //     );
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_memo_reverts() {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let (mut path_usd, _admin) = transfer_test_setup(&mut storage);
-
-    //     let result = path_usd.transfer_from_with_memo(
-    //         Address::random(),
-    //         ITIP20::transferFromWithMemoCall {
-    //             from: Address::random(),
-    //             to: Address::random(),
-    //             amount: U256::from(100),
-    //             memo: [0u8; 32].into(),
-    //         },
-    //     );
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
-    //     );
-    // }
-
-    // #[test]
-    // fn test_mint() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let (mut path_usd, admin) = transfer_test_setup(&mut storage);
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     let balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     path_usd.mint(
-    //         admin,
-    //         ITIP20::mintCall {
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     let balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(balance_after, balance_before + amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_burn() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: admin, amount })?;
-
-    //     let balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: admin })?;
-
-    //     path_usd.burn(admin, ITIP20::burnCall { amount })?;
-
-    //     let balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: admin })?;
-    //     assert_eq!(balance_after, balance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_approve() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let owner = Address::random();
-    //     let spender = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-
-    //     let result = path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
-
-    //     assert!(result);
-
-    //     let allowance = path_usd.allowance(ITIP20::allowanceCall { owner, spender })?;
-    //     assert_eq!(allowance, amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_stablecoin_exchange() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     path_usd.mint(
-    //         admin,
-    //         ITIP20::mintCall {
-    //             to: STABLECOIN_EXCHANGE_ADDRESS,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     let dex_balance_before = path_usd.balance_of(ITIP20::balanceOfCall {
-    //         account: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     let recipient_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     let result = path_usd.transfer(
-    //         STABLECOIN_EXCHANGE_ADDRESS,
-    //         ITIP20::transferCall {
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     )?;
-    //     assert!(result);
-
-    //     let dex_balance_after = path_usd.balance_of(ITIP20::balanceOfCall {
-    //         account: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     let recipient_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(dex_balance_after, dex_balance_before - amount);
-    //     assert_eq!(recipient_balance_after, recipient_balance_before + amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_stablecoin_exchange() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(
-    //         from,
-    //         ITIP20::approveCall {
-    //             spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     let from_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-
-    //     let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-
-    //     let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     let result = path_usd.transfer_from(
-    //         STABLECOIN_EXCHANGE_ADDRESS,
-    //         ITIP20::transferFromCall { from, to, amount },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let from_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-
-    //     let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-
-    //     let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     assert_eq!(from_balance_after, from_balance_before - amount);
-    //     assert_eq!(to_balance_after, to_balance_before + amount);
-    //     assert_eq!(allowance_after, allowance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_transfer_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd.token.grant_role_internal(sender, *TRANSFER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     let sender_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-
-    //     let recipient_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     let result = path_usd.transfer(
-    //         sender,
-    //         ITIP20::transferCall {
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     )?;
-    //     assert!(result);
-
-    //     let sender_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(sender_balance_after, sender_balance_before - amount);
-    //     assert_eq!(recipient_balance_after, recipient_balance_before + amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_receive_role_reverts() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd
-    //         .token
-    //         .grant_role_internal(recipient, *RECEIVE_WITH_MEMO_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     let result = path_usd.transfer(
-    //         sender,
-    //         ITIP20::transferCall {
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     );
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
-    //     );
-
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_transfer_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let spender = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd.token.grant_role_internal(from, *TRANSFER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
-
-    //     let from_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-
-    //     let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-
-    //     let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     let result =
-    //         path_usd.transfer_from(spender, ITIP20::transferFromCall { from, to, amount })?;
-
-    //     assert!(result);
-
-    //     let from_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     assert_eq!(from_balance_after, from_balance_before - amount);
-    //     assert_eq!(to_balance_after, to_balance_before + amount);
-    //     assert_eq!(allowance_after, allowance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_receive_role_reverts() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let spender = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd
-    //         .token
-    //         .grant_role_internal(to, *RECEIVE_WITH_MEMO_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
-
-    //     let result = path_usd.transfer_from(spender, ITIP20::transferFromCall { from, to, amount });
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
-    //     );
-
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_memo_with_transfer_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd.token.grant_role_internal(sender, *TRANSFER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     let sender_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     path_usd.transfer_with_memo(
-    //         sender,
-    //         ITIP20::transferWithMemoCall {
-    //             to: recipient,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     let sender_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(sender_balance_after, sender_balance_before - amount);
-    //     assert_eq!(recipient_balance_after, recipient_balance_before + amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_memo_with_receive_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd
-    //         .token
-    //         .grant_role_internal(recipient, *RECEIVE_WITH_MEMO_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     let sender_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance_before =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     path_usd.transfer_with_memo(
-    //         sender,
-    //         ITIP20::transferWithMemoCall {
-    //             to: recipient,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     let sender_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance_after =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(sender_balance_after, sender_balance_before - amount);
-    //     assert_eq!(recipient_balance_after, recipient_balance_before + amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_memo_with_stablecoin_exchange() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(
-    //         from,
-    //         ITIP20::approveCall {
-    //             spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     let from_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     let result = path_usd.transfer_from_with_memo(
-    //         STABLECOIN_EXCHANGE_ADDRESS,
-    //         ITIP20::transferFromWithMemoCall {
-    //             from,
-    //             to,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let from_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender: STABLECOIN_EXCHANGE_ADDRESS,
-    //     })?;
-
-    //     assert_eq!(from_balance_after, from_balance_before - amount);
-    //     assert_eq!(to_balance_after, to_balance_before + amount);
-    //     assert_eq!(allowance_after, allowance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_memo_with_transfer_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let spender = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd.token.grant_role_internal(from, *TRANSFER_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
-
-    //     let from_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     let result = path_usd.transfer_from_with_memo(
-    //         spender,
-    //         ITIP20::transferFromWithMemoCall {
-    //             from,
-    //             to,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let from_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     assert_eq!(from_balance_after, from_balance_before - amount);
-    //     assert_eq!(to_balance_after, to_balance_before + amount);
-    //     assert_eq!(allowance_after, allowance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_memo_with_receive_role() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let from = Address::random();
-    //     let to = Address::random();
-    //     let spender = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-    //     path_usd
-    //         .token
-    //         .grant_role_internal(to, *RECEIVE_WITH_MEMO_ROLE)?;
-
-    //     path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
-
-    //     path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
-
-    //     let from_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     let result = path_usd.transfer_from_with_memo(
-    //         spender,
-    //         ITIP20::transferFromWithMemoCall {
-    //             from,
-    //             to,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let from_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
-    //     let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
-    //     let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
-    //         owner: from,
-    //         spender,
-    //     })?;
-
-    //     assert_eq!(from_balance_after, from_balance_before - amount);
-    //     assert_eq!(to_balance_after, to_balance_before + amount);
-    //     assert_eq!(allowance_after, allowance_before - amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_pause_and_unpause() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let pauser = Address::random();
-    //     let unpauser = Address::random();
-
-    //     path_usd.initialize(admin).unwrap();
-
-    //     // Grant PAUSE_ROLE and UNPAUSE_ROLE
-    //     path_usd.token.grant_role_internal(pauser, *PAUSE_ROLE)?;
-    //     path_usd
-    //         .token
-    //         .grant_role_internal(unpauser, *UNPAUSE_ROLE)?;
-
-    //     // Verify initial state (not paused)
-    //     assert!(!path_usd.paused().unwrap());
-
-    //     // Pause the token
-    //     path_usd.pause(pauser, ITIP20::pauseCall {}).unwrap();
-    //     assert!(path_usd.paused().unwrap());
-
-    //     // Unpause the token
-    //     path_usd.unpause(unpauser, ITIP20::unpauseCall {}).unwrap();
-    //     assert!(!path_usd.paused().unwrap());
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_role_management() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let user = Address::random();
-
-    //     path_usd.initialize(admin).unwrap();
-
-    //     // Grant ISSUER_ROLE to user
-    //     path_usd
-    //         .token
-    //         .grant_role(
-    //             admin,
-    //             IRolesAuth::grantRoleCall {
-    //                 role: *ISSUER_ROLE,
-    //                 account: user,
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     // Check that user has the role
-    //     assert!(
-    //         path_usd
-    //             .token
-    //             .has_role(IRolesAuth::hasRoleCall {
-    //                 role: *ISSUER_ROLE,
-    //                 account: user,
-    //             })
-    //             .expect("Could not get role")
-    //     );
-
-    //     // Revoke the role
-    //     path_usd
-    //         .token
-    //         .revoke_role(
-    //             admin,
-    //             IRolesAuth::revokeRoleCall {
-    //                 role: *ISSUER_ROLE,
-    //                 account: user,
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     // Check that user no longer has the role
-    //     assert!(
-    //         !path_usd
-    //             .token
-    //             .has_role(IRolesAuth::hasRoleCall {
-    //                 role: *ISSUER_ROLE,
-    //                 account: user,
-    //             })
-    //             .expect("Could not get role")
-    //     );
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_supply_cap() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let recipient = Address::random();
-    //     let supply_cap = U256::from(1000);
-
-    //     path_usd.initialize(admin).unwrap();
-
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Set supply cap
-    //     path_usd
-    //         .token
-    //         .set_supply_cap(
-    //             admin,
-    //             ITIP20::setSupplyCapCall {
-    //                 newSupplyCap: supply_cap,
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     assert_eq!(path_usd.token.supply_cap().unwrap(), supply_cap);
-
-    //     // Try to mint more than supply cap
-    //     let result = path_usd.mint(
-    //         admin,
-    //         ITIP20::mintCall {
-    //             to: recipient,
-    //             amount: U256::from(1001),
-    //         },
-    //     );
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::supply_cap_exceeded())
-    //     );
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_invalid_supply_caps() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let recipient = Address::random();
-    //     let supply_cap = U256::from(1000);
-    //     let bad_supply_cap = uint!(0x100000000000000000000000000000000_U256);
-
-    //     path_usd.initialize(admin).unwrap();
-
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Set supply cap to u128 max plus one
-    //     let result = path_usd.token.set_supply_cap(
-    //         admin,
-    //         ITIP20::setSupplyCapCall {
-    //             newSupplyCap: bad_supply_cap,
-    //         },
-    //     );
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::supply_cap_exceeded())
-    //     );
-
-    //     // Set supply cap
-    //     path_usd
-    //         .token
-    //         .set_supply_cap(
-    //             admin,
-    //             ITIP20::setSupplyCapCall {
-    //                 newSupplyCap: supply_cap,
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     // Try to mint the exact supply cap
-    //     path_usd
-    //         .mint(
-    //             admin,
-    //             ITIP20::mintCall {
-    //                 to: recipient,
-    //                 amount: U256::from(1000),
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     // Try to set the supply cap to something lower than the total supply
-    //     let smaller_supply_cap = U256::from(999);
-    //     let result = path_usd.token.set_supply_cap(
-    //         admin,
-    //         ITIP20::setSupplyCapCall {
-    //             newSupplyCap: smaller_supply_cap,
-    //         },
-    //     );
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::TIP20(TIP20Error::invalid_supply_cap())
-    //     );
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_change_transfer_policy_id() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new(1);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let new_policy_id = 42u64;
-
-    //     path_usd.initialize(admin).unwrap();
-
-    //     // Admin can change transfer policy ID
-    //     path_usd
-    //         .token
-    //         .change_transfer_policy_id(
-    //             admin,
-    //             ITIP20::changeTransferPolicyIdCall {
-    //                 newPolicyId: new_policy_id,
-    //             },
-    //         )
-    //         .unwrap();
-
-    //     assert_eq!(
-    //         path_usd
-    //             .token
-    //             .transfer_policy_id()
-    //             .expect("Could not get policy"),
-    //         new_policy_id
-    //     );
-
-    //     // Non-admin cannot change transfer policy ID
-    //     let non_admin = Address::random();
-    //     let result = path_usd.token.change_transfer_policy_id(
-    //         non_admin,
-    //         ITIP20::changeTransferPolicyIdCall { newPolicyId: 100 },
-    //     );
-
-    //     assert_eq!(
-    //         result.unwrap_err(),
-    //         TempoPrecompileError::RolesAuthError(RolesAuthError::unauthorized())
-    //     );
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_post_allegretto() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::Allegretto);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Mint to sender without any special roles
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     // Post-Allegretto: transfer should work without TRANSFER_ROLE
-    //     let result = path_usd.transfer(
-    //         sender,
-    //         ITIP20::transferCall {
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let sender_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(sender_balance, U256::ZERO);
-    //     assert_eq!(recipient_balance, amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_post_allegretto() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::Allegretto);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let owner = Address::random();
-    //     let spender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Mint to owner and approve spender
-    //     path_usd.mint(admin, ITIP20::mintCall { to: owner, amount })?;
-    //     path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
-
-    //     // Post-Allegretto: transfer_from should work without TRANSFER_ROLE
-    //     let result = path_usd.transfer_from(
-    //         spender,
-    //         ITIP20::transferFromCall {
-    //             from: owner,
-    //             to: recipient,
-    //             amount,
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let owner_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: owner })?;
-    //     let recipient_balance =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(owner_balance, U256::ZERO);
-    //     assert_eq!(recipient_balance, amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_with_memo_post_allegretto() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::Allegretto);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let sender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Mint to sender without any special roles
-    //     path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
-
-    //     // Post-Allegretto: transfer_with_memo should work without TRANSFER_ROLE or RECEIVE_WITH_MEMO_ROLE
-    //     path_usd.transfer_with_memo(
-    //         sender,
-    //         ITIP20::transferWithMemoCall {
-    //             to: recipient,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     let sender_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
-    //     let recipient_balance =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(sender_balance, U256::ZERO);
-    //     assert_eq!(recipient_balance, amount);
-    //     Ok(())
-    // }
-
-    // #[test]
-    // fn test_transfer_from_with_memo_post_allegretto() -> eyre::Result<()> {
-    //     let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::Allegretto);
-    //     let mut path_usd = PathUSD::new(&mut storage);
-    //     let admin = Address::random();
-    //     let owner = Address::random();
-    //     let spender = Address::random();
-    //     let recipient = Address::random();
-    //     let amount = U256::from(1000);
-    //     let memo = [1u8; 32];
-
-    //     path_usd.initialize(admin)?;
-    //     path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
-
-    //     // Mint to owner and approve spender
-    //     path_usd.mint(admin, ITIP20::mintCall { to: owner, amount })?;
-    //     path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
-
-    //     // Post-Allegretto: transfer_from_with_memo should work without any special roles
-    //     let result = path_usd.transfer_from_with_memo(
-    //         spender,
-    //         ITIP20::transferFromWithMemoCall {
-    //             from: owner,
-    //             to: recipient,
-    //             amount,
-    //             memo: memo.into(),
-    //         },
-    //     )?;
-
-    //     assert!(result);
-
-    //     let owner_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: owner })?;
-    //     let recipient_balance =
-    //         path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
-
-    //     assert_eq!(owner_balance, U256::ZERO);
-    //     assert_eq!(recipient_balance, amount);
-    //     Ok(())
-    // }
+    #[test]
+    fn test_transfer_with_memo_reverts() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = transfer_test_setup(admin)?;
+
+            let result = path_usd.transfer_with_memo(
+                Address::random(),
+                ITIP20::transferWithMemoCall {
+                    to: Address::random(),
+                    amount: U256::from(100),
+                    memo: [0u8; 32].into(),
+                },
+            );
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_memo_reverts() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = transfer_test_setup(admin)?;
+
+            let result = path_usd.transfer_from_with_memo(
+                Address::random(),
+                ITIP20::transferFromWithMemoCall {
+                    from: Address::random(),
+                    to: Address::random(),
+                    amount: U256::from(100),
+                    memo: [0u8; 32].into(),
+                },
+            );
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_mint() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = transfer_test_setup(admin)?;
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            let balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            path_usd.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: recipient,
+                    amount,
+                },
+            )?;
+
+            let balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(balance_after, balance_before + amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_burn() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: admin, amount })?;
+
+            let balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: admin })?;
+
+            path_usd.burn(admin, ITIP20::burnCall { amount })?;
+
+            let balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: admin })?;
+            assert_eq!(balance_after, balance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_approve() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let owner = Address::random();
+            let spender = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+
+            let result = path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
+
+            assert!(result);
+
+            let allowance = path_usd.allowance(ITIP20::allowanceCall { owner, spender })?;
+            assert_eq!(allowance, amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_stablecoin_exchange() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            path_usd.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: STABLECOIN_EXCHANGE_ADDRESS,
+                    amount,
+                },
+            )?;
+
+            let dex_balance_before = path_usd.balance_of(ITIP20::balanceOfCall {
+                account: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            let recipient_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            let result = path_usd.transfer(
+                STABLECOIN_EXCHANGE_ADDRESS,
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount,
+                },
+            )?;
+            assert!(result);
+
+            let dex_balance_after = path_usd.balance_of(ITIP20::balanceOfCall {
+                account: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            let recipient_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(dex_balance_after, dex_balance_before - amount);
+            assert_eq!(recipient_balance_after, recipient_balance_before + amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_stablecoin_exchange() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(
+                from,
+                ITIP20::approveCall {
+                    spender: STABLECOIN_EXCHANGE_ADDRESS,
+                    amount,
+                },
+            )?;
+
+            let from_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+
+            let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+
+            let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            let result = path_usd.transfer_from(
+                STABLECOIN_EXCHANGE_ADDRESS,
+                ITIP20::transferFromCall { from, to, amount },
+            )?;
+
+            assert!(result);
+
+            let from_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+
+            let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+
+            let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            assert_eq!(from_balance_after, from_balance_before - amount);
+            assert_eq!(to_balance_after, to_balance_before + amount);
+            assert_eq!(allowance_after, allowance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_transfer_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd.token.grant_role_internal(sender, *TRANSFER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            let sender_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+
+            let recipient_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            let result = path_usd.transfer(
+                sender,
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount,
+                },
+            )?;
+            assert!(result);
+
+            let sender_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(sender_balance_after, sender_balance_before - amount);
+            assert_eq!(recipient_balance_after, recipient_balance_before + amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_receive_role_reverts() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd
+                .token
+                .grant_role_internal(recipient, *RECEIVE_WITH_MEMO_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            let result = path_usd.transfer(
+                sender,
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount,
+                },
+            );
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_transfer_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let spender = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd.token.grant_role_internal(from, *TRANSFER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
+
+            let from_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+
+            let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+
+            let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            let result =
+                path_usd.transfer_from(spender, ITIP20::transferFromCall { from, to, amount })?;
+
+            assert!(result);
+
+            let from_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            assert_eq!(from_balance_after, from_balance_before - amount);
+            assert_eq!(to_balance_after, to_balance_before + amount);
+            assert_eq!(allowance_after, allowance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_receive_role_reverts() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let spender = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd
+                .token
+                .grant_role_internal(to, *RECEIVE_WITH_MEMO_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
+
+            let result =
+                path_usd.transfer_from(spender, ITIP20::transferFromCall { from, to, amount });
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::transfers_disabled())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_memo_with_transfer_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd.token.grant_role_internal(sender, *TRANSFER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            let sender_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            path_usd.transfer_with_memo(
+                sender,
+                ITIP20::transferWithMemoCall {
+                    to: recipient,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            let sender_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(sender_balance_after, sender_balance_before - amount);
+            assert_eq!(recipient_balance_after, recipient_balance_before + amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_memo_with_receive_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd
+                .token
+                .grant_role_internal(recipient, *RECEIVE_WITH_MEMO_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            let sender_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            path_usd.transfer_with_memo(
+                sender,
+                ITIP20::transferWithMemoCall {
+                    to: recipient,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            let sender_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(sender_balance_after, sender_balance_before - amount);
+            assert_eq!(recipient_balance_after, recipient_balance_before + amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_memo_with_stablecoin_exchange() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(
+                from,
+                ITIP20::approveCall {
+                    spender: STABLECOIN_EXCHANGE_ADDRESS,
+                    amount,
+                },
+            )?;
+
+            let from_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            let result = path_usd.transfer_from_with_memo(
+                STABLECOIN_EXCHANGE_ADDRESS,
+                ITIP20::transferFromWithMemoCall {
+                    from,
+                    to,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            assert!(result);
+
+            let from_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender: STABLECOIN_EXCHANGE_ADDRESS,
+            })?;
+
+            assert_eq!(from_balance_after, from_balance_before - amount);
+            assert_eq!(to_balance_after, to_balance_before + amount);
+            assert_eq!(allowance_after, allowance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_memo_with_transfer_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let spender = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd.token.grant_role_internal(from, *TRANSFER_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
+
+            let from_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            let result = path_usd.transfer_from_with_memo(
+                spender,
+                ITIP20::transferFromWithMemoCall {
+                    from,
+                    to,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            assert!(result);
+
+            let from_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            assert_eq!(from_balance_after, from_balance_before - amount);
+            assert_eq!(to_balance_after, to_balance_before + amount);
+            assert_eq!(allowance_after, allowance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_memo_with_receive_role() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let from = Address::random();
+            let to = Address::random();
+            let spender = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            path_usd
+                .token
+                .grant_role_internal(to, *RECEIVE_WITH_MEMO_ROLE)?;
+
+            path_usd.mint(admin, ITIP20::mintCall { to: from, amount })?;
+
+            path_usd.approve(from, ITIP20::approveCall { spender, amount })?;
+
+            let from_balance_before =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_before = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_before = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            let result = path_usd.transfer_from_with_memo(
+                spender,
+                ITIP20::transferFromWithMemoCall {
+                    from,
+                    to,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            assert!(result);
+
+            let from_balance_after =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: from })?;
+            let to_balance_after = path_usd.balance_of(ITIP20::balanceOfCall { account: to })?;
+            let allowance_after = path_usd.allowance(ITIP20::allowanceCall {
+                owner: from,
+                spender,
+            })?;
+
+            assert_eq!(from_balance_after, from_balance_before - amount);
+            assert_eq!(to_balance_after, to_balance_before + amount);
+            assert_eq!(allowance_after, allowance_before - amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_pause_and_unpause() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let pauser = Address::random();
+            let unpauser = Address::random();
+
+            path_usd.initialize(admin)?;
+
+            // Grant PAUSE_ROLE and UNPAUSE_ROLE
+            path_usd.token.grant_role_internal(pauser, *PAUSE_ROLE)?;
+            path_usd
+                .token
+                .grant_role_internal(unpauser, *UNPAUSE_ROLE)?;
+
+            assert!(!path_usd.paused()?);
+
+            path_usd.pause(pauser, ITIP20::pauseCall {})?;
+            assert!(path_usd.paused()?);
+
+            path_usd.unpause(unpauser, ITIP20::unpauseCall {})?;
+            assert!(!path_usd.paused()?);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_role_management() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let user = Address::random();
+
+            path_usd.initialize(admin)?;
+
+            // Grant ISSUER_ROLE to user
+            path_usd.token.grant_role(
+                admin,
+                IRolesAuth::grantRoleCall {
+                    role: *ISSUER_ROLE,
+                    account: user,
+                },
+            )?;
+
+            // Check that user has the role
+            assert!(path_usd.token.has_role(IRolesAuth::hasRoleCall {
+                role: *ISSUER_ROLE,
+                account: user,
+            })?);
+
+            // Revoke the role
+            path_usd.token.revoke_role(
+                admin,
+                IRolesAuth::revokeRoleCall {
+                    role: *ISSUER_ROLE,
+                    account: user,
+                },
+            )?;
+
+            // Check that user no longer has the role
+            assert!(!path_usd.token.has_role(IRolesAuth::hasRoleCall {
+                role: *ISSUER_ROLE,
+                account: user,
+            })?);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_supply_cap() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let recipient = Address::random();
+            let supply_cap = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Set supply cap
+            path_usd.token.set_supply_cap(
+                admin,
+                ITIP20::setSupplyCapCall {
+                    newSupplyCap: supply_cap,
+                },
+            )?;
+
+            assert_eq!(path_usd.token.supply_cap()?, supply_cap);
+
+            // Try to mint more than supply cap
+            let result = path_usd.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: recipient,
+                    amount: U256::from(1001),
+                },
+            );
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::supply_cap_exceeded())
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_invalid_supply_caps() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let recipient = Address::random();
+            let supply_cap = U256::from(1000);
+            let bad_supply_cap = uint!(0x100000000000000000000000000000000_U256);
+
+            path_usd.initialize(admin)?;
+
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Set supply cap to u128 max plus one
+            let result = path_usd.token.set_supply_cap(
+                admin,
+                ITIP20::setSupplyCapCall {
+                    newSupplyCap: bad_supply_cap,
+                },
+            );
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::supply_cap_exceeded())
+            );
+
+            // Set supply cap
+            path_usd.token.set_supply_cap(
+                admin,
+                ITIP20::setSupplyCapCall {
+                    newSupplyCap: supply_cap,
+                },
+            )?;
+
+            // Try to mint the exact supply cap
+            path_usd.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: recipient,
+                    amount: U256::from(1000),
+                },
+            )?;
+
+            // Try to set the supply cap to something lower than the total supply
+            let smaller_supply_cap = U256::from(999);
+            let result = path_usd.token.set_supply_cap(
+                admin,
+                ITIP20::setSupplyCapCall {
+                    newSupplyCap: smaller_supply_cap,
+                },
+            );
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::TIP20(TIP20Error::invalid_supply_cap())
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_change_transfer_policy_id() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let new_policy_id = 42u64;
+
+            path_usd.initialize(admin)?;
+
+            // Admin can change transfer policy ID
+            path_usd.token.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: new_policy_id,
+                },
+            )?;
+
+            assert_eq!(path_usd.token.transfer_policy_id()?, new_policy_id);
+
+            // Non-admin cannot change transfer policy ID
+            let non_admin = Address::random();
+            let result = path_usd.token.change_transfer_policy_id(
+                non_admin,
+                ITIP20::changeTransferPolicyIdCall { newPolicyId: 100 },
+            );
+
+            assert_eq!(
+                result.unwrap_err(),
+                TempoPrecompileError::RolesAuthError(RolesAuthError::unauthorized())
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_post_allegretto() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+        storage.set_spec(TempoHardfork::Allegretto);
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Mint to sender without any special roles
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            // Post-Allegretto: transfer should work without TRANSFER_ROLE
+            let result = path_usd.transfer(
+                sender,
+                ITIP20::transferCall {
+                    to: recipient,
+                    amount,
+                },
+            )?;
+
+            assert!(result);
+
+            let sender_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(sender_balance, U256::ZERO);
+            assert_eq!(recipient_balance, amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_post_allegretto() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+        storage.set_spec(TempoHardfork::Allegretto);
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let owner = Address::random();
+            let spender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Mint to owner and approve spender
+            path_usd.mint(admin, ITIP20::mintCall { to: owner, amount })?;
+            path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
+
+            // Post-Allegretto: transfer_from should work without TRANSFER_ROLE
+            let result = path_usd.transfer_from(
+                spender,
+                ITIP20::transferFromCall {
+                    from: owner,
+                    to: recipient,
+                    amount,
+                },
+            )?;
+
+            assert!(result);
+
+            let owner_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: owner })?;
+            let recipient_balance =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(owner_balance, U256::ZERO);
+            assert_eq!(recipient_balance, amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_with_memo_post_allegretto() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+        storage.set_spec(TempoHardfork::Allegretto);
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let sender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Mint to sender without any special roles
+            path_usd.mint(admin, ITIP20::mintCall { to: sender, amount })?;
+
+            // Post-Allegretto: transfer_with_memo should work without TRANSFER_ROLE or RECEIVE_WITH_MEMO_ROLE
+            path_usd.transfer_with_memo(
+                sender,
+                ITIP20::transferWithMemoCall {
+                    to: recipient,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            let sender_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: sender })?;
+            let recipient_balance =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(sender_balance, U256::ZERO);
+            assert_eq!(recipient_balance, amount);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_transfer_from_with_memo_post_allegretto() -> eyre::Result<()> {
+        let (mut storage, admin) = setup_storage();
+        storage.set_spec(TempoHardfork::Allegretto);
+
+        StorageContext::enter(&mut storage, || {
+            let mut path_usd = PathUSD::new();
+            let owner = Address::random();
+            let spender = Address::random();
+            let recipient = Address::random();
+            let amount = U256::from(1000);
+            let memo = [1u8; 32];
+
+            path_usd.initialize(admin)?;
+            path_usd.token.grant_role_internal(admin, *ISSUER_ROLE)?;
+
+            // Mint to owner and approve spender
+            path_usd.mint(admin, ITIP20::mintCall { to: owner, amount })?;
+            path_usd.approve(owner, ITIP20::approveCall { spender, amount })?;
+
+            // Post-Allegretto: transfer_from_with_memo should work without any special roles
+            let result = path_usd.transfer_from_with_memo(
+                spender,
+                ITIP20::transferFromWithMemoCall {
+                    from: owner,
+                    to: recipient,
+                    amount,
+                    memo: memo.into(),
+                },
+            )?;
+
+            assert!(result);
+
+            let owner_balance = path_usd.balance_of(ITIP20::balanceOfCall { account: owner })?;
+            let recipient_balance =
+                path_usd.balance_of(ITIP20::balanceOfCall { account: recipient })?;
+
+            assert_eq!(owner_balance, U256::ZERO);
+            assert_eq!(recipient_balance, amount);
+            Ok(())
+        })
+    }
 }


### PR DESCRIPTION
This PR migrates PathUSD unit tests to use the new abstractions introduced in #1177.