### PR TITLE
docs: remove outdated pending swaps claim from burn function

### DIFF
--- a/docs/pages/protocol/fees/spec-fee-amm.mdx
+++ b/docs/pages/protocol/fees/spec-fee-amm.mdx
@@ -114,7 +114,7 @@ function burn(
 ) external returns (uint256 amountUserToken, uint256 amountValidatorToken)
 ```
 
-Burns LP tokens and receives pro-rata share of reserves. Reverts if withdrawal would prevent pending swaps at the end of the block. Emits `Burn` event.
+Burns LP tokens and receives pro-rata share of reserves. Emits `Burn` event.
 
 ```solidity
 function executeFeeSwap(


### PR DESCRIPTION
**Problem**
The burn function documentation currently says "Reverts if withdrawal would prevent pending swaps at the end of the block" but this behavior was removed in https://github.com/tempoxyz/tempo/pull/1537.

**Code**
https://github.com/tempoxyz/tempo/pull/1537/files#diff-280ed8053a68ec1d2d4495107f2fcb2d5ea25ac0b140ffa207bfef7c38bea7abL203-L211

**Changes**
- Updated `burn` function description in `spec-fee-amm.mdx`