### PR TITLE
chore: add contract codeowners to precompiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,16 +9,17 @@ crates/chainspec/ @0xKitsune @klkvr @mattsse
 crates/commonware-node/ @joshieDo @SuperFluffy
 crates/commonware-node-config/ @joshieDo @SuperFluffy
 crates/consensus/ @joshieDo @SuperFluffy
-crates/contracts/ @0xKitsune @fgimenez @klkvr @mattsse
+crates/contracts/ @0xKitsune @fgimenez @klkvr @mattsse @legion2002 @howydev
 crates/e2e/ @joshieDo @SuperFluffy
 crates/evm/ @0xKitsune @klkvr @mattsse
 crates/eyre/ @SuperFluffy
 crates/faucet/ @klkvr @mattsse
 crates/node/ @0xKitsune @klkvr @mattsse
 crates/payload/ @0xKitsune @klkvr @mattsse
-crates/precompiles/ @0xKitsune @fgimenez @klkvr @mattsse
+crates/precompiles/ @0xKitsune @fgimenez @klkvr @mattsse @legion2002 @howydev
 crates/precompiles-macros/ @0xrusowsky @mattsse
 crates/primitives/ @klkvr @mattsse
 crates/revm/ @klkvr @mattsse @rakita @0xKitsune
 crates/telemetry-util/ @SuperFluffy
 crates/transaction-pool/ @0xKitsune @klkvr @mattsse
+docs/specs/ @legion2002 @howydev @0xKitsune


### PR DESCRIPTION
Precompiles have been feature freezed, but fixes have started to drift from solidity implementation again. 
Solidity team should be notified for any future changes to precompiles, so we can review security and update solidity impl/tests accordingly.