### PR TITLE
feat(node): minimal pruning mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2", default-features = false }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0-rc.2" }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -53,8 +53,8 @@ struct TempoArgs {
     )]
     pub follow: Option<String>,
 
-    /// Run in minimal storage mode. Sets all prune distances to 10064 and blocks-per-file to
-    /// 50000. Note: merkle_changesets uses the default value of 128 blocks (set via config file
+    /// Run in minimal storage mode. Sets all prune distances to 10064 and keeps 50000 blocks
+    /// per static file. Note: merkle_changesets uses the default value of 128 blocks (set via config file
     /// if different value needed).
     #[arg(long)]
     pub minimal: bool,

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -53,6 +53,12 @@ struct TempoArgs {
     )]
     pub follow: Option<String>,
 
+    /// Run in minimal storage mode. Sets all prune distances to 10064 and blocks-per-file to
+    /// 50000. Note: merkle_changesets uses the default value of 128 blocks (set via config file
+    /// if different value needed).
+    #[arg(long)]
+    pub minimal: bool,
+
     #[command(flatten)]
     pub consensus: tempo_commonware_node::Args,
 
@@ -250,6 +256,22 @@ fn main() -> eyre::Result<()> {
             .apply(|mut builder: WithLaunchContext<_>| {
                 if let Some(follow_url) = &args.follow {
                     builder.config_mut().debug.rpc_consensus_url = Some(follow_url.clone());
+                }
+
+                if args.minimal {
+                    let config = builder.config_mut();
+
+                    config.pruning.sender_recovery_distance = Some(10064);
+                    config.pruning.transaction_lookup_distance = Some(10064);
+                    config.pruning.receipts_distance = Some(10064);
+                    config.pruning.account_history_distance = Some(10064);
+                    config.pruning.storage_history_distance = Some(10064);
+
+                    config.static_files.blocks_per_file_headers = Some(50000);
+                    config.static_files.blocks_per_file_transactions = Some(50000);
+                    config.static_files.blocks_per_file_receipts = Some(50000);
+
+                    info!("Minimal mode enabled: prune distances=10064, blocks_per_file=50000");
                 }
 
                 builder

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -266,6 +266,7 @@ fn main() -> eyre::Result<()> {
                     config.pruning.receipts_distance = Some(10064);
                     config.pruning.account_history_distance = Some(10064);
                     config.pruning.storage_history_distance = Some(10064);
+                    config.pruning.bodies_distance = Some(10064);
 
                     config.static_files.blocks_per_file_headers = Some(50000);
                     config.static_files.blocks_per_file_transactions = Some(50000);


### PR DESCRIPTION
Adds `--minimal` flag to only keep 10064 blocks worth of history in storage. Halves Andantino database size by roughly 60% (196 GB vs 455 GB).

Before:

| Segment      | Block Range | Transaction Range | Shape (columns x rows) | Size      |
|--------------|-------------|-------------------|------------------------|-----------|
| Headers      | 0..=8839874 | N/A               | 3 x 8839875            | 3.8 GiB   |
| Transactions | 0..=8839874 | 0..=408287337     | 1 x 408287338          | 96.6 GiB  |
| Receipts     | 0..=8839874 | 0..=408287337     | 1 x 408287338          | 73.9 GiB  |
| **Total**        |             |                   |                        | **174.4 GiB** |


| Table Name                 | # Entries | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|----------------------------|-----------|--------------|------------|----------------|------------|
| AccountChangeSets          | 114207004 | 87721        | 2490080    | 0              | 9.8 GiB    |
| AccountsHistory            | 14220311  | 6279         | 466398     | 20923          | 1.9 GiB    |
| AccountsTrie               | 1272733   | 172          | 44555      | 0              | 174.7 MiB  |
| AccountsTrieChangeSets     | 34911     | 859          | 4493       | 0              | 20.9 MiB   |
| BlockBodyIndices           | 8839875   | 236          | 52322      | 0              | 205.3 MiB  |
| BlockOmmers                | 0         | 0            | 0          | 0              | 0 B        |
| BlockWithdrawals           | 0         | 0            | 0          | 0              | 0 B        |
| Bytecodes                  | 98553     | 148          | 10358      | 155878         | 649.9 MiB  |
| CanonicalHeaders           | 0         | 0            | 0          | 0              | 0 B        |
| ChainState                 | 2         | 0            | 1          | 0              | 4 KiB      |
| HashedAccounts             | 14208404  | 6136         | 398353     | 0              | 1.5 GiB    |
| HashedStorages             | 430589106 | 136362       | 7937604    | 0              | 30.8 GiB   |
| HeaderNumbers              | 8839875   | 2201         | 158661     | 0              | 628.4 MiB  |
| HeaderTerminalDifficulties | 0         | 0            | 0          | 0              | 0 B        |
| Headers                    | 0         | 0            | 0          | 0              | 0 B        |
| Metadata                   | 1         | 0            | 1          | 0              | 4 KiB      |
| PlainAccountState          | 14208404  | 3674         | 351167     | 0              | 1.4 GiB    |
| PlainStorageState          | 430589106 | 131005       | 7880138    | 0              | 30.6 GiB   |
| PruneCheckpoints           | 1         | 0            | 1          | 0              | 4 KiB      |
| Receipts                   | 0         | 0            | 0          | 0              | 0 B        |
| StageCheckpointProgresses  | 1         | 0            | 1          | 0              | 4 KiB      |
| StageCheckpoints           | 16        | 0            | 1          | 0              | 4 KiB      |
| StorageChangeSets          | 882770407 | 886181       | 13691285   | 0              | 55.6 GiB   |
| StoragesHistory            | 438115951 | 425601       | 16613938   | 150422         | 65.6 GiB   |
| StoragesTrie               | 30790303  | 118411       | 1620095    | 0              | 6.6 GiB    |
| StoragesTrieChangeSets     | 143702    | 4461         | 20033      | 0              | 95.7 MiB   |
| TransactionBlocks          | 8839874   | 255          | 56666      | 0              | 222.3 MiB  |
| TransactionHashNumbers     | 408287338 | 124818       | 7330556    | 0              | 28.4 GiB   |
| TransactionSenders         | 408287338 | 17037        | 3815773    | 0              | 14.6 GiB   |
| Transactions               | 0         | 0            | 0          | 0              | 0 B        |
| VersionHistory             | 12        | 0            | 1          | 0              | 4 KiB      |
| **Tables**                     |           |              |            |                | **248.8 GiB**  |
| Freelist                   | 8730898   |              |            |                | 33.3 GiB   |



After:

| Segment      | Block Range | Transaction Range | Shape (columns x rows) | Size      |
|--------------|-------------|-------------------|------------------------|-----------|
| Headers      | 0..=8862006 | N/A               | 3 x 8862007            | 3.8 GiB   |
| Transactions | 0..=8862006 | 0..=410435013     | 1 x 410435014          | 97.1 GiB  |
| Receipts     | 0..=0       | N/A               | 1 x 0                  | 80 B      |
| **Total**        |             |                   |                        | **100.9 GiB** |


| Table Name                 | # Entries | Branch Pages | Leaf Pages | Overflow Pages | Total Size |
|----------------------------|-----------|--------------|------------|----------------|------------|
| AccountChangeSets          | 18653111  | 7154         | 434454     | 0              | 1.7 GiB    |
| AccountsHistory            | 137834    | 69           | 5885       | 25             | 23.4 MiB   |
| AccountsTrie               | 1279982   | 534          | 70677      | 0              | 278.2 MiB  |
| AccountsTrieChangeSets     | 39224     | 963          | 5034       | 0              | 23.4 MiB   |
| BlockBodyIndices           | 8862007   | 237          | 52453      | 0              | 205.8 MiB  |
| BlockOmmers                | 0         | 0            | 0          | 0              | 0 B        |
| BlockWithdrawals           | 0         | 0            | 0          | 0              | 0 B        |
| Bytecodes                  | 98994     | 152          | 10408      | 156187         | 651.4 MiB  |
| CanonicalHeaders           | 0         | 0            | 0          | 0              | 0 B        |
| ChainState                 | 2         | 0            | 1          | 0              | 4 KiB      |
| HashedAccounts             | 14364807  | 6662         | 420595     | 0              | 1.6 GiB    |
| HashedStorages             | 432949012 | 140915       | 8491830    | 0              | 32.9 GiB   |
| HeaderNumbers              | 8862007   | 3150         | 200110     | 0              | 794 MiB    |
| HeaderTerminalDifficulties | 0         | 0            | 0          | 0              | 0 B        |
| Headers                    | 0         | 0            | 0          | 0              | 0 B        |
| Metadata                   | 1         | 0            | 1          | 0              | 4 KiB      |
| PlainAccountState          | 14364807  | 3940         | 348146     | 0              | 1.3 GiB    |
| PlainStorageState          | 432949012 | 130483       | 7996785    | 0              | 31 GiB     |
| PruneCheckpoints           | 7         | 0            | 1          | 0              | 4 KiB      |
| Receipts                   | 1021453   | 208          | 45842      | 12             | 179.9 MiB  |
| StageCheckpointProgresses  | 1         | 0            | 1          | 0              | 4 KiB      |
| StageCheckpoints           | 16        | 0            | 1          | 0              | 4 KiB      |
| StorageChangeSets          | 103759246 | 23612        | 1661192    | 0              | 6.4 GiB    |
| StoragesHistory            | 1640488   | 3880         | 98268      | 421            | 400.7 MiB  |
| StoragesTrie               | 30906236  | 250854       | 2783785    | 0              | 11.6 GiB   |
| StoragesTrieChangeSets     | 147794    | 4592         | 20375      | 0              | 97.5 MiB   |
| TransactionBlocks          | 8862006   | 256          | 56808      | 0              | 222.9 MiB  |
| TransactionHashNumbers     | 25038010  | 6903         | 449006     | 0              | 1.7 GiB    |
| TransactionSenders         | 1021453   | 45           | 9548       | 0              | 37.5 MiB   |
| Transactions               | 0         | 0            | 0          | 0              | 0 B        |
| VersionHistory             | 2         | 0            | 1          | 0              | 4 KiB      |
| -------------------------- | --------- | ------------ | ---------- | -------------- | ---------- |
| **Tables**                     |           |              |            |                | **91.2 GiB**   |
| Freelist                   | 881508    |              |            |                | 3.4 GiB    |
