### PR TITLE
fix: make cursor work properly when query spans more than one orderbook

### DIFF
--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -73,7 +73,7 @@ impl<
                 .as_ref()
                 .is_none_or(|f| f.is_bid.unwrap_or(false));
 
-            let cursor = params
+            let mut cursor = params
                 .cursor
                 .map(|cursor| parse_order_cursor(&cursor))
                 .transpose()?;
@@ -95,8 +95,16 @@ impl<
                     continue;
                 }
 
+                // If the cursor exists and the starting order is not in the book, skip this book
+                if let Some(cursor) = cursor
+                    && exchange.get_order(cursor).is_err()
+                {
+                    continue;
+                }
+
                 let starting_order = if all_orders.is_empty() {
-                    cursor // Use cursor only for the first book
+                    // If the cursor is in this book then use it
+                    cursor.take()
                 } else {
                     None
                 };


### PR DESCRIPTION
fixes https://github.com/tempoxyz/tempo/issues/1203

previously if a cursor was used and the query matched multiple orderbooks, the iteration would not start at the cursor, it would start at the first book. Now, we skip books until it is the one that contains the cursor, and start from there