### PR TITLE
fix(stablecoin-exchange): add MAX_ORDER_ITERATIONS limit to prevent DoS via unbounded order iteration

### DIFF
--- a/crates/contracts/src/precompiles/stablecoin_exchange.rs
+++ b/crates/contracts/src/precompiles/stablecoin_exchange.rs
@@ -110,6 +110,7 @@ crate::sol! {
         error MaxInputExceeded();
         error BelowMinimumOrderSize(uint128 amount);
         error InvalidBaseToken();
+        error MaxOrderIterationsExceeded(uint32 maxIterations);
     }
 }
 
@@ -187,5 +188,12 @@ impl StablecoinExchangeError {
     /// Creates an error for invalid base token.
     pub const fn invalid_base_token() -> Self {
         Self::InvalidBaseToken(IStablecoinExchange::InvalidBaseToken {})
+    }
+
+    /// Creates an error when max order iterations exceeded during swap.
+    pub const fn max_order_iterations_exceeded(max_iterations: u32) -> Self {
+        Self::MaxOrderIterationsExceeded(IStablecoinExchange::MaxOrderIterationsExceeded {
+            maxIterations: max_iterations,
+        })
     }
 }

--- a/docs/specs/src/StablecoinExchange.sol
+++ b/docs/specs/src/StablecoinExchange.sol
@@ -33,6 +33,10 @@ contract StablecoinExchange is IStablecoinExchange {
     /// @notice Minimum order amount (10 units with 6 decimals)
     uint128 public constant MIN_ORDER_AMOUNT = 10_000_000;
 
+    /// @notice Maximum number of orders that can be iterated through in a single swap
+    /// @dev Prevents DoS attacks where an attacker places many small orders to force expensive iteration
+    uint32 public constant MAX_ORDER_ITERATIONS = 100;
+
     /// @notice TIP20 token address prefix (12 bytes)
     bytes12 public constant TIP20_PREFIX = 0x20C000000000000000000000;
 
@@ -684,6 +688,7 @@ contract StablecoinExchange is IStablecoinExchange {
         uint128 amountOut
     ) internal returns (uint128 amountIn) {
         uint128 remainingOut = amountOut;
+        uint32 iterations = 0;
 
         if (baseForQuote) {
             int16 currentTick = book.bestBidTick;
@@ -696,6 +701,11 @@ contract StablecoinExchange is IStablecoinExchange {
             uint128 orderId = level.head;
 
             while (remainingOut > 0) {
+                ++iterations;
+                if (iterations > MAX_ORDER_ITERATIONS) {
+                    revert IStablecoinExchange.MaxOrderIterationsExceeded(MAX_ORDER_ITERATIONS);
+                }
+
                 // Get the price at the current tick and fetch the current order from storage
                 uint32 price = tickToPrice(currentTick);
                 IStablecoinExchange.Order memory currentOrder = orders[orderId];
@@ -746,6 +756,11 @@ contract StablecoinExchange is IStablecoinExchange {
             uint128 orderId = level.head;
 
             while (remainingOut > 0) {
+                ++iterations;
+                if (iterations > MAX_ORDER_ITERATIONS) {
+                    revert IStablecoinExchange.MaxOrderIterationsExceeded(MAX_ORDER_ITERATIONS);
+                }
+
                 uint32 price = tickToPrice(currentTick);
                 IStablecoinExchange.Order memory currentOrder = orders[orderId];
 
@@ -799,6 +814,7 @@ contract StablecoinExchange is IStablecoinExchange {
         uint128 amountIn
     ) internal returns (uint128 amountOut) {
         uint128 remainingIn = amountIn;
+        uint32 iterations = 0;
 
         if (baseForQuote) {
             int16 currentTick = book.bestBidTick;
@@ -811,6 +827,11 @@ contract StablecoinExchange is IStablecoinExchange {
             uint128 orderId = level.head;
 
             while (remainingIn > 0) {
+                ++iterations;
+                if (iterations > MAX_ORDER_ITERATIONS) {
+                    revert IStablecoinExchange.MaxOrderIterationsExceeded(MAX_ORDER_ITERATIONS);
+                }
+
                 uint32 price = tickToPrice(currentTick);
                 IStablecoinExchange.Order memory currentOrder = orders[orderId];
 
@@ -860,6 +881,11 @@ contract StablecoinExchange is IStablecoinExchange {
             uint128 orderId = level.head;
 
             while (remainingIn > 0) {
+                ++iterations;
+                if (iterations > MAX_ORDER_ITERATIONS) {
+                    revert IStablecoinExchange.MaxOrderIterationsExceeded(MAX_ORDER_ITERATIONS);
+                }
+
                 uint32 price = tickToPrice(currentTick);
                 IStablecoinExchange.Order memory currentOrder = orders[orderId];
 

--- a/docs/specs/src/interfaces/IStablecoinExchange.sol
+++ b/docs/specs/src/interfaces/IStablecoinExchange.sol
@@ -58,6 +58,7 @@ interface IStablecoinExchange {
     error MaxInputExceeded();
     error BelowMinimumOrderSize(uint128 amount);
     error InvalidBaseToken();
+    error MaxOrderIterationsExceeded(uint32 limit);
 
     event FlipOrderPlaced(
         uint128 indexed orderId,


### PR DESCRIPTION
Closes CHAIN-322
Closes TMPO-50

Added a `MAX_ORDER_ITERATIONS` constant (100) that limits the number of orders that can be processed in a single swap. When exceeded, the swap fails with a new `MaxOrderIterationsExceeded` error, preventing gas exhaustion attacks.

 - Added `MAX_ORDER_ITERATIONS = 100` constant
- Added `MaxOrderIterationsExceeded(uint32)` error to Solidity interface
- Added iteration counter and limit check to both fill functions
- Added tests verifying the iteration limit behavior
- Updated solidity reference implementation
