### PR TITLE
fix: update custom errors returned by feeAMM

### DIFF
--- a/docs/specs/src/FeeManager.sol
+++ b/docs/specs/src/FeeManager.sol
@@ -30,6 +30,7 @@ contract FeeManager is IFeeManager, FeeAMM {
         address userToken;
         address validatorToken;
     }
+
     TokenPair[] private poolsWithFees;
     mapping(bytes32 => bool) private poolInFeesArray;
 

--- a/docs/specs/src/Nonce.sol
+++ b/docs/specs/src/Nonce.sol
@@ -53,7 +53,10 @@ contract Nonce is INonce {
     /// @param account The account whose nonce to increment
     /// @param nonceKey The nonce key to increment (must be > 0)
     /// @return newNonce The new nonce value after incrementing
-    function _incrementNonce(address account, uint256 nonceKey) internal returns (uint64 newNonce) {
+    function _incrementNonce(address account, uint256 nonceKey)
+        internal
+        returns (uint64 newNonce)
+    {
         if (nonceKey == 0) {
             revert InvalidNonceKey();
         }

--- a/docs/specs/src/StablecoinExchange.sol
+++ b/docs/specs/src/StablecoinExchange.sol
@@ -227,12 +227,13 @@ contract StablecoinExchange is IStablecoinExchange {
             } else {
                 balances[maker][escrowToken] = 0;
                 if (revertOnTransferFail) {
-                    ITIP20(escrowToken)
-                        .transferFrom(maker, address(this), escrowAmount - userBalance);
+                    ITIP20(escrowToken).transferFrom(
+                        maker, address(this), escrowAmount - userBalance
+                    );
                 } else {
-                    try ITIP20(escrowToken)
-                        .transferFrom(maker, address(this), escrowAmount - userBalance) { }
-                    catch {
+                    try ITIP20(escrowToken).transferFrom(
+                        maker, address(this), escrowAmount - userBalance
+                    ) { } catch {
                         return 0;
                     }
                 }
@@ -565,7 +566,9 @@ contract StablecoinExchange is IStablecoinExchange {
     /// @param user The user to transfer from
     /// @param token The token to transfer
     /// @param amount The amount to transfer
-    function _decrementBalanceOrTransferFrom(address user, address token, uint128 amount) internal {
+    function _decrementBalanceOrTransferFrom(address user, address token, uint128 amount)
+        internal
+    {
         uint128 userBalance = balances[user][token];
         if (userBalance >= amount) {
             balances[user][token] -= amount;

--- a/docs/specs/src/TIP20.sol
+++ b/docs/specs/src/TIP20.sol
@@ -180,7 +180,10 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         emit BurnBlocked(from, amount);
     }
 
-    function mintWithMemo(address to, uint256 amount, bytes32 memo) external onlyRole(ISSUER_ROLE) {
+    function mintWithMemo(address to, uint256 amount, bytes32 memo)
+        external
+        onlyRole(ISSUER_ROLE)
+    {
         _mint(to, amount);
         emit Mint(to, amount);
         emit TransferWithMemo(address(0), to, amount, memo);
@@ -512,5 +515,4 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
                         REWARD DISTRIBUTION VIEWS
     //////////////////////////////////////////////////////////////*/
 
-
-    }
+}

--- a/docs/specs/src/interfaces/IFeeAMM.sol
+++ b/docs/specs/src/interfaces/IFeeAMM.sol
@@ -62,7 +62,10 @@ interface IFeeAMM {
         external
         returns (uint256 amountUserToken, uint256 amountValidatorToken);
 
-    function getPool(address userToken, address validatorToken) external view returns (Pool memory);
+    function getPool(address userToken, address validatorToken)
+        external
+        view
+        returns (Pool memory);
 
     function getPoolId(address userToken, address validatorToken) external pure returns (bytes32);
 

--- a/docs/specs/test/AccountKeychain.t.sol
+++ b/docs/specs/test/AccountKeychain.t.sol
@@ -42,7 +42,7 @@ contract AccountKeychainTest is Test {
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
             amount: 1000e6 // 1000 USDC
-        });
+         });
 
         // Verify interface compiles and can be called
         keychain.authorizeKey(
@@ -120,11 +120,11 @@ contract AccountKeychainTest is Test {
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
             amount: 1000e6 // 1000 USDC
-        });
+         });
         limits[1] = IAccountKeychain.TokenLimit({
             token: USDT,
             amount: 500e6 // 500 USDT
-        });
+         });
 
         keychain.authorizeKey(
             aliceAccessKey,

--- a/docs/specs/test/BaseTest.t.sol
+++ b/docs/specs/test/BaseTest.t.sol
@@ -57,7 +57,7 @@ contract BaseTest is Test {
     function setUp() public virtual {
         // Is this tempo chain?
         isTempo = _TIP403REGISTRY.code.length + _TIP20FACTORY.code.length + _PATH_USD.code.length
-                + _STABLECOIN_DEX.code.length + _NONCE.code.length > 0;
+            + _STABLECOIN_DEX.code.length + _NONCE.code.length > 0;
 
         console.log("Tests running with isTempo =", isTempo);
 

--- a/docs/specs/test/FeeAMM.t.sol
+++ b/docs/specs/test/FeeAMM.t.sol
@@ -70,9 +70,8 @@ contract FeeAMMTest is BaseTest {
         uint256 minLiq = 1000; // MIN_LIQUIDITY constant
 
         vm.prank(alice);
-        uint256 liquidity = amm.mintWithValidatorToken(
-            address(userToken), address(validatorToken), amountV, alice
-        );
+        uint256 liquidity =
+            amm.mintWithValidatorToken(address(userToken), address(validatorToken), amountV, alice);
 
         // Expected liquidity: amountV/2 - MIN_LIQUIDITY
         uint256 expected = amountV / 2 - minLiq;
@@ -93,9 +92,8 @@ contract FeeAMMTest is BaseTest {
         uint256 amountV = 2 * minLiq; // amountV/2 == MIN_LIQUIDITY -> should revert
 
         vm.prank(alice);
-        try amm.mintWithValidatorToken(
-            address(userToken), address(validatorToken), amountV, alice
-        ) {
+        try amm.mintWithValidatorToken(address(userToken), address(validatorToken), amountV, alice)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory revertData) {
             assertEq(bytes4(revertData), IFeeAMM.InsufficientLiquidity.selector);

--- a/docs/specs/test/Nonce.t.sol
+++ b/docs/specs/test/Nonce.t.sol
@@ -139,9 +139,8 @@ contract NonceTest is BaseTest {
         // We use a direct require in the helper, so we test with try-catch
         bool reverted = false;
         try this.externalIncrementNonceViaStorage(testAlice, 0) {
-        // Should not reach here
-        }
-        catch {
+            // Should not reach here
+        } catch {
             reverted = true;
         }
         assertTrue(reverted, "Should revert when trying to increment protocol key 0");

--- a/docs/specs/test/StablecoinExchange.t.sol
+++ b/docs/specs/test/StablecoinExchange.t.sol
@@ -323,9 +323,8 @@ contract StablecoinExchangeTest is BaseTest {
         }
 
         vm.prank(alice);
-        uint128 amountIn = exchange.swapExactAmountOut(
-            address(pathUSD), address(token1), amountOut, maxAmountIn
-        );
+        uint128 amountIn =
+            exchange.swapExactAmountOut(address(pathUSD), address(token1), amountOut, maxAmountIn);
 
         assertEq(amountIn, expectedAmountIn);
         assertEq(token1.balanceOf(alice), initialBaseBalance + amountOut);
@@ -569,9 +568,8 @@ contract StablecoinExchangeTest is BaseTest {
             expectedError = abi.encodeWithSelector(IStablecoinExchange.InvalidTick.selector);
         } else if (amount < MIN_ORDER_AMOUNT) {
             shouldRevert = true;
-            expectedError = abi.encodeWithSelector(
-                IStablecoinExchange.BelowMinimumOrderSize.selector, amount
-            );
+            expectedError =
+                abi.encodeWithSelector(IStablecoinExchange.BelowMinimumOrderSize.selector, amount);
         }
 
         // Execute and verify
@@ -585,9 +583,8 @@ contract StablecoinExchangeTest is BaseTest {
         } else {
             // May fail due to insufficient balance/allowance - that's OK
             try exchange.place(address(token1), amount, true, tick) {
-            // Success is fine
-            }
-                catch {
+                // Success is fine
+            } catch {
                 // Failure due to balance/allowance is also OK for fuzz test
             }
         }
@@ -640,9 +637,8 @@ contract StablecoinExchangeTest is BaseTest {
         } else {
             // May fail due to insufficient balance/allowance - that's OK
             try exchange.placeFlip(address(token1), amount, isBid, tick, flipTick) {
-            // Success is fine
-            }
-                catch {
+                // Success is fine
+            } catch {
                 // Failure due to balance/allowance is also OK for fuzz test
             }
         }
@@ -952,9 +948,8 @@ contract StablecoinExchangeTest is BaseTest {
             exchange.executeBlock();
 
             // Should find direct path
-            uint128 amountOut = exchange.quoteSwapExactAmountIn(
-                address(pathUSD), address(token1), MIN_ORDER_AMOUNT
-            );
+            uint128 amountOut =
+                exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), MIN_ORDER_AMOUNT);
             assertGt(amountOut, 0);
         } else if (scenario == 1) {
             // Sibling tokens through pathUSD
@@ -978,9 +973,8 @@ contract StablecoinExchangeTest is BaseTest {
             exchange.executeBlock();
 
             // Should route token1 -> pathUSD -> token2
-            uint128 amountOut = exchange.quoteSwapExactAmountIn(
-                address(token1), address(token2), MIN_ORDER_AMOUNT
-            );
+            uint128 amountOut =
+                exchange.quoteSwapExactAmountIn(address(token1), address(token2), MIN_ORDER_AMOUNT);
             assertGt(amountOut, 0);
         } else {
             // Reverse direction
@@ -991,9 +985,8 @@ contract StablecoinExchangeTest is BaseTest {
             exchange.executeBlock();
 
             // Should find path in reverse
-            uint128 amountOut = exchange.quoteSwapExactAmountIn(
-                address(token1), address(pathUSD), MIN_ORDER_AMOUNT
-            );
+            uint128 amountOut =
+                exchange.quoteSwapExactAmountIn(address(token1), address(pathUSD), MIN_ORDER_AMOUNT);
             assertGt(amountOut, 0);
         }
     }

--- a/docs/specs/test/TIP20.t.sol
+++ b/docs/specs/test/TIP20.t.sol
@@ -1849,7 +1849,9 @@ contract TIP20Test is BaseTest {
     }
 
     /// @notice Fuzz test for scheduled rewards - should always revert with ScheduledRewardsDisabled
-    function testFuzz_scheduledRewards_AlwaysReverts(uint256 rewardAmount, uint32 duration) public {
+    function testFuzz_scheduledRewards_AlwaysReverts(uint256 rewardAmount, uint32 duration)
+        public
+    {
         rewardAmount = bound(rewardAmount, 1e18, 100e18);
         duration = uint32(bound(duration, 1, 365 days)); // duration > 0
 

--- a/docs/specs/test/TIP20Factory.t.sol
+++ b/docs/specs/test/TIP20Factory.t.sol
@@ -144,9 +144,8 @@ contract TIP20FactoryTest is BaseTest {
         vm.assume(!factory.isTIP20(invalidQuote));
 
         // Try-catch is better for precompiles than expectRevert
-        try factory.createToken("Token", "TK", "USD", ITIP20(invalidQuote), admin) returns (
-            address
-        ) {
+        try factory.createToken("Token", "TK", "USD", ITIP20(invalidQuote), admin) returns (address)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory reason) {
             // Verify it's the correct error

--- a/docs/specs/test/TIP403Registry.t.sol
+++ b/docs/specs/test/TIP403Registry.t.sol
@@ -49,7 +49,7 @@ contract TIP403RegistryTest is BaseTest {
         assertTrue(registry.isAuthorized(newPolicyId, alice));
         assertTrue(registry.isAuthorized(newPolicyId, bob));
         assertFalse(registry.isAuthorized(newPolicyId, charlie)); // Not in
-        // initial set
+            // initial set
     }
 
     function test_CreatePolicy_WithInitialAccounts_Blacklist() public {
@@ -68,7 +68,7 @@ contract TIP403RegistryTest is BaseTest {
         assertFalse(registry.isAuthorized(newPolicyId, alice));
         assertFalse(registry.isAuthorized(newPolicyId, bob));
         assertTrue(registry.isAuthorized(newPolicyId, charlie)); // Not in
-        // initial set
+            // initial set
     }
 
     function test_CreatePolicy_WithAdmin() public {
@@ -697,9 +697,8 @@ contract TIP403RegistryTest is BaseTest {
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
 
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice is the admin, so she should be able to modify it
         vm.prank(alice);
@@ -745,9 +744,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a whitelist policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = bob;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice should be able to modify the policy (she is the admin)
         vm.prank(alice);
@@ -761,9 +759,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a blacklist policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = bob;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         // Alice should be able to modify the policy (she is the admin)
         vm.prank(alice);
@@ -850,9 +847,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = david;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice transfers admin to bob
         vm.prank(alice);

--- a/docs/specs/test/ValidatorConfig.t.sol
+++ b/docs/specs/test/ValidatorConfig.t.sol
@@ -106,9 +106,8 @@ contract ValidatorConfigTest is BaseTest {
 
     function test_AddValidator_Unauthorized() public {
         vm.prank(nonOwner);
-        try validatorConfig.addValidator(
-            validator1, publicKey1, true, inboundAddr1, outboundAddr1
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));
@@ -118,9 +117,8 @@ contract ValidatorConfigTest is BaseTest {
     function test_AddValidator_DuplicateValidator() public {
         validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1);
 
-        try validatorConfig.addValidator(
-            validator1, publicKey2, true, inboundAddr2, outboundAddr2
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey2, true, inboundAddr2, outboundAddr2)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.ValidatorAlreadyExists.selector));
@@ -320,9 +318,8 @@ contract ValidatorConfigTest is BaseTest {
         vm.assume(caller != admin);
 
         vm.prank(caller);
-        try validatorConfig.addValidator(
-            validator1, publicKey1, true, inboundAddr1, outboundAddr1
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));
@@ -446,9 +443,8 @@ contract ValidatorConfigTest is BaseTest {
         validatorConfig.addValidator(validator2, publicKey2, true, inboundAddr2, outboundAddr2);
 
         // Original owner cannot add validators
-        try validatorConfig.addValidator(
-            validator3, publicKey3, true, inboundAddr3, outboundAddr3
-        ) {
+        try validatorConfig.addValidator(validator3, publicKey3, true, inboundAddr3, outboundAddr3)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));


### PR DESCRIPTION
This PR updates the feeAMM to return custom errors rather than strings to match the reference contract.