### PR TITLE
perf(orderbook): optimize tick bitmap traversal using word-level bit manipulation

### DIFF
--- a/crates/node/src/rpc/dex/mod.rs
+++ b/crates/node/src/rpc/dex/mod.rs
@@ -502,9 +502,9 @@ impl<'b> BookIterator<'b> {
     }
 
     /// Get the next initialized tick after the given tick
-    /// Returns None if there are no more ticks
+    /// Returns None if there are no more ticks or on error
     pub fn get_next_tick(&mut self, tick: i16) -> Option<i16> {
-        let (next_tick, more_ticks) = self.handler.next_initialized_tick(tick, self.bids);
+        let (next_tick, more_ticks) = self.handler.next_initialized_tick(tick, self.bids).ok()?;
 
         if more_ticks { Some(next_tick) } else { None }
     }

--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -689,7 +689,7 @@ impl StablecoinExchange {
             book_handler_order.delete_tick_bit(order.tick(), order.is_bid())?;
 
             let (tick, has_liquidity) =
-                book_handler.next_initialized_tick(order.tick(), order.is_bid());
+                book_handler.next_initialized_tick(order.tick(), order.is_bid())?;
 
             // Update best_tick when tick is exhausted
             if order.is_bid() {
@@ -977,7 +977,7 @@ impl StablecoinExchange {
 
             if best_tick == order.tick() {
                 let (next_tick, has_liquidity) =
-                    book_handler.next_initialized_tick(order.tick(), order.is_bid());
+                    book_handler.next_initialized_tick(order.tick(), order.is_bid())?;
 
                 if order.is_bid() {
                     let new_best = if has_liquidity { next_tick } else { i16::MIN };
@@ -1059,7 +1059,7 @@ impl StablecoinExchange {
             // If no liquidity at this level, move to next tick
             if level.total_liquidity == 0 {
                 let (next_tick, initialized) =
-                    book_handler.next_initialized_tick(current_tick, is_bid);
+                    book_handler.next_initialized_tick(current_tick, is_bid)?;
 
                 if !initialized {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1112,7 +1112,7 @@ impl StablecoinExchange {
             // If we exhausted this level or filled our requirement, move to next tick
             if fill_amount == level.total_liquidity {
                 let (next_tick, initialized) =
-                    book_handler.next_initialized_tick(current_tick, is_bid);
+                    book_handler.next_initialized_tick(current_tick, is_bid)?;
 
                 if !initialized && remaining_out > 0 {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1253,7 +1253,7 @@ impl StablecoinExchange {
             // If no liquidity at this level, move to next tick
             if level.total_liquidity == 0 {
                 let (next_tick, initialized) =
-                    book_handler.next_initialized_tick(current_tick, is_bid);
+                    book_handler.next_initialized_tick(current_tick, is_bid)?;
 
                 if !initialized {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());
@@ -1293,7 +1293,7 @@ impl StablecoinExchange {
             // If we exhausted this level, move to next tick
             if fill_amount == level.total_liquidity {
                 let (next_tick, initialized) =
-                    book_handler.next_initialized_tick(current_tick, is_bid);
+                    book_handler.next_initialized_tick(current_tick, is_bid)?;
 
                 if !initialized && remaining_in > 0 {
                     return Err(StablecoinExchangeError::insufficient_liquidity().into());


### PR DESCRIPTION
Closes TMPO-53

Optimizes `next_initialized_bid_tick()` and `next_initialized_ask_tick()` to use efficient bitmap word traversal instead of linear tick-by-tick search. Reduces storage reads from O(n) to O(n/256) in worst case, where n is the tick distance traversed.

- Read entire 256-bit bitmap words instead of checking individual ticks
- Use `trailing_zeros()` / `leading_zeros()` bit manipulation to find next set bit in O(1)
- Only read next/previous word when current word is exhausted
- Added tests for `next_initialized_tick` traversal behavior

