### PR TITLE
feat: add reward docs to tempo sdk, and claude skill for syncing docs changes

### DIFF
--- a/docs/pages/sdk/typescript/viem/actions.mdx
+++ b/docs/pages/sdk/typescript/viem/actions.mdx
@@ -31,10 +31,14 @@
 | [`policy.watchWhitelistUpdated`](/sdk/typescript/viem/policy.watchWhitelistUpdated) | Watches for whitelist update events |
 | **Reward Actions** | |
 | [`reward.cancel`](/sdk/typescript/viem/reward.cancel) | Cancels an active reward stream and refunds remaining tokens |
+| [`reward.claim`](/sdk/typescript/viem/reward.claim) | Claims accumulated rewards for the caller |
 | [`reward.getStream`](/sdk/typescript/viem/reward.getStream) | Gets a reward stream by its ID |
 | [`reward.getTotalPerSecond`](/sdk/typescript/viem/reward.getTotalPerSecond) | Gets the total reward per second rate for all active streams |
+| [`reward.getUserRewardInfo`](/sdk/typescript/viem/reward.getUserRewardInfo) | Gets reward information for a specific account |
 | [`reward.setRecipient`](/sdk/typescript/viem/reward.setRecipient) | Sets or changes the reward recipient for a token holder |
 | [`reward.start`](/sdk/typescript/viem/reward.start) | Starts a new reward stream that distributes tokens to opted-in holders |
+| [`reward.watchRewardRecipientSet`](/sdk/typescript/viem/reward.watchRewardRecipientSet) | Watches for reward recipient set events |
+| [`reward.watchRewardScheduled`](/sdk/typescript/viem/reward.watchRewardScheduled) | Watches for reward scheduled events |
 | **Stablecoin Exchange Actions** | |
 | [`dex.buy`](/sdk/typescript/viem/dex.buy) | Buys a specific amount of tokens from the Stablecoin Exchange orderbook |
 | [`dex.cancel`](/sdk/typescript/viem/dex.cancel) | Cancels an order from the orderbook |

--- a/docs/pages/sdk/typescript/viem/reward.claim.mdx
+++ b/docs/pages/sdk/typescript/viem/reward.claim.mdx
@@ -1,0 +1,62 @@
+import WriteParameters from '../../../../snippets/write-parameters.mdx'
+
+# `reward.claim`
+
+Claims accumulated rewards for the caller.
+
+## Usage
+
+Use the `reward.claim` action on the Viem `client` to claim rewards that have accumulated for your address.
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client, token } from './viem.config'
+
+const { receipt } = await client.reward.claimSync({
+  token,
+})
+
+console.log('Transaction hash:', receipt.transactionHash)
+// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/viem.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.claim` action and wait for inclusion manually:
+
+```ts twoslash
+import { client, token } from './viem.config'
+
+const hash = await client.reward.claim({
+  token,
+})
+const receipt = await client.waitForTransactionReceipt({ hash })
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+}
+```
+
+## Parameters
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<WriteParameters />

