### PR TITLE
feat(tempo-bench): add --profile flag for samply profiling

### DIFF
--- a/bin/tempo-bench/Cargo.toml
+++ b/bin/tempo-bench/Cargo.toml
@@ -46,3 +46,9 @@ rlimit = "0.10.2"
 governor = "0.10.1"
 rand = "0.9.2"
 rand_08 = { package = "rand", version = "0.8" }
+tempfile = "3"
+which = "7"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["signal"] }

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -183,8 +183,27 @@ just localnet 50000
 tempo-bench run-max-tps --duration 15 --tps 20000 --faucet
 ```
 
-### Sampling
-Use the following commands to run the node with [sampling](https://github.com/mstange/samply):
+### Profiling
+
+Use the `--profile` flag to automatically start a tempo node with [samply](https://github.com/mstange/samply) profiling:
+
 ```bash
-	samply record --output tempo.samply -- just localnet 50000
+tempo-bench run-max-tps --duration 15 --tps 20000 --profile
+```
+
+This will:
+1. Generate a genesis file (or use `--genesis` to specify one)
+2. Start a tempo node wrapped with samply
+3. Run the benchmark
+4. Save the profile to `tempo.samply` (or specify with `--profile-output`)
+
+Additional profiling options:
+- `--profile-output <PATH>`: Output path for the samply profile (default: `tempo.samply`)
+- `--tempo-bin <PATH>`: Path to the tempo binary
+- `--genesis <PATH>`: Path to an existing genesis file
+- `--genesis-accounts <N>`: Number of accounts to generate (default: 1000)
+
+Alternatively, you can manually run the node with samply:
+```bash
+samply record --output tempo.samply -- just localnet 50000
 ```


### PR DESCRIPTION
## Summary

Add `--profile` flag to `tempo-bench` that automatically spawns a tempo node wrapped with samply profiler, runs the benchmark, and saves the profile on exit.

### New CLI options

- `--profile`: Enable samply profiling of the tempo node
- `--profile-output <PATH>`: Output path for the samply profile (default: `tempo.samply`)
- `--tempo-bin <PATH>`: Path to tempo binary (optional, auto-detected)
- `--genesis <PATH>`: Path to existing genesis file (optional)
- `--genesis-accounts <N>`: Number of accounts to generate (default: 1000)

### Usage

```bash
tempo-bench run-max-tps --duration 15 --tps 20000 --profile
```

This will:
1. Generate a genesis file (or use `--genesis` to specify one)
2. Start a tempo node wrapped with samply
3. Run the benchmark
4. Save the profile to `tempo.samply`

Closes #1258