### PR TITLE
feat(precompiles): add lazy initialization for precompiles

### DIFF
--- a/crates/precompiles-macros/src/layout.rs
+++ b/crates/precompiles-macros/src/layout.rs
@@ -171,6 +171,20 @@ pub(crate) fn gen_constructor(
                 Ok(())
             }
 
+            /// Lazily initializes the precompile if it hasn't been initialized yet.
+            ///
+            /// This checks if the precompile has bytecode deployed at its address.
+            /// If not, it automatically calls `__initialize()` to set the marker bytecode.
+            /// This enables precompiles to work without requiring manual initialization
+            /// during genesis block generation.
+            #[inline(always)]
+            pub fn __ensure_initialized(&mut self) -> crate::error::Result<()> {
+                if !self.storage.has_code(self.address)? {
+                    self.__initialize()?;
+                }
+                Ok(())
+            }
+
             #[inline(always)]
             fn emit_event(&mut self, event: impl ::alloy::primitives::IntoLogData) -> crate::error::Result<()> {
                 self.storage.emit_event(self.address, event.into_log_data())

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -232,6 +232,15 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     fn is_static(&self) -> bool {
         self.is_static
     }
+
+    #[inline]
+    fn has_code(&mut self, address: Address) -> Result<bool, TempoPrecompileError> {
+        let mut has_code = false;
+        self.with_account_info(address, &mut |info| {
+            has_code = !info.is_empty_code_hash();
+        })?;
+        Ok(has_code)
+    }
 }
 
 impl From<EvmInternalsError> for TempoPrecompileError {

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -142,6 +142,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     fn is_static(&self) -> bool {
         self.is_static
     }
+
+    fn has_code(&mut self, address: Address) -> Result<bool, TempoPrecompileError> {
+        let account = self.accounts.get(&address);
+        Ok(account.is_some_and(|a| !a.is_empty_code_hash()))
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -80,6 +80,9 @@ pub trait PrecompileStorageProvider {
 
     /// Returns whether the current call context is static.
     fn is_static(&self) -> bool;
+
+    /// Returns whether the account at the given address has non-empty bytecode.
+    fn has_code(&mut self, address: Address) -> Result<bool>;
 }
 
 /// Storage operations for a given (contract) address.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -170,6 +170,11 @@ impl StorageCtx {
     pub fn is_static(&self) -> bool {
         Self::with_storage(|s| s.is_static())
     }
+
+    /// Returns whether the account at the given address has non-empty bytecode.
+    pub fn has_code(&mut self, address: Address) -> Result<bool> {
+        Self::try_with_storage(|s| s.has_code(address))
+    }
 }
 
 impl<'evm> StorageCtx {


### PR DESCRIPTION
Removes the need for manually initializing precompiles 
  during genesis generation. Now they auto-init on first call.

  Checks if code already exists before setting it to avoid revert issues with revm.

  Closes #1254