### PR TITLE
fix(docs): reword to reframe references to account abstraction

### DIFF
--- a/docs/pages/learn/tempo/modern-transactions.mdx
+++ b/docs/pages/learn/tempo/modern-transactions.mdx
@@ -14,7 +14,7 @@ On other chains, even when available, these are generally add-on functionalities
 
 ## Batched Payments
 
-Payment processors and platforms often need to send thousands of payments at once (e.g., payroll runs, merchant settlements, customer refunds). Tempo's native account abstraction enables batch transactions where multiple operations execute atomically in a single transaction.
+Payment processors and platforms often need to send thousands of payments at once (e.g., payroll runs, merchant settlements, customer refunds). Tempo supports batch transactions where multiple operations execute atomically in a single transaction.
 
 This unlocks high-volume use cases: orchestrators can submit thousands of payouts as a single operation, rather than submitting them one-by-one and tracking individual success or failure. If any operation in the batch fails, the entire batch reverts, ensuring atomic execution across all payments. This is critical for payment operators who need guaranteed settlement guarantees for their workflows.
 
@@ -34,7 +34,7 @@ Tempo's protocol-level fee sponsorship allows an account to sign a transaction w
 
 ## Scheduled Payments
 
-Tempo's account abstraction transaction type includes scheduling as a protocol feature. Users can specify a time window for transaction execution, and validators will include the transaction when it becomes valid. 
+The Tempo transaction type includes scheduling as a protocol feature. Users can specify a time window for transaction execution, and validators will include the transaction when it becomes valid. 
 
 This enables "set and forget" payment operations directly at the protocol level, enabling recurring payments like subscriptions or scheduled disbursements. No need for external automation services or off-chain infrastructure to manage recurring transactions.
 

