### PR TITLE
perf(stablecoin-exchange): optimize LCA computation for multihop routing

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -1583,10 +1583,12 @@ impl StablecoinExchange {
         let path_in = self.find_path_to_root(token_in)?;
         let path_out = self.find_path_to_root(token_out)?;
 
-        // Find the lowest common ancestor (LCA)
+        // Find the lowest common ancestor (LCA) using O(n+m) algorithm:
+        // Build a HashSet from path_out for O(1) lookups, then iterate path_in
+        let path_out_set: std::collections::HashSet<Address> = path_out.iter().copied().collect();
         let mut lca = None;
         for token_a in &path_in {
-            if path_out.contains(token_a) {
+            if path_out_set.contains(token_a) {
                 lca = Some(*token_a);
                 break;
             }


### PR DESCRIPTION
Closes TMPO-52

Optimizes the lowest common ancestor (LCA) computation in `find_trade_path()` from O(n×m) to O(n+m) time complexity.

Replaces linear `.contains()` lookup on `path_out` Vec with a `HashSet` for O(1) membership checks when finding the LCA between two tokens in multi-hop routing.
