### PR TITLE
fix: increase min order size

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -25,8 +25,8 @@ use crate::{
 use alloy::primitives::{Address, B256, U256};
 use tempo_precompiles_macros::contract;
 
-/// Minimum order size of $10 USD
-pub const MIN_ORDER_AMOUNT: u128 = 10_000_000;
+/// Minimum order size of $100 USD
+pub const MIN_ORDER_AMOUNT: u128 = 100_000_000;
 
 /// Allowed tick spacing for order placement
 pub const TICK_SPACING: i16 = 10;

--- a/docs/pages/protocol/exchange/providing-liquidity.mdx
+++ b/docs/pages/protocol/exchange/providing-liquidity.mdx
@@ -31,7 +31,7 @@ function place(
 
 **Parameters:**
 - `token` - The token address you're trading (must trade against its quote token)
-- `amount` - The amount of the token denominated in `token`
+- `amount` - The amount of the token denominated in `token` (minimum $100)
 - `isBid` - `true` for a buy order, `false` for a sell order
 - `tick` - The price tick: `(price - 1) * 100_000` where price is in quote token per token
 

--- a/docs/pages/protocol/exchange/spec.mdx
+++ b/docs/pages/protocol/exchange/spec.mdx
@@ -68,6 +68,7 @@ Crossed books are permitted; the implementation does not enforce that best bid �
 - Only USD‑denominated tokens are supported, and their quotes must also be USD
 - Orders must specify ticks within the configured bounds (±2000)
 - Tick spacing is 10: `tick % 10 == 0` for orders and flip orders
+- Minimum order size is $100 (100_000_000 in 6‑decimal units)
 - Withdrawals require sufficient internal balance
 
 ### Interface

--- a/docs/specs/src/StablecoinExchange.sol
+++ b/docs/specs/src/StablecoinExchange.sol
@@ -30,8 +30,8 @@ contract StablecoinExchange is IStablecoinExchange {
     /// @notice Maximum valid price (PRICE_SCALE + int16.max)
     uint32 public constant MAX_PRICE = 132_767;
 
-    /// @notice Minimum order amount (10 units with 6 decimals)
-    uint128 public constant MIN_ORDER_AMOUNT = 10_000_000;
+    /// @notice Minimum order amount (100 units with 6 decimals)
+    uint128 public constant MIN_ORDER_AMOUNT = 100_000_000;
 
     /// @notice TIP20 token address prefix (12 bytes)
     bytes12 public constant TIP20_PREFIX = 0x20C000000000000000000000;

--- a/docs/specs/test/StablecoinExchange.t.sol
+++ b/docs/specs/test/StablecoinExchange.t.sol
@@ -477,9 +477,9 @@ contract StablecoinExchangeTest is BaseTest {
                         MINIMUM ORDER SIZE TESTS
     //////////////////////////////////////////////////////////////*/
 
-    // MIN_ORDER_AMOUNT = 10_000_000 (10 units with 6 decimals)
+    // MIN_ORDER_AMOUNT = 100_000_000 (100 units with 6 decimals)
     // Note: The Rust impl doesn't expose this as a view function, so we hardcode it
-    uint128 constant MIN_ORDER_AMOUNT = 10_000_000;
+    uint128 constant MIN_ORDER_AMOUNT = 100_000_000;
 
     function test_PlaceOrder_RevertIf_BelowMinimumOrderSize(uint128 amount) public {
         vm.assume(amount < MIN_ORDER_AMOUNT);


### PR DESCRIPTION
Addresses TMPO-20.

This increases the minimum order size to $100. This adds a comfortable margin for error to ensure that even with somewhat higher-than-targeted gas prices, the gas cost of swaps is likely to be less than 1 bp on the amount swapped.