### PR TITLE
fix: tx requests with fee_token should be treated as TempoTx

### DIFF
--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -116,6 +116,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoBlockEnv> for TempoTransactionRequest {
                 || nonce_key.is_some()
                 || key_authorization.is_some()
                 || key_id.is_some()
+                || fee_token.is_some()
             {
                 // Create mock signature for gas estimation
                 // If key_type is not provided, default to secp256k1


### PR DESCRIPTION
Currently a transaction request with a `fee_token`, a single call, with secp256k1 key, and no 2d nonce will not be considered a Tempo tx, and therefore will return incorrect gas estimations if we change gas schedule for Tempo Tx.