### PR TITLE
feat(POC): add pathUSD token controller

### DIFF
--- a/docs/specs/src/ReserveStore.sol
+++ b/docs/specs/src/ReserveStore.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { ITIP20 } from "./interfaces/ITIP20.sol";
+
+/// @title ReserveStore
+/// @notice A minimal contract to hold reserve ledger tokens for a specific stablecoin
+/// @dev Deployed per stablecoin to keep ledger token reserves separate for reconciliation purposes.
+///      Pre-approves the controller to transfer tokens on its behalf.
+contract ReserveStore {
+
+    /// @notice The reserve ledger token (backing token)
+    ITIP20 public immutable RESERVE_LEDGER;
+
+    /// @notice The controller that can move tokens from this store
+    address public immutable CONTROLLER;
+
+    /// @notice The stablecoin this store backs
+    ITIP20 public immutable STABLECOIN;
+
+    /// @param reserveLedger The reserve ledger token address
+    /// @param controller The controller contract address
+    /// @param stablecoin The stablecoin this store backs
+    constructor(address reserveLedger, address controller, address stablecoin) {
+        RESERVE_LEDGER = ITIP20(reserveLedger);
+        CONTROLLER = controller;
+        STABLECOIN = ITIP20(stablecoin);
+
+        RESERVE_LEDGER.approve(controller, type(uint256).max);
+    }
+
+}

--- a/docs/specs/src/TIP20Controller.sol
+++ b/docs/specs/src/TIP20Controller.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { TIP20RolesAuth } from "./abstracts/TIP20RolesAuth.sol";
+import { ITIP20 } from "./interfaces/ITIP20.sol";
+
+/// @title TIP20 Wrapping Controller
+/// @notice A controller contract that wraps a ledger TIP20 token into a wrapped TIP20 token (e.g., pathUSD) with 1:1 ratio.
+/// @dev The controller must have ISSUER_ROLE on the wrapped token to mint and burn.
+contract TIP20Controller is TIP20RolesAuth {
+
+    error TransferFailed();
+
+    /// @notice Role required to mint and burn via this controller
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    /// @notice The backing ledger token (TIP20)
+    ITIP20 public immutable LEDGER_TOKEN;
+
+    /// @notice The wrapped token (e.g., pathUSD)
+    ITIP20 public immutable WRAPPED_TOKEN;
+
+    /// @notice Emitted when wrapped tokens are minted
+    event Mint(address indexed minter, uint256 amount);
+
+    /// @notice Emitted when wrapped tokens are burned
+    event Burn(address indexed burner, uint256 amount);
+
+    /// @param ledgerToken The backing ledger token address
+    /// @param wrappedToken The wrapped token address (e.g., pathUSD)
+    /// @param admin The initial admin who can grant MINTER_ROLE
+    constructor(ITIP20 ledgerToken, ITIP20 wrappedToken, address admin) {
+        LEDGER_TOKEN = ledgerToken;
+        WRAPPED_TOKEN = wrappedToken;
+        hasRole[admin][DEFAULT_ADMIN_ROLE] = true;
+    }
+
+    /// @notice Mints wrapped tokens by depositing ledger tokens
+    /// @dev Caller must have approved this contract to spend their ledger tokens
+    /// @param amount The amount of tokens to mint (1:1 ratio with ledger tokens)
+    function mint(uint256 amount) external onlyRole(MINTER_ROLE) {
+        // Pull ledger tokens from minter to this contract
+        if (!LEDGER_TOKEN.transferFrom(msg.sender, address(this), amount)) revert TransferFailed();
+
+        // Mint wrapped tokens to minter
+        WRAPPED_TOKEN.mint(msg.sender, amount);
+
+        emit Mint(msg.sender, amount);
+    }
+
+    /// @notice Burns wrapped tokens and returns ledger tokens
+    /// @dev Caller must have approved this contract to spend their wrapped tokens
+    /// @param amount The amount of wrapped tokens to burn (1:1 ratio with ledger tokens returned)
+    function burn(uint256 amount) external onlyRole(MINTER_ROLE) {
+        // Pull wrapped tokens from burner to this contract
+        if (!WRAPPED_TOKEN.transferFrom(msg.sender, address(this), amount)) {
+            revert TransferFailed();
+        }
+
+        // Burn the wrapped tokens from this contract's balance
+        WRAPPED_TOKEN.burn(amount);
+
+        // Transfer ledger tokens back to burner
+        if (!LEDGER_TOKEN.transfer(msg.sender, amount)) revert TransferFailed();
+
+        emit Burn(msg.sender, amount);
+    }
+
+}

