### PR TITLE
docs: mention tempoup

### DIFF
--- a/docs/pages/guide/node/installation.mdx
+++ b/docs/pages/guide/node/installation.mdx
@@ -5,15 +5,11 @@ We provide three different installation paths - installing a pre-built binary, b
 ## Pre-built Binary
 
 ```bash /dev/null/download.sh#L1-4
-# Download latest version
-# e.g.
-# curl -L https://testnet-assets.tempoxyz.dev/binaries/v<version>/tempo-v<version>-<arch>-<platform>.tar.gz -o tempo.tar.gz
-curl -L https://testnet-assets.tempoxyz.dev/binaries/v0.7.2/tempo-v0.7.2-x86_64-unknown-linux-gnu.tar.gz -o tempo.tar.gz
-tar -xzvf tempo.tar.gz
-chmod +x tempo
-sudo mv tempo /usr/local/bin/tempo
+curl -L https://tempo.xyz/install | bash
 tempo --version
 ```
+
+To update Tempo in the future, simply run `tempoup`.
 
 ## Build from Source
 


### PR DESCRIPTION
Prefer installing pre-built binaries using `tempoup`. This does not include comprehensive docs for `tempoup`, I wonder if we should move [these](https://github.com/tempoxyz/tempo/tree/main/tempoup) into the docs, or alternatively link to them from the docs.