### PR TITLE
feat(specs): propose always charging max fee

### DIFF
--- a/docs/pages/guide/use-accounts/fee-sponsorship.mdx
+++ b/docs/pages/guide/use-accounts/fee-sponsorship.mdx
@@ -62,7 +62,6 @@ When `feePayerSignature` is absent:
 1. Recover both sender and fee payer addresses from their signatures
 2. Charge gas fees to the fee payer's balance
 3. Execute transaction with sender as the transaction origin
-4. Refund unused gas to the fee payer
 
 ## Security
 

--- a/docs/pages/protocol/fees/spec-fee-amm.mdx
+++ b/docs/pages/protocol/fees/spec-fee-amm.mdx
@@ -130,26 +130,16 @@ function reserveLiquidity(
     address userToken,
     address validatorToken,
     uint256 maxAmount
-) internal returns (bool)
-```
-
-Reserves liquidity for a pending fee swap. Calculates `maxAmountOut = (maxAmount * M) / SCALE`. Verifies sufficient validator token reserves (accounting for pending swaps). Tracks pending swap input.
-
-```solidity
-function releaseLiquidityPostTx(
-    address userToken,
-    address validatorToken,
-    uint256 refundAmount
 ) internal
 ```
 
-Releases reserved liquidity when fees are refunded. Decreases pending swap input by refund amount.
+Reserves liquidity for a pending fee swap. Calculates `maxAmountOut = (maxAmount * M) / SCALE`. Verifies sufficient validator token reserves (accounting for pending swaps). Tracks pending swap input for the full `maxAmount`.
 
 #### 2. FeeManager Contract
 
 Tempo introduces a precompiled contract, the `FeeManager`, at the address `0xfeec000000000000000000000000000000000000`.
 
-The `FeeManager` is a singleton contract that implements all the functions of the Fee AMM for every pool. It also handles the collection and refunding of fees during each transaction, stores fee token preferences for users and validators, and implements the `executeBlock()` function that is called by a system transaction at the end of each block.
+The `FeeManager` is a singleton contract that implements all the functions of the Fee AMM for every pool. It also handles the collection and accounting of fees during each transaction (without refunds of unused gas), stores fee token preferences for users and validators, and implements the `executeBlock()` function that is called by a system transaction at the end of each block.
 
 ##### Key Functions
 
@@ -173,18 +163,7 @@ function collectFeePreTx(
 ) external
 ```
 
