### PR TITLE
fix(tip20): fix setFeeRecipient ABI mismatch (#1735)

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -61,7 +61,7 @@ crate::sol! {
         function transferWithMemo(address to, uint256 amount, bytes32 memo) external;
         function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
         function feeRecipient() external view returns (address);
-        function setFeeRecipient(address newRecipient) external view returns (address);
+        function setFeeRecipient(address newRecipient) external;
 
         // Admin Functions
         function changeTransferPolicyId(uint64 newPolicyId) external;


### PR DESCRIPTION
Fixes #1735
Remove `view returns (address)` from `setFeeRecipient` to match `mutate_void` implementation.