### PR TITLE
fix: update docs/wagmi links

### DIFF
--- a/docs/pages/sdk/typescript/wagmi/actions/index.mdx
+++ b/docs/pages/sdk/typescript/wagmi/actions/index.mdx
@@ -39,9 +39,9 @@
 | [`reward.getTotalPerSecond`](/sdk/typescript/wagmi/actions/reward.getTotalPerSecond) | Gets the total reward per second rate for all active streams |
 | [`reward.getUserRewardInfo`](/sdk/typescript/wagmi/actions/reward.getUserRewardInfo) | Gets reward information for a specific account |
 | [`reward.setRecipient`](/sdk/typescript/wagmi/actions/reward.setRecipient) | Sets or changes the reward recipient for a token holder |
-| [`reward.distribute`](/sdk/typescript/wagmi/actions/reward.distribute) | Distributes tokens to opted-in holders |
+| [`reward.start`](/sdk/typescript/wagmi/actions/reward.start) | Starts a reward stream that distributes tokens to opted-in holders |
 | [`reward.watchRewardRecipientSet`](/sdk/typescript/wagmi/actions/reward.watchRewardRecipientSet) | Watches for reward recipient set events |
-| [`reward.watchRewardDistributed`](/sdk/typescript/wagmi/actions/reward.watchRewardDistributed) | Watches for reward scheduled events |
+| [`reward.watchRewardScheduled`](/sdk/typescript/wagmi/actions/reward.watchRewardScheduled) | Watches for reward scheduled events |
 | **Stablecoin DEX Actions** | |
 | [`dex.buy`](/sdk/typescript/wagmi/actions/dex.buy) | Buys a specific amount of tokens from the Stablecoin DEX orderbook |
 | [`dex.cancel`](/sdk/typescript/wagmi/actions/dex.cancel) | Cancels an order from the orderbook |

--- a/docs/pages/sdk/typescript/wagmi/hooks/index.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/index.mdx
@@ -41,7 +41,7 @@
 | [`reward.useStart`](/sdk/typescript/wagmi/hooks/reward.useStart) | Hook for starting a new reward stream that distributes tokens to opted-in holders |
 | [`reward.useUserRewardInfo`](/sdk/typescript/wagmi/hooks/reward.useUserRewardInfo) | Hook for getting reward information for a specific account |
 | [`reward.useWatchRewardRecipientSet`](/sdk/typescript/wagmi/hooks/reward.useWatchRewardRecipientSet) | Hook for watching reward recipient set events |
-| [`reward.useWatchRewardDistributed`](/sdk/typescript/wagmi/hooks/reward.useWatchRewardDistributed) | Hook for watching reward scheduled events |
+| [`reward.useWatchRewardScheduled`](/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled) | Hook for watching reward scheduled events |
 | **Stablecoin DEX Hooks** | |
 | [`dex.useBalance`](/sdk/typescript/wagmi/hooks/dex.useBalance) | Hook for getting a user's token balance on the Stablecoin DEX |
 | [`dex.useBuy`](/sdk/typescript/wagmi/hooks/dex.useBuy) | Hook for buying a specific amount of tokens from the Stablecoin DEX orderbook |

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useStart.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useStart.mdx
@@ -82,11 +82,11 @@ See [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/framework/
 
 ### data
 
-See [Wagmi Action `reward.distribute` Return Type](/sdk/typescript/wagmi/actions/reward.distribute#return-type)
+See [Wagmi Action `reward.start` Return Type](/sdk/typescript/wagmi/actions/reward.start#return-type)
 
 ### mutate/mutateAsync
 
-See [Wagmi Action `reward.distribute` Parameters](/sdk/typescript/wagmi/actions/reward.distribute#parameters)
+See [Wagmi Action `reward.start` Parameters](/sdk/typescript/wagmi/actions/reward.start#parameters)
 
 ## Parameters
 

--- a/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled.mdx
+++ b/docs/pages/sdk/typescript/wagmi/hooks/reward.useWatchRewardScheduled.mdx
@@ -35,7 +35,7 @@ Hooks.reward.useWatchRewardDistributed({
 
 ## Parameters
 
-See [Wagmi Action `reward.watchRewardDistributed` Parameters](/sdk/typescript/wagmi/actions/reward.watchRewardDistributed#parameters)
+See [Wagmi Action `reward.watchRewardScheduled` Parameters](/sdk/typescript/wagmi/actions/reward.watchRewardScheduled#parameters)
 
 ### config
 


### PR DESCRIPTION
This PR fixes broken links in the docs. Note that viem needs to be updated to use the new `TIP20` function signatures for reward distribution. 