### PR TITLE
feat: add prepare txenv sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11954,6 +11954,7 @@ dependencies = [
  "futures",
  "metrics",
  "parking_lot",
+ "rayon",
  "reth-chainspec",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ proptest = "1.7"
 proptest-arbitrary-interop = "0.1.0"
 rand = "0.8.5"
 rand_core = "0.6.4"
+rayon = "1.10"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 sha2 = "0.10"

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -246,7 +246,7 @@ fn main() -> eyre::Result<()> {
             node,
             node_exit_future,
         } = builder
-            .node(TempoNode::new(&args.node_args, validator_key))
+            .node(TempoNode::new(&args.node_args, validator_key).set_follower(args.follow.is_some()))
             .apply(|mut builder: WithLaunchContext<_>| {
                 if let Some(follow_url) = &args.follow {
                     builder.config_mut().debug.rpc_consensus_url = Some(follow_url.clone());

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -246,7 +246,9 @@ fn main() -> eyre::Result<()> {
             node,
             node_exit_future,
         } = builder
-            .node(TempoNode::new(&args.node_args, validator_key).set_follower(args.follow.is_some()))
+            .node(
+                TempoNode::new(&args.node_args, validator_key).set_follower(args.follow.is_some()),
+            )
             .apply(|mut builder: WithLaunchContext<_>| {
                 if let Some(follow_url) = &args.follow {
                     builder.config_mut().debug.rpc_consensus_url = Some(follow_url.clone());

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -34,8 +34,10 @@ use reth_rpc_eth_api::{
     helpers::config::{EthConfigApiServer, EthConfigHandler},
 };
 use reth_tracing::tracing::{debug, info};
-use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore};
-use reth_transaction_pool::{TransactionListenerKind, TransactionPool};
+use reth_transaction_pool::{
+    TransactionListenerKind, TransactionPool, TransactionValidationTaskExecutor,
+    blobstore::InMemoryBlobStore,
+};
 use std::{default::Default, sync::Arc};
 use tempo_chainspec::spec::{TEMPO_BASE_FEE, TempoChainSpec};
 use tempo_consensus::TempoConsensus;
@@ -65,7 +67,7 @@ impl TempoNodeArgs {
     pub fn pool_builder(&self) -> TempoPoolBuilder {
         TempoPoolBuilder {
             aa_valid_after_max_secs: self.aa_valid_after_max_secs,
-            follower: false
+            follower: false,
         }
     }
 }
@@ -460,18 +462,16 @@ where
         );
 
         if !self.follower {
-            let pending = transaction_pool.new_transactions_listener_for(TransactionListenerKind::All);
+            let pending =
+                transaction_pool.new_transactions_listener_for(TransactionListenerKind::All);
             ctx.task_executor().spawn_critical(
                 "txpool preparation",
-               Box::pin(
-                   tempo_transaction_pool::prepare::prepare_pooled_transactions(pending),
-               )
+                Box::pin(tempo_transaction_pool::prepare::prepare_pooled_transactions(pending)),
             );
             debug!(target: "reth::cli", "Spawned txpool prepare task");
         }
 
         info!(target: "reth::cli", "Transaction pool initialized");
-
 
         Ok(transaction_pool)
     }

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -37,6 +37,7 @@ alloy-evm.workspace = true
 futures.workspace = true
 tracing.workspace = true
 parking_lot.workspace = true
+rayon.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 thiserror.workspace = true
 metrics.workspace = true
@@ -47,5 +48,5 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-ethereum-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 test-case.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -48,5 +48,5 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-ethereum-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 test-case.workspace = true

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -16,6 +16,7 @@ pub mod amm;
 pub mod best;
 pub mod maintain;
 pub mod metrics;
+pub mod prepare;
 pub mod tt_2d_pool;
 
 pub use metrics::AA2dPoolMetrics;

--- a/crates/transaction-pool/src/prepare.rs
+++ b/crates/transaction-pool/src/prepare.rs
@@ -1,0 +1,136 @@
+//! Additional tasks for preparing executable transactions.
+
+use crate::transaction::TempoPooledTransaction;
+use rayon::ThreadPoolBuilder;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use reth_transaction_pool::NewTransactionEvent;
+use tokio::sync::mpsc::Receiver;
+
+/// Minimum batch size during low throughput before processing.
+const MIN_BATCH_SIZE: usize = 128;
+
+/// Maximum batch size to collect in a single recv_many call.
+const MAX_BATCH_SIZE: usize = 4096;
+
+/// Threshold in transactions per second above which we use eager batching.
+const HIGH_THROUGHPUT_THRESHOLD: f64 = 256.0;
+
+/// Time window for measuring transaction rate.
+const RATE_MEASUREMENT_WINDOW: Duration = Duration::from_secs(1);
+
+/// Number of threads in the dedicated rayon pool for transaction preparation.
+///
+/// Set to half of available CPUs to leave resources for other tasks.
+fn prepare_pool_size() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| (n.get() / 2).max(1))
+        .unwrap_or(1)
+}
+
+/// Tracks transaction rate over a sliding window.
+struct RateTracker {
+    /// Transactions received in the current measurement window.
+    count: usize,
+    /// Start of the current measurement window.
+    window_start: Instant,
+    /// Measured transactions per second.
+    rate: f64,
+}
+
+impl RateTracker {
+    fn new() -> Self {
+        Self {
+            count: 0,
+            window_start: Instant::now(),
+            rate: 0.0,
+        }
+    }
+
+    /// Record received transactions and update the rate measurement.
+    fn record(&mut self, count: usize) {
+        self.count += count;
+        let elapsed = self.window_start.elapsed();
+
+        // Update rate measurement if window elapsed
+        if elapsed >= RATE_MEASUREMENT_WINDOW {
+            self.rate = self.count as f64 / elapsed.as_secs_f64();
+            self.count = 0;
+            self.window_start = Instant::now();
+        }
+    }
+
+    /// Returns true if we're in high throughput mode.
+    fn is_high_throughput(&self) -> bool {
+        self.rate > HIGH_THROUGHPUT_THRESHOLD
+    }
+}
+
+/// Prepares pending transactions by pre-computing their tx env..
+///
+/// This function receives transactions from a channel and batches them for efficient
+/// CPU-bound processing. Pre-computing the tx environment avoids the cost during
+/// payload building.
+///
+/// Batching is adaptive based on measured transaction rate:
+/// - High throughput (>256 tx/s): Process immediately with whatever is available (1-4096 txs)
+/// - Low throughput (≤256 tx/s): Wait to accumulate 128+ transactions before processing
+/// - This ensures low latency during bursts and efficient batching during normal load
+pub async fn prepare_pooled_transactions(mut transactions: Receiver<NewTransactionEvent<TempoPooledTransaction>>) {
+    // Create dedicated thread pool for transaction preparation
+    let pool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(prepare_pool_size())
+            .thread_name(|i| format!("tempo-tx-prepare-{i}"))
+            .build()
+            .expect("failed to create rayon thread pool"),
+    );
+
+    let mut batch = Vec::with_capacity(MIN_BATCH_SIZE);
+    let mut rate_tracker = RateTracker::new();
+
+    loop {
+        let is_high_throughput = rate_tracker.is_high_throughput();
+
+        if is_high_throughput {
+            // High throughput: grab what's available and process immediately
+            let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
+            if count == 0 {
+                // Channel closed
+                return;
+            }
+            rate_tracker.record(count);
+        } else {
+            // Low throughput: wait to accumulate MIN_BATCH_SIZE before processing
+            while batch.len() < MIN_BATCH_SIZE {
+                let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
+                if count == 0 {
+                    // Channel closed
+                    return;
+                }
+                rate_tracker.record(count);
+            }
+        }
+
+        // Process batch on dedicated rayon thread pool
+        let batch_size = batch.len();
+        let batch_to_process = std::mem::take(&mut batch);
+        let pool = pool.clone();
+        tokio::task::spawn_blocking(move || {
+            pool.install(|| {
+                use rayon::prelude::*;
+                batch_to_process.par_iter().for_each(|tx| {
+                    tx.transaction.transaction.prepare_tx_env();
+                });
+            });
+        })
+        .await
+        .expect("blocking task panicked");
+
+        // Allocate capacity based on recent batch size, clamped to reasonable bounds
+        let next_capacity = batch_size.clamp(MIN_BATCH_SIZE, MAX_BATCH_SIZE);
+        batch = Vec::with_capacity(next_capacity);
+    }
+}

--- a/crates/transaction-pool/src/prepare.rs
+++ b/crates/transaction-pool/src/prepare.rs
@@ -2,11 +2,11 @@
 
 use crate::transaction::TempoPooledTransaction;
 use rayon::ThreadPoolBuilder;
+use reth_transaction_pool::NewTransactionEvent;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use reth_transaction_pool::NewTransactionEvent;
 use tokio::sync::mpsc::Receiver;
 
 /// Minimum batch size during low throughput before processing.
@@ -20,6 +20,70 @@ const HIGH_THROUGHPUT_THRESHOLD: f64 = 256.0;
 
 /// Time window for measuring transaction rate.
 const RATE_MEASUREMENT_WINDOW: Duration = Duration::from_secs(1);
+
+/// Prepares pending transactions by pre-computing their tx env..
+///
+/// This function receives transactions from a channel and batches them for efficient
+/// CPU-bound processing. Pre-computing the tx environment avoids the cost during
+/// payload building.
+///
+/// Batching is adaptive based on measured transaction rate:
+/// - High throughput (>256 tx/s): Process immediately with whatever is available (1-4096 txs)
+/// - Low throughput (≤256 tx/s): Wait to accumulate 128+ transactions before processing
+/// - This ensures low latency during bursts and efficient batching during normal load
+pub async fn prepare_pooled_transactions(
+    mut transactions: Receiver<NewTransactionEvent<TempoPooledTransaction>>,
+) {
+    // Create dedicated thread pool for transaction preparation
+    let pool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(prepare_pool_size())
+            .thread_name(|i| format!("tempo-tx-prepare-{i}"))
+            .build()
+            .expect("failed to create rayon thread pool"),
+    );
+
+    let mut batch = Vec::with_capacity(MIN_BATCH_SIZE);
+    let mut rate_tracker = RateTracker::new();
+
+    loop {
+        let is_high_throughput = rate_tracker.is_high_throughput();
+
+        if is_high_throughput {
+            // High throughput: grab what's available and process immediately
+            let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
+            if count == 0 {
+                // Channel closed
+                return;
+            }
+            rate_tracker.record(count);
+        } else {
+            // Low throughput: wait to accumulate MIN_BATCH_SIZE before processing
+            while batch.len() < MIN_BATCH_SIZE {
+                let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
+                if count == 0 {
+                    // Channel closed
+                    return;
+                }
+                rate_tracker.record(count);
+            }
+        }
+
+        // Process batch on dedicated rayon thread pool (fire and forget)
+        let batch_size = batch.len();
+        let batch_to_process = std::mem::take(&mut batch);
+        pool.spawn(move || {
+            use rayon::prelude::*;
+            batch_to_process.par_iter().for_each(|tx| {
+                tx.transaction.transaction.prepare_tx_env();
+            });
+        });
+
+        // Allocate capacity based on recent batch size, clamped to reasonable bounds
+        let next_capacity = batch_size.clamp(MIN_BATCH_SIZE, MAX_BATCH_SIZE);
+        batch = Vec::with_capacity(next_capacity);
+    }
+}
 
 /// Number of threads in the dedicated rayon pool for transaction preparation.
 ///