-Called by the protocol before transaction execution. The fee token (`userToken`) is determined by the protocol before calling using logic that considers: explicit tx fee token, setUserToken calls, stored user preference, tx.to if TIP-20. Reserves AMM liquidity if user token differs from validator token. Collects maximum possible fee from user. Access: Protocol only (`msg.sender == address(0)`).
-
-```solidity
-function collectFeePostTx(
-    address user,
-    uint256 maxAmount,
-    uint256 actualUsed,
-    address userToken
-) external
-```
-
-Called by the protocol after transaction execution. The validator token and fee recipient are inferred from `block.coinbase`. Calculates refund amount: `refundAmount = maxAmount - actualUsed`. Refunds unused tokens to user. Releases reserved liquidity for refunded amount. Tracks collected fees for block-end settlement. Access: Protocol only (`msg.sender == address(0)`).
+Called by the protocol before transaction execution. The fee token (`userToken`) is determined by the protocol before calling using logic that considers: explicit tx fee token, setUserToken calls, stored user preference, tx.to if TIP-20. Reserves AMM liquidity if user token differs from validator token, collects the maximum fee from the user using `transferFeePreTx`, and immediately records the full `maxAmount` as the fee owed to the validator (either directly or as expected AMM output). Access: Protocol only (`msg.sender == address(0)`).
 
 ```solidity
 function executeBlock() external
@@ -216,18 +195,10 @@ Called once in a system transaction at the end of each block. Processes all coll
    - `FeeManager.collectFeePreTx(user, userToken, maxAmount)` is called:
      - If user token differs from validator token, reserves AMM liquidity via `reserveLiquidity()`
      - Collects maximum fee from user using `transferFeePreTx()`
+     - Records the full `maxAmount` as the fee owed to the validator (either directly or as expected AMM output)
    - If any check fails (insufficient balance, insufficient liquidity), transaction is invalid
 
-2. **Post-Transaction**:
-   - Calculate actual gas used (`actualUsed = gasUsed * gasPrice`)
-   - `FeeManager.collectFeePostTx(user, maxAmount, actualUsed, userToken)` is called:
-     - Validator token and fee recipient are inferred from `block.coinbase`
-     - Calculates refund: `refundAmount = maxAmount - actualUsed`
-     - Refunds unused tokens to user via `transferFeePostTx()`
-     - Releases reserved liquidity for refunded amount via `releaseLiquidityPostTx()`
-     - Tracks collected fees (actual used amount) for block-end settlement
-
-3. **Block End**:
+2. **Block End**:
    - System transaction calls `FeeManager.executeBlock()`:
      - For each token with collected fees:
        - If token differs from validator token, executes pending fee swaps via `executePendingFeeSwaps()`

--- a/docs/pages/protocol/fees/spec-fee.mdx
+++ b/docs/pages/protocol/fees/spec-fee.mdx
@@ -23,14 +23,10 @@ Before the execution of each transaction, the protocol takes the following steps
 * Determine the [`fee_payer`](#fee-payer) of the transaction.
 * Determine the `fee_token` of the transaction, according to the [rules for fee token preferences](#fee-token-preferences). If the fee token cannot be determined, the transaction is invalid.
 * Compute the `max_fee` of the transaction as `gas_limit * gas_price`.
-* Deduct `max_fee` from the `fee_payer`'s balance of `fee_token`. If `fee_payer` does not have sufficient balance in `fee_token`, the transaction is invalid.
+* Transfer `max_fee` from the `fee_payer`'s balance of `fee_token` to the FeeManager. If `fee_payer` does not have sufficient balance in `fee_token`, the transaction is invalid.
 * Reserve `max_fee` of liquidity on the [fee AMM](/protocol/fees/spec-fee-amm) between the `fee_token` and the validator's preferred fee token. If there is insufficient liquidity, the transaction is invalid.
 
-After the execution of each transaction:
-
-* Compute the `refund_amount` as `(gas_limit - gas_used) * gas_price`.
-* Credit the `fee_payer`'s address with `refund_amount` of `fee_token`.
-* Log a `Transfer` event from the user to the [fee manager contract](/protocol/fees/spec-fee-amm) for the net amount of the fee payment.
+Note that for purposes of the block's `gas_limit`, the transaction still only uses `gas_used`, even though it pays for the full gas limit of the transaction.
 
 ## Fee payer
 
@@ -170,23 +166,15 @@ If either check fails, the transaction is rejected before execution.
 
 #### 3. Transaction execution
 
-The transaction executes normally. The actual gas consumed may be less than the maximum that was collected.
+The transaction executes normally. The actual gas consumed may be less than the maximum that was collected, but the user still pays the full `max_fee`.
 
-#### 4. Post-transaction refund
-
-After execution, the `FeeManager`:
-
-- Calculates the actual fee owed based on gas used
-- Refunds any unused tokens to the user
-- Queues the actual fee amount for conversion (if needed)
-
-#### 5. Fee swap queuing
+#### 4. Fee swap queuing
 
 If the user's fee token differs from the validator's preferred token, the fee is added to a pending fee swap queue for that token pair. The swap doesn't execute immediately—it's batched with all other fees collected during the block.
 
 If the user's fee token matches the validator's preference, no conversion is needed and the fee goes directly to the validator.
 
-#### 6. End-of-block settlement
+#### 5. End-of-block settlement
 
 At the end of each block, the protocol:
 
@@ -218,19 +206,18 @@ Here's a complete example of the fee lifecycle:
 2. **Validator** prefers to receive fees in **USDT**
 3. Alice's transaction has a max fee of 1.0 USDC
 4. The FeeManager collects 1.0 USDC from Alice before execution
-5. Transaction executes and uses 0.8 USDC worth of gas
-6. The FeeManager refunds 0.2 USDC to Alice
-7. The remaining 0.8 USDC is queued for conversion
-8. At block end, the Fee AMM swaps 0.8 USDC → 0.7976 USDT (0.8 × 0.9970)
-9. Validator receives 0.7976 USDT
-10. Liquidity providers earn 0.0024 USDT from the 0.3% fee
+5. Transaction executes and uses 0.8 USDC worth of gas (for accounting only)
+6. No refund is issued
+7. The full 1.0 USDC is queued for conversion
+8. At block end, the Fee AMM swaps 1.0 USDC → 0.9970 USDT (1.0 × 0.9970)
+9. Validator receives 0.9970 USDT
+10. Liquidity providers earn 0.0030 USDT from the 0.3% fee
 
 ### Gas costs
 
 The fee conversion process adds minimal overhead to transactions:
 
-- **Pre-transaction**: ~5,000 gas for balance and liquidity checks
-- **Post-transaction**: ~3,000 gas for refund and queue operations
+- **Pre-transaction**: ~5,000 gas for balance checks, liquidity checks, and fee accounting
 - **Block settlement**: Amortized across all transactions in the block
 
 For complete technical specifications on the Fee AMM mechanism, see the [Fee AMM Protocol Specification](/protocol/fees/spec-fee-amm).

--- a/docs/pages/protocol/tip20/spec.mdx
+++ b/docs/pages/protocol/tip20/spec.mdx
@@ -219,12 +219,6 @@ interface ITIP20 {
     /// @param amount The fee amount
     function transferFeePreTx(address from, uint256 amount) external;
     
-    /// @notice Post-transaction fee handling (restricted to precompiles)
-    /// @param to The account to refund
-    /// @param refund The refund amount
-    /// @param actualUsed The actual fee used
-    function transferFeePostTx(address to, uint256 refund, uint256 actualUsed) external;
-
 
     // =========================================================================
     //                                Events
@@ -433,7 +427,7 @@ Roles are assigned and managed through `grantRole`, `revokeRole`, `renounceRole`
 
 
 ## System Functions
-System level functions `systemTransferFrom`, `transferFeePreTx`, and `transferFeePostTx` are only callable by other Tempo protocol precompiles. These entrypoints power transaction fee collection, refunds, and internal accounting within the Fee AMM and Stablecoin DEX. They must not be callable by general contracts or users.
+System level functions `systemTransferFrom` and `transferFeePreTx` are only callable by other Tempo protocol precompiles. These entrypoints power transaction fee collection and internal accounting within the Fee AMM and Stablecoin DEX. They must not be callable by general contracts or users.
 
 ## Token Rewards Distribution
 See [rewards distribution](/protocol/tip20-rewards/spec) for more information.
@@ -536,4 +530,4 @@ interface ITIP20Factory {
 - `totalSupply()` must always be `<= supplyCap` 
 - When `paused` is `true`, no functions that move tokens (`transfer`, `transferFrom`, memo variants, `systemTransferFrom`, `startReward`, `setRewardRecipient`, `claimRewards`) can succeed.
 - TIP20 tokens can not send any amount another TIP20 token address.
-- `systemTransferFrom`, `transferFeePreTx`, and `transferFeePostTx` never change `totalSupply()`.
+- `systemTransferFrom` and `transferFeePreTx` never change `totalSupply()`.

--- a/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -387,7 +387,7 @@ fee_payer_hash = keccak256(0x78 || rlp([  // Note: 0x78 magic byte
 **Fee Payer Resolution:**
 - Fee payer signature present → recovered address via `ecrecover`
 - Fee payer signature absent → sender address
-- This address is used for all fee accounting (pre-charge, refund) via TIP Fee Manager precompile
+- This address is used for all fee accounting (pre-charge and settlement) via the FeeManager precompile
 
 #### Transaction Flow
 

--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -54,15 +54,6 @@ contract FeeAMM is IFeeAMM {
         pendingFeeSwapIn[poolId] += uint128(maxAmount);
     }
 
-    function releaseLiquidityPostTx(address userToken, address validatorToken, uint256 refundAmount)
-        internal
-    {
-        bytes32 poolId = getPoolId(userToken, validatorToken);
-
-        // Track pending swap input
-        pendingFeeSwapIn[poolId] -= uint128(refundAmount);
-    }
-
     function rebalanceSwap(address userToken, address validatorToken, uint256 amountOut, address to)
         external
         returns (uint256 amountIn)

--- a/docs/specs/src/TIP20.sol
+++ b/docs/specs/src/TIP20.sol
@@ -386,28 +386,8 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
             balanceOf[from] -= amount;
             balanceOf[TIP_FEE_MANAGER_ADDRESS] += amount;
         }
-    }
 
-    function transferFeePostTx(address to, uint256 refund, uint256 actualUsed) external {
-        require(msg.sender == TIP_FEE_MANAGER_ADDRESS);
-        require(to != address(0));
-
-        uint256 feeManagerBalance = balanceOf[TIP_FEE_MANAGER_ADDRESS];
-        if (refund > feeManagerBalance) {
-            revert InsufficientBalance(feeManagerBalance, refund, address(this));
-        }
-
-        address tosRewardRecipient = _updateRewardsAndGetRecipient(to);
-        if (tosRewardRecipient != address(0)) {
-            optedInSupply += uint128(refund);
-        }
-
-        unchecked {
-            balanceOf[TIP_FEE_MANAGER_ADDRESS] -= refund;
-            balanceOf[to] += refund;
-        }
-
-        emit Transfer(to, TIP_FEE_MANAGER_ADDRESS, actualUsed);
+        emit Transfer(from, TIP_FEE_MANAGER_ADDRESS, amount);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/interfaces/IFeeManager.sol
+++ b/docs/specs/src/interfaces/IFeeManager.sol
@@ -8,9 +8,9 @@ interface IFeeManager is IFeeAMM {
     event UserTokenSet(address indexed user, address indexed token);
     event ValidatorTokenSet(address indexed validator, address indexed token);
 
-    // NOTE: collectFeePreTx and collectFeePostTx are protocol-internal functions
-    // called directly by the execution handler, not exposed via the public interface.
-    // TODO: Design fuzz tests for collectFeePreTx/collectFeePostTx to test against the precompile implementation.
+    // NOTE: collectFeePreTx is a protocol-internal function called directly by the
+    // execution handler, not exposed via the public interface.
+    // TODO: Design fuzz tests for collectFeePreTx to test against the precompile implementation.
 
     function executeBlock() external;
 

--- a/docs/specs/src/interfaces/ITIP20.sol
+++ b/docs/specs/src/interfaces/ITIP20.sol
@@ -201,8 +201,6 @@ interface ITIP20 {
     /// @return success True if the transfer was successful.
     function transfer(address to, uint256 amount) external returns (bool);
 
-    function transferFeePostTx(address to, uint256 refund, uint256 actualUsed) external;
-
     function transferFeePreTx(address from, uint256 amount) external;
 
     /// @notice Transfers tokens from one address to another using allowance.

--- a/docs/specs/test/TIP20.t.sol
+++ b/docs/specs/test/TIP20.t.sol
@@ -897,47 +897,6 @@ contract TIP20Test is BaseTest {
         }
     }
 
-    function testTransferFeePostTx() public {
-        address feeManager = 0xfeEC000000000000000000000000000000000000;
-
-        if (!isTempo) {
-            // Setup: pre-transfer to fee manager
-            vm.prank(feeManager);
-            token.transferFeePreTx(alice, 100e18);
-
-            // Unauthorized
-            vm.prank(alice);
-            try token.transferFeePostTx(alice, 50e18, 50e18) {
-                revert CallShouldHaveReverted();
-            } catch {
-                // Expected revert
-            }
-
-            // to == address(0)
-            vm.prank(feeManager);
-            try token.transferFeePostTx(address(0), 50e18, 50e18) {
-                revert CallShouldHaveReverted();
-            } catch {
-                // Expected revert
-            }
-
-            // Success - refund 50, used 50
-            uint256 aliceBefore = token.balanceOf(alice);
-            vm.prank(feeManager);
-            token.transferFeePostTx(alice, 50e18, 50e18);
-            assertEq(token.balanceOf(alice), aliceBefore + 50e18);
-        } else {
-            vm.prank(alice);
-            try token.transferFeePostTx(alice, 50e18, 50e18) {
-                revert CallShouldHaveReverted();
-            } catch (bytes memory err) {
-                // On Tempo, this function doesnt exist so expect invalid function selector error
-                bytes4 errorSelector = bytes4(err);
-                assertEq(uint32(errorSelector), uint32(0xaa4bc69a));
-            }
-        }
-    }
-
     /*//////////////////////////////////////////////////////////////
                         LOOP PREVENTION TESTS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
This PR proposes removing the refund of fees at the end of each transaction, and instead charging the maximum amount of fees, before the transaction.

This would simplify the protocol, save a (probably very small) amount of computation in every transaction, and set up for some other possible protocol changes (like having FeeAMM swaps happen immediately, and possibly down the line things like delayed execution).

This PR contains the relevant changes to the spec and docs.