### PR TITLE
chore: remove paths-ignore in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@ name: Test
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
   merge_group:
 
 concurrency:
@@ -101,4 +97,3 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: test,msrv,genesis,snapshot-re-execute


### PR DESCRIPTION
Removes `paths-ignore` from the `test` workflow. This will run `test` on all PRs, even when not relevant, but is the shortest term fix for getting docs changes in due to the hanging `test-success` check