### PR TITLE
chore(just): added nextest in default just command alongside cross

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,8 +3,9 @@ cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
 act_debug_mode := env("ACT", "false")
 
 [group('deps')]
-install-cross:
+install-deps:
     cargo install cross --git https://github.com/cross-rs/cross
+    cargo install cargo-nextest 
 
 [group('build')]
 [doc('Builds all tempo binaries in cargo release mode')]


### PR DESCRIPTION
Since docs prefer nextest as the preferred test runner, we can ensure that nextest is installed in the dependency step of the local setup.