### PR TITLE
ci: add pre-push hook to validate tag version against Cargo.toml

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+
+cargo_version=$(awk -F '"' '/^version =/ {print $2; exit}' Cargo.toml)
+if [[ -z "${cargo_version}" ]]; then
+  echo "pre-push: unable to determine Cargo.toml version" >&2
+  exit 1
+fi
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "${local_ref}" != refs/tags/* ]]; then
+    continue
+  fi
+
+  if [[ "${local_sha}" == "${zero_sha}" ]]; then
+    continue
+  fi
+
+  tag_name=${local_ref#refs/tags/}
+  tag_version=${tag_name#v}
+
+  if [[ "${tag_version}" != "${cargo_version}" ]]; then
+    echo "pre-push: tag ${tag_name} does not match Cargo.toml version ${cargo_version}" >&2
+    echo "pre-push: please update Cargo.toml or use a matching tag (v${cargo_version})." >&2
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
### Motivation
- Prevent pushing tags whose version doesn't match the workspace package version in `Cargo.toml` to avoid mismatched releases and binary/version drift. 
- Provide a local guard so maintainers catch version/tag mismatches before they reach CI or the remote registry. 

### Description
- Add an executable hook script at `.githooks/pre-push` that extracts the workspace version from `Cargo.toml` and validates pushed tag names. 
- The hook reads refs from stdin, ignores non-tag refs and tag deletions (zero SHA), strips an optional leading `v` from the tag, and fails the push if the tag version does not equal the `Cargo.toml` version. 
- The script prints a clear error message instructing to update `Cargo.toml` or use a matching tag when mismatches are detected. 

### Testing
- Committed the new `.githooks/pre-push` file and made it executable, and the commit succeeded. 
- No automated tests were run for the hook itself. 
- The hook is script-only and must be installed or referenced (e.g., via `core.hooksPath` or a local setup step) for enforcement during pushes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694997cbb4508321a36ff4ba3db13406)