### PR TITLE
fix(precompiles-macros): account for last field `SLOTS`

### DIFF
--- a/crates/precompiles-macros/src/storable.rs
+++ b/crates/precompiles-macros/src/storable.rs
@@ -187,13 +187,16 @@ fn gen_packing_module_from_ir(fields: &[LayoutField<'_>], mod_ident: &Ident) -> 
     let last_field = &fields[fields.len() - 1];
     let last_slot_const = PackingConstants::new(last_field.name).slot();
     let packing_constants = packing::gen_constants_from_ir(fields, true);
+    let last_type = &last_field.ty;
 
     quote! {
         pub mod #mod_ident {
             use super::*;
 
             #packing_constants
-            pub const SLOT_COUNT: usize = (#last_slot_const.saturating_add(::alloy::primitives::U256::ONE)).as_limbs()[0] as usize;
+            pub const SLOT_COUNT: usize = (#last_slot_const.saturating_add(
+                ::alloy::primitives::U256::from_limbs([<#last_type as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
+            )).as_limbs()[0] as usize;
         }
     }
 }

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -52,6 +52,7 @@ tempo_precompiles_macros::storable_nested_arrays!();
 ///     slot.write(42)?;
 /// }
 /// ```
+#[derive(Debug, Clone)]
 pub struct ArrayHandler<T, const N: usize>
 where
     T: StorableType,

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -147,6 +147,7 @@ where
 ///
 /// Vectors have a maximum capacity of `u32::MAX / element_size` to prevent
 /// arithmetic overflow in storage slot calculations.
+#[derive(Debug, Clone)]
 pub struct VecHandler<T>
 where
     T: Storable,

--- a/crates/precompiles/tests/storage_tests/structs.rs
+++ b/crates/precompiles/tests/storage_tests/structs.rs
@@ -4,7 +4,7 @@
 //! verifying that multi-slot structs are correctly handled and that deletion works.
 
 use super::*;
-use tempo_precompiles::storage::{Mapping, StorageCtx};
+use tempo_precompiles::storage::{Mapping, StorableType, StorageCtx};
 
 #[test]
 fn test_struct_storage() {
@@ -92,6 +92,17 @@ fn test_struct_storage() {
             TestBlock::default()
         );
     });
+}
+
+#[test]
+fn test_multi_slot_last_field_slot_count() {
+    #[derive(Storable)]
+    struct MultiSlotLast {
+        flag: bool,     // slot 0
+        arr: [U256; 2], // slot 1-2
+    }
+
+    assert_eq!(MultiSlotLast::SLOTS, 3);
 }
 
 #[test]


### PR DESCRIPTION
This PR updates the `SLOT_COUNT` calculation of the `Storable` macro so that it accounts for the last field's actual `SLOTS` rather than defaulting to `1`.

Additionally, it derives `Debug` and `Clone` on `ArrayHandler` and `VecHandler`