### PR TITLE
docs: point to upstream foundryup

### DIFF
--- a/docs/pages/sdk/foundry/index.mdx
+++ b/docs/pages/sdk/foundry/index.mdx
@@ -10,12 +10,29 @@ For general information about Foundry, see the [Foundry documentation](https://g
 
 ### Install using `foundryup`
 
-This will install the latest `nightly` release of the Tempo fork.
+Tempo's Foundry fork is installed through the standard upstream `foundryup` using the `-n tempo` flag, no separate installer is required.
+
+Getting started is very easy:
+
+Install regular `foundryup`:
 
 ```bash
 curl -L https://foundry.paradigm.xyz | bash
+```
+
+Or if you already have `foundryup` installed:
+
+```bash
+foundryup --update
+```
+
+Next, run:
+
+```bash
 foundryup -n tempo
 ```
+
+It will automatically install the latest `nightly` release of the precompiled binaries: [`forge`](https://getfoundry.sh/forge/overview#forge) and [`cast`](https://getfoundry.sh/cast/overview#cast).
 
 To install a specific version, replace `<TAG_NAME>` with the desired release tag:
 


### PR DESCRIPTION
We're merging the `-n` flag upstream today, so we should point users to use regular `foundryup`.