### PR TITLE
feat(consensus): make it very difficult to leak consensus secrets

### DIFF
--- a/crates/commonware-node-config/Cargo.toml
+++ b/crates/commonware-node-config/Cargo.toml
@@ -20,6 +20,9 @@ indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 
+[features]
+shout_the_secret = []
+
 [dev-dependencies]
 serde_json.workspace = true
 rand.workspace = true

--- a/crates/commonware-node-config/src/i_reveal_secrets.rs
+++ b/crates/commonware-node-config/src/i_reveal_secrets.rs
@@ -1,0 +1,51 @@
+use std::marker::PhantomData;
+
+use commonware_codec::Encode as _;
+
+use super::{SigningKey, SigningShare};
+
+pub struct IKnowWhatIamDoing;
+pub struct IShouldntRevealSecrets<T, const I_KNOW_WHAT_I_AM_DOING: bool = false> {
+    _phantom: PhantomData<T>,
+}
+
+impl IShouldntRevealSecrets<IKnowWhatIamDoing, false> {
+    pub fn i_swear(self) -> IShouldntRevealSecrets<IKnowWhatIamDoing, true> {
+        IShouldntRevealSecrets {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub fn i_know_what_i_am_doing() -> IShouldntRevealSecrets<IKnowWhatIamDoing, false> {
+    IShouldntRevealSecrets {
+        _phantom: PhantomData,
+    }
+}
+
+pub fn shout_this_secret<const WRITE_THE_SECRET: bool>(
+    secret: &impl Secret,
+    _: IShouldntRevealSecrets<IKnowWhatIamDoing, true>,
+) -> String {
+    if WRITE_THE_SECRET {
+        secret.shout_the_secret()
+    } else {
+        "".to_string()
+    }
+}
+
+pub trait Secret {
+    fn shout_the_secret(&self) -> String;
+}
+
+impl Secret for SigningKey {
+    fn shout_the_secret(&self) -> String {
+        const_hex::encode_prefixed(self.inner.encode().as_ref())
+    }
+}
+
+impl Secret for SigningShare {
+    fn shout_the_secret(&self) -> String {
+        const_hex::encode_prefixed(self.inner.encode().as_ref())
+    }
+}

--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -27,6 +27,11 @@ use serde::{
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "shout_the_secret")]
+pub mod i_reveal_secrets;
+#[cfg(not(feature = "shout_the_secret"))]
+mod i_reveal_secrets;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Peers {
     inner: OrderedAssociated<PublicKey, SocketAddr>,
@@ -194,7 +199,14 @@ impl SigningKey {
     }
 
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), SigningKeyError> {
-        std::fs::write(path, self.to_string()).map_err(SigningKeyErrorKind::Write)?;
+        std::fs::write(
+            path,
+            i_reveal_secrets::shout_this_secret::<true>(
+                self,
+                i_reveal_secrets::i_know_what_i_am_doing().i_swear(),
+            ),
+        )
+        .map_err(SigningKeyErrorKind::Write)?;
         Ok(())
     }
 
@@ -205,7 +217,7 @@ impl SigningKey {
 
 impl Display for SigningKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&const_hex::encode_prefixed(self.inner.encode().as_ref()))
+        f.write_str("XXXXXXXXXXXXX")
     }
 }
 
@@ -256,14 +268,21 @@ impl SigningShare {
     }
 
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), SigningShareError> {
-        std::fs::write(path, self.to_string()).map_err(SigningShareErrorKind::Write)?;
+        std::fs::write(
+            path,
+            i_reveal_secrets::shout_this_secret::<true>(
+                self,
+                i_reveal_secrets::i_know_what_i_am_doing().i_swear(),
+            ),
+        )
+        .map_err(SigningShareErrorKind::Write)?;
         Ok(())
     }
 }
 
 impl Display for SigningShare {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&const_hex::encode_prefixed(self.inner.encode().as_ref()))
+        f.write_str("XXXXXXXXXXXXX")
     }
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
-tempo-commonware-node-config.workspace = true
+tempo-commonware-node-config = { workspace = true, features = ["shout_the_secret"] }
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
 

--- a/xtask/src/generate_devnet.rs
+++ b/xtask/src/generate_devnet.rs
@@ -6,6 +6,7 @@ use rand::SeedableRng as _;
 use reth_network_peers::pk2id;
 use secp256k1::SECP256K1;
 use serde::Serialize;
+use tempo_commonware_node_config::i_reveal_secrets;
 
 use crate::genesis_args::GenesisArgs;
 
@@ -117,8 +118,14 @@ impl GenerateDevnet {
                     devmode,
                     node_image_tag: image_tag.clone(),
 
-                    consensus_on_disk_signing_key: validator.signing_key.to_string(),
-                    consensus_on_disk_signing_share: validator.signing_share.to_string(),
+                    consensus_on_disk_signing_key: i_reveal_secrets::shout_this_secret::<true>(
+                        &validator.signing_key,
+                        i_reveal_secrets::i_know_what_i_am_doing().i_swear(),
+                    ),
+                    consensus_on_disk_signing_share: i_reveal_secrets::shout_this_secret::<true>(
+                        &validator.signing_share,
+                        i_reveal_secrets::i_know_what_i_am_doing().i_swear(),
+                    ),
 
                     // FIXME(janis): this should not be zero
                     consensus_fee_recipient: Address::ZERO,


### PR DESCRIPTION
This makes it very hard to accidentally leak secrets by making the user jump through hoops before a secret is formatted as a `String`.

Related: https://github.com/commonwarexyz/monorepo/pull/2423