### PR TITLE
test(precompiles): add additional `policy_exists` tests

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -2873,16 +2873,12 @@ pub(crate) mod tests {
             // Test special policies 0 and 1 (should always work)
             token.change_transfer_policy_id(
                 admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: 0,
-                },
+                ITIP20::changeTransferPolicyIdCall { newPolicyId: 0 },
             )?;
 
             token.change_transfer_policy_id(
                 admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: 1,
-                },
+                ITIP20::changeTransferPolicyIdCall { newPolicyId: 1 },
             )?;
 
             // Test random invalid policy IDs should fail

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -495,7 +495,9 @@ mod tests {
             let mut rng = rand::thread_rng();
             for _ in 0..100 {
                 let random_policy_id = rng.gen_range(2..u64::MAX);
-                assert!(!registry.policy_exists(ITIP403Registry::policyExistsCall { policyId: random_policy_id })?);
+                assert!(!registry.policy_exists(ITIP403Registry::policyExistsCall {
+                    policyId: random_policy_id
+                })?);
             }
 
             // Create 50 policies
@@ -517,7 +519,9 @@ mod tests {
 
             // All created policies should exist
             for policy_id in &created_policy_ids {
-                assert!(registry.policy_exists(ITIP403Registry::policyExistsCall { policyId: *policy_id })?);
+                assert!(registry.policy_exists(ITIP403Registry::policyExistsCall {
+                    policyId: *policy_id
+                })?);
             }
 
             Ok(())


### PR DESCRIPTION
This PR adds additional tests to assert `policy_exists` functionality.