### PR TITLE
perf(pool): update 2D pool metrics only on state updates

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -217,7 +217,6 @@ impl AA2dPool {
 
         // Record metrics
         self.metrics.inc_inserted();
-        self.update_metrics();
 
         if inserted_as_pending {
             if !promoted.is_empty() {


### PR DESCRIPTION
Updating these metrics on each new added transactions is very expensive, we still update them on state updates and that's enough for now