### PR TITLE
fix: correctly estimate 2d nonce gas

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -946,6 +946,8 @@ where
             })?;
         }
 
+        // Short-circuit if there is no spending for this transaction and `collectFeePreTx`
+        // call will not collect any fees.
         if gas_balance_spending.is_zero() {
             evm.nonce_2d_gas = nonce_2d_gas;
             return Ok(());


### PR DESCRIPTION
right now when we short-circuit due to zero spending we don't set `evm.nonce_2d_gas` properly