### PR TITLE
 Updated the broken link of  Safe Deployer repository link in predeployed contracts

### DIFF
--- a/docs/pages/quickstart/predeployed-contracts.mdx
+++ b/docs/pages/quickstart/predeployed-contracts.mdx
@@ -22,7 +22,7 @@ Popular Ethereum contracts deployed for convenience.
 | [**CreateX**](https://github.com/pcaversaccio/createx) | `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed` | Deterministic contract deployment |
 | [**Permit2**](https://docs.uniswap.org/contracts/permit2/overview) | `0x000000000022d473030f116ddee9f6b43ac78ba3` | Token approvals and transfers |
 | [**Arachnid Create2 Factory**](https://github.com/Arachnid/deterministic-deployment-proxy) | `0x4e59b44847b379578588920cA78FbF26c0B4956C` | CREATE2 deployment proxy |
-| [**Safe Deployer**](https://github.com/safe-global/safe-deployer) | `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` | Safe deployer contract |
+| [**Safe Deployer**](https://github.com/safe-global/safe-deployments) | `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` | Safe deployer contract |
 
 ### Contract ABIs
 


### PR DESCRIPTION
Fixes the repository link for Safe Deployer in the predeployed contracts documentation.

*Changed:
- Updated link from `github.com/safe-global/safe-deployer` to `github.com/safe-global/safe-deployments`

This ensures users are directed to the correct Safe Global deployments repository.

How has it been tested?

Manually Tested.