### PR TITLE
fix(executor): propagate fork choice update errors 

### DIFF
--- a/crates/commonware-node/src/consensus/application/executor.rs
+++ b/crates/commonware-node/src/consensus/application/executor.rs
@@ -23,7 +23,9 @@ use futures::{
 };
 use reth_provider::BlockNumReader as _;
 use tempo_node::{TempoExecutionData, TempoFullNode};
-use tracing::{Level, Span, debug, error, info, info_span, instrument, warn, warn_span};
+use tracing::{
+    Level, Span, debug, error, error_span, info, info_span, instrument, warn, warn_span,
+};
 
 use crate::consensus::{Digest, block::Block};
 
@@ -243,11 +245,11 @@ where
                     // Backfills will be spawned as tasks and will also send
                     // resolved the blocks to this queue.
                     if let Err(error) = self.handle_message(msg).await {
-                        error!(
+                        error_span!("shutdown").in_scope(|| error!(
                             %error,
                             "executor encountered fatal fork choice update error; \
                             shutting down to prevent consensus-execution divergence"
-                        );
+                        ));
                         break;
                     }
                 },


### PR DESCRIPTION
Closes CHAIN-177
Closes TMPO-23

Fork choice update errors in the executor were silently discarded using `let _ = ...`, which could cause consensus-execution layer divergence when the execution layer rejects canonical chain updates. With this changes, when a fork choice update fails, the executor now shuts down cleanly instead of continuing with stale state.

- `handle_message()` now returns `Result<()>` and propagates errors
- `finalize()` now returns `Result<()>` and propagates errors
- `run()` loop breaks on error with a warning log
- `forward_finalized()` propagates canonicalize and fill_holes errors