### PR TITLE
Remove the 'most performant' description from Reth

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can get started today by integrating with the [Tempo testnet](https://docs.t
 
 - Performance and finality
 
-  - Built on the [Reth SDK](https://github.com/paradigmxyz/reth), the most performant and flexible EVM (Ethereum Virtual Machine) execution client.
+  - Built on the [Reth SDK](https://github.com/paradigmxyz/reth) flexible EVM (Ethereum Virtual Machine) execution client.
   - Simplex Consensus (via [Commonware](https://commonware.xyz/)): fast, sub‑second finality in normal conditions; graceful degradation under adverse networks.
 
 - Coming soon


### PR DESCRIPTION
Removed 'the most performant and' from the description of the Reth SDK. Nethermind compared the different execution clients and Reth is the slowest one. https://www.nethermind.io/blog/getting-ethereum-ready-for-gigagas

In our experience this is also the case. It's a mistake to say that it's the most performant one.