### PR TITLE
fix(consensus): DKGs with failed shares are still successful, on-chain DKG is source of truth

### DIFF
--- a/crates/commonware-node/src/dkg/ceremony/mod.rs
+++ b/crates/commonware-node/src/dkg/ceremony/mod.rs
@@ -849,8 +849,8 @@ where
                         n_reveals,
                         error = %eyre::Report::new(error),
                         "failed to finalize our share even though the overall \
-                        the overall DKG ceremony was a success; we will \
-                        participate as a verifier since we do not have a share"
+                        DKG ceremony was a success; will participate as a \
+                        verifier since we failed to participate as a player"
                     );
                 }
             };

--- a/crates/commonware-node/src/dkg/manager/actor/post_allegretto.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/post_allegretto.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use alloy_consensus::BlockHeader;
+use alloy_consensus::BlockHeader as _;
 use commonware_codec::{DecodeExt as _, EncodeSize, Read, Write};
 use commonware_consensus::{
     Block as _, Reporter as _, simplex::signing_scheme::bls12381_threshold::Scheme, types::Epoch,


### PR DESCRIPTION
This patch ensures that the full DKG ceremony isn't failed if a player can't get its shares from on-chain data.

The reasoning is simple: if the overall DKG ceremony was a success, it means that a quorum of dealers and players have successfully participated. The case of DKG success && player failure (for all players) is not possible unless all critical number of nodes crashed and had critical data loss at the same time.

Furthermore, this patch handles the case of a DKG outcome mismatch between what was published to chain and what the network came to consensus over, and what a node decides locally: if there is a mismatch, the node will always select what was published on chain.