### PR TITLE
fix: validate calldata length in TIP-20 payment classification

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -90,7 +90,7 @@ impl TempoPooledTransaction {
 
     /// Returns whether this is a payment transaction.
     ///
-    /// Based on classifier v1: payment if tx.to has TIP20 reserved prefix.
+    /// True if `to` has TIP20 prefix and calldata is a valid `transfer` or `transferWithMemo`.
     pub fn is_payment(&self) -> bool {
         self.is_payment
     }


### PR DESCRIPTION
Only classify transactions as payments if calldata exactly matches
  `transfer(address,uint256)` (68 bytes) or `transferWithMemo(address,uint256,bytes32)` (100 bytes).

Closes #1379