### PR TITLE
chore: remove stale hardfork references from docs and tests

### DIFF
--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -29,8 +29,6 @@ use alloy::primitives::{Address, U256};
 #[contract(addr = NONCE_PRECOMPILE_ADDRESS)]
 pub struct NonceManager {
     nonces: Mapping<Address, Mapping<U256, u64>>,
-    /// Deprecated post-AllegroModerato: tracks number of active nonce keys per account
-    active_key_count: Mapping<Address, U256>,
 }
 
 impl NonceManager {

--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -32,8 +32,8 @@ pub const MIN_ORDER_AMOUNT: u128 = 10_000_000;
 pub const TICK_SPACING: i16 = 10;
 
 /// Calculate quote amount with specified rounding direction
-/// - `RoundingDirection::Down`: Pre-Moderato behavior (floor division)
-/// - `RoundingDirection::Up`: Post-Moderato behavior, favors protocol when user deposits funds
+/// - `RoundingDirection::Down`: Floor division, used for payouts (favors protocol)
+/// - `RoundingDirection::Up`: Ceiling division, used for deposits (favors protocol)
 fn calculate_quote_amount(amount: u128, tick: i16, rounding: RoundingDirection) -> Option<u128> {
     base_to_quote(amount, tick, rounding)
 }

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -533,7 +533,6 @@ mod tests {
         };
 
         let mut db = EmptyDB::default();
-        // Stablecoin exchange fee token inference requires Allegretto hardfork
         let token = db.get_fee_token(tx, caller)?;
         assert_eq!(token, token_in);
 


### PR DESCRIPTION
Ref https://github.com/tempoxyz/tempo/pull/1707

Cleans up leftover hardfork references after the hardfork logic removal:
- Remove deprecated `active_key_count` field from NonceManager
- Update rounding direction comments (remove Pre/Post-Moderato references)
- Update fee manager doc comments to describe current behavior
- Rename tests to remove hardfork suffixes and update test comments
- Remove stale hardfork comment from stablecoin exchange fee token test
