### PR TITLE
fix: catch slot collisions when using `base_slot` attrib

### DIFF
--- a/crates/precompiles-macros/src/layout.rs
+++ b/crates/precompiles-macros/src/layout.rs
@@ -233,14 +233,12 @@ fn gen_collision_checks(allocated_fields: &[LayoutField<'_>]) -> proc_macro2::To
     let mut generated = proc_macro2::TokenStream::new();
     let mut check_fn_calls = Vec::new();
 
-    // Generate collision detection check functions
+    // Generate collision detection check functions for all fields
     for (idx, allocated) in allocated_fields.iter().enumerate() {
-        if let Some((check_fn_name, check_fn)) =
-            packing::gen_collision_check_fn(idx, allocated, allocated_fields)
-        {
-            generated.extend(check_fn);
-            check_fn_calls.push(check_fn_name);
-        }
+        let (check_fn_name, check_fn) =
+            packing::gen_collision_check_fn(idx, allocated, allocated_fields);
+        generated.extend(check_fn);
+        check_fn_calls.push(check_fn_name);
     }
 
     // Generate a module initializer that calls all check functions

--- a/crates/precompiles/tests/storage_tests/layouts.rs
+++ b/crates/precompiles/tests/storage_tests/layouts.rs
@@ -302,3 +302,22 @@ fn test_no_collision_when_using_manual_slot_with_packing() {
 
     assert_eq!(slots::D, U256::from(100));
 }
+
+#[test]
+#[should_panic(
+    expected = "Storage slot collision: field `c` (slot 1, offset 0) overlaps with field `d` (slot 1, offset 0)"
+)]
+fn test_collision_when_using_base_slot() {
+    #[contract]
+    pub struct Layout {
+        a: u128, // assigned to slot 0 with 0 offset
+        b: u128, // assigned to slot 0 with 16 offset
+        c: u128, // assigned to slot 1 with 0 offset
+        #[base_slot(1)]
+        d: u128, // manually assigned to slot 1
+        e: u128, // assigned to slot 1 with 16 offset.
+    }
+
+    let (_, address) = setup_storage();
+    let _layout = Layout::__new(address);
+}


### PR DESCRIPTION
## Motivation

follow-up concern from the auditors after patching TMPO-18 and TMPO-19.
hardens slot collision checks by running them on all slots rather than only vs the manually assigned with the `slot` attribute