### PR TITLE
docs: point to Allium Tempo recipes

### DIFF
--- a/docs/pages/quickstart/developer-tools.mdx
+++ b/docs/pages/quickstart/developer-tools.mdx
@@ -67,7 +67,7 @@ Integrating with Tempo is easy by leveraging services provided by our infrastruc
 Get access to Tempo data through the [Allium App](https://app.allium.so/join), explore the full API in the [Allium docs](https://docs.allium.so/), and browse real examples of production apps built on Allium [here](https://docs.allium.so/api/developer/overview).
 
 :::tip
-Allium has a [recipe](https://github.com/Allium-Science/allium-recipes/tree/main/tempo) to help you query Tempo data with SQL quickly!
+Allium has a [ready-to-use recipe](https://github.com/Allium-Science/allium-recipes/tree/main/tempo) for querying Tempo data with SQL.
 :::
 
 ### Artemis


### PR DESCRIPTION
Highlights Allium's public recipe to start querying Tempo data with SQL quickly