### PR TITLE
chore(evm): add ExecutionResult to SystemTransactionFailed error

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -177,7 +177,7 @@ where
                 ..
             } = &mut result.result
             else {
-                return Err(TempoInvalidTransaction::SystemTransactionFailed.into());
+                return Err(TempoInvalidTransaction::SystemTransactionFailed(result.result).into());
             };
 
             *gas_used = 0;

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -2,7 +2,7 @@
 
 use alloy_evm::error::InvalidTxError;
 use alloy_primitives::{Address, U256};
-use revm::context::result::{EVMError, HaltReason, InvalidTransaction};
+use revm::context::result::{EVMError, ExecutionResult, HaltReason, InvalidTransaction};
 
 /// Tempo-specific invalid transaction errors.
 ///
@@ -19,8 +19,8 @@ pub enum TempoInvalidTransaction {
     SystemTransactionMustBeCall,
 
     /// System transaction execution failed.
-    #[error("system transaction execution failed")]
-    SystemTransactionFailed,
+    #[error("system transaction execution failed, result: {_0:?}")]
+    SystemTransactionFailed(ExecutionResult<TempoHaltReason>),
 
     /// Fee payer signature recovery failed.
     ///


### PR DESCRIPTION
Right now if a system transaction is invalid, we get a log like this:
```
2025-12-04T23:15:17.121126Z  WARN payload_builder: failed to resolve pending payload err=evm execution error: EVM reported invalid transaction (0x0303cadf380bf741011477a4bd72b92aaf8aca36a0fc5e23c26bc0b62b239319): system transaction execution failed
```

If this contained the full result then it would be a more useful log during debugging