### PR TITLE
perf(sub-block): avoid double encoding during signature hashing

### DIFF
--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -132,6 +132,10 @@ impl Encodable for SubBlock {
         self.rlp_header().encode(out);
         self.rlp_encode_fields(out);
     }
+
+    fn length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
 }
 
 /// A subblock with a signature.


### PR DESCRIPTION
Avoid double encoding during signature hashing