--- a/docs/specs/src/TIP20Controller.sol
+++ b/docs/specs/src/TIP20Controller.sol
@@ -3,67 +3,285 @@ pragma solidity ^0.8.13;
 
 import { TIP20RolesAuth } from "./abstracts/TIP20RolesAuth.sol";
 import { ITIP20 } from "./interfaces/ITIP20.sol";
+import { ITIP20Controller } from "./interfaces/ITIP20Controller.sol";
 
-/// @title TIP20 Wrapping Controller
-/// @notice A controller contract that wraps a ledger TIP20 token into a wrapped TIP20 token (e.g., pathUSD) with 1:1 ratio.
-/// @dev The controller must have ISSUER_ROLE on the wrapped token to mint and burn.
-contract TIP20Controller is TIP20RolesAuth {
+/// @title TIP20Controller
+/// @notice A singleton controller contract that manages minting rate limits and allowances for
+/// multiple TIP20 stablecoins backed by a single reserve ledger token
+/// @dev Adapted from TokenAuthority - uses ReserveStore contracts instead of wrap/unwrap
+///      for TIP20 compatibility. Each stablecoin has its own ReserveStore to keep ledger
+///      tokens separate for reconciliation purposes.
+contract TIP20Controller is ITIP20Controller, TIP20RolesAuth {
 
-    error TransferFailed();
+    /*//////////////////////////////////////////////////////////////////////////
+                                Immutable Variables
+    //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Role required to mint and burn via this controller
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    /// @notice The reserve ledger token used to back all stablecoins
+    address public immutable RESERVE_LEDGER_TOKEN;
 
-    /// @notice The backing ledger token (TIP20)
-    ITIP20 public immutable LEDGER_TOKEN;
+    /// @notice Absolute maximum amount for any single operation (1 billion with 6 decimals)
+    uint256 public constant ABSOLUTE_MAX = 1_000_000_000 * 10e6;
 
-    /// @notice The wrapped token (e.g., pathUSD)
-    ITIP20 public immutable WRAPPED_TOKEN;
+    /*//////////////////////////////////////////////////////////////////////////
+                                Role Constants
+    //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when wrapped tokens are minted
-    event Mint(address indexed minter, uint256 amount);
+    /// @notice Role required to set mint rate limits and minter allowances
+    bytes32 public constant MINT_RATE_LIMIT_SETTER_ROLE = keccak256("MINT_RATE_LIMIT_SETTER_ROLE");
 
-    /// @notice Emitted when wrapped tokens are burned
-    event Burn(address indexed burner, uint256 amount);
+    /// @notice Role required to burn tokens
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
-    /// @param ledgerToken The backing ledger token address
-    /// @param wrappedToken The wrapped token address (e.g., pathUSD)
-    /// @param admin The initial admin who can grant MINTER_ROLE
-    constructor(ITIP20 ledgerToken, ITIP20 wrappedToken, address admin) {
-        LEDGER_TOKEN = ledgerToken;
-        WRAPPED_TOKEN = wrappedToken;
-        hasRole[admin][DEFAULT_ADMIN_ROLE] = true;
+    /// @notice Role required to unwrap stablecoins back to reserve tokens
+    bytes32 public constant UNWRAPPER_ROLE = keccak256("UNWRAPPER_ROLE");
+
+    /// @notice Role for bridge ecosystem contracts that bypass rate limits
+    bytes32 public constant BRIDGE_ECOSYSTEM_CONTRACT_ROLE =
+        keccak256("BRIDGE_ECOSYSTEM_CONTRACT_ROLE");
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                State Variables
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Maps stablecoin contract address and user address to minter allowance
+    /// @dev minterAllowances[stablecoinContract][user] = remaining tokens that can be minted
+    mapping(address stablecoinContract => mapping(address user => uint256 minterAllowance)) public
+        minterAllowances;
+
+    /// @notice Maps stablecoin contract address to per-transaction mint limit
+    mapping(address stablecoinContract => uint256 mintTxnLimit) public mintTxnLimits;
+
+    /// @notice Maps stablecoin contract address to its ReserveStore address
+    mapping(address stablecoinContract => address reserveStore) public reserveStores;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Constructor
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Constructs the TIP20Controller contract
+    /// @param _reserveLedgerToken The address of the reserve ledger token
+    /// @param _admin The address to be granted admin role
+    constructor(address _reserveLedgerToken, address _admin) {
+        RESERVE_LEDGER_TOKEN = _reserveLedgerToken;
+        hasRole[_admin][DEFAULT_ADMIN_ROLE] = true;
     }
 
-    /// @notice Mints wrapped tokens by depositing ledger tokens
-    /// @dev Caller must have approved this contract to spend their ledger tokens
-    /// @param amount The amount of tokens to mint (1:1 ratio with ledger tokens)
-    function mint(uint256 amount) external onlyRole(MINTER_ROLE) {
-        // Pull ledger tokens from minter to this contract
-        if (!LEDGER_TOKEN.transferFrom(msg.sender, address(this), amount)) revert TransferFailed();
+    /*//////////////////////////////////////////////////////////////////////////
+                                        Mint
+    //////////////////////////////////////////////////////////////////////////*/
 
-        // Mint wrapped tokens to minter
-        WRAPPED_TOKEN.mint(msg.sender, amount);
+    /// @notice Mints stablecoins to a recipient address
+    /// @dev Checks and decrements transaction limit and minter allowance before minting.
+    ///      Caller must have pre-approved this contract to spend their reserve ledger tokens.
+    /// @param stablecoinContract The address of the stablecoin contract to mint from
+    /// @param to The address to receive the minted tokens
+    /// @param amount The amount of tokens to mint
+    function mint(address stablecoinContract, address to, uint256 amount) external {
+        if (amount == 0) revert AmountCannotBeZero();
 
-        emit Mint(msg.sender, amount);
+        uint256 mintTxnLimit = mintTxnLimits[stablecoinContract];
+        uint256 minterAllowance = minterAllowances[stablecoinContract][msg.sender];
+        if (minterAllowance < amount) revert MinterAllowanceExceeded();
+        if (mintTxnLimit < amount) revert MintTxnLimitExceeded();
+
+        minterAllowances[stablecoinContract][msg.sender] -= amount;
+
+        _mint(stablecoinContract, to, amount);
     }
 
-    /// @notice Burns wrapped tokens and returns ledger tokens
-    /// @dev Caller must have approved this contract to spend their wrapped tokens
-    /// @param amount The amount of wrapped tokens to burn (1:1 ratio with ledger tokens returned)
-    function burn(uint256 amount) external onlyRole(MINTER_ROLE) {
-        // Pull wrapped tokens from burner to this contract
-        if (!WRAPPED_TOKEN.transferFrom(msg.sender, address(this), amount)) {
+    /// @notice Mints stablecoins to a specified address for bridge ecosystem contracts
+    /// @dev Callable only by contracts with BRIDGE_ECOSYSTEM_CONTRACT_ROLE.
+    ///      Does not enforce minter allowance or per-transaction mint limits.
+    /// @param stablecoinContract The address of the stablecoin contract to mint from
+    /// @param to The recipient address that will receive the minted tokens
+    /// @param amount The amount of tokens to mint
+    function mintBridgeEcosystem(address stablecoinContract, address to, uint256 amount)
+        external
+        onlyRole(BRIDGE_ECOSYSTEM_CONTRACT_ROLE)
+    {
+        _mint(stablecoinContract, to, amount);
+    }
+
+    /// @notice Burns tokens from the sender's balance for a given stablecoin contract
+    /// @dev Transfers stablecoin from sender, burns it, and returns reserve ledger tokens
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount of tokens to burn
+    function burn(address stablecoinContract, uint256 amount) external onlyRole(BURNER_ROLE) {
+        if (stablecoinContract == RESERVE_LEDGER_TOKEN) {
+            if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(msg.sender, address(this), amount)) {
+                revert TransferFailed();
+            }
+            ITIP20(RESERVE_LEDGER_TOKEN).burn(amount);
+        } else {
+            address reserveStore = reserveStores[stablecoinContract];
+            if (reserveStore == address(0)) revert ReserveStoreNotConfigured();
+
+            if (!ITIP20(stablecoinContract).transferFrom(msg.sender, address(this), amount)) {
+                revert TransferFailed();
+            }
+            ITIP20(stablecoinContract).burn(amount);
+
+            if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(reserveStore, msg.sender, amount)) {
+                revert TransferFailed();
+            }
+        }
+
+        emit Burn(msg.sender, stablecoinContract, amount);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Wrap/Unwrap
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Wraps reserve ledger tokens into stablecoins
+    /// @dev Transfers reserve tokens from sender to ReserveStore, mints stablecoins to recipient.
+    ///      Unlike mint(), this does not require minter allowance or respect rate limits.
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param to The address to receive the stablecoins
+    /// @param amount The amount to wrap
+    function wrap(address stablecoinContract, address to, uint256 amount) external {
+        if (amount == 0) revert AmountCannotBeZero();
+        if (amount > ABSOLUTE_MAX) revert AmountExceedsAbsoluteMax();
+
+        address reserveStore = reserveStores[stablecoinContract];
+        if (reserveStore == address(0)) revert ReserveStoreNotConfigured();
+
+        if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(msg.sender, reserveStore, amount)) {
+            revert TransferFailed();
+        }
+        ITIP20(stablecoinContract).mint(to, amount);
+
+        emit Wrap(msg.sender, stablecoinContract, to, amount);
+    }
+
+    /// @notice Unwraps stablecoins back to reserve ledger tokens
+    /// @dev Burns stablecoins from sender, transfers reserve tokens from ReserveStore to sender.
+    ///      Unlike burn(), this returns the reserve tokens instead of destroying them.
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount to unwrap
+    function unwrap(address stablecoinContract, uint256 amount) external onlyRole(UNWRAPPER_ROLE) {
+        if (amount == 0) revert AmountCannotBeZero();
+
+        address reserveStore = reserveStores[stablecoinContract];
+        if (reserveStore == address(0)) revert ReserveStoreNotConfigured();
+
+        if (!ITIP20(stablecoinContract).transferFrom(msg.sender, address(this), amount)) {
+            revert TransferFailed();
+        }
+        ITIP20(stablecoinContract).burn(amount);
+
+        if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(reserveStore, msg.sender, amount)) {
             revert TransferFailed();
         }
 
-        // Burn the wrapped tokens from this contract's balance
-        WRAPPED_TOKEN.burn(amount);
+        emit Unwrap(msg.sender, stablecoinContract, amount);
+    }
 
-        // Transfer ledger tokens back to burner
-        if (!LEDGER_TOKEN.transfer(msg.sender, amount)) revert TransferFailed();
+    /*//////////////////////////////////////////////////////////////////////////
+                                Mint Rate Setters
+    //////////////////////////////////////////////////////////////////////////*/
 
-        emit Burn(msg.sender, amount);
+    /// @notice Sets the per-transaction mint limit for a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param mintTxnLimit The per-transaction mint limit to set
+    function setTxnMintLimit(address stablecoinContract, uint256 mintTxnLimit)
+        external
+        onlyRole(MINT_RATE_LIMIT_SETTER_ROLE)
+    {
+        if (mintTxnLimit >= type(uint256).max / 2) revert AmountExceedsAbsoluteMax();
+        mintTxnLimits[stablecoinContract] = mintTxnLimit;
+
+        emit TxnMintLimitSet(msg.sender, stablecoinContract, mintTxnLimit);
+    }
+
+    /// @notice Sets the mint allowance for a specific minter on a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param minter The address of the minter
+    /// @param minterAllowance The allowance amount to set for the minter
+    function setMinterAllowance(address stablecoinContract, address minter, uint256 minterAllowance)
+        external
+        onlyRole(MINT_RATE_LIMIT_SETTER_ROLE)
+    {
+        if (minterAllowance >= type(uint256).max / 2) revert AmountExceedsAbsoluteMax();
+        minterAllowances[stablecoinContract][minter] = minterAllowance;
+
+        emit MinterAllowanceSet(msg.sender, stablecoinContract, minter, minterAllowance);
+    }
+
+    /// @notice Sets the reserve store for a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param reserveStore The address of the reserve store
+    function setReserveStore(address stablecoinContract, address reserveStore)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        reserveStores[stablecoinContract] = reserveStore;
+
+        emit ReserveStoreSet(msg.sender, stablecoinContract, reserveStore);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                Getters
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Gets the mint allowance for a specific minter on a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param minter The address of the minter
+    /// @return minterAllowance The remaining allowance for the minter
+    function getMinterAllowance(address stablecoinContract, address minter)
+        external
+        view
+        returns (uint256 minterAllowance)
+    {
+        return minterAllowances[stablecoinContract][minter];
+    }
+
+    /// @notice Gets the per-transaction mint limit for a specific stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @return mintTxnLimit The per-transaction mint limit
+    function getStablecoinTxnMintLimit(address stablecoinContract)
+        external
+        view
+        returns (uint256 mintTxnLimit)
+    {
+        return mintTxnLimits[stablecoinContract];
+    }
+
+    /// @notice Gets the reserve store for a specific stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @return reserveStore The address of the reserve store
+    function getReserveStore(address stablecoinContract)
+        external
+        view
+        returns (address reserveStore)
+    {
+        return reserveStores[stablecoinContract];
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                Internal Functions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function _mint(address stablecoinContract, address to, uint256 amount) internal {
+        if (amount > ABSOLUTE_MAX) revert AmountExceedsAbsoluteMax();
+
+        if (stablecoinContract == RESERVE_LEDGER_TOKEN) {
+            if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(msg.sender, address(this), amount)) {
+                revert TransferFailed();
+            }
+            ITIP20(RESERVE_LEDGER_TOKEN).transfer(to, amount);
+        } else {
+            address reserveStore = reserveStores[stablecoinContract];
+            if (reserveStore == address(0)) revert ReserveStoreNotConfigured();
+
+            if (!ITIP20(RESERVE_LEDGER_TOKEN).transferFrom(msg.sender, reserveStore, amount)) {
+                revert TransferFailed();
+            }
+            ITIP20(stablecoinContract).mint(to, amount);
+        }
+
+        emit Mint(msg.sender, stablecoinContract, to, amount);
     }
 
 }

--- a/docs/specs/src/interfaces/ITIP20Controller.sol
+++ b/docs/specs/src/interfaces/ITIP20Controller.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title ITIP20Controller
+/// @notice Interface for the TIP20Controller contract which manages minting rate limits and
+/// allowances for stablecoins backed by a reserve ledger token
+/// @dev Adapted from TokenAuthority for TIP20 tokens - uses ReserveStore instead of wrap/unwrap
+interface ITIP20Controller {
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Errors
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Thrown when a mint operation would exceed the per-transaction mint limit
+    error MintTxnLimitExceeded();
+
+    /// @notice Thrown when a mint operation would exceed the minter's allowance
+    error MinterAllowanceExceeded();
+
+    /// @notice Thrown when attempting to perform an operation with an amount of zero
+    error AmountCannotBeZero();
+
+    /// @notice Thrown when a mint operation would exceed the absolute maximum amount
+    error AmountExceedsAbsoluteMax();
+
+    /// @notice Thrown when no reserve store is configured for a stablecoin
+    error ReserveStoreNotConfigured();
+
+    /// @notice Thrown when a transfer operation fails
+    error TransferFailed();
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Events
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when the per-transaction mint limit is updated for a stablecoin
+    /// @param sender The address that set the limit
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param mintTxnLimit The new per-transaction mint limit
+    event TxnMintLimitSet(
+        address indexed sender, address indexed stablecoinContract, uint256 mintTxnLimit
+    );
+
+    /// @notice Emitted when a minter's allowance is set for a stablecoin
+    /// @param sender The address that set the allowance
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param minter The address of the minter whose allowance is being set
+    /// @param minterAllowance The new allowance for the minter
+    event MinterAllowanceSet(
+        address indexed sender,
+        address indexed stablecoinContract,
+        address indexed minter,
+        uint256 minterAllowance
+    );
+
+    /// @notice Emitted when tokens are minted to a recipient
+    /// @param sender The address that initiated the mint operation
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param to The address receiving the minted tokens
+    /// @param amount The amount of tokens minted
+    event Mint(
+        address indexed sender,
+        address indexed stablecoinContract,
+        address indexed to,
+        uint256 amount
+    );
+
+    /// @notice Emitted when tokens are burned
+    /// @param sender The address that initiated the burn operation
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount of tokens burned
+    event Burn(address indexed sender, address indexed stablecoinContract, uint256 amount);
+
+    /// @notice Emitted when a reserve store is set for a stablecoin
+    /// @param sender The address that set the reserve store
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param reserveStore The address of the reserve store
+    event ReserveStoreSet(
+        address indexed sender, address indexed stablecoinContract, address indexed reserveStore
+    );
+
+    /// @notice Emitted when reserve tokens are wrapped into stablecoins
+    /// @param sender The address that initiated the wrap
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param to The address receiving the stablecoins
+    /// @param amount The amount wrapped
+    event Wrap(
+        address indexed sender,
+        address indexed stablecoinContract,
+        address indexed to,
+        uint256 amount
+    );
+
+    /// @notice Emitted when stablecoins are unwrapped back to reserve tokens
+    /// @param sender The address that initiated the unwrap
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount unwrapped
+    event Unwrap(address indexed sender, address indexed stablecoinContract, uint256 amount);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Functions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Mints stablecoins to a recipient address
+    /// @param stablecoinContract The address of the stablecoin contract to mint from
+    /// @param to The address to receive the minted tokens
+    /// @param amount The amount of tokens to mint
+    function mint(address stablecoinContract, address to, uint256 amount) external;
+
+    /// @notice Mints stablecoins to a specified address for bridge ecosystem contracts
+    /// @param stablecoinContract The address of the stablecoin contract to mint from
+    /// @param to The recipient address that will receive the minted tokens
+    /// @param amount The amount of tokens to mint
+    function mintBridgeEcosystem(address stablecoinContract, address to, uint256 amount) external;
+
+    /// @notice Burns tokens from the sender's balance for a given stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount of tokens to burn
+    function burn(address stablecoinContract, uint256 amount) external;
+
+    /// @notice Wraps reserve ledger tokens into stablecoins
+    /// @dev Transfers reserve tokens from sender to ReserveStore, mints stablecoins to recipient
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param to The address to receive the stablecoins
+    /// @param amount The amount to wrap
+    function wrap(address stablecoinContract, address to, uint256 amount) external;
+
+    /// @notice Unwraps stablecoins back to reserve ledger tokens
+    /// @dev Burns stablecoins from sender, transfers reserve tokens from ReserveStore to sender
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param amount The amount to unwrap
+    function unwrap(address stablecoinContract, uint256 amount) external;
+
+    /// @notice Sets the per-transaction mint limit for a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param mintTxnLimit The per-transaction mint limit to set
+    function setTxnMintLimit(address stablecoinContract, uint256 mintTxnLimit) external;
+
+    /// @notice Sets the mint allowance for a specific minter on a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param minter The address of the minter
+    /// @param minterAllowance The allowance amount to set for the minter
+    function setMinterAllowance(address stablecoinContract, address minter, uint256 minterAllowance)
+        external;
+
+    /// @notice Sets the reserve store for a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param reserveStore The address of the reserve store
+    function setReserveStore(address stablecoinContract, address reserveStore) external;
+
+    /// @notice Gets the mint allowance for a specific minter on a stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @param minter The address of the minter
+    /// @return minterAllowance The remaining allowance for the minter
+    function getMinterAllowance(address stablecoinContract, address minter)
+        external
+        view
+        returns (uint256 minterAllowance);
+
+    /// @notice Gets the per-transaction mint limit for a specific stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @return mintTxnLimit The per-transaction mint limit
+    function getStablecoinTxnMintLimit(address stablecoinContract)
+        external
+        view
+        returns (uint256 mintTxnLimit);
+
+    /// @notice Gets the reserve store for a specific stablecoin contract
+    /// @param stablecoinContract The address of the stablecoin contract
+    /// @return reserveStore The address of the reserve store
+    function getReserveStore(address stablecoinContract)
+        external
+        view
+        returns (address reserveStore);
+
+}

--- a/docs/specs/test/TIP20Controller.t.sol
+++ b/docs/specs/test/TIP20Controller.t.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { TIP20 } from "../src/TIP20.sol";
+import { TIP20Controller } from "../src/TIP20Controller.sol";
+import { ITIP20 } from "../src/interfaces/ITIP20.sol";
+import { ITIP20RolesAuth } from "../src/interfaces/ITIP20RolesAuth.sol";
+import { BaseTest } from "./BaseTest.t.sol";
+
+contract TIP20ControllerTest is BaseTest {
+
+    TIP20Controller controller;
+    TIP20 ledgerToken;
+    TIP20 wrappedToken;
+
+    bytes32 constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create ledger token (backing token) and wrapped token (pathUSD-like)
+        ledgerToken =
+            TIP20(factory.createToken("Ledger USD", "LUSD", "USD", TIP20(_PATH_USD), admin));
+        wrappedToken =
+            TIP20(factory.createToken("Wrapped USD", "WUSD", "USD", TIP20(_PATH_USD), admin));
+
+        // Deploy controller with admin
+        controller =
+            new TIP20Controller(ITIP20(address(ledgerToken)), ITIP20(address(wrappedToken)), admin);
+
+        // Grant ISSUER_ROLE on wrappedToken to the controller so it can mint/burn
+        vm.prank(admin);
+        wrappedToken.grantRole(_ISSUER_ROLE, address(controller));
+
+        // Grant MINTER_ROLE on controller to alice (she will be our minter)
+        vm.prank(admin);
+        controller.grantRole(MINTER_ROLE, alice);
+
+        // Mint some ledger tokens to alice for testing
+        vm.prank(admin);
+        ledgerToken.grantRole(_ISSUER_ROLE, admin);
+        vm.prank(admin);
+        ledgerToken.mint(alice, 1000e6);
+    }
+
+    // ========== MINT FLOW TESTS ==========
+
+    function test_mint_success() public {
+        uint256 amount = 100e6;
+
+        // Alice approves controller to spend her ledger tokens
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), amount);
+
+        // Check balances before
+        uint256 aliceLedgerBefore = ledgerToken.balanceOf(alice);
+        uint256 aliceWrappedBefore = wrappedToken.balanceOf(alice);
+        uint256 controllerLedgerBefore = ledgerToken.balanceOf(address(controller));
+
+        // Alice mints wrapped tokens
+        vm.prank(alice);
+        controller.mint(amount);
+
+        // Check balances after
+        assertEq(
+            ledgerToken.balanceOf(alice),
+            aliceLedgerBefore - amount,
+            "Alice ledger balance should decrease"
+        );
+        assertEq(
+            wrappedToken.balanceOf(alice),
+            aliceWrappedBefore + amount,
+            "Alice wrapped balance should increase"
+        );
+        assertEq(
+            ledgerToken.balanceOf(address(controller)),
+            controllerLedgerBefore + amount,
+            "Controller should hold ledger tokens"
+        );
+    }
+
+    function test_mint_revertsWithoutMinterRole() public {
+        uint256 amount = 100e6;
+
+        // Bob doesn't have MINTER_ROLE
+        vm.prank(bob);
+        ledgerToken.approve(address(controller), amount);
+
+        vm.prank(bob);
+        try controller.mint(amount) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP20RolesAuth.Unauthorized.selector));
+        }
+    }
+
+    function test_mint_revertsWithoutApproval() public {
+        uint256 amount = 100e6;
+
+        // Alice has MINTER_ROLE but hasn't approved
+        vm.prank(alice);
+        try controller.mint(amount) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP20.InsufficientAllowance.selector));
+        }
+    }
+
+    // ========== BURN FLOW TESTS ==========
+
+    function test_burn_success() public {
+        uint256 mintAmount = 100e6;
+        uint256 burnAmount = 50e6;
+
+        // First mint some wrapped tokens
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), mintAmount);
+        vm.prank(alice);
+        controller.mint(mintAmount);
+
+        // Alice approves controller to spend her wrapped tokens
+        vm.prank(alice);
+        wrappedToken.approve(address(controller), burnAmount);
+
+        // Check balances before burn
+        uint256 aliceLedgerBefore = ledgerToken.balanceOf(alice);
+        uint256 aliceWrappedBefore = wrappedToken.balanceOf(alice);
+        uint256 controllerLedgerBefore = ledgerToken.balanceOf(address(controller));
+
+        // Alice burns wrapped tokens
+        vm.prank(alice);
+        controller.burn(burnAmount);
+
+        // Check balances after
+        assertEq(
+            ledgerToken.balanceOf(alice),
+            aliceLedgerBefore + burnAmount,
+            "Alice ledger balance should increase"
+        );
+        assertEq(
+            wrappedToken.balanceOf(alice),
+            aliceWrappedBefore - burnAmount,
+            "Alice wrapped balance should decrease"
+        );
+        assertEq(
+            ledgerToken.balanceOf(address(controller)),
+            controllerLedgerBefore - burnAmount,
+            "Controller ledger balance should decrease"
+        );
+    }
+
+    function test_burn_revertsWithoutMinterRole() public {
+        uint256 amount = 100e6;
+
+        // First mint some wrapped tokens to bob (via admin granting role temporarily)
+        vm.prank(admin);
+        controller.grantRole(MINTER_ROLE, bob);
+
+        vm.prank(admin);
+        ledgerToken.mint(bob, amount);
+
+        vm.prank(bob);
+        ledgerToken.approve(address(controller), amount);
+        vm.prank(bob);
+        controller.mint(amount);
+
+        // Revoke bob's MINTER_ROLE
+        vm.prank(admin);
+        controller.revokeRole(MINTER_ROLE, bob);
+
+        // Bob tries to burn without MINTER_ROLE
+        vm.prank(bob);
+        wrappedToken.approve(address(controller), amount);
+
+        vm.prank(bob);
+        try controller.burn(amount) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP20RolesAuth.Unauthorized.selector));
+        }
+    }
+
+    function test_burn_revertsWithoutApproval() public {
+        uint256 amount = 100e6;
+
+        // First mint some wrapped tokens
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), amount);
+        vm.prank(alice);
+        controller.mint(amount);
+
+        // Alice tries to burn without approving wrapped tokens
+        vm.prank(alice);
+        try controller.burn(amount) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP20.InsufficientAllowance.selector));
+        }
+    }
+
+    // ========== E2E FLOW TESTS ==========
+
+    function test_e2e_mintAndBurnFullCycle() public {
+        uint256 amount = 500e6;
+
+        // Initial state
+        assertEq(ledgerToken.balanceOf(alice), 1000e6, "Alice starts with 1000 ledger tokens");
+        assertEq(wrappedToken.balanceOf(alice), 0, "Alice starts with 0 wrapped tokens");
+        assertEq(
+            ledgerToken.balanceOf(address(controller)), 0, "Controller starts with 0 ledger tokens"
+        );
+
+        // Step 1: Alice mints wrapped tokens
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), amount);
+        vm.prank(alice);
+        controller.mint(amount);
+
+        assertEq(ledgerToken.balanceOf(alice), 500e6, "Alice has 500 ledger tokens after mint");
+        assertEq(wrappedToken.balanceOf(alice), 500e6, "Alice has 500 wrapped tokens after mint");
+        assertEq(
+            ledgerToken.balanceOf(address(controller)), 500e6, "Controller holds 500 ledger tokens"
+        );
+
+        // Step 2: Alice burns all wrapped tokens
+        vm.prank(alice);
+        wrappedToken.approve(address(controller), amount);
+        vm.prank(alice);
+        controller.burn(amount);
+
+        assertEq(ledgerToken.balanceOf(alice), 1000e6, "Alice has 1000 ledger tokens after burn");
+        assertEq(wrappedToken.balanceOf(alice), 0, "Alice has 0 wrapped tokens after burn");
+        assertEq(ledgerToken.balanceOf(address(controller)), 0, "Controller holds 0 ledger tokens");
+    }
+
+    function test_e2e_multipleMintAndBurn() public {
+        // Mint in batches
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), 300e6);
+
+        vm.prank(alice);
+        controller.mint(100e6);
+        assertEq(wrappedToken.balanceOf(alice), 100e6);
+
+        vm.prank(alice);
+        controller.mint(200e6);
+        assertEq(wrappedToken.balanceOf(alice), 300e6);
+
+        // Burn in batches
+        vm.prank(alice);
+        wrappedToken.approve(address(controller), 300e6);
+
+        vm.prank(alice);
+        controller.burn(150e6);
+        assertEq(wrappedToken.balanceOf(alice), 150e6);
+        assertEq(ledgerToken.balanceOf(alice), 850e6);
+
+        vm.prank(alice);
+        controller.burn(150e6);
+        assertEq(wrappedToken.balanceOf(alice), 0);
+        assertEq(ledgerToken.balanceOf(alice), 1000e6);
+    }
+
+    function test_e2e_multipleMintersCanOperate() public {
+        // Grant MINTER_ROLE to bob
+        vm.prank(admin);
+        controller.grantRole(MINTER_ROLE, bob);
+
+        // Give bob some ledger tokens
+        vm.prank(admin);
+        ledgerToken.mint(bob, 500e6);
+
+        // Alice mints
+        vm.prank(alice);
+        ledgerToken.approve(address(controller), 200e6);
+        vm.prank(alice);
+        controller.mint(200e6);
+
+        // Bob mints
+        vm.prank(bob);
+        ledgerToken.approve(address(controller), 300e6);
+        vm.prank(bob);
+        controller.mint(300e6);
+
+        // Verify independent balances
+        assertEq(wrappedToken.balanceOf(alice), 200e6);
+        assertEq(wrappedToken.balanceOf(bob), 300e6);
+        assertEq(ledgerToken.balanceOf(address(controller)), 500e6);
+
+        // Both can burn independently
+        vm.prank(alice);
+        wrappedToken.approve(address(controller), 200e6);
+        vm.prank(alice);
+        controller.burn(200e6);
+
+        vm.prank(bob);
+        wrappedToken.approve(address(controller), 300e6);
+        vm.prank(bob);
+        controller.burn(300e6);
+
+        assertEq(wrappedToken.balanceOf(alice), 0);
+        assertEq(wrappedToken.balanceOf(bob), 0);
+        assertEq(ledgerToken.balanceOf(address(controller)), 0);
+    }
+
+    // ========== ROLE MANAGEMENT TESTS ==========
+
+    function test_adminCanGrantAndRevokeMinterRole() public {
+        assertFalse(controller.hasRole(charlie, MINTER_ROLE));
+
+        // Grant role
+        vm.prank(admin);
+        controller.grantRole(MINTER_ROLE, charlie);
+        assertTrue(controller.hasRole(charlie, MINTER_ROLE));
+
+        // Revoke role
+        vm.prank(admin);
+        controller.revokeRole(MINTER_ROLE, charlie);
+        assertFalse(controller.hasRole(charlie, MINTER_ROLE));
+    }
+
+    function test_nonAdminCannotGrantMinterRole() public {
+        vm.prank(alice);
+        try controller.grantRole(MINTER_ROLE, bob) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP20RolesAuth.Unauthorized.selector));
+        }
+    }
+
+}


### PR DESCRIPTION
POC implementation for a token controller, which allows you to multiplex a single stablecoin into multiple stablecoins on the chain using a simple wrapping mechanism.

Will primarily be used by Bridge for Path USD.

We add the wrapped token and the reserve token as immutables for efficiency. Which means you need to deploy a controller for each new token you want to create.
There is also a way to do a singleton controller here, which can be reused for multiple tokens, but comes at the cost of 1 extra storage operation per read. ( this might be totally fine, since mint/burn are not critical path functions for transfers )