### PR TITLE
fix: verify block hash when reading validators to prevent uncle block reads

### DIFF
--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -672,17 +672,21 @@ struct Metrics {
 }
 
 /// Attempts to read the validator config from the smart contract until it becomes available.
+///
+/// If `expected_block_hash` is provided, it will be passed to `read_from_contract` to ensure
+/// we read from the correct canonical block and not an uncle block.
 async fn read_validator_config_with_retry<C: commonware_runtime::Clock>(
     context: &C,
     node: &TempoFullNode,
     epoch: Epoch,
     epoch_length: u64,
+    expected_block_hash: Option<alloy_primitives::B256>,
 ) -> OrderedAssociated<PublicKey, DecodedValidator> {
     let mut attempts = 1;
     let retry_after = Duration::from_secs(1);
     loop {
         if let Ok(validators) =
-            validators::read_from_contract(attempts, node, epoch, epoch_length).await
+            validators::read_from_contract(attempts, node, epoch, epoch_length, expected_block_hash).await
         {
             break validators;
         }


### PR DESCRIPTION
Fixes #1295  

The DKG manager reads validator config from the on-chain contract using block height. If a reorg happens between when the DKG actor reads and the application actor finalizes could accidentally read from an uncle block instead of the correct one. Added an optional expected_block_hash parameter that verifies we're reading from the right block. When there's a mismatch, we return an error instead of reading wrong data.

Now when reading validators at epoch boundaries, we pass the finalized block's hash to make sure we're always reading from the correct canonical block.