### PR TITLE
fix(stablecoin-exchange): use centralized price conversion functions 

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_exchange/orderbook.rs
@@ -27,6 +27,15 @@ pub enum RoundingDirection {
     Up,
 }
 
+/// Checked ceiling division for u128.
+/// Returns None if divisor is zero.
+fn checked_div_ceil(numerator: u128, divisor: u128) -> Option<u128> {
+    if divisor == 0 {
+        return None;
+    }
+    Some(numerator.div_ceil(divisor))
+}
+
 /// Convert base token amount to quote token amount at a given tick.
 ///
 /// Formula: quote_amount = (base_amount * price) / PRICE_SCALE
@@ -44,7 +53,7 @@ pub fn base_to_quote(base_amount: u128, tick: i16, rounding: RoundingDirection) 
 
     match rounding {
         RoundingDirection::Down => numerator.checked_div(PRICE_SCALE as u128),
-        RoundingDirection::Up => Some(numerator.div_ceil(PRICE_SCALE as u128)),
+        RoundingDirection::Up => checked_div_ceil(numerator, PRICE_SCALE as u128),
     }
 }
 
@@ -65,7 +74,7 @@ pub fn quote_to_base(quote_amount: u128, tick: i16, rounding: RoundingDirection)
 
     match rounding {
         RoundingDirection::Down => numerator.checked_div(price),
-        RoundingDirection::Up => Some(numerator.div_ceil(price)),
+        RoundingDirection::Up => checked_div_ceil(numerator, price),
     }
 }
 


### PR DESCRIPTION
Ref TMPO-24

Consolidates all price conversion calculations to use the centralized `base_to_quote()` and `quote_to_base()` helper functions.

- Deleted `calculate_quote_amount()` since it just wrapped `base_to_quote()`
- Updated 5 functions that were still using manual `mul/div` calculations:
  - `fill_orders_exact_out_post_moderato()`
  - `fill_orders_exact_out_pre_moderato()` (maintains round-down for consensus compatibility)
  - `fill_orders_exact_in_post_moderato()`
  - `quote_exact_out()`
  - `quote_exact_in()`
- Added `checked_div_ceil()` helper to use checked division when rounding up, preventing potential panics on division by zero
