### PR TITLE
docs(examples): add Tempo Testnet chain config example for viem/wagmi

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,41 @@
+# Tempo SDK Examples
+
+## Adding Tempo Testnet to wagmi/viem
+
+Copy the code from the file `tempoTestnetChain.ts` into your project.
+
+This file contains the official Tempo Testnet chain configuration for easy integration with wagmi or viem.
+
+Example usage:
+
+```ts
+import { tempoTestnet } from './tempoTestnetChain'
+
+createConfig({
+  chains: [tempoTestnet],
+  transports: {
+    [tempoTestnet.id]: http(),
+  },
+})
+
+cat > docs/examples/README.md << 'EOF'
+# Tempo SDK Examples
+
+## Adding Tempo Testnet to wagmi/viem
+
+Copy the code from the file `tempoTestnetChain.ts` into your project.
+
+This file contains the official Tempo Testnet chain configuration for easy integration with wagmi or viem.
+
+Example usage:
+
+```ts
+import { tempoTestnet } from './tempoTestnetChain'
+
+createConfig({
+  chains: [tempoTestnet],
+  transports: {
+    [tempoTestnet.id]: http(),
+  },
+})
+git add docs/examples

--- a/docs/examples/tempoTestnetChain.ts
+++ b/docs/examples/tempoTestnetChain.ts
@@ -1,0 +1,36 @@
+import { defineChain } from 'viem'
+
+/**
+ * Tempo Testnet configuration for viem and wagmi
+ * 
+ * Use this to add Tempo Testnet to your dApp:
+ * 
+ * import { tempoTestnet } from './tempoTestnetChain'
+ * 
+ * createConfig({
+ *   chains: [tempoTestnet],
+ *   ...
+ * })
+ */
+export const tempoTestnet = defineChain({
+  id: 42429,
+  name: 'Tempo Testnet (Andantino)',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'USD',
+    symbol: 'USD',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.testnet.tempo.xyz'],
+      webSocket: ['wss://rpc.testnet.tempo.xyz'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Tempo Explorer',
+      url: 'https://explore.tempo.xyz',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Adds a ready-to-use example of the Tempo Testnet chain configuration using viem's `defineChain`.

This helps developers quickly integrate Tempo Testnet into wagmi or viem-based dApps without manual setup of chain ID, RPC URLs, etc.

Changes:
- New folder: docs/examples/
- tempoTestnetChain.ts – official chain definition
- README.md – instructions and wagmi usage example

Pure documentation improvement to make testnet onboarding easier.

