### PR TITLE
chore: bump commonware to 4a5fca0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "paste",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2443,8 +2443,9 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
+ "anyhow",
  "blake3",
  "blst",
  "bytes",
@@ -2452,6 +2453,7 @@ dependencies = [
  "chacha20poly1305",
  "commonware-codec",
  "commonware-utils",
+ "ecdsa",
  "ed25519-consensus",
  "getrandom 0.2.16",
  "p256",
@@ -2468,13 +2470,14 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "futures",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+ "toml 0.9.8",
  "tracing",
  "tracing-subscriber 0.3.22",
 ]
@@ -2482,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2508,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bimap",
  "bytes",
@@ -2530,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "async-lock",
  "axum",
@@ -2562,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2585,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -2605,13 +2608,14 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "0.0.63"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=31a2bf3009963ad3ba907712aca0cad39a153c03#31a2bf3009963ad3ba907712aca0cad39a153c03"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=4a5fca0223772b1a1627138d970ce231f876e6ff#4a5fca0223772b1a1627138d970ce231f876e6ff"
 dependencies = [
  "bytes",
  "cfg-if",
  "commonware-codec",
  "futures",
  "getrandom 0.2.16",
+ "hashbrown 0.16.1",
  "num-bigint",
  "num-integer",
  "num-rational",
@@ -7572,7 +7576,7 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "zstd",
 ]
@@ -7647,7 +7651,7 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "serde",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -8967,7 +8971,7 @@ dependencies = [
  "shellexpand",
  "strum 0.27.2",
  "thiserror 2.0.17",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "url",
  "vergen",
@@ -10888,6 +10892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12362,9 +12375,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -12393,7 +12421,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.1",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -12425,6 +12453,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.5+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cd6190959dce0994aa8970cd32ab116d1851ead27e866039acaf2524ce44fa"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,17 +243,17 @@ vergen = "9"
 vergen-git2 = "1"
 
 [patch.crates-io]
-# main branch, right after https://github.com/commonwarexyz/monorepo/pull/2271 was merged
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "31a2bf3009963ad3ba907712aca0cad39a153c03" }
+# main branch, right after https://github.com/commonwarexyz/monorepo/pull/2433 was merged
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "4a5fca0223772b1a1627138d970ce231f876e6ff" }
 
 # [patch."https://github.com/paradigmxyz/reth"]
 # reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }

--- a/crates/commonware-node-config/src/tests.rs
+++ b/crates/commonware-node-config/src/tests.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use commonware_cryptography::{
     PrivateKeyExt as _, Signer as _, bls12381::primitives::variant::MinSig, ed25519::PrivateKey,
 };
-use commonware_utils::set::OrderedAssociated;
+use commonware_utils::{TryFromIterator as _, ordered::Map};
 use rand::SeedableRng as _;
 
 use crate::{Peers, PublicPolynomial, SigningKey, SigningShare};
