### PR TITLE
Add `stable` Docker tag for tag-triggered builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
             type=sha,prefix=sha-
@@ -64,6 +65,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
             type=sha,prefix=sha-
@@ -81,6 +83,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
             type=sha,prefix=sha-
@@ -98,6 +101,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
             type=sha,prefix=sha-


### PR DESCRIPTION
### Motivation
- When a build is triggered by a pushed git tag, publish an additional `stable` Docker tag so releases can be referenced by a stable alias.
- Ensure consistency across all published images so the same tagging semantics apply to `tempo`, `tempo-bench`, `tempo-sidecar`, and `tempo-xtask`.

### Description
- Added `type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}` to the `tags` block for each `docker/metadata-action@v5` entry.
- Updated the workflow file `/.github/workflows/docker.yml` to apply the `stable` tag for tag-triggered builds.

### Testing
- No automated tests were run because this is a workflow configuration change only.
- The change was committed to the branch and is ready for verification by running the GitHub Actions workflow on a tag push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694ba0854fac832aadaeb01440007d20)