### PR TITLE
feat(docs): add redundant pair balance check to Stablecoin DEX

### DIFF
--- a/docs/pages/protocol/exchange/spec.mdx
+++ b/docs/pages/protocol/exchange/spec.mdx
@@ -30,6 +30,10 @@ Places are delayed until the end of each block, and are processed in an `execute
 
 The contract maintains per‑user, per‑token internal balances. Order placement escrows funds from these balances (or transfers any shortfall from the user). When an order fills, the maker is credited internally with the counter‑asset at the order’s tick price. Users can withdraw available balances at any time.
 
+**Implementation note (non‑normative):**  
+
+The current reference implementation additionally tracks aggregate escrowed base and quote balances per trading pair and decrements them on fills and cancellations. This per‑pair accounting is a technically redundant runtime invariant check that enforces that each pair never spends more base or quote token than it has escrowed, providing an additional guardrail to prevent any bugs that can be triggered in a single pair from putting other pairs at risk.
+
 #### Delayed order placement
 
 Orders placed during a block are recorded as pending and are not visible on the active book until the block ends. A system transaction calls `executeBlock()` to insert all pending orders into their ticks in creation order within the block. This reduces mid‑block MEV surfaces and JIT strategies.

--- a/docs/pages/protocol/exchange/spec.mdx
+++ b/docs/pages/protocol/exchange/spec.mdx
@@ -32,7 +32,7 @@ The contract maintains per‑user, per‑token internal balances. Order placemen
 
 **Implementation note (non‑normative):**  
 
-The current reference implementation additionally tracks aggregate escrowed base and quote balances per trading pair and decrements them on fills and cancellations. This per‑pair accounting is a technically redundant runtime invariant check that enforces that each pair never spends more base or quote token than it has escrowed, providing an additional guardrail to prevent any bugs that can be triggered in a single pair from putting other pairs at risk.
+The current implementation additionally tracks aggregate escrowed base and quote balances per trading pair and decrements them on fills and cancellations. This per‑pair accounting is a technically redundant runtime invariant check that enforces that each pair never spends more base or quote token than it has escrowed, providing an additional guardrail to prevent any bugs that can be triggered in a single pair from putting other pairs at risk.
 
 #### Delayed order placement
 

--- a/docs/pages/protocol/exchange/spec.mdx
+++ b/docs/pages/protocol/exchange/spec.mdx
@@ -32,7 +32,11 @@ The contract maintains per‑user, per‑token internal balances. Order placemen
 
 **Implementation note (non‑normative):**  
 
-The current implementation additionally tracks aggregate escrowed base and quote balances per trading pair and decrements them on fills and cancellations. This per‑pair accounting is a technically redundant runtime invariant check that enforces that each pair never spends more base or quote token than it has escrowed, providing an additional guardrail to prevent any bugs that can be triggered in a single pair from putting other pairs at risk.
+The current implementation additionally tracks aggregate escrowed base and quote balances per trading pair, and decrements them on fills and cancellations. 
+
+This per‑pair accounting is a technically redundant runtime invariant check that enforces that each pair never spends more base or quote token than it has escrowed, providing an additional guardrail to keep pairs isolated.
+
+If this invariant is violated, the implementation reverts with `PairBalanceInvariant(key)` . If the implementation is bug-free, this error should never be triggered. This invariant check is not required by the spec, and may be removed in the future.
 
 #### Delayed order placement
 

--- a/docs/specs/src/StablecoinExchange.sol
+++ b/docs/specs/src/StablecoinExchange.sol
@@ -620,7 +620,9 @@ contract StablecoinExchange is IStablecoinExchange {
         if (pb.quoteEscrowed < quoteAmount) {
             revert IStablecoinExchange.PairBalanceInvariant(key);
         }
-        pb.quoteEscrowed -= quoteAmount;
+        unchecked {
+            pb.quoteEscrowed -= quoteAmount;
+        }
     }
 
     /// @notice Decrement base escrow for a pair, reverting if this would violate the invariant
@@ -629,7 +631,9 @@ contract StablecoinExchange is IStablecoinExchange {
         if (pb.baseEscrowed < baseAmount) {
             revert IStablecoinExchange.PairBalanceInvariant(key);
         }
-        pb.baseEscrowed -= baseAmount;
+        unchecked {
+            pb.baseEscrowed -= baseAmount;
+        }
     }
 
     /// @notice Swap tokens for exact amount out (supports multi-hop routing)

--- a/docs/specs/src/StablecoinExchange.sol
+++ b/docs/specs/src/StablecoinExchange.sol
@@ -59,8 +59,19 @@ contract StablecoinExchange is IStablecoinExchange {
                               STORAGE
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Tracks escrowed balances per trading pair, to isolate risk
+    struct PairBalance {
+        /// Escrowed base tokens backing active ask liquidity
+        uint128 baseEscrowed;
+        /// Escrowed quote tokens backing active bid liquidity
+        uint128 quoteEscrowed;
+    }
+
     /// Mapping of pair key to orderbook
     mapping(bytes32 pairKey => Orderbook orderbook) public books;
+
+    /// Mapping of pair key to aggregate escrowed balances
+    mapping(bytes32 pairKey => PairBalance balance) internal pairBalances;
 
     /// Mapping of order ID to order data
     mapping(uint128 orderId => IStablecoinExchange.Order order) internal orders;
@@ -237,6 +248,14 @@ contract StablecoinExchange is IStablecoinExchange {
                     }
                 }
             }
+
+            // Track escrowed balances for this pair
+            PairBalance storage pb = pairBalances[key];
+            if (isBid) {
+                pb.quoteEscrowed += escrowAmount;
+            } else {
+                pb.baseEscrowed += escrowAmount;
+            }
         }
         orderId = pendingOrderId + 1;
         ++pendingOrderId;
@@ -310,6 +329,14 @@ contract StablecoinExchange is IStablecoinExchange {
                 // For asks, escrow base tokens
                 escrowAmount = order.remaining;
             }
+
+            // Decrement pair-level escrow tracking; revert explicitly if this would underflow
+            if (order.isBid) {
+                _decrementPairQuoteEscrow(order.bookKey, escrowAmount);
+            } else {
+                _decrementPairBaseEscrow(order.bookKey, escrowAmount);
+            }
+
             balances[order.maker][token] += escrowAmount;
 
             delete orders[orderId];
@@ -350,6 +377,14 @@ contract StablecoinExchange is IStablecoinExchange {
                 // For asks, escrow base tokens
                 escrowAmount = order.remaining;
             }
+
+            // Decrement pair-level escrow tracking; revert explicitly if this would underflow
+            if (order.isBid) {
+                _decrementPairQuoteEscrow(order.bookKey, escrowAmount);
+            } else {
+                _decrementPairBaseEscrow(order.bookKey, escrowAmount);
+            }
+
             balances[order.maker][token] += escrowAmount;
 
             delete orders[orderId];
@@ -505,15 +540,18 @@ contract StablecoinExchange is IStablecoinExchange {
 
         emit OrderFilled(orderId, order.maker, msg.sender, fillAmount, order.remaining > 0);
 
-        // Credit maker with appropriate tokens
+        // Adjust pair-level escrow balances and credit maker with appropriate tokens.
+        // Both sides use the same tick price and quote amount for a given fill.
+        uint32 price = tickToPrice(order.tick);
+        uint128 quoteAmount = (fillAmount * price) / PRICE_SCALE;
         if (isBid) {
             // Bid order: maker gets base tokens
             balances[order.maker][book.base] += fillAmount;
+            _decrementPairQuoteEscrow(order.bookKey, quoteAmount);
         } else {
             // Ask order: maker gets quote tokens
-            uint32 price = tickToPrice(order.tick);
-            uint128 quoteAmount = (fillAmount * price) / PRICE_SCALE;
             balances[order.maker][book.quote] += quoteAmount;
+            _decrementPairBaseEscrow(order.bookKey, fillAmount);
         }
 
         if (order.remaining == 0) {
@@ -574,6 +612,24 @@ contract StablecoinExchange is IStablecoinExchange {
             uint128 remaining = amount - userBalance;
             ITIP20(token).transferFrom(user, address(this), remaining);
         }
+    }
+
+    /// @notice Decrement quote escrow for a pair, reverting if this would violate the invariant
+    function _decrementPairQuoteEscrow(bytes32 key, uint128 quoteAmount) internal {
+        PairBalance storage pb = pairBalances[key];
+        if (pb.quoteEscrowed < quoteAmount) {
+            revert IStablecoinExchange.PairBalanceInvariant(key);
+        }
+        pb.quoteEscrowed -= quoteAmount;
+    }
+
+    /// @notice Decrement base escrow for a pair, reverting if this would violate the invariant
+    function _decrementPairBaseEscrow(bytes32 key, uint128 baseAmount) internal {
+        PairBalance storage pb = pairBalances[key];
+        if (pb.baseEscrowed < baseAmount) {
+            revert IStablecoinExchange.PairBalanceInvariant(key);
+        }
+        pb.baseEscrowed -= baseAmount;
     }
 
     /// @notice Swap tokens for exact amount out (supports multi-hop routing)

--- a/docs/specs/src/interfaces/IStablecoinExchange.sol
+++ b/docs/specs/src/interfaces/IStablecoinExchange.sol
@@ -44,6 +44,7 @@ interface IStablecoinExchange {
 
     // Errors
     error Unauthorized();
+    error PairBalanceInvariant(bytes32 pairKey);
     error PairDoesNotExist();
     error PairAlreadyExists();
     error OrderDoesNotExist();


### PR DESCRIPTION
This is a proof-of-concept for a possible runtime invariant check that we could add to the Stablecoin DEX to add defense in depth. 

Since the Stablecoin DEX is a singleton, a bug that affects one pair (say, one that the attacker creates and puts into a contrived state) could put funds that belong to other pairs at risk. This was part of what made the hack of Balancer v2 (which stored funds in a shared Vault contract) so severe.

This change would track the balances escrowed to each pair, and cause interactions to fail if they would cause the balance escrowed to a given pair to go negative.

This change would add an extra SSTORE per pair interacted with. 

The check does not affect the interface for or behavior of the pool (assuming there are no bugs in the implementation). If we can formally verify the property at compile time, or get sufficient comfort through audits, we could remove this check in the future.