@@ -65,72 +129,5 @@ impl RateTracker {
     /// Returns true if we're in high throughput mode.
     fn is_high_throughput(&self) -> bool {
         self.rate > HIGH_THROUGHPUT_THRESHOLD
-    }
-}
-
-/// Prepares pending transactions by pre-computing their tx env..
-///
-/// This function receives transactions from a channel and batches them for efficient
-/// CPU-bound processing. Pre-computing the tx environment avoids the cost during
-/// payload building.
-///
-/// Batching is adaptive based on measured transaction rate:
-/// - High throughput (>256 tx/s): Process immediately with whatever is available (1-4096 txs)
-/// - Low throughput (≤256 tx/s): Wait to accumulate 128+ transactions before processing
-/// - This ensures low latency during bursts and efficient batching during normal load
-pub async fn prepare_pooled_transactions(mut transactions: Receiver<NewTransactionEvent<TempoPooledTransaction>>) {
-    // Create dedicated thread pool for transaction preparation
-    let pool = Arc::new(
-        ThreadPoolBuilder::new()
-            .num_threads(prepare_pool_size())
-            .thread_name(|i| format!("tempo-tx-prepare-{i}"))
-            .build()
-            .expect("failed to create rayon thread pool"),
-    );
-
-    let mut batch = Vec::with_capacity(MIN_BATCH_SIZE);
-    let mut rate_tracker = RateTracker::new();
-
-    loop {
-        let is_high_throughput = rate_tracker.is_high_throughput();
-
-        if is_high_throughput {
-            // High throughput: grab what's available and process immediately
-            let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
-            if count == 0 {
-                // Channel closed
-                return;
-            }
-            rate_tracker.record(count);
-        } else {
-            // Low throughput: wait to accumulate MIN_BATCH_SIZE before processing
-            while batch.len() < MIN_BATCH_SIZE {
-                let count = transactions.recv_many(&mut batch, MAX_BATCH_SIZE).await;
-                if count == 0 {
-                    // Channel closed
-                    return;
-                }
-                rate_tracker.record(count);
-            }
-        }
-
-        // Process batch on dedicated rayon thread pool
-        let batch_size = batch.len();
-        let batch_to_process = std::mem::take(&mut batch);
-        let pool = pool.clone();
-        tokio::task::spawn_blocking(move || {
-            pool.install(|| {
-                use rayon::prelude::*;
-                batch_to_process.par_iter().for_each(|tx| {
-                    tx.transaction.transaction.prepare_tx_env();
-                });
-            });
-        })
-        .await
-        .expect("blocking task panicked");
-
-        // Allocate capacity based on recent batch size, clamped to reasonable bounds
-        let next_capacity = batch_size.clamp(MIN_BATCH_SIZE, MAX_BATCH_SIZE);
-        batch = Vec::with_capacity(next_capacity);
     }
 }

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -402,9 +402,6 @@ where
                     }
                 }
 
-                // Pre-compute TempoTxEnv to avoid the cost during payload building.
-                transaction.transaction().prepare_tx_env();
-
                 TransactionValidationOutcome::Valid {
                     balance,
                     state_nonce,


### PR DESCRIPTION
preparing the evm txenv input is a decent workload during tx validation, we can avoid this in the validation part and offload for validating (non follower) nodes.

this listens for new txs and batches preparation on a dedicated pool.
spawning behaviour adapts to the current rate of new tx arrivals.