### PR TITLE
fix(e2e): ensure write transaction finishes before exiting `TestingNode::stop_execution`

### DIFF
--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -4,7 +4,7 @@ use crate::execution_runtime::{self, ExecutionNode, ExecutionNodeConfig, Executi
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::simulated::{Control, Oracle, SocketManager};
 use commonware_runtime::{Handle, deterministic::Context};
-use reth_db::{DatabaseEnv, mdbx::DatabaseArguments, open_db_read_only};
+use reth_db::{Database, DatabaseEnv, mdbx::DatabaseArguments, open_db_read_only};
 use reth_ethereum::{
     provider::{
         DatabaseProviderFactory, ProviderFactory,
@@ -282,6 +282,7 @@ impl TestingNode {
     /// # Panics
     /// Panics if execution node is not running.
     async fn stop_execution(&mut self) {
+        debug!(%self.uid, "stopping execution node for testing node");
         let execution_node = self.execution_node.take().unwrap_or_else(|| {
             panic!(
                 "execution node is not running for {}, cannot stop",
@@ -298,7 +299,22 @@ impl TestingNode {
             .expect("failed to get last block number from database");
         self.last_db_block_on_stop = Some(last_db_block);
 
-        execution_node.shutdown().await
+        execution_node.shutdown().await;
+
+        // Acquire a RW transaction and immediately drop it. This blocks until any
+        // pending write transaction completes, ensuring all database writes are
+        // fully flushed. Without this, a pending write could still be in-flight
+        // after shutdown returns, leading to database/static-file inconsistencies
+        // when the node restarts.
+        drop(
+            self.execution_database
+                .as_ref()
+                .expect("database should exist")
+                .tx_mut()
+                .expect("failed to acquire rw transaction"),
+        );
+
+        debug!(%self.uid, "stopped execution node for testing node");
     }
 
     /// Check if both consensus and execution are running


### PR DESCRIPTION
When restarting a node, there might be a lingering write transaction in the process of being committed which can result in the following edge case (and apparently not so low chance event):

* Storage at block 27
* Reth persistence layer starts to append 28,29,30.
  * `StaticFileProvider` commits up to block 30 (successful)
  * `DatabaseProviderRW` is in the process of committing up to block 30 (not finished yet)
* `TestingNode::stop_execution` is called and returns
* `TestingNode::start_execution` is eventually called again
  * Reth spawns and opens a DB read-only transaction ( `DbTxRW` from above hasnt finished yet, so this one gets a stale view)
  * DB<>SF consistency check is triggered. This `DbTx` is at 27, so it unwinds SF from 30 to 27.
  * `DbTxRW::commit` from before finishes in the background.
  * Eventually on lauching the node, a new DB read-only transaction is created, now at block 30. And it expects SF to be at 30 when it fetches the best block -> error


Solution:
Don't return from `TestingNode::stop_execution` until a DB read-write is available
