### PR TITLE
docs: fix broken link in node guide index

### DIFF
--- a/docs/pages/guide/node/index.mdx
+++ b/docs/pages/guide/node/index.mdx
@@ -33,7 +33,7 @@ Prebuilt binaries are available for:
   />
   <Card.Link
     description="Configure and run a full RPC node"
-    href="/guide/node/usage"
+    href="/guide/node/rpc"
     icon={LucidePlay}
     title="Running an RPC Node"
   />


### PR DESCRIPTION
## Summary

This PR fixes a broken link in the node guide landing page (`/guide/node/index.mdx`).

## Problem

The "Running an RPC Node" card on the node guide index page links to `/guide/node/usage`, which returns a 404 error. The correct page is `/guide/node/rpc`.

## Changes

- Updated the `href` in the Card.Link component from `/guide/node/usage` to `/guide/node/rpc` (line 36)

## Testing

- Verified that `/guide/node/usage` returns 404
- Verified that `/guide/node/rpc` exists and contains the correct content
- Confirmed this is the only occurrence of the incorrect link in the repository