### PR TITLE
fix: address connector overflow

### DIFF
--- a/docs/components/guides/steps/wallet/ConnectWallet.tsx
+++ b/docs/components/guides/steps/wallet/ConnectWallet.tsx
@@ -49,7 +49,7 @@ export function ConnectWallet(props: DemoStepProps) {
 
     if (!hasNonWebAuthnWallet) {
       return (
-        <div className="flex flex-wrap gap-2 justify-end">
+        <div className="flex flex-wrap gap-2 justify-center">
           {injectedConnectors.map((conn) => (
             <Button
               variant="default"
@@ -142,13 +142,17 @@ export function ConnectWallet(props: DemoStepProps) {
     chains,
   ])
 
+  const stackConnectors = injectedConnectors.length > 2
+
   return (
     <Step
       active={active}
       completed={completed}
-      actions={actions}
       number={stepNumber}
       title="Connect your browser wallet."
-    />
+      actions={!stackConnectors && actions}
+    >
+      { stackConnectors && actions }
+    </Step>
   )
 }


### PR DESCRIPTION
## Before (overflow)
<img width="1524" height="1098" alt="CleanShot 2025-12-11 at 17 02 28@2x" src="https://github.com/user-attachments/assets/578e6e9d-6098-48c8-90ce-96cf7109c0e4" />

## After
### > 2 connectors: actions are stacked
<img width="1516" height="994" alt="CleanShot 2025-12-11 at 17 45 36@2x" src="https://github.com/user-attachments/assets/13626435-d834-4e57-a3d5-83f0bbf9ab94" />

### ≤ 2 connectors: actions are adjacent
<img width="1518" height="834" alt="CleanShot 2025-12-11 at 17 45 20@2x" src="https://github.com/user-attachments/assets/891cc512-e781-44b1-ad65-32359280ec98" />


