### PR TITLE
docs: add dRPC in Developer tools

### DIFF
--- a/docs/pages/quickstart/developer-tools.mdx
+++ b/docs/pages/quickstart/developer-tools.mdx
@@ -229,6 +229,12 @@ Sign up through the [Blockdaemon Developer Dashboard](https://app.blockdaemon.co
 
 View the Tempo Testnet RPC endpoint in the [Conduit Hub](https://hub.conduit.xyz/tempo-testnet) and get started with the [Tempo RPC Quickstart](https://docs.conduit.xyz/rpc-nodes/getting-started/tempo-rpc-quickstart).
 
+### dRPC
+
+[dRPC](https://drpc.org) provides managed Tempo RPC endpoints through NodeCloud, with smart routing, analytics, key control, and front-end protection across 180+ networks. The platform runs on 40 providers in 8 geoclusters, with a free tier and flat-rate plans starting at $10.
+
+Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-testnet-rpc), and learn more about NodeCloud on the [dRPC NodeCloud page](https://drpc.org/nodecloud-multichain-rpc-management).
+
 ### Quicknode
 
 [Quicknode](https://quicknode.com) is the enterprise-grade development platform for building, scaling, and launching onchain applications with speed and reliability. Their globally optimized RPC network makes it easy to run high-performance Tempo workloads from day one.


### PR DESCRIPTION
- Added a `dRPC` section to `docs/pages/quickstart/developer-tools.mdx` with a concise blurb describing NodeCloud features and pricing.
- Pointed the primary CTA to the Tempo chain page at `https://drpc.org/chainlist/tempo-testnet-rpc`.