### PR TITLE
feat(builder): pre-execution and execution time metrics

### DIFF
--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -20,16 +20,18 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used: Histogram,
     /// Amount of gas used in the payload.
     pub(crate) gas_used_last: Gauge,
+    /// The time it took to execute pre-execution changes in seconds.
+    pub(crate) pre_execution_changes_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute start-of-block system transactions in seconds.
     pub(crate) start_block_txs_execution_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
-    /// The time it took to execute all transactions in seconds.
-    pub(crate) total_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute system transactions in seconds.
     pub(crate) system_transactions_execution_duration_seconds: Histogram,
+    /// The time it took to execute all transactions in seconds.
+    pub(crate) total_transaction_execution_duration_seconds: Histogram,
     /// The time it took to finalize the payload in seconds. Includes merging transitions and calculating the state root.
     pub(crate) payload_finalization_duration_seconds: Histogram,
     /// Total time it took to build the payload in seconds.


### PR DESCRIPTION
1. Adds `pre_execution_changes_duration_seconds` metric
2. Changes `total_transaction_execution_duration_seconds` metric to include pre-execution changes and system transactions