### PR TITLE
fix(precompiles): remove duplicate assertions in order tests

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/order.rs
+++ b/crates/precompiles/src/stablecoin_exchange/order.rs
@@ -363,7 +363,6 @@ mod tests {
         assert!(order.is_bid());
         assert_eq!(order.amount(), 1000);
         assert_eq!(order.remaining(), 1000);
-        assert!(order.is_bid());
         assert!(!order.is_ask());
         assert_eq!(order.tick(), 5);
         assert!(!order.is_flip());
@@ -375,7 +374,6 @@ mod tests {
         let order = Order::new_ask(1, TEST_MAKER, TEST_BOOK_KEY, 1000, 5);
 
         assert_eq!(order.order_id(), 1);
-        assert!(!order.is_bid());
         assert!(!order.is_bid());
         assert!(order.is_ask());
         assert!(!order.is_flip());


### PR DESCRIPTION
Removed copy-paste duplicate assertions in stablecoin exchange order tests.

In test_new_bid_order, is_bid() was checked twice with no state changes in between. Same issue in test_new_ask_order where is_bid() check was duplicated on consecutive lines.

These duplicates add no value since Order is immutable in test context.