### PR TITLE
feat: add reporting page

### DIFF
--- a/docs/pages/guide/reporting.mdx
+++ b/docs/pages/guide/reporting.mdx
@@ -1,0 +1,7 @@
+import { IndexSupplyQuery } from '../../components/IndexSupplyQuery'
+
+# Reporting
+
+You can write custom queries to explore onchain data.
+
+<IndexSupplyQuery />


### PR DESCRIPTION
Adds a new page at `guides/reporting` that lets us run IS queries against testnet using a nice interface optimized for Tempo. Not linked to by any docs so, while it is openly accessible, will be hard(ish) to find. Intention is the team can use this when we need to craft an IS query