### PR TITLE
fix: std `get_validator_token` to return the default token when unset

### DIFF
--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -831,7 +831,7 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             let balance = U256::from(1000);
-            let path_usd = TIP20Setup::path_usd(admin)
+            let _path_usd = TIP20Setup::path_usd(admin)
                 .with_issuer(admin)
                 .with_mint(user, balance)
                 .apply()?;


### PR DESCRIPTION
## Motivation

audit issue: `TMPO-51`
linear: `CHAIN-198`

## Solution

default token logic to `fn get_validator_token()`