### PR TITLE
feat: allow to start node from an arbitrary epoch boundary 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11552,6 +11552,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reth-consensus-common",
  "reth-ethereum",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-node-builder",
  "reth-node-core",

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -65,3 +65,7 @@ tokio = { workspace = true, features = ["macros", "sync"] }
 tokio-util.workspace = true
 tracing.workspace = true
 pin-project = "1.1.10"
+
+[dev-dependencies]
+reth-ethereum-primitives.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }

--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -140,6 +140,25 @@ pub struct Args {
     #[command(flatten)]
     pub exit: ExitArgs,
 
+    /// Enable sync floor mode for starting from the highest execution block instead of genesis.
+    ///
+    /// When enabled on a fresh datadir (no existing consensus state), the node will:
+    /// 1. Auto-detect the highest block from the execution layer
+    /// 2. Set the marshal floor to ignore blocks below that height
+    /// 3. Initialize epoch state from the PublicOutcome in that block's extra_data
+    ///
+    /// The highest block must be an epoch boundary block (last block of an epoch),
+    /// since only boundary blocks contain the PublicOutcome in their extra_data.
+    /// This is guaranteed when using `--consensus.exit-after-epoch` which exits
+    /// exactly at the epoch boundary.
+    ///
+    /// This is ignored if consensus state already exists (a warning is logged).
+    ///
+    /// Use this after a breaking storage migration where consensus data was deleted
+    /// but execution data was preserved.
+    #[arg(long = "consensus.sync-floor", requires = "signing_share")]
+    pub sync_floor: bool,
+
     /// Cache for the signing key loaded from CLI-provided file.
     #[clap(skip)]
     loaded_signing_key: OnceLock<Option<SigningKey>>,

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -91,6 +91,7 @@ pub struct Builder<TBlocker, TContext, TPeerManager> {
     pub subblock_broadcast_interval: Duration,
 
     pub exit: ExitConfig,
+    pub sync_floor: bool,
 }
 
 impl<TBlocker, TContext, TPeerManager> Builder<TBlocker, TContext, TPeerManager>
@@ -258,6 +259,7 @@ where
                 partition_prefix: format!("{}_dkg_manager", self.partition_prefix),
                 peer_manager: self.peer_manager.clone(),
                 exit: self.exit,
+                sync_floor: self.sync_floor,
             },
         )
         .await

