### PR TITLE
ci: unpin solc version now that patch has been released

### DIFF
--- a/docs/specs/foundry.toml
+++ b/docs/specs/foundry.toml
@@ -5,9 +5,6 @@ libs = ["lib"]
 optimizer = true
 optimizer_runs = 200
 
-# TODO(rusowsky): remove once solc patch is released
-solc_version = "0.8.30"
-
 [profile.ci]
 optimizer = true
 optimizer_runs = 1

--- a/docs/specs/lib/forge-std/foundry.toml
+++ b/docs/specs/lib/forge-std/foundry.toml
@@ -3,9 +3,6 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 optimizer = true
 optimizer_runs = 200
 
-# TODO(rusowsky): remove once solc patch is released
-solc_version = "0.8.30"
-
 [rpc_endpoints]
 # The RPC URLs are modified versions of the default for testing initialization.
 mainnet = "https://eth.merkle.io" # Different API key.


### PR DESCRIPTION
## Motivation

now that solc released a patch in v0.8.33, we can unpin v0.8.30 and use the latest stable again