### PR TITLE
docs: add redirect for /guide/node/usage

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -27,6 +27,11 @@
       "permanent": true
     },
     {
+      "source": "/guide/node/usage",
+      "destination": "/guide/node/rpc",
+      "permanent": true
+    },
+    {
       "source": "/errors/tx/MissingFeeToken",
       "destination": "/guide/payments/pay-fees-in-any-stablecoin#add-pay-with-fee-token-logic",
       "permanent": false


### PR DESCRIPTION
## Description
Adds a permanent redirect from the old `/guide/node/usage` URL to the new `/guide/node/rpc` URL.

## Problem
The "Running an RPC Node" page was renamed from `usage.mdx` to `rpc.mdx`, and the sidebar navigation was updated accordingly. However, the old URL `/guide/node/usage` still returns a 404 error instead of redirecting to the new location.

## Solution
Add a permanent redirect in `docs/vercel.json` to ensure users and search engines are properly redirected from the old URL to the new one.

## Changes
- **File:** `docs/vercel.json`
- **Change:** Added redirect entry:
  ```json
  {
    "source": "/guide/node/usage",
    "destination": "/guide/node/rpc",
    "permanent": true
  }
  ```

## Testing
1. ✅ Current behavior: https://docs.tempo.xyz/guide/node/usage returns 404
2. ✅ After fix: https://docs.tempo.xyz/guide/node/usage will redirect to https://docs.tempo.xyz/guide/node/rpc
3. ✅ Redirect type: 308 (Permanent Redirect) for SEO preservation

## References
- Old URL (404): https://docs.tempo.xyz/guide/node/usage
- New URL (works): https://docs.tempo.xyz/guide/node/rpc
- Sidebar link: Already updated to use `/guide/node/rpc`

## Additional Context
This is a minor documentation fix to improve user experience by preventing 404 errors when users access the old URL from bookmarks, external links, or search engine results.