### PR TITLE
docs(alloy): add tip20 example in crate docs

### DIFF
--- a/crates/alloy/README.md
+++ b/crates/alloy/README.md
@@ -32,3 +32,37 @@ async fn build_provider() -> Result<impl Provider<TempoNetwork>, TransportError>
         .await
 }
 ```
+
+This crate also exposes bindings for all Tempo precompiles, such as [TIP20](https://docs.tempo.xyz/protocol/tip20/overview):
+
+```rust
+use alloy::{
+    primitives::{U256, address},
+    providers::ProviderBuilder,
+};
+use tempo_alloy::{TempoNetwork, contracts::precompiles::ITIP20};
+ 
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect(&std::env::var("RPC_URL").expect("No RPC URL set"))
+        .await?;
+ 
+    let token = ITIP20::new( 
+        address!("0x20c0000000000000000000000000000000000001"), // AlphaUSD 
+        provider, 
+    ); 
+ 
+    let receipt = token 
+        .transfer( 
+            address!("0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb"), 
+            U256::from(100).pow(U256::from(10e6)), // 100 tokens (6 decimals) 
+        ) 
+        .send() 
+        .await?
+        .get_receipt() 
+        .await?; 
+ 
+    Ok(())
+}
+```


### PR DESCRIPTION
Adds a basic TIP20 transfer example to the `tempo-alloy` crate docs.