### PR TITLE
fix: correct WebAuthn default size comment

### DIFF
--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -181,7 +181,7 @@ fn create_mock_tempo_signature(
         SignatureType::WebAuthn => {
             // Create a dummy WebAuthn signature with the specified size
             // key_data contains the total size of webauthn_data (excluding 128 bytes for public keys)
-            // Default: 200 bytes if no key_data provided
+            // Default: 800 bytes if no key_data provided
 
             // Base clientDataJSON template (50 bytes): {"type":"webauthn.get","challenge":"","origin":""}
             // Authenticator data (37 bytes): 32 rpIdHash + 1 flags + 4 signCount


### PR DESCRIPTION
Update comment to reflect actual DEFAULT_WEBAUTHN_SIZE value of 800 bytes.
The previous comment incorrectly stated 200 bytes, which could mislead developers about the gas estimation behavior.