### PR TITLE
fix(`docs`): update outdated description of `TempoTransaction` on protocol page

### DIFF
--- a/docs/pages/documentation/protocol/index.mdx
+++ b/docs/pages/documentation/protocol/index.mdx
@@ -42,7 +42,7 @@ This section provides details on the Tempo Protocol specifications, and serves a
     title="Fees"
   />
   <Card.Link
-    description="AATransaction (0x76) and deprecated FeeTokenTransaction (0x77) transaction types"
+    description="EIP-2718 transaction type with native passkeys, batching, scheduling, and fee sponsorship"
     href="/documentation/protocol/transactions"
     icon={LucideLayers}
     title="Tempo Transactions"


### PR DESCRIPTION
Previously:

<img width="341" height="191" alt="Screenshot from 2025-12-08 22-56-21" src="https://github.com/user-attachments/assets/30308e60-eb04-49de-aa91-865d0e6c0cc4" />

This description feels outdated on https://docs.tempo.xyz/documentation/protocol, there is no further mention of 0x77 in the docs and we no longer refer to AATransaction as such