### PR TITLE
chore(alloy): move crate docs into readme file

### DIFF
--- a/crates/alloy/README.md
+++ b/crates/alloy/README.md
@@ -1,0 +1,34 @@
+# Tempo Alloy
+
+Tempo types for [Alloy](https://alloy.rs).
+
+## Getting Started
+
+To use `tempo-alloy`, add the crate as a dependency in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+```
+
+## Development Status
+
+`tempo-alloy` is currently in development and is not yet ready for production use.
+
+## Usage
+
+To get started, instantiate a provider with [`TempoNetwork`]:
+
+```rust
+use alloy::{
+    providers::{Provider, ProviderBuilder},
+    transports::TransportError
+};
+use tempo_alloy::TempoNetwork;
+
+async fn build_provider() -> Result<impl Provider<TempoNetwork>, TransportError> {
+    ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect("https://rpc.testnet.tempo.xyz")
+        .await
+}
+```

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,36 +1,4 @@
-//! Tempo types for Alloy.
-//!
-//! # Getting Started
-//!
-//! To use `tempo-alloy`, add the crate as a dependency in your `Cargo.toml` file:
-//!
-//! ```toml
-//! [dependencies]
-//! tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-//! ```
-//!
-//! # Development Status
-//!
-//! `tempo-alloy` is currently in development and is not yet ready for production use.
-//!
-//! # Usage
-//!
-//! To get started, instantiate a provider with [`TempoNetwork`]:
-//!
-//! ```rust
-//! use alloy::{
-//!     providers::{Provider, ProviderBuilder},
-//!     transports::TransportError
-//! };
-//! use tempo_alloy::TempoNetwork;
-//!
-//! async fn build_provider() -> Result<impl Provider<TempoNetwork>, TransportError> {
-//!     ProviderBuilder::new_with_network::<TempoNetwork>()
-//!         .connect("https://rpc.testnet.tempo.xyz")
-//!         .await
-//! }
-//! ```
-
+#![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
Moves the crate-level docs for `tempo-alloy` into a README file instead, as it contains what we'd expect for a README as well.

Let me know if we'd like anything else here.

Closes #975 