--- a/crates/commonware-node/src/dkg/manager/actor/post_allegretto.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/post_allegretto.rs
@@ -15,10 +15,10 @@ use commonware_cryptography::{
 use commonware_p2p::{Receiver, Sender, utils::mux::MuxHandle};
 use commonware_runtime::{Clock, ContextCell, Spawner, Storage};
 use commonware_utils::set::{Ordered, OrderedAssociated};
-use eyre::{WrapErr as _, ensure};
+use eyre::{OptionExt as _, WrapErr as _, ensure};
 use rand_core::CryptoRngCore;
 use reth_ethereum::chainspec::EthChainSpec as _;
-use tempo_chainspec::hardfork::TempoHardforks as _;
+use reth_primitives_traits::Block as _;
 use tempo_dkg_onchain_artifacts::PublicOutcome;
 use tracing::{Span, info, instrument, warn};
 
@@ -50,11 +50,17 @@ where
         tx: &mut DkgReadWriteTransaction<ContextCell<TContext>>,
     ) -> eyre::Result<()> {
         let spec = self.config.execution_node.chain_spec();
-        if !tx.has_post_allegretto_state().await && spec.is_allegretto_active_at_timestamp(0) {
-            info!(
-                "allegretto hardfork is active at timestamp 0, reading initial validators and public polynomial from genesis block"
-            );
-
+        let init_source: Option<PublicOutcome> = if tx.has_post_allegretto_state().await {
+            if self.config.sync_floor {
+                warn!("sync_floor passed but ignored; only takes effect on fresh datadirs");
+            }
+            None
+        } else if self.config.sync_floor {
+            let outcome = read_sync_floor_block(&self.config.execution_node.provider)?;
+            info!("initializing from sync floor block");
+            Some(outcome)
+        } else {
+            info!("initializing from genesis block");
             let initial_dkg_outcome = PublicOutcome::decode(spec.genesis().extra_data.as_ref())
                 .wrap_err_with(|| {
                     format!(
@@ -70,6 +76,11 @@ where
                 "at genesis, the epoch must be zero, but genesis reported `{}`",
                 initial_dkg_outcome.epoch.get()
             );
+            Some(initial_dkg_outcome)
+        };
+
+        if let Some(initial_dkg_outcome) = init_source {
+            let expected_epoch = initial_dkg_outcome.epoch;
 
             let our_share = self.config.initial_share.clone();
             if let Some(our_share) = our_share.clone() {
@@ -94,7 +105,7 @@ where
             let initial_validators = validators::read_from_contract(
                 0,
                 &self.config.execution_node,
-                Epoch::zero(),
+                expected_epoch,
                 self.config.epoch_length,
             )
             .await
@@ -124,7 +135,7 @@ where
             tx.set_epoch(EpochState {
                 dkg_outcome: DkgOutcome {
                     dkg_successful: true,
-                    epoch: Epoch::zero(),
+                    epoch: expected_epoch,
                     participants: initial_dkg_outcome.participants,
                     public: initial_dkg_outcome.public,
                     share: self.config.initial_share.clone(),
@@ -659,4 +670,83 @@ impl Read for EpochState {
 
 impl RegimeEpochState for EpochState {
     const REGIME: HardforkRegime = HardforkRegime::PostAllegretto;
+}
+
+/// Reads the sync floor block from the execution provider and decodes its PublicOutcome.
+fn read_sync_floor_block<P>(provider: &P) -> eyre::Result<PublicOutcome>
+where
+    P: reth_provider::BlockNumReader + reth_provider::BlockReader,
+{
+    let h = provider
+        .best_block_number()
+        .wrap_err("sync_floor: failed to get best block number")?;
+
+    let block = provider
+        .block_by_number(h)
+        .wrap_err_with(|| format!("sync_floor: failed to fetch block {h}"))?
+        .ok_or_eyre(format!("sync_floor: block {h} not found"))?;
+
+    let extra_data = block.header().extra_data();
+
+    PublicOutcome::decode(extra_data.as_ref()).wrap_err_with(|| {
+        format!(
+            "sync_floor: failed decoding extra_data as PublicOutcome at height {h}; bytes = {}",
+            extra_data.len()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::bytes;
+    use commonware_cryptography::{
+        bls12381::primitives::{group::G2, poly::Poly},
+        ed25519::PublicKey,
+    };
+    use reth_ethereum_primitives::Block;
+    use reth_provider::test_utils::MockEthProvider;
+
+    #[test]
+    fn read_sync_floor_block_backwards_compatibility() {
+        // Hardcoded PublicOutcome - if encoding format changes, this test fails
+        // Generated with: epoch=1, 1 participant (seed=42), threshold=1 polynomial
+        let extra_data = bytes!(
+            "0101" // epoch=1, participants_len=1
+            "78eda21ba04a15e2000fe8810fe3e56741d23bb9ae44aa9d5bb21b76675ff34b" // ed25519 pubkey
+            "8fbe20bb785531d9fb0f680dd96ecfb3eabccc4c7e672c4caf4a72e7207467081f743b469dbf18ef426770c94d7c63cc0014344e918045ac36b96b7983a69bf968bee7941d6bb895f206117b17e128dc82fa1b1e28db416c6d48b0bf977e9ae8" // bls poly
+        );
+
+        let provider = MockEthProvider::default();
+
+        let mut block = Block::default();
+        block.header.extra_data = extra_data;
+        provider.add_block(block.hash_slow(), block);
+
+        let result = read_sync_floor_block(&provider);
+        assert!(
+            result.is_ok(),
+            "should decode valid PublicOutcome: {:?}",
+            result.err()
+        );
+
+        let outcome = result.unwrap();
+        assert_eq!(outcome.epoch, Epoch::new(1));
+        assert_eq!(outcome.participants.len(), 1);
+
+        // Assert ed25519 pubkey
+        let expected_pubkey = PublicKey::decode(
+            &bytes!("78eda21ba04a15e2000fe8810fe3e56741d23bb9ae44aa9d5bb21b76675ff34b")[..],
+        )
+        .unwrap();
+        assert_eq!(outcome.participants[0], expected_pubkey);
+
+        // Assert BLS polynomial (threshold=1, so 1 G2 coefficient)
+        let g2 = G2::decode(
+            &bytes!("8fbe20bb785531d9fb0f680dd96ecfb3eabccc4c7e672c4caf4a72e7207467081f743b469dbf18ef426770c94d7c63cc0014344e918045ac36b96b7983a69bf968bee7941d6bb895f206117b17e128dc82fa1b1e28db416c6d48b0bf977e9ae8")[..],
+        )
+        .unwrap();
+        let expected_poly: Poly<G2> = Poly::from(vec![g2]);
+        assert_eq!(outcome.public, expected_poly);
+    }
 }

--- a/crates/commonware-node/src/dkg/manager/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/mod.rs
@@ -92,4 +92,7 @@ pub(crate) struct Config<TPeerManager> {
 
     /// Exit configuration for coordinated shutdown at epoch boundaries.
     pub(crate) exit: ExitConfig,
+
+    /// Whether to enable sync floor mode (start from highest execution block instead of genesis).
+    pub(crate) sync_floor: bool,
 }

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -141,6 +141,7 @@ pub async fn run_consensus_stack(
             args: config.exit,
             shutdown_token,
         },
+        sync_floor: config.sync_floor,
     }
     .try_init()
     .await

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -313,6 +313,7 @@ pub async fn setup_validators(
                 args: exit_args.clone(),
                 shutdown_token: tokio_util::sync::CancellationToken::new(),
             },
+            sync_floor: false,
         };
 
         nodes.push(TestingNode::new(

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -402,6 +402,29 @@ impl TestingNode {
 
         BlockchainProvider::new(provider_factory).expect("failed to create blockchain provider")
     }
+
+    /// Simulate fresh consensus storage by changing the partition prefix.
+    ///
+    /// This simulates deleting the consensus datadir for a breaking storage migration.
+    /// The old partitions remain in memory but won't be accessed with the new prefix.
+    /// Must be called when consensus is stopped.
+    ///
+    /// # Panics
+    /// Panics if consensus is running.
+    pub fn clear_consensus_storage(&mut self) {
+        assert!(
+            !self.is_consensus_running(),
+            "consensus must be stopped before clearing storage for {}",
+            self.uid
+        );
+
+        // Change partition_prefix to simulate fresh consensus storage
+        let old_prefix = &self.consensus_config.partition_prefix;
+        let new_prefix = format!("{old_prefix}_fresh");
+        self.consensus_config.partition_prefix = new_prefix.clone();
+
+        debug!(%self.uid, %new_prefix, "changed partition prefix to simulate fresh storage");
+    }
 }
 
 #[cfg(test)]

--- a/crates/e2e/src/tests/dkg/exit_after_epoch.rs
+++ b/crates/e2e/src/tests/dkg/exit_after_epoch.rs
@@ -7,13 +7,22 @@ use commonware_runtime::{
     Clock as _, Runner as _,
     deterministic::{Config, Runner},
 };
+use reth_ethereum::storage::BlockNumReader;
 use tempo_commonware_node_config::SigningShare;
 use tracing::info;
 
 use crate::{Setup, setup_validators};
 
+/// Test exit-after-epoch with share export, then restart with sync_floor.
+///
+/// This simulates the rolling upgrade scenario:
+/// 1. Node exits after epoch 1 and exports its share
+/// 2. Consensus storage is deleted (simulating breaking migration)
+/// 3. Node restarts with sync_floor enabled, using exported share
+/// 4. Node should resume from the execution layer's highest block
+/// 5. Verify it advances at least 2 blocks into the new epoch
 #[test_traced]
-fn single_validator_exits_after_epoch_and_exports_share() {
+fn exit_after_epoch_and_restart_with_sync_floor() {
     let _ = tempo_eyre::install();
 
     let epoch_length = 10;
@@ -35,12 +44,12 @@ fn single_validator_exits_after_epoch_and_exports_share() {
 
     executor.start(|context| async move {
         let (mut validators, _execution_runtime) = setup_validators(context.clone(), setup).await;
+        let node = &mut validators[0];
 
-        // Start the single validator
-        validators[0].start().await;
+        // Start the validator
+        node.start().await;
 
-        // Wait for the export file to be created (indicates successful exit-after-epoch)
-        // The node should process epoch 1 (blocks 10-19) and then export + shutdown
+        // Wait for the export file to be created
         for i in 0..120 {
             context.sleep(Duration::from_secs(1)).await;
 
@@ -65,10 +74,72 @@ fn single_validator_exits_after_epoch_and_exports_share() {
         );
 
         // Verify the exported file can be read as a valid signing share
-        // (same format as --consensus.signing-share input)
-        let _share = SigningShare::read_from_file(&export_path)
+        let share = SigningShare::read_from_file(&export_path)
             .expect("should be able to read exported share");
+        info!("export file contains valid signing share");
 
-        info!("test passed: export file contains valid signing share");
+        // Get the block number at exit (should be end of epoch 1 = block 19)
+        let exit_block = node
+            .execution()
+            .provider
+            .best_block_number()
+            .expect("should get best block number");
+        info!(exit_block, "node exited at block");
+
+        // The exit block should be the last block of epoch 1
+        let expected_exit_block = (target_epoch + 1) * epoch_length - 1; // epoch 1 ends at block 19
+        assert_eq!(
+            exit_block, expected_exit_block,
+            "exit block should be last block of target epoch"
+        );
+
+        // Stop the node
+        node.stop().await;
+        info!("node stopped after exit");
+
+        // Clear consensus storage (simulating deleting datadir/consensus)
+        node.clear_consensus_storage();
+        node.consensus_config_mut().share = Some(share.into_inner());
+        node.consensus_config_mut().sync_floor = true;
+        node.consensus_config_mut().exit.args.exit_after_epoch = None;
+        node.consensus_config_mut().exit.args.exit_export_share = None;
+
+        // Restart the node
+        node.start().await;
+        info!("node restarted with sync_floor");
+
+        // Wait for the node to advance at least 2 blocks past the exit block
+        let target_block = exit_block + 2;
+        for i in 0..30 {
+            context.sleep(Duration::from_secs(1)).await;
+
+            let current_block = node
+                .execution()
+                .provider
+                .best_block_number()
+                .expect("should get best block number");
+
+            if current_block >= target_block {
+                break;
+            }
+
+            if i % 10 == 0 {
+                info!(
+                    iteration = i,
+                    current_block, target_block, "waiting for block progress"
+                );
+            }
+        }
+
+        let final_block = node
+            .execution()
+            .provider
+            .best_block_number()
+            .expect("should get best block number");
+
+        assert!(
+            final_block >= target_block,
+            "node should have advanced at least 2 blocks past exit: final={final_block}, target={target_block}"
+        );
     });
 }


### PR DESCRIPTION
* follow-up to #1553
* on top of #1623 

With the node at epoch boundary and with the exported share, this allows the node to proceed after a `rm -rf datadir/consensus`

wip - needs a reth change for the test to work 