### PR TITLE
ci: pin solc v0.8.30

### DIFF
--- a/docs/specs/foundry.toml
+++ b/docs/specs/foundry.toml
@@ -6,7 +6,7 @@ optimizer = true
 optimizer_runs = 200
 
 # TODO(rusowsky): remove once solc patch is released
-solc_version = "0.8.31"
+solc_version = "0.8.30"
 
 [profile.ci]
 optimizer = true

--- a/docs/specs/lib/forge-std/foundry.toml
+++ b/docs/specs/lib/forge-std/foundry.toml
@@ -4,7 +4,7 @@ optimizer = true
 optimizer_runs = 200
 
 # TODO(rusowsky): remove once solc patch is released
-solc_version = "0.8.31"
+solc_version = "0.8.30"
 
 [rpc_endpoints]
 # The RPC URLs are modified versions of the default for testing initialization.


### PR DESCRIPTION
## Motivation

temporarily pin solc v0.8.30 until their patch is released, so that CI can finalize