### PR TITLE
fix: add revert if policy doesn't exist

### DIFF
--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -34,6 +34,7 @@ crate::sol! {
         // Errors
         error Unauthorized();
         error IncompatiblePolicyType();
+        error PolicyNotFound();
     }
 }
 
@@ -46,5 +47,10 @@ impl TIP403RegistryError {
     /// Creates an error for incompatible policy types
     pub const fn incompatible_policy_type() -> Self {
         Self::IncompatiblePolicyType(ITIP403Registry::IncompatiblePolicyType {})
+    }
+
+    /// Creates an error for non-existent policy
+    pub const fn policy_not_found() -> Self {
+        Self::PolicyNotFound(ITIP403Registry::PolicyNotFound {})
     }
 }

--- a/docs/specs/src/TIP403Registry.sol
+++ b/docs/specs/src/TIP403Registry.sol
@@ -7,7 +7,7 @@ contract TIP403Registry is ITIP403Registry {
 
     uint64 public policyIdCounter = 2; // Skip special policies (documented in isAuthorized).
 
-    mapping(uint64 => PolicyData) public policyData;
+    mapping(uint64 => PolicyData) internal _policyData;
 
     /*//////////////////////////////////////////////////////////////
                       POLICY TYPE-SPECIFIC STORAGE
@@ -23,7 +23,7 @@ contract TIP403Registry is ITIP403Registry {
         public
         returns (uint64 newPolicyId)
     {
-        policyData[newPolicyId = policyIdCounter++] =
+        _policyData[newPolicyId = policyIdCounter++] =
             PolicyData({ policyType: policyType, admin: admin });
 
         emit PolicyCreated(newPolicyId, msg.sender, policyType);
@@ -37,7 +37,7 @@ contract TIP403Registry is ITIP403Registry {
     ) public returns (uint64 newPolicyId) {
         newPolicyId = policyIdCounter++;
 
-        policyData[newPolicyId] = PolicyData({ policyType: policyType, admin: admin });
+        _policyData[newPolicyId] = PolicyData({ policyType: policyType, admin: admin });
 
         // Set the initial policy set.
         for (uint256 i = 0; i < accounts.length; i++) {
@@ -55,9 +55,9 @@ contract TIP403Registry is ITIP403Registry {
     }
 
     function setPolicyAdmin(uint64 policyId, address admin) external {
-        require(policyData[policyId].admin == msg.sender, Unauthorized());
+        require(_policyData[policyId].admin == msg.sender, Unauthorized());
 
-        policyData[policyId].admin = admin;
+        _policyData[policyId].admin = admin;
 
         emit PolicyAdminUpdated(policyId, msg.sender, admin);
     }
@@ -67,7 +67,7 @@ contract TIP403Registry is ITIP403Registry {
     //////////////////////////////////////////////////////////////*/
 
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
-        PolicyData memory data = policyData[policyId];
+        PolicyData memory data = _policyData[policyId];
 
         require(data.admin == msg.sender, Unauthorized());
         require(data.policyType == PolicyType.WHITELIST, IncompatiblePolicyType());
@@ -78,7 +78,7 @@ contract TIP403Registry is ITIP403Registry {
     }
 
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
-        PolicyData memory data = policyData[policyId];
+        PolicyData memory data = _policyData[policyId];
 
         require(data.admin == msg.sender, Unauthorized());
         require(data.policyType == PolicyType.BLACKLIST, IncompatiblePolicyType());
@@ -110,11 +110,22 @@ contract TIP403Registry is ITIP403Registry {
             return policyId == 1;
         }
 
-        PolicyData memory data = policyData[policyId];
+        PolicyData memory data = _policyData[policyId];
 
         return data.policyType == PolicyType.WHITELIST
             ? policySet[policyId][user]
             : !policySet[policyId][user];
+    }
+
+    function policyData(uint64 policyId)
+        public
+        view
+        returns (PolicyType policyType, address admin)
+    {
+        require(policyExists(policyId), PolicyNotFound());
+
+        PolicyData memory data = _policyData[policyId];
+        return (data.policyType, data.admin);
     }
 
 }

--- a/docs/specs/src/interfaces/ITIP403Registry.sol
+++ b/docs/specs/src/interfaces/ITIP403Registry.sol
@@ -27,6 +27,9 @@ interface ITIP403Registry {
     /// @notice Error when attempting to operate on a policy with incompatible type
     error IncompatiblePolicyType();
 
+    /// @notice Error when querying a policy that does not exist
+    error PolicyNotFound();
+
     /// @notice Emitted when a policy's admin is updated
     /// @param policyId The ID of the policy that was updated
     /// @param updater The address that performed the update

--- a/docs/specs/test/TIP403Registry.t.sol
+++ b/docs/specs/test/TIP403Registry.t.sol
@@ -702,6 +702,15 @@ contract TIP403RegistryTest is BaseTest {
         assertFalse(registry.isAuthorized(999, alice));
     }
 
+    function test_PolicyData_RevertsForNonExistentPolicy() public {
+        // Querying policy data for non-existent policy should revert
+        try registry.policyData(999) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(ITIP403Registry.PolicyNotFound.selector));
+        }
+    }
+
     function test_PolicyIdCounter_Increment() public {
         uint64 initialCounter = registry.policyIdCounter();
 


### PR DESCRIPTION
Addresses TMPO 29


It reverts when a policy doesn't exist, instead of returning false. This removes ambiguity from errors, for what is causing the issue.

It does incur one extra storage read of the policyId counter per policy fetch. I don't see a way to avoid this. Maybe the perf degradation is not worth the fix, because it primarily affects offchain tooling, and it should be pretty easy to check offchain if a policy exists or not.

CC: @0xKitsune 