### PR TITLE
Small tempo bench justfile fixes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,7 +34,18 @@ localnet accounts="1000" reset="true" profile="maxperf" features="asm-keccak" ar
         mkdir ./localnet/
         just genesis {{accounts}} ./localnet {{profile}}
     fi;
-    cargo run --bin tempo --profile {{profile}} --features {{features}} -- \
+    # Build the binary (cargo will only rebuild if source changed)
+    {{cargo_build_binary}} build --bin tempo --profile {{profile}} --features {{features}}
+    # Determine binary path based on profile
+    if [[ "{{profile}}" = "release" ]]; then
+        BINARY_PATH="./target/release/tempo"
+    elif [[ "{{profile}}" = "maxperf" ]]; then
+        BINARY_PATH="./target/maxperf/tempo"
+    else
+        BINARY_PATH="./target/debug/tempo"
+    fi
+    # Run the binary directly
+    ${BINARY_PATH} \
                       node \
                       --chain ./localnet/genesis.json \
                       --dev \

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -165,19 +165,13 @@ The benchmark will continuously output performance metrics including transaction
 
 ## Quick Start
 
-### 1. Generate genesis.json
-
-```bash
-cargo x generate-genesis --accounts 50000 --output genesis.json
-```
-
-### 2. Start the Node
+### 1. Start the Node
 
 ```bash
 just localnet 50000
 ```
 
-### 3. Run max TPS benchmark
+### 2. Run max TPS benchmark
 
 ```bash
 tempo-bench run-max-tps --duration 15 --tps 20000 --faucet


### PR DESCRIPTION
- adjust justfile so it doesn't recompile binaries every time a localnet is started
- change instructions since `just localnet` will do the account creation automatically