### PR TITLE
perf: remove redundant balance read in transfer

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -735,7 +735,6 @@ impl TIP20Token {
         self.handle_rewards_on_transfer(from, to, amount)?;
 
         // Adjust balances
-        let from_balance = self.get_balance(from)?;
         let new_from_balance = from_balance
             .checked_sub(amount)
             .ok_or(TempoPrecompileError::under_overflow())?;


### PR DESCRIPTION
Fixes TMPO 31

The _transfer() function was reading the sender's balance twice - once
for the sufficiency check at the start, and again after calling
handle_rewards_on_transfer(). Since handle_rewards_on_transfer() only
updates reward-related state and does not modify token balances, the
second read is redundant and wastes gas on every transfer.

This removes the unnecessary SLOAD operation by reusing the balance
from the initial sufficiency check.