--- a/docs/pages/protocol/transactions/index.mdx
+++ b/docs/pages/protocol/transactions/index.mdx
@@ -91,16 +91,10 @@ If you are an EVM smart contract developer, see the [Tempo extension for Foundry
 
 <Card.Container>
   <Card.Link
-    description="Native protocol support for account abstraction features including WebAuthn/P256 signatures, parallelizable nonces, gas sponsorship, call batching, and scheduled transactions"
+    description="Native protocol support for new transaction features including WebAuthn/P256 signatures, parallelizable nonces, gas sponsorship, call batching, and scheduled transactions"
     href="/protocol/transactions/spec-tempo-transaction"
     icon={LucideFileCode}
     title="Specification"
-  />
-  <Card.Link
-    description="Default Account Abstraction model for automatic smart contract wallet delegation (experimental, likely to be deprecated)"
-    href="/protocol/transactions/spec-default-aa"
-    icon={LucideFileCode}
-    title="Default Account Abstraction Specification"
   />
   <Card.Link
     description="Configure users to pay transaction fees in any supported stablecoin"

--- a/docs/pages/protocol/transactions/spec-default-delegation.mdx
+++ b/docs/pages/protocol/transactions/spec-default-delegation.mdx
@@ -1,20 +1,20 @@
-# Accounts [Default Account Abstraction (Experimental)]
+# Accounts [Default Delegation (Experimental)]
 
 :::warning
 **Note: This feature will likely be deprecated before mainnet launch.** We recommend using the standard [Tempo Transaction](/protocol/transactions/spec-tempo-transaction) type instead if you need smart contract functionality.
 :::
 
-Tempo uses a "Default Account Abstraction" (DAA) model for accounts on the Tempo blockchain. DAA extends the Ethereum account model by allowing any externally owned account (EOA) to be seamlessly upgraded into a smart contract wallet, without requiring user intervention or setup.
+Tempo uses a "Default Delegation" (DD) model for accounts on the Tempo blockchain. DD extends the Ethereum account model by allowing any externally owned account (EOA) to be seamlessly upgraded into a smart contract wallet, without requiring user intervention or setup.
 
 The core mechanism is that, on first use (when an EOA sends its first transaction and has never been used before), the protocol automatically delegates the account to a canonical smart contract implementation by setting its code to a special format. This enables all EOAs to immediately benefit from smart wallet features, while preserving full backward compatibility with legacy ECDSA transactions and not affecting contract accounts.
 
 Additionally, a registrar precompile is introduced to allow anyone to permissionlessly delegate an EOA to the default implementation by proving control of the address via a signature. The default implementation contract is treated as always warm for gas purposes.
 
-Tempo's DAA model is fully compatible with EIP-7702. For a detailed understanding of the underlying delegation format and semantics, see the [EIP-7702 specification](https://eips.ethereum.org/EIPS/eip-7702).
+Tempo's DD model is fully compatible with EIP-7702. For a detailed understanding of the underlying delegation format and semantics, see the [EIP-7702 specification](https://eips.ethereum.org/EIPS/eip-7702).
 
 ## Features
 
-Default Account Abstraction (DAA) allows any EOA to be used as a smart contract wallet.
+Default Delegation (DD) allows any EOA to be used as a smart contract wallet.
 
 It does so through two new behaviors in-protocol:
 
@@ -40,7 +40,7 @@ Additionally, **DEFAULT_7702_IMPL** is treated as **always warm** for gas, like 
 - “Delegated to X” ⇔ `code(account) == EF_PREFIX || X` (exact 7702 format)
 - “Plain EOA” ⇔ `code(account) == EMPTY`
 
-> **Out of scope:** The runtime behavior/ABI of `DEFAULT_7702_IMPL` itself (separate spec). DAA only defines delegation mechanics.
+> **Out of scope:** The runtime behavior/ABI of `DEFAULT_7702_IMPL` itself (separate spec). DD only defines delegation mechanics.
 
 ### 1) Auto-delegation on first use
 
@@ -116,14 +116,14 @@ delegateToDefault(bytes32 hash, uint8 v, bytes32 r, bytes32 s)
 
 - **Legacy ECDSA transactions:** Unchanged validation. The only new effect is auto-delegation on the **first** tx for plain EOAs with `nonce == 0`.
 - **Contracts / codeful accounts:** Never auto-delegated; registrar reverts.
-- **7702 tooling:** Fully compatible; DAA uses the **exact** 7702 delegation bytecode format and override semantics.
+- **7702 tooling:** Fully compatible; DD uses the **exact** 7702 delegation bytecode format and override semantics.
 
 ## Security Considerations
 
 - **Forced delegation by third parties:** Anyone can delegate an EOA via the registrar if they can produce **any** valid signature by that key (by design). This does **not** grant fund control if `DEFAULT_7702_IMPL` respects the original key, but it does change account semantics and may surprise tooling. Accepted as a trade-off.
 - **Signature replay & no domain binding:** Signatures from other chains or contexts can be reused. This is deliberate; downstream apps MUST NOT treat registrar delegation as consent for anything beyond delegation.
 - **Malleability constraints:** Enforce low-`s` and canonical `v` mapping to avoid malleability and recovery edge cases.
-- **CREATE/CREATE2 & contracts at EOA addresses:** DAA never writes code to an account that already has code; changing a contract account’s code via registrar is disallowed (revert). Accounts created as contracts at genesis are unaffected.
+- **CREATE/CREATE2 & contracts at EOA addresses:** DD never writes code to an account that already has code; changing a contract account’s code via registrar is disallowed (revert). Accounts created as contracts at genesis are unaffected.
 
 ## Test Cases (illustrative)
 
@@ -211,7 +211,7 @@ fn is_7702_delegated(code: bytes) -> bool:
 
 ## Deployment / Activation
 - **Genesis:** Insert `DEFAULT_7702_IMPL` as an immutable, predeployed contract at `0x7702c00000000000…` with its code defined by the separate implementation spec.
-- **Fork rules:** DAA is active from genesis on Tempo. Clients must include:
+- **Fork rules:** DD is active from genesis on Tempo. Clients must include:
   - the auto-delegation state transition hook,
   - the DefaultAccountRegistrar precompile at `0x7702ac00000000000…`,
   - the always-warm treatment for `DEFAULT_7702_IMPL`.

--- a/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This spec introduces native protocol support for the following account abstraction features, using a new Tempo transaction type -
+This spec introduces native protocol support for the following features, using a new Tempo transaction type:
 
 * WebAuthn/P256 signature validation - enables passkey accounts
 * Parallelizable nonces - allows higher tx throughput for each account
@@ -31,7 +31,7 @@ pub struct TempoTransaction {
     calls: Vec<Call>,                           // Batch of calls to execute atomically
     access_list: AccessList,                    // EIP-2930 access list
 
-    // AA-specific fields
+    // nonce-related fields
     nonce_key: U256,                            // 2D nonce key (0 = protocol nonce, >0 = user nonces)
     nonce: u64,                                 // Current nonce value for the nonce key
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -33,7 +33,7 @@
     },
     {
       "source": "/errors/tx/Keychain",
-      "destination": "/protocol/transactions/spec-default-aa",
+      "destination": "/protocol/transactions/spec-default-delegation",
       "permanent": false
     },
     {

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -321,8 +321,8 @@ export default defineConfig({
                 link: '/protocol/transactions/AccountKeychain',
               },
               {
-                text: 'Default Account Abstraction Specification',
-                link: '/protocol/transactions/spec-default-aa',
+                text: 'Default Delegation Specification',
+                link: '/protocol/transactions/spec-default-delegation',
               },
               {
                 text: 'Rust Implementation',


### PR DESCRIPTION
The docs still have some errant references to the Tempo transaction as being about "account abstraction"; this rewords those references.

The docs also call the (soon-to-be-removed) default delegation feature "default account abstraction." This PR renames that feature to "default delegation" to further reduce any ambiguity.