### PR TITLE
feat(tempo-bench): change default TIP-20 transfer weight to 1

### DIFF
--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -90,17 +90,22 @@ Options:
       --tip20-weight <TIP20_WEIGHT>
           A weight that determines the likelihood of generating a TIP-20 transfer transaction
 
-          [default: 0.8]
+          [default: 1]
 
       --place-order-weight <PLACE_ORDER_WEIGHT>
           A weight that determines the likelihood of generating a DEX place transaction
 
-          [default: 0.01]
+          [default: 0]
 
       --swap-weight <SWAP_WEIGHT>
           A weight that determines the likelihood of generating a DEX swapExactAmountIn transaction
 
-          [default: 0.19]
+          [default: 0]
+
+      --erc20-weight <ERC20_WEIGHT>
+          A weight that determines the likelihood of generating an ERC-20 transfer transaction
+
+          [default: 0]
 
       --sample-size <SAMPLE_SIZE>
           An amount of receipts to wait for after sending all the transactions
@@ -116,6 +121,9 @@ Options:
           Clear the transaction pool before running the benchmark.
 
           Calls admin_clearTxpool.
+
+      --disable-2d-nonces
+          Disable 2D nonces
 
   -h, --help
           Print help (see a summary with '-h')

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -131,15 +131,15 @@ pub struct MaxTpsArgs {
     benchmark_mode: Option<String>,
 
     /// A weight that determines the likelihood of generating a TIP-20 transfer transaction.
-    #[arg(long, default_value_t = 0.8)]
+    #[arg(long, default_value_t = 1.0)]
     tip20_weight: f64,
 
     /// A weight that determines the likelihood of generating a DEX place transaction.
-    #[arg(long, default_value_t = 0.01)]
+    #[arg(long, default_value_t = 0.0)]
     place_order_weight: f64,
 
     /// A weight that determines the likelihood of generating a DEX swapExactAmountIn transaction.
-    #[arg(long, default_value_t = 0.19)]
+    #[arg(long, default_value_t = 0.0)]
     swap_weight: f64,
 
     /// A weight that determines the likelihood of generating an ERC-20 transfer transaction.


### PR DESCRIPTION
## Summary
- change default tip-20 weight to 1
- document the ERC-20 weight and disable-2d-nonces options for tempo-bench run-max-tps
- note default weight values matching max_tps.rs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c53a8f1c48321930e1d3a6dc93f49)