--- a/docs/pages/sdk/typescript/viem/reward.getUserRewardInfo.mdx
+++ b/docs/pages/sdk/typescript/viem/reward.getUserRewardInfo.mdx
@@ -1,0 +1,61 @@
+import ReadParameters from '../../../../snippets/read-parameters.mdx'
+
+# `reward.getUserRewardInfo`
+
+Gets reward information for a specific account.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client, token } from './viem.config'
+
+const { rewardBalance, rewardPerToken, rewardRecipient } =
+  await client.reward.getUserRewardInfo({
+    account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+    token,
+  })
+
+console.log('Reward recipient:', rewardRecipient)
+// @log: Reward recipient: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+console.log('Reward balance:', rewardBalance)
+// @log: Reward balance: 1000000000000000000n
+console.log('Reward per token:', rewardPerToken)
+// @log: Reward per token: 385802469135802469135n
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Accumulated reward balance claimable by the account */
+  rewardBalance: bigint
+  /** Reward per token checkpoint for the account */
+  rewardPerToken: bigint
+  /** Current reward recipient address (zero address if opted out) */
+  rewardRecipient: Address
+}
+```
+
+## Parameters
+
+### account
+
+- **Type:** `Address`
+
+Address of the account to get reward info for.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<ReadParameters />

--- a/docs/pages/sdk/typescript/viem/reward.watchRewardRecipientSet.mdx
+++ b/docs/pages/sdk/typescript/viem/reward.watchRewardRecipientSet.mdx
@@ -1,0 +1,73 @@
+# `reward.watchRewardRecipientSet`
+
+Watches for reward recipient set events when token holders change their reward recipient.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client, token } from './viem.config'
+
+const unwatch = client.reward.watchRewardRecipientSet({
+  onRewardRecipientSet: (args, log) => {
+    console.log('Holder:', args.holder)
+    console.log('Recipient:', args.recipient)
+  },
+  token,
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onRewardRecipientSet
+
+- **Type:**
+
+```ts
+declare function onRewardRecipientSet(args: Args, log: Log): void
+
+type Args = {
+  /** Token holder address who set their reward recipient */
+  holder: Address
+  /** New reward recipient address (zero address indicates opt-out) */
+  recipient: Address
+}
+```
+
+Callback to invoke when a reward recipient is set.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token to watch.
+
+### holder (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by holder address.
+
+### recipient (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by recipient address.

--- a/docs/pages/sdk/typescript/viem/reward.watchRewardScheduled.mdx
+++ b/docs/pages/sdk/typescript/viem/reward.watchRewardScheduled.mdx
@@ -1,0 +1,73 @@
+# `reward.watchRewardScheduled`
+
+Watches for reward scheduled events when new reward streams are started.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { client, token } from './viem.config'
+
+const unwatch = client.reward.watchRewardScheduled({
+  onRewardScheduled: (args, log) => {
+    console.log('Stream ID:', args.id)
+    console.log('Funder:', args.funder)
+    console.log('Amount:', args.amount)
+    console.log('Duration:', args.durationSeconds, 'seconds')
+  },
+  token,
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [viem.config.ts] filename="viem.config.ts"
+// [!include ~/snippets/viem.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onRewardScheduled
+
+- **Type:**
+
+```ts
+declare function onRewardScheduled(args: Args, log: Log): void
+
+type Args = {
+  /** Total amount allocated to the stream */
+  amount: bigint
+  /** Duration of the stream in seconds (0 for immediate distributions) */
+  durationSeconds: number
+  /** Address that funded the stream */
+  funder: Address
+  /** Unique stream ID (0 for immediate distributions) */
+  id: bigint
+}
+```
+
+Callback to invoke when a reward stream is scheduled.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token to watch.
+
+### funder (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by funder address.

--- a/docs/pages/sdk/typescript/wagmi/actions/index.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/index.mdx
@@ -27,6 +27,14 @@
 | [`policy.watchBlacklistUpdated`](#TODO) | Watches for blacklist update events |
 | [`policy.watchCreate`](#TODO) | Watches for policy creation events |
 | [`policy.watchWhitelistUpdated`](#TODO) | Watches for whitelist update events |
+| **Reward Actions** | |
+| [`reward.claim`](/sdk/typescript/wagmi/actions/reward.claim) | Claims accumulated rewards for the caller |
+| [`reward.getTotalPerSecond`](/sdk/typescript/wagmi/actions/reward.getTotalPerSecond) | Gets the total reward per second rate for all active streams |
+| [`reward.getUserRewardInfo`](/sdk/typescript/wagmi/actions/reward.getUserRewardInfo) | Gets reward information for a specific account |
+| [`reward.setRecipient`](/sdk/typescript/wagmi/actions/reward.setRecipient) | Sets or changes the reward recipient for a token holder |
+| [`reward.start`](/sdk/typescript/wagmi/actions/reward.start) | Starts a new reward stream that distributes tokens to opted-in holders |
+| [`reward.watchRewardRecipientSet`](/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet) | Watches for reward recipient set events |
+| [`reward.watchRewardScheduled`](/sdk/typescript/wagmi/actions/reward.watchRewardScheduled) | Watches for reward scheduled events |
 | **Stablecoin Exchange Actions** | |
 | [`dex.buy`](/sdk/typescript/wagmi/actions/dex.buy) | Buys a specific amount of tokens from the Stablecoin Exchange orderbook |
 | [`dex.cancel`](/sdk/typescript/wagmi/actions/dex.cancel) | Cancels an order from the orderbook |

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.claim.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.claim.mdx
@@ -1,0 +1,64 @@
+import WriteParameters from '../../../../../snippets/write-parameters.mdx'
+
+# `reward.claim`
+
+Claims accumulated rewards for the caller.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const { receipt } = await Actions.reward.claimSync(config, {
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Transaction hash:', receipt.transactionHash)
+// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.claim` action and wait for inclusion manually:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { waitForTransactionReceipt } from 'wagmi/actions'
+import { config } from './wagmi.config'
+
+const hash = await Actions.reward.claim(config, {
+  token: '0x20c0000000000000000000000000000000000000',
+})
+const receipt = await waitForTransactionReceipt(config, { hash })
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+}
+```
+
+## Parameters
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<WriteParameters wagmi />

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.getTotalPerSecond.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.getTotalPerSecond.mdx
@@ -1,0 +1,50 @@
+import ReadParameters from '../../../../../snippets/read-parameters.mdx'
+
+# `reward.getTotalPerSecond`
+
+Gets the total reward per second rate for all active streams.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const rate = await Actions.reward.getTotalPerSecond(config, {
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Total rate per second:', rate)
+// @log: Total rate per second: 385802469135802469135n
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnValue = bigint
+```
+
+Returns the current aggregate per-second emission rate scaled by `ACC_PRECISION` (1e18). This value represents the sum of all active reward streams' emission rates.
+
+:::tip
+The rate decreases when streams end (via `finalizeStreams`) or are canceled.
+:::
+
+## Parameters
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<ReadParameters wagmi />

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.getUserRewardInfo.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.getUserRewardInfo.mdx
@@ -1,0 +1,63 @@
+import ReadParameters from '../../../../../snippets/read-parameters.mdx'
+
+# `reward.getUserRewardInfo`
+
+Gets reward information for a specific account.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const { rewardBalance, rewardPerToken, rewardRecipient } =
+  await Actions.reward.getUserRewardInfo(config, {
+    account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+    token: '0x20c0000000000000000000000000000000000000',
+  })
+
+console.log('Reward recipient:', rewardRecipient)
+// @log: Reward recipient: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+console.log('Reward balance:', rewardBalance)
+// @log: Reward balance: 1000000000000000000n
+console.log('Reward per token:', rewardPerToken)
+// @log: Reward per token: 385802469135802469135n
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Accumulated reward balance claimable by the account */
+  rewardBalance: bigint
+  /** Reward per token checkpoint for the account */
+  rewardPerToken: bigint
+  /** Current reward recipient address (zero address if opted out) */
+  rewardRecipient: Address
+}
+```
+
+## Parameters
+
+### account
+
+- **Type:** `Address`
+
+Address of the account to get reward info for.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<ReadParameters wagmi />

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.setRecipient.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.setRecipient.mdx
@@ -1,0 +1,114 @@
+import WriteParameters from '../../../../../snippets/write-parameters.mdx'
+
+# `reward.setRecipient`
+
+Sets or changes the reward recipient for a token holder.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const { holder, receipt, recipient } = await Actions.reward.setRecipientSync(config, {
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Holder:', holder)
+// @log: Holder: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+console.log('Recipient:', recipient)
+// @log: Recipient: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Opt Out of Rewards
+
+Set `recipient` to the zero address to opt out from rewards distribution:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+await Actions.reward.setRecipientSync(config, {
+  recipient: '0x0000000000000000000000000000000000000000',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+### Delegate Rewards
+
+Set `recipient` to another address to delegate your rewards to them:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+await Actions.reward.setRecipientSync(config, {
+  recipient: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.setRecipient` action and wait for inclusion manually:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { Actions as viem_Actions } from 'tempo.ts/viem'
+import { waitForTransactionReceipt } from 'wagmi/actions'
+import { config } from './wagmi.config'
+
+const hash = await Actions.reward.setRecipient(config, {
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+const receipt = await waitForTransactionReceipt(config, { hash })
+
+const { args: { holder, recipient } }
+  = viem_Actions.reward.setRecipient.extractEvent(receipt.logs)
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Token holder address who set their reward recipient */
+  holder: Address
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+  /** Reward recipient address (zero address indicates opt-out) */
+  recipient: Address
+}
+```
+
+:::tip
+Rewards are automatically distributed to the current recipient before changing. This happens during any balance-changing operation (transfers, mints, burns).
+:::
+
+## Parameters
+
+### recipient
+
+- **Type:** `Address`
+
+The reward recipient address. Use zero address to opt out of rewards.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<WriteParameters wagmi />

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.start.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.start.mdx
@@ -1,0 +1,118 @@
+import WriteParameters from '../../../../../snippets/write-parameters.mdx'
+
+# `reward.start`
+
+Starts a new reward stream that distributes tokens to opted-in holders.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { parseEther } from 'viem'
+import { config } from './wagmi.config'
+
+const { amount, durationSeconds, funder, id, receipt } =
+  await Actions.reward.startSync(config, {
+    amount: parseEther('1000'),
+    seconds: 2_592_000, // 30 days
+    token: '0x20c0000000000000000000000000000000000000',
+  })
+
+console.log('Stream ID:', id)
+// @log: Stream ID: 1n
+console.log('Amount:', amount)
+// @log: Amount: 1000000000000000000000n
+console.log('Duration:', durationSeconds, 'seconds')
+// @log: Duration: 2592000 seconds
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Immediate Distribution
+
+Set `seconds` to `0` for immediate distribution to current opted-in holders:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { parseEther } from 'viem'
+import { config } from './wagmi.config'
+
+const { id } = await Actions.reward.startSync(config, {
+  amount: parseEther('100'),
+  seconds: 0, // Immediate distribution
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Stream ID:', id)
+// @log: Stream ID: 0n
+```
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.start` action and wait for inclusion manually:
+
+```ts twoslash
+import { Actions } from 'tempo.ts/wagmi'
+import { Actions as viem_Actions } from 'tempo.ts/viem'
+import { parseEther } from 'viem'
+import { waitForTransactionReceipt } from 'wagmi/actions'
+import { config } from './wagmi.config'
+
+const hash = await Actions.reward.start(config, {
+  amount: parseEther('1000'),
+  seconds: 2_592_000,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+const receipt = await waitForTransactionReceipt(config, { hash })
+
+const { args: { id, funder, amount, durationSeconds } }
+  = viem_Actions.reward.start.extractEvent(receipt.logs)
+```
+
+## Return Type
+
+```ts
+type ReturnType = {
+  /** Total amount allocated to the stream */
+  amount: bigint
+  /** Duration of the stream in seconds (0 for immediate distributions) */
+  durationSeconds: number
+  /** Address that funded the stream */
+  funder: Address
+  /** Unique stream ID (0 for immediate distributions; all that is currently supported) */
+  id: bigint
+  /** Transaction receipt */
+  receipt: TransactionReceipt
+}
+```
+
+## Parameters
+
+### amount
+
+- **Type:** `bigint`
+
+The amount of tokens to distribute. Must be greater than 0.
+
+### seconds
+
+- **Type:** `number`
+
+The duration in seconds. Currently, must be `0` (meaning immediate distribution).
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token.
+
+<WriteParameters wagmi />

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet.mdx
@@ -1,0 +1,75 @@
+# `reward.watchRewardRecipientSet`
+
+Watches for reward recipient set events when token holders change their reward recipient.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const unwatch = Actions.reward.watchRewardRecipientSet(config, {
+  onRewardRecipientSet: (args, log) => {
+    console.log('Holder:', args.holder)
+    console.log('Recipient:', args.recipient)
+  },
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onRewardRecipientSet
+
+- **Type:**
+
+```ts
+declare function onRewardRecipientSet(args: Args, log: Log): void
+
+type Args = {
+  /** Token holder address who set their reward recipient */
+  holder: Address
+  /** New reward recipient address (zero address indicates opt-out) */
+  recipient: Address
+}
+```
+
+Callback to invoke when a reward recipient is set.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token to watch.
+
+### holder (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by holder address.
+
+### recipient (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by recipient address.

--- a/docs/pages/sdk/typescript/wagmi/actions/reward.watchRewardScheduled.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/reward.watchRewardScheduled.mdx
@@ -1,0 +1,75 @@
+# `reward.watchRewardScheduled`
+
+Watches for reward scheduled events when new reward streams are started.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+import { Actions } from 'tempo.ts/wagmi'
+import { config } from './wagmi.config'
+
+const unwatch = Actions.reward.watchRewardScheduled(config, {
+  onRewardScheduled: (args, log) => {
+    console.log('Stream ID:', args.id)
+    console.log('Funder:', args.funder)
+    console.log('Amount:', args.amount)
+    console.log('Duration:', args.durationSeconds, 'seconds')
+  },
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+// Later, stop watching
+unwatch()
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+```ts
+type ReturnType = () => void
+```
+
+Returns a function to unsubscribe from the event.
+
+## Parameters
+
+### onRewardScheduled
+
+- **Type:**
+
+```ts
+declare function onRewardScheduled(args: Args, log: Log): void
+
+type Args = {
+  /** Total amount allocated to the stream */
+  amount: bigint
+  /** Duration of the stream in seconds (0 for immediate distributions) */
+  durationSeconds: number
+  /** Address that funded the stream */
+  funder: Address
+  /** Unique stream ID (0 for immediate distributions) */
+  id: bigint
+}
+```
+
+Callback to invoke when a reward stream is scheduled.
+
+### token
+
+- **Type:** `Address`
+
+Address of the TIP-20 token to watch.
+
+### funder (optional)
+
+- **Type:** `Address | undefined`
+
+Filter events by funder address.

--- a/docs/pages/sdk/typescript/wagmi/hooks/index.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/index.mdx
@@ -27,6 +27,14 @@
 | [`policy.useWatchBlacklistUpdated`](#TODO) | Hook for watching blacklist update events |
 | [`policy.useWatchCreate`](#TODO) | Hook for watching policy creation events |
 | [`policy.useWatchWhitelistUpdated`](#TODO) | Hook for watching whitelist update events |
+| **Reward Hooks** | |
+| [`reward.useClaim`](/sdk/typescript/wagmi/hooks/reward.useClaim) | Hook for claiming accumulated rewards |
+| [`reward.useGetTotalPerSecond`](/sdk/typescript/wagmi/hooks/reward.useGetTotalPerSecond) | Hook for getting the total reward per second rate for all active streams |
+| [`reward.useSetRecipient`](/sdk/typescript/wagmi/hooks/reward.useSetRecipient) | Hook for setting or changing the reward recipient for a token holder |
+| [`reward.useStart`](/sdk/typescript/wagmi/hooks/reward.useStart) | Hook for starting a new reward stream that distributes tokens to opted-in holders |
+| [`reward.useUserRewardInfo`](/sdk/typescript/wagmi/hooks/reward.useUserRewardInfo) | Hook for getting reward information for a specific account |
+| [`reward.useWatchRewardRecipientSet`](/sdk/typescript/wagmi/hooks/reward.useWatchRewardRecipientSet) | Hook for watching reward recipient set events |
+| [`reward.useWatchRewardScheduled`](/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled) | Hook for watching reward scheduled events |
 | **Stablecoin Exchange Hooks** | |
 | [`dex.useBalance`](/sdk/typescript/wagmi/hooks/dex.useBalance) | Hook for getting a user's token balance on the Stablecoin Exchange |
 | [`dex.useBuy`](/sdk/typescript/wagmi/hooks/dex.useBuy) | Hook for buying a specific amount of tokens from the Stablecoin Exchange orderbook |

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useClaim.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useClaim.mdx
@@ -1,0 +1,87 @@
+# `reward.useClaim`
+
+Claims accumulated rewards for the caller.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+const { data: result, mutate } = Hooks.reward.useClaimSync()
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Transaction hash:', result.receipt.transactionHash)
+// @log: Transaction hash: 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.claim` action and wait for inclusion manually:
+
+```ts twoslash
+// @errors: 2322
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+import { useWaitForTransactionReceipt } from 'wagmi'
+import { config } from './wagmi.config'
+
+const { data: hash, mutate } = Hooks.reward.useClaim()
+const { data: receipt } = useWaitForTransactionReceipt({ hash })
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+## Return Type
+
+See [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook return types.
+
+### data
+
+See [Wagmi Action `reward.claim` Return Type](/sdk/typescript/wagmi/actions/reward.claim#return-type)
+
+### mutate/mutateAsync
+
+See [Wagmi Action `reward.claim` Parameters](/sdk/typescript/wagmi/actions/reward.claim#parameters)
+
+## Parameters
+
+### config
+
+`Config | undefined`
+
+[`Config`](https://wagmi.sh/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](https://wagmi.sh/react/api/WagmiProvider).
+
+### mutation
+
+See the [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook parameters.

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useGetTotalPerSecond.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useGetTotalPerSecond.mdx
@@ -1,0 +1,49 @@
+# `reward.useGetTotalPerSecond`
+
+Gets the total reward per second rate for all active streams.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+const { data: rate } = Hooks.reward.useGetTotalPerSecond({
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Total rate per second:', rate)
+// @log: Total rate per second: 385802469135802469135n
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+See [TanStack Query query docs](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) for more info hook return types.
+
+### data
+
+See [Wagmi Action `reward.getTotalPerSecond` Return Type](/sdk/typescript/wagmi/actions/reward.getTotalPerSecond#return-type)
+
+## Parameters
+
+See [Wagmi Action `reward.getTotalPerSecond` Parameters](/sdk/typescript/wagmi/actions/reward.getTotalPerSecond#parameters)
+
+### query
+
+See the [TanStack Query query docs](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) for more info hook parameters.

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useSetRecipient.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useSetRecipient.mdx
@@ -1,0 +1,97 @@
+# `reward.useSetRecipient`
+
+Sets or changes the reward recipient for a token holder.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+const { data: result, mutate } = Hooks.reward.useSetRecipientSync()
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Holder:', result.holder)
+// @log: Holder: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+console.log('Recipient:', result.recipient)
+// @log: Recipient: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.setRecipient` action and wait for inclusion manually:
+
+```ts twoslash
+// @errors: 2322
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+import { Actions } from 'tempo.ts/viem'
+import { useWaitForTransactionReceipt } from 'wagmi'
+import { config } from './wagmi.config'
+
+const { data: hash, mutate } = Hooks.reward.useSetRecipient()
+const { data: receipt } = useWaitForTransactionReceipt({ hash })
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+if (receipt) {
+  const { args: { holder, recipient } }
+    = Actions.reward.setRecipient.extractEvent(receipt.logs)
+}
+```
+
+## Return Type
+
+See [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook return types.
+
+### data
+
+See [Wagmi Action `reward.setRecipient` Return Type](/sdk/typescript/wagmi/actions/reward.setRecipient#return-type)
+
+### mutate/mutateAsync
+
+See [Wagmi Action `reward.setRecipient` Parameters](/sdk/typescript/wagmi/actions/reward.setRecipient#parameters)
+
+## Parameters
+
+### config
+
+`Config | undefined`
+
+[`Config`](https://wagmi.sh/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](https://wagmi.sh/react/api/WagmiProvider).
+
+### mutation
+
+See the [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook parameters.

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useStart.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useStart.mdx
@@ -1,0 +1,103 @@
+# `reward.useStart`
+
+Starts a new reward stream that distributes tokens to opted-in holders.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+import { parseEther } from 'viem'
+
+const { data: result, mutate } = Hooks.reward.useStartSync()
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  amount: parseEther('1000'),
+  seconds: 2_592_000, // 30 days
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Stream ID:', result.id)
+// @log: Stream ID: 1n
+console.log('Amount:', result.amount)
+// @log: Amount: 1000000000000000000000n
+console.log('Duration:', result.durationSeconds, 'seconds')
+// @log: Duration: 2592000 seconds
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+### Asynchronous Usage
+
+The example above uses a `*Sync` variant of the action, that will wait for the transaction to be included before returning.
+
+If you are optimizing for performance, you should use the non-sync `reward.start` action and wait for inclusion manually:
+
+```ts twoslash
+// @errors: 2322
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+import { Actions } from 'tempo.ts/viem'
+import { parseEther } from 'viem'
+import { useWaitForTransactionReceipt } from 'wagmi'
+import { config } from './wagmi.config'
+
+const { data: hash, mutate } = Hooks.reward.useStart()
+const { data: receipt } = useWaitForTransactionReceipt({ hash })
+
+// Call `mutate` in response to user action (e.g. button click, form submission)
+mutate({
+  amount: parseEther('1000'),
+  seconds: 2_592_000,
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+if (receipt) {
+  const { args: { id, funder, amount, durationSeconds } }
+    = Actions.reward.start.extractEvent(receipt.logs)
+}
+```
+
+## Return Type
+
+See [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook return types.
+
+### data
+
+See [Wagmi Action `reward.start` Return Type](/sdk/typescript/wagmi/actions/reward.start#return-type)
+
+### mutate/mutateAsync
+
+See [Wagmi Action `reward.start` Parameters](/sdk/typescript/wagmi/actions/reward.start#parameters)
+
+## Parameters
+
+### config
+
+`Config | undefined`
+
+[`Config`](https://wagmi.sh/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](https://wagmi.sh/react/api/WagmiProvider).
+
+### mutation
+
+See the [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/react/reference/useMutation) for more info hook parameters.

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useUserRewardInfo.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useUserRewardInfo.mdx
@@ -1,0 +1,54 @@
+# `reward.useUserRewardInfo`
+
+Gets reward information for a specific account.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+const { data } = Hooks.reward.useUserRewardInfo({
+  account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
+  token: '0x20c0000000000000000000000000000000000000',
+})
+
+console.log('Reward recipient:', data.rewardRecipient)
+// @log: Reward recipient: 0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb
+console.log('Reward balance:', data.rewardBalance)
+// @log: Reward balance: 1000000000000000000n
+console.log('Reward per token:', data.rewardPerToken)
+// @log: Reward per token: 385802469135802469135n
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Return Type
+
+See [TanStack Query query docs](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) for more info hook return types.
+
+### data
+
+See [Wagmi Action `reward.getUserRewardInfo` Return Type](/sdk/typescript/wagmi/actions/reward.getUserRewardInfo#return-type)
+
+## Parameters
+
+See [Wagmi Action `reward.getUserRewardInfo` Parameters](/sdk/typescript/wagmi/actions/reward.getUserRewardInfo#parameters)
+
+### query
+
+See the [TanStack Query query docs](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) for more info hook parameters.

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardRecipientSet.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardRecipientSet.mdx
@@ -1,0 +1,44 @@
+# `reward.useWatchRewardRecipientSet`
+
+Watches for reward recipient set events when token holders change their reward recipient.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+Hooks.reward.useWatchRewardRecipientSet({
+  onRewardRecipientSet: (args, log) => {
+    console.log('Holder:', args.holder)
+    console.log('Recipient:', args.recipient)
+  },
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Parameters
+
+See [Wagmi Action `reward.watchRewardRecipientSet` Parameters](/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet#parameters)
+
+### config
+
+`Config | undefined`
+
+[`Config`](https://wagmi.sh/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](https://wagmi.sh/react/api/WagmiProvider).

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled.mdx
@@ -1,0 +1,46 @@
+# `reward.useWatchRewardScheduled`
+
+Watches for reward scheduled events when new reward streams are started.
+
+## Usage
+
+:::code-group
+
+```ts twoslash [example.ts]
+// @errors: 2322
+import { config } from './wagmi.config'
+declare module 'wagmi' {
+  interface Register {
+    config: typeof config
+  }
+}
+// ---cut---
+import { Hooks } from 'tempo.ts/wagmi'
+
+Hooks.reward.useWatchRewardScheduled({
+  onRewardScheduled: (args, log) => {
+    console.log('Stream ID:', args.id)
+    console.log('Funder:', args.funder)
+    console.log('Amount:', args.amount)
+    console.log('Duration:', args.durationSeconds, 'seconds')
+  },
+  token: '0x20c0000000000000000000000000000000000000',
+})
+```
+
+```ts twoslash [wagmi.config.ts] filename="wagmi.config.ts"
+// @noErrors
+// [!include ~/snippets/wagmi.config.ts:setup]
+```
+
+:::
+
+## Parameters
+
+See [Wagmi Action `reward.watchRewardScheduled` Parameters](/sdk/typescript/wagmi/actions/reward.watchRewardScheduled#parameters)
+
+### config
+
+`Config | undefined`
+
+[`Config`](https://wagmi.sh/react/api/createConfig#config) to use instead of retrieving from the nearest [`WagmiProvider`](https://wagmi.sh/react/api/WagmiProvider).

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -661,12 +661,40 @@ export default defineConfig({
                 text: 'Reward',
                 items: [
                   {
+                    text: 'cancel',
+                    link: '/sdk/typescript/viem/reward.cancel',
+                  },
+                  {
+                    text: 'claim',
+                    link: '/sdk/typescript/viem/reward.claim',
+                  },
+                  {
+                    text: 'getStream',
+                    link: '/sdk/typescript/viem/reward.getStream',
+                  },
+                  {
+                    text: 'getTotalPerSecond',
+                    link: '/sdk/typescript/viem/reward.getTotalPerSecond',
+                  },
+                  {
+                    text: 'getUserRewardInfo',
+                    link: '/sdk/typescript/viem/reward.getUserRewardInfo',
+                  },
+                  {
                     text: 'setRecipient',
                     link: '/sdk/typescript/viem/reward.setRecipient',
                   },
                   {
                     text: 'start',
                     link: '/sdk/typescript/viem/reward.start',
+                  },
+                  {
+                    text: 'watchRewardRecipientSet',
+                    link: '/sdk/typescript/viem/reward.watchRewardRecipientSet',
+                  },
+                  {
+                    text: 'watchRewardScheduled',
+                    link: '/sdk/typescript/viem/reward.watchRewardScheduled',
                   },
                 ],
               },
@@ -996,6 +1024,39 @@ export default defineConfig({
                 ],
               },
               {
+                text: 'Reward',
+                items: [
+                  {
+                    text: 'claim',
+                    link: '/sdk/typescript/wagmi/actions/reward.claim',
+                  },
+                  {
+                    text: 'getTotalPerSecond',
+                    link: '/sdk/typescript/wagmi/actions/reward.getTotalPerSecond',
+                  },
+                  {
+                    text: 'getUserRewardInfo',
+                    link: '/sdk/typescript/wagmi/actions/reward.getUserRewardInfo',
+                  },
+                  {
+                    text: 'setRecipient',
+                    link: '/sdk/typescript/wagmi/actions/reward.setRecipient',
+                  },
+                  {
+                    text: 'start',
+                    link: '/sdk/typescript/wagmi/actions/reward.start',
+                  },
+                  {
+                    text: 'watchRewardRecipientSet',
+                    link: '/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet',
+                  },
+                  {
+                    text: 'watchRewardScheduled',
+                    link: '/sdk/typescript/wagmi/actions/reward.watchRewardScheduled',
+                  },
+                ],
+              },
+              {
                 text: 'Stablecoin Exchange',
                 items: [
                   {
@@ -1297,6 +1358,39 @@ export default defineConfig({
                   {
                     text: 'useWatchWhitelistUpdated',
                     link: '/sdk/typescript/wagmi/hooks/policy.useWatchWhitelistUpdated',
+                  },
+                ],
+              },
+              {
+                text: 'Reward',
+                items: [
+                  {
+                    text: 'useClaim',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useClaim',
+                  },
+                  {
+                    text: 'useGetTotalPerSecond',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useGetTotalPerSecond',
+                  },
+                  {
+                    text: 'useSetRecipient',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useSetRecipient',
+                  },
+                  {
+                    text: 'useStart',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useStart',
+                  },
+                  {
+                    text: 'useUserRewardInfo',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useUserRewardInfo',
+                  },
+                  {
+                    text: 'useWatchRewardRecipientSet',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useWatchRewardRecipientSet',
+                  },
+                  {
+                    text: 'useWatchRewardScheduled',
+                    link: '/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled',
                   },
                 ],
               },


### PR DESCRIPTION
Add comprehensive documentation for the reward module across all SDK layers (Viem actions, Wagmi actions, and Wagmi hooks).

Created 18 new documentation pages covering `claim`, `getUserRewardInfo`, `getTotalPerSecond`, `setRecipient`, `start`, `watchRewardScheduled`, and `watchRewardRecipientSet` functions. Updated all three index files and the sidebar configuration in `vocs.config.tsx` to include the new reward sections. 

Also added a reusable skill file documenting the process for syncing `tempo.ts` SDK documentation in the future.