### PR TITLE
Docs: clarify glibc requirement for Linux binaries

### DIFF
--- a/docs/pages/guide/node/system-requirements.mdx
+++ b/docs/pages/guide/node/system-requirements.mdx
@@ -4,6 +4,22 @@ These are the minimum and recommended system requirements for running a validato
 It is likely, that the nodes will not require as much resources at the beginning of the chain,
 but we still highly recommend to follow the recommended specifications. This will allow for future growth and scalability.
 
+### Linux
+
+The current prebuilt `tempo` Linux binaries (≥v0.8.0) are dynamically linked against glibc ≥ 2.38.
+
+You can check your glibc version with:
+
+```bash
+ldd --version
+```
+
+This means:
+- Ubuntu 22.04 (glibc 2.35) is **not supported** for the prebuilt binaries Ubuntu 24.04+ is required
+- Or optionally use any of the following Installation way 
+  -  `Docker` 
+  -  `Build from source on older distributions`
+
 ## RPC Node
 
 | Component | Minimum | Recommended |


### PR DESCRIPTION
## Context
Refrencing Issue #1726 
Installing `tempo` on Ubuntu 22.04 fails with:
- GLIBC_2.38 not found
- GLIBC_2.39 not found

<img width="751" height="280" alt="Screenshot 2025-12-23 at 19 41 40" src="https://github.com/user-attachments/assets/b1418845-0291-4636-9d92-cc95c998ac4d" />

_Output from running tempo --version, checking glibc version and OS version_

Ubuntu 22.04 ships with glibc 2.35, so the current prebuilt Linux binaries do not run on it.

## Steps to reproduce
- Spin up a cloud Instance with Ubuntu 22.04 OS
- Update system packages
- Install Tempo `curl -L https://tempo.xyz/install | bash`
- Reload .bashrc `source /home/node/.bashrc`
- Run `tempo --version`
- View ur OS glibc with `ldd --version`

## Change

This PR documents the glibc requirement and lists supported alternatives (Ubuntu 24.04, Docker, or building from source).

Pls review @kuyziss @gakonst 