### PR TITLE
fix(stablecoin-exchange): calculate flip order amount from actual received funds

### DIFF
--- a/crates/precompiles/src/stablecoin_exchange/mod.rs
+++ b/crates/precompiles/src/stablecoin_exchange/mod.rs
@@ -692,14 +692,16 @@ impl StablecoinExchange {
                 order.amount()
             } else {
                 // Ask filled: maker received quote tokens (rounded down)
-                // Flip creates bid: escrows quote tokens (rounded up)
+                // Flip creates bid: escrows quote tokens
                 // Calculate max base affordable with the quote received
+                //
+                // Note: Maker profits from the spread (sell high at tick, buy low at flip_tick),
+                // but order quantity decreases slightly each flip due to double rounding down
+                // (base->quote->base). This ensures we never exceed available funds.
                 let quote_received =
                     base_to_quote(fill_amount, order.tick(), RoundingDirection::Down)
                         .ok_or(TempoPrecompileError::under_overflow())?;
 
-                // Calculate how much base can be bought with quote_received at flip_tick
-                // Round down to ensure we don't exceed available quote
                 quote_to_base(quote_received, order.flip_tick(), RoundingDirection::Down)
                     .ok_or(TempoPrecompileError::under_overflow())?
             };


### PR DESCRIPTION
Closes CHAIN-387

Fixes flip order issues for both ask->bid and bid->ask scenarios.

* ask->bid
When an ask flip order is filled, the maker receives quote tokens rounded down. The flip logic then tried to place a bid using the original base amount, which could require more quote for escrow than was actually received.

With the changes in this PR we apply consistent rounding when calculating the flip amount:

```rust
let quote_received = base_to_quote(fill_amount, order.tick(), RoundingDirection::Down);
let flip_amount = quote_to_base(quote_received, order.flip_tick(), RoundingDirection::Down);
```

By rounding down consistently, the flip order is sized to what can actually be escrowed with received funds.

* bid -> ask

When a bid flip order is partially filled and the maker withdraws their internal balance, the subsequent fill would still create a flip order by using tokens just credited from the current fill. This violated the design intent that flip orders should only use pre-existing internal balance.

In this case we use `order.amount()` instead of `fill_amount`:

```rust
let flip_amount = if order.is_bid() {
    order.amount()  // Use original amount, not fill_amount
} else {
    // ask->bid rounding-aware calculation
};
```

This ensures the flip requires the original order amount for escrow, which won't be available if the maker withdrew after partial fills.
