### PR TITLE
feat: add blacklist check on transfer

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -770,6 +770,8 @@ impl<'a, S: PrecompileStorageProvider> StablecoinExchange<'a, S> {
                 .checked_mul(price as u128)
                 .and_then(|v| v.checked_div(orderbook::PRICE_SCALE as u128))
                 .ok_or(TempoPrecompileError::under_overflow())?;
+            TIP20Token::from_address(orderbook.quote, self.storage)?
+                .ensure_transfer_authorized(order.maker(), taker)?;
             self.increment_balance(order.maker(), orderbook.quote, quote_amount)?;
         }
 


### PR DESCRIPTION
Fixes #1383 

Adds `ensure_transfer_authorized` before `increment_balance` in `stablecoin_exchange/mod.rs::partial_fill_order()`