@@ -24,7 +24,7 @@ fn peers_snapshot() {
 
 #[test]
 fn peers_roundtrip() {
-    let peers: Peers = OrderedAssociated::from_iter([
+    let peers: Peers = Map::try_from_iter([
         (
             PrivateKey::from_seed(0).public_key(),
             "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
@@ -42,6 +42,7 @@ fn peers_roundtrip() {
             "172.3.2.4:42".parse::<SocketAddr>().unwrap(),
         ),
     ])
+    .unwrap()
     .into();
     assert_eq!(
         peers,

--- a/crates/commonware-node/src/alias.rs
+++ b/crates/commonware-node/src/alias.rs
@@ -1,13 +1,26 @@
 //! A collection of aliases for frequently used (primarily commonware) types.
 
 pub(crate) mod marshal {
-    use commonware_consensus::{marshal, simplex::signing_scheme::bls12381_threshold::Scheme};
-    use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+    use commonware_consensus::marshal;
+    use commonware_consensus::simplex::signing_scheme::bls12381_threshold::Scheme;
+    use commonware_consensus::simplex::types::Finalization;
+    use commonware_cryptography::bls12381::primitives::variant::MinSig;
+    use commonware_cryptography::ed25519::PublicKey;
+    use commonware_storage::archive::immutable;
+    use commonware_utils::acknowledgement::Exact;
 
+    use crate::consensus::Digest;
     use crate::consensus::block::Block;
 
-    pub(crate) type Actor<TContext> =
-        marshal::Actor<TContext, Block, crate::epoch::SchemeProvider, Scheme<PublicKey, MinSig>>;
+    pub(crate) type Actor<TContext> = marshal::Actor<
+        TContext,
+        Block,
+        crate::epoch::SchemeProvider,
+        Scheme<PublicKey, MinSig>,
+        immutable::Archive<TContext, Digest, Finalization<Scheme<PublicKey, MinSig>, Digest>>,
+        immutable::Archive<TContext, Digest, Block>,
+        Exact,
+    >;
 
     pub(crate) type Mailbox = marshal::Mailbox<Scheme<PublicKey, MinSig>, Block>;
 }

--- a/crates/commonware-node/src/alias.rs
+++ b/crates/commonware-node/src/alias.rs
@@ -1,16 +1,15 @@
 //! A collection of aliases for frequently used (primarily commonware) types.
 
 pub(crate) mod marshal {
-    use commonware_consensus::marshal;
-    use commonware_consensus::simplex::signing_scheme::bls12381_threshold::Scheme;
-    use commonware_consensus::simplex::types::Finalization;
-    use commonware_cryptography::bls12381::primitives::variant::MinSig;
-    use commonware_cryptography::ed25519::PublicKey;
+    use commonware_consensus::{
+        marshal,
+        simplex::{signing_scheme::bls12381_threshold::Scheme, types::Finalization},
+    };
+    use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
     use commonware_storage::archive::immutable;
     use commonware_utils::acknowledgement::Exact;
 
-    use crate::consensus::Digest;
-    use crate::consensus::block::Block;
+    use crate::consensus::{Digest, block::Block};
 
     pub(crate) type Actor<TContext> = marshal::Actor<
         TContext,

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -253,10 +253,6 @@ impl Inner<Init> {
         err(level = Level::ERROR)
     )]
     async fn handle_genesis(mut self, genesis: Genesis) -> eyre::Result<Digest> {
-        #[expect(
-            clippy::option_if_let_else,
-            reason = "if-let-else would put the 0-case at the bottom"
-        )]
         let source = match genesis.epoch.previous() {
             // epoch 0 has no previous epoch
             None => self.genesis_block.digest(),

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -302,7 +302,7 @@ impl Inner<Init> {
         err(level = Level::WARN),
     )]
     async fn handle_propose<TContext: Pacer>(
-        mut self,
+        self,
         request: Propose,
         context: TContext,
     ) -> eyre::Result<()> {

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -223,7 +223,8 @@ impl Inner<Init> {
         err(level = Level::ERROR),
     )]
     async fn handle_broadcast(mut self, broadcast: Broadcast) -> eyre::Result<()> {
-        let Some(latest_proposed) = self.state.latest_proposed_block.read().await.clone() else {
+        let Some((round, latest_proposed)) = self.state.latest_proposed_block.read().await.clone()
+        else {
             return Err(eyre!("there was no latest block to broadcast"));
         };
         ensure!(
@@ -233,7 +234,7 @@ impl Inner<Init> {
             latest_proposed.digest(),
         );
 
-        self.marshal.broadcast(latest_proposed).await;
+        self.marshal.proposed(round, latest_proposed).await;
         Ok(())
     }
 
@@ -301,7 +302,7 @@ impl Inner<Init> {
         err(level = Level::WARN),
     )]
     async fn handle_propose<TContext: Pacer>(
-        self,
+        mut self,
         request: Propose,
         context: TContext,
     ) -> eyre::Result<()> {
@@ -353,7 +354,7 @@ impl Inner<Init> {
 
         {
             let mut lock = self.state.latest_proposed_block.write().await;
-            *lock = Some(proposal.clone());
+            *lock = Some((round, proposal.clone()));
         }
 
         // Make sure reth sees the new payload so that in the next round we can
@@ -760,7 +761,7 @@ pub(in crate::consensus) struct Uninit(());
 /// Carries the runtime initialized state of the application.
 #[derive(Clone, Debug)]
 struct Init {
-    latest_proposed_block: Arc<RwLock<Option<Block>>>,
+    latest_proposed_block: Arc<RwLock<Option<(Round, Block)>>>,
     dkg_manager: crate::dkg::manager::Mailbox,
     /// The communication channel to the [`executor::Executor`] task.
     executor_mailbox: ExecutorMailbox,

--- a/crates/commonware-node/src/dkg/ceremony/mod.rs
+++ b/crates/commonware-node/src/dkg/ceremony/mod.rs
@@ -17,7 +17,7 @@ use commonware_p2p::{
     utils::mux::{MuxHandle, SubReceiver, SubSender},
 };
 use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Storage};
-use commonware_utils::{max_faults, set::Ordered, union};
+use commonware_utils::{max_faults, ordered::Set, union};
 use eyre::{WrapErr as _, bail, ensure};
 use futures::FutureExt as _;
 use indexmap::IndexSet;
@@ -75,10 +75,10 @@ pub(super) struct Config {
     pub(super) hardfork_regime: HardforkRegime,
 
     /// The dealers in the round.
-    pub(super) dealers: Ordered<PublicKey>,
+    pub(super) dealers: Set<PublicKey>,
 
     /// The players in the round.
-    pub(super) players: Ordered<PublicKey>,
+    pub(super) players: Set<PublicKey>,
 }
 
 pub(super) struct Ceremony<TReceiver, TSender>
@@ -782,7 +782,7 @@ where
         dealer_me.outcome.as_ref()
     }
 
-    pub(super) fn dealers(&self) -> &Ordered<PublicKey> {
+    pub(super) fn dealers(&self) -> &Set<PublicKey> {
         &self.config.dealers
     }
 
@@ -822,7 +822,7 @@ pub(super) struct PrivateOutcome {
 
     /// The participants of the new epoch. If successful, this will the players
     /// in the ceremony. If not successful, these are the dealers.
-    pub(super) participants: Ordered<PublicKey>,
+    pub(super) participants: Set<PublicKey>,
 
     /// The role the node will have in the next epoch.
     pub(super) role: Role,

--- a/crates/commonware-node/src/dkg/ceremony/payload.rs
+++ b/crates/commonware-node/src/dkg/ceremony/payload.rs
@@ -165,20 +165,20 @@ mod tests {
         bls12381::{dkg, primitives::variant::MinSig},
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_utils::{set::Ordered, union};
+    use commonware_utils::{TryFromIterator as _, ordered::Set, union};
     use rand::{SeedableRng as _, rngs::StdRng};
 
     use crate::dkg::ceremony::ACK_NAMESPACE;
 
     use super::Ack;
 
-    fn three_public_keys() -> Ordered<PublicKey> {
-        vec![
+    fn three_public_keys() -> Set<PublicKey> {
+        Set::try_from_iter(vec![
             PrivateKey::from_seed(0).public_key(),
             PrivateKey::from_seed(1).public_key(),
             PrivateKey::from_seed(2).public_key(),
-        ]
-        .into()
+        ])
+        .unwrap()
     }
 
     #[test]

--- a/crates/commonware-node/src/dkg/ceremony/persisted.rs
+++ b/crates/commonware-node/src/dkg/ceremony/persisted.rs
@@ -139,28 +139,28 @@ mod tests {
         bls12381::{dkg, primitives::variant::MinSig},
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_utils::{quorum, set::Ordered, union};
+    use commonware_utils::{NZU32, TryFromIterator as _, ordered::Set, quorum, union};
     use rand::{SeedableRng as _, rngs::StdRng};
     use tempo_dkg_onchain_artifacts::IntermediateOutcome;
 
-    fn four_private_keys() -> Ordered<PrivateKey> {
-        vec![
+    fn four_private_keys() -> Set<PrivateKey> {
+        Set::try_from_iter(vec![
             PrivateKey::from_seed(0),
             PrivateKey::from_seed(1),
             PrivateKey::from_seed(2),
             PrivateKey::from_seed(3),
-        ]
-        .into()
+        ])
+        .unwrap()
     }
 
-    fn four_public_keys() -> Ordered<PublicKey> {
-        vec![
+    fn four_public_keys() -> Set<PublicKey> {
+        Set::try_from_iter(vec![
             PrivateKey::from_seed(0).public_key(),
             PrivateKey::from_seed(1).public_key(),
             PrivateKey::from_seed(2).public_key(),
             PrivateKey::from_seed(3).public_key(),
-        ]
-        .into()
+        ])
+        .unwrap()
     }
 
     fn dealing(dealer_index: usize) -> Dealing {
@@ -242,7 +242,7 @@ mod tests {
         let bytes = dealing(0).encode();
 
         assert_eq!(
-            Dealing::read_cfg(&mut bytes.as_ref(), &(quorum(4) as usize)).unwrap(),
+            Dealing::read_cfg(&mut bytes.as_ref(), &NZU32!(quorum(4))).unwrap(),
             dealing(0),
         )
     }

--- a/crates/commonware-node/src/dkg/manager/actor/pre_allegretto.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/pre_allegretto.rs
@@ -415,7 +415,7 @@ impl Read for EpochState {
         _cfg: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let epoch = Epoch::read(buf)?;
-        let participants = Set::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), ()))?;
+        let participants = Set::read_cfg(buf, &(RangeCfg::from(1..=usize::MAX), ()))?;
         let quorum = quorum(participants.len() as u32);
         let public =
             Public::<MinSig>::read_cfg(buf, &RangeCfg::from(NZU32!(quorum)..=NZU32!(quorum)))?;

--- a/crates/commonware-node/src/dkg/manager/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/mod.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{
     ed25519::{PrivateKey, PublicKey},
 };
 use commonware_runtime::{Clock, Metrics, Spawner, Storage};
-use commonware_utils::set::OrderedAssociated;
+use commonware_utils::ordered::Map;
 use eyre::WrapErr as _;
 use futures::channel::mpsc;
 use rand_core::CryptoRngCore;
@@ -35,10 +35,8 @@ pub(crate) async fn init<TContext, TPeerManager>(
 ) -> eyre::Result<(Actor<TContext, TPeerManager>, Mailbox)>
 where
     TContext: Clock + CryptoRngCore + Metrics + Spawner + Storage,
-    TPeerManager: commonware_p2p::Manager<
-            PublicKey = PublicKey,
-            Peers = OrderedAssociated<PublicKey, SocketAddr>,
-        > + Sync,
+    TPeerManager:
+        commonware_p2p::Manager<PublicKey = PublicKey, Peers = Map<PublicKey, SocketAddr>> + Sync,
 {
     let (tx, rx) = mpsc::unbounded();
 

--- a/crates/commonware-node/src/dkg/manager/validators.rs
+++ b/crates/commonware-node/src/dkg/manager/validators.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Address;
 use commonware_codec::{DecodeExt as _, EncodeSize, RangeCfg, Read, Write, varint::UInt};
 use commonware_consensus::{types::Epoch, utils};
 use commonware_cryptography::ed25519::PublicKey;
-use commonware_utils::set::{Ordered, OrderedAssociated};
+use commonware_utils::ordered::{Map, Set};
 use eyre::{OptionExt as _, WrapErr as _};
 use reth_ethereum::evm::revm::{State, database::StateProviderDatabase};
 use reth_node_builder::{Block as _, ConfigureEvm as _};
@@ -37,7 +37,7 @@ pub(super) async fn read_from_contract(
     node: &TempoFullNode,
     for_epoch: Epoch,
     epoch_length: u64,
-) -> eyre::Result<OrderedAssociated<PublicKey, DecodedValidator>> {
+) -> eyre::Result<Map<PublicKey, DecodedValidator>> {
     let last_height = last_height_before_epoch(for_epoch, epoch_length);
 
     // Try mapping the block height to a hash tracked by reth.
@@ -104,7 +104,7 @@ pub(super) async fn read_from_contract(
 #[instrument(skip_all, fields(validators_to_decode = contract_vals.len()))]
 async fn decode_from_contract(
     contract_vals: Vec<IValidatorConfig::Validator>,
-) -> OrderedAssociated<PublicKey, DecodedValidator> {
+) -> Map<PublicKey, DecodedValidator> {
     let mut decoded = HashMap::new();
     for val in contract_vals.into_iter().filter(|val| val.active) {
         // NOTE: not reporting errors because `decode_from_contract` emits
@@ -119,7 +119,7 @@ async fn decode_from_contract(
             );
         }
     }
-    decoded.into_iter().collect::<_>()
+    Map::from_iter_dedup(decoded)
 }
 
 /// Tracks the participants of each DKG ceremony, and, by extension, the p2p network.
@@ -131,13 +131,13 @@ async fn decode_from_contract(
 /// 3. the syncing players, that will become players in the next ceremony
 #[derive(Clone, Debug)]
 pub(crate) struct ValidatorState {
-    dealers: OrderedAssociated<PublicKey, DecodedValidator>,
-    players: OrderedAssociated<PublicKey, DecodedValidator>,
-    syncing_players: OrderedAssociated<PublicKey, DecodedValidator>,
+    dealers: Map<PublicKey, DecodedValidator>,
+    players: Map<PublicKey, DecodedValidator>,
+    syncing_players: Map<PublicKey, DecodedValidator>,
 }
 
 impl ValidatorState {
-    pub(super) fn new(validators: OrderedAssociated<PublicKey, DecodedValidator>) -> Self {
+    pub(super) fn new(validators: Map<PublicKey, DecodedValidator>) -> Self {
         Self {
             dealers: validators.clone(),
             players: validators.clone(),
@@ -148,43 +148,38 @@ impl ValidatorState {
     /// Returns a validator state with only public key and inbound address set.
     ///
     /// All other values take default values.
-    pub(super) fn with_unknown_contract_state(
-        validators: OrderedAssociated<PublicKey, SocketAddr>,
-    ) -> Self {
-        let validators = validators
-            .iter_pairs()
-            .map(|(key, addr)| {
-                let key = key.clone();
-                let validator = DecodedValidator {
-                    public_key: key.clone(),
-                    inbound: *addr,
-                    outbound: SocketAddr::from(([0, 0, 0, 0], 0)),
-                    index: 0,
-                    address: Address::ZERO,
-                };
-                (key, validator)
-            })
-            .collect();
+    pub(super) fn with_unknown_contract_state(validators: Map<PublicKey, SocketAddr>) -> Self {
+        let validators = Map::from_iter_dedup(validators.iter_pairs().map(|(key, addr)| {
+            let key = key.clone();
+            let validator = DecodedValidator {
+                public_key: key.clone(),
+                inbound: *addr,
+                outbound: SocketAddr::from(([0, 0, 0, 0], 0)),
+                index: 0,
+                address: Address::ZERO,
+            };
+            (key, validator)
+        }));
         Self::new(validators)
     }
 
-    pub(super) fn dealers(&self) -> &OrderedAssociated<PublicKey, DecodedValidator> {
+    pub(super) fn dealers(&self) -> &Map<PublicKey, DecodedValidator> {
         &self.dealers
     }
 
-    pub(super) fn players(&self) -> &OrderedAssociated<PublicKey, DecodedValidator> {
+    pub(super) fn players(&self) -> &Map<PublicKey, DecodedValidator> {
         &self.players
     }
 
-    pub(super) fn syncing_players(&self) -> &OrderedAssociated<PublicKey, DecodedValidator> {
+    pub(super) fn syncing_players(&self) -> &Map<PublicKey, DecodedValidator> {
         &self.syncing_players
     }
 
-    pub(super) fn dealer_pubkeys(&self) -> Ordered<PublicKey> {
+    pub(super) fn dealer_pubkeys(&self) -> Set<PublicKey> {
         self.dealers.keys().clone()
     }
 
-    pub(super) fn player_pubkeys(&self) -> Ordered<PublicKey> {
+    pub(super) fn player_pubkeys(&self) -> Set<PublicKey> {
         self.players.keys().clone()
     }
 
@@ -197,19 +192,18 @@ impl ValidatorState {
     /// If a validator has entries across the tracked sets, then then its entry
     /// for the latest pushed set is taken. For those cases where looking up
     /// domain names failed, the last successfully looked up name is taken.
-    pub(super) fn resolve_addresses_and_merge_peers(
-        &self,
-    ) -> OrderedAssociated<PublicKey, SocketAddr> {
+    pub(super) fn resolve_addresses_and_merge_peers(&self) -> Map<PublicKey, SocketAddr> {
         // IMPORTANT: Starting with the syncing players to ensure that the
         // latest address for a validator with a given pubkey is used.
-        // OrderedAssociated takes the first instance of a key it sees and
+        // Map takes the first instance of a key it sees and
         // drops the later instances.
-        self.syncing_players()
-            .iter_pairs()
-            .chain(self.players().iter_pairs())
-            .chain(self.dealers().iter_pairs())
-            .map(|(pubkey, validator)| (pubkey.clone(), validator.inbound_socket_addr()))
-            .collect()
+        Map::from_iter_dedup(
+            self.syncing_players()
+                .iter_pairs()
+                .chain(self.players().iter_pairs())
+                .chain(self.dealers().iter_pairs())
+                .map(|(pubkey, validator)| (pubkey.clone(), validator.inbound_socket_addr())),
+        )
     }
 
     /// Pushes `syncing_players` into the participants queue.
@@ -221,8 +215,8 @@ impl ValidatorState {
     /// Removes and returns the old dealers.
     pub(super) fn push_on_success(
         &mut self,
-        syncing_players: OrderedAssociated<PublicKey, DecodedValidator>,
-    ) -> OrderedAssociated<PublicKey, DecodedValidator> {
+        syncing_players: Map<PublicKey, DecodedValidator>,
+    ) -> Map<PublicKey, DecodedValidator> {
         let players = std::mem::replace(&mut self.syncing_players, syncing_players);
         let dealers = std::mem::replace(&mut self.players, players);
         std::mem::replace(&mut self.dealers, dealers)
@@ -236,8 +230,8 @@ impl ValidatorState {
     /// will become the next regular players.
     pub(super) fn push_on_failure(
         &mut self,
-        syncing_players: OrderedAssociated<PublicKey, DecodedValidator>,
-    ) -> OrderedAssociated<PublicKey, DecodedValidator> {
+        syncing_players: Map<PublicKey, DecodedValidator>,
+    ) -> Map<PublicKey, DecodedValidator> {
         let players = std::mem::replace(&mut self.syncing_players, syncing_players);
         // The previous players are dropped/returned - these are for who the
         // ceremony failed for.
@@ -270,10 +264,9 @@ impl Read for ValidatorState {
     ) -> Result<Self, commonware_codec::Error> {
         // The range 0..=usize::MAX here is ok: what we are writing to disk
         // is completely under our control and there is no danger of DoS.
-        let dealers = OrderedAssociated::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
-        let players = OrderedAssociated::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
-        let syncing_players =
-            OrderedAssociated::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
+        let dealers = Map::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
+        let players = Map::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
+        let syncing_players = Map::read_cfg(buf, &(RangeCfg::from(0..=usize::MAX), (), ()))?;
         Ok(Self {
             dealers,
             players,

--- a/crates/commonware-node/src/dkg/manager/validators.rs
+++ b/crates/commonware-node/src/dkg/manager/validators.rs
@@ -148,6 +148,7 @@ impl ValidatorState {
     /// Returns a validator state with only public key and inbound address set.
     ///
     /// All other values take default values.
+    //// TODO: remove unused on post_allegretto
     pub(super) fn with_unknown_contract_state(validators: Map<PublicKey, SocketAddr>) -> Self {
         let validators = Map::from_iter_dedup(validators.iter_pairs().map(|(key, addr)| {
             let key = key.clone();

--- a/crates/commonware-node/src/epoch/manager/actor.rs
+++ b/crates/commonware-node/src/epoch/manager/actor.rs
@@ -50,7 +50,7 @@ use bytes::Bytes;
 use commonware_codec::{DecodeExt as _, Encode as _};
 use commonware_consensus::{
     Reporters,
-    simplex::{self, signing_scheme::bls12381_threshold::Scheme, types::Voter},
+    simplex::{self, signing_scheme::bls12381_threshold::Scheme, types::Certificate},
     types::{Epoch, ViewDelta},
     utils,
 };
@@ -496,7 +496,7 @@ where
                     available locally; cannot serve request"
                 )
             })?;
-        let message = Voter::<Scheme<PublicKey, MinSig>, Digest>::Finalization(cert);
+        let message = Certificate::<Scheme<PublicKey, MinSig>, Digest>::Finalization(cert);
         recovered_global_sender
             .send(
                 requested_epoch.get(),

--- a/crates/commonware-node/src/epoch/manager/ingress.rs
+++ b/crates/commonware-node/src/epoch/manager/ingress.rs
@@ -3,7 +3,7 @@ use commonware_cryptography::{
     bls12381::primitives::{group::Share, poly::Public, variant::MinSig},
     ed25519::PublicKey,
 };
-use commonware_utils::set::Ordered;
+use commonware_utils::ordered::Set;
 use eyre::WrapErr as _;
 use futures::channel::mpsc;
 use tracing::{Span, warn};
@@ -57,7 +57,7 @@ pub(crate) struct Enter {
     pub(crate) epoch: Epoch,
     pub(crate) public: Public<MinSig>,
     pub(crate) share: Option<Share>,
-    pub(crate) participants: Ordered<PublicKey>,
+    pub(crate) participants: Set<PublicKey>,
 }
 
 #[derive(Debug)]

--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -735,7 +735,7 @@ async fn build_subblock(
         transactions,
     };
 
-    let signature = signer.sign(None, subblock.signature_hash().as_slice());
+    let signature = signer.sign(&[], subblock.signature_hash().as_slice());
     let signed_subblock = SignedSubBlock {
         inner: subblock,
         signature: Bytes::copy_from_slice(signature.as_ref()),
@@ -770,7 +770,7 @@ async fn validate_subblock(
         return Err(eyre::eyre!("invalid signature"));
     };
 
-    if !sender.verify(None, subblock.signature_hash().as_slice(), &signature) {
+    if !sender.verify(&[], subblock.signature_hash().as_slice(), &signature) {
         return Err(eyre::eyre!("invalid signature"));
     }
 

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -21,7 +21,7 @@ use commonware_cryptography::{
     bls12381::primitives::{poly::Public, variant::MinSig},
     ed25519::PublicKey,
 };
-use commonware_utils::set::OrderedAssociated;
+use commonware_utils::ordered::Map;
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::StreamExt;
 use reth_db::mdbx::DatabaseEnv;
@@ -124,7 +124,7 @@ impl Builder {
         }
     }
 
-    pub fn with_validators(self, validators: OrderedAssociated<PublicKey, SocketAddr>) -> Self {
+    pub fn with_validators(self, validators: Map<PublicKey, SocketAddr>) -> Self {
         Self {
             validators: Some(validators.into()),
             ..self

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -345,7 +345,7 @@ where
                 ));
             };
 
-            if !validator.verify(None, signature_hash.as_slice(), &signature) {
+            if !validator.verify(&[], signature_hash.as_slice(), &signature) {
                 return Err(BlockValidationError::msg("invalid subblock signature"));
             }
 


### PR DESCRIPTION
Bumps commonware to https://github.com/commonwarexyz/monorepo/tree/4a5fca0223772b1a1627138d970ce231f876e6ff, which is the version of commonware-main right after merging https://github.com/commonwarexyz/monorepo/pull/2433.