### PR TITLE
fix(txpool): treat InvalidValidAfter as bad transaction

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -206,10 +206,10 @@ impl PoolTransactionError for TempoPoolTransactionError {
             | Self::MissingFeeToken
             | Self::BlackListedFeePayer { .. }
             | Self::InvalidValidBefore { .. }
-            | Self::InvalidValidAfter { .. }
             | Self::Keychain(_)
             | Self::InsufficientLiquidity(_) => false,
-            Self::NonZeroValue | Self::SubblockNonceKey => true,
+
+            Self::NonZeroValue | Self::SubblockNonceKey | Self::InvalidValidAfter { .. } => true,
         }
     }
 


### PR DESCRIPTION
Mark InvalidValidAfter as a permanent pool error so transactions that can never
become valid are not retained indefinitely.
