### PR TITLE
[Don't merge] chore: add project skills

### DIFF
--- a/.claude/skills/tempo-ai-argocd/SKILL.md
+++ b/.claude/skills/tempo-ai-argocd/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tempo-ai-argocd
+description: Manages ArgoCD applications via Tailscale. Use when asked about deployments, syncing apps, rollbacks, or checking app status in dev/staging/prod environments.
+---
+
+# ArgoCD Operations
+
+Manage ArgoCD applications across environments discovered via Tailscale.
+
+## Prerequisites
+
+- `tempo-argocd` CLI installed (run `./install.sh` from tempo-ai repo)
+- Connected to Tailscale
+
+## Commands
+
+```bash
+# Discover environments
+tempo-argocd servers
+
+# All commands: tempo-argocd <env> <command> [args]
+tempo-argocd <env> list                  # List all apps
+tempo-argocd <env> get <app>             # App details
+tempo-argocd <env> sync <app>            # Sync app
+tempo-argocd <env> diff <app>            # Preview changes
+tempo-argocd <env> logs <app>            # Pod logs
+tempo-argocd <env> history <app>         # Deployment history
+tempo-argocd <env> rollback <app> [rev]  # Rollback
+tempo-argocd <env> health                # Server health
+```
+
+## Workflow
+
+1. Run `tempo-argocd servers` to see available environments
+2. If user mentions "dev", "prod", "staging" - ask which specific environment (e.g., dev-euw, prd-nae)
+3. Run command with environment prefix
+
+## Authentication
+
+If output shows "NOT AUTHENTICATED", tell user to run the login command shown:
+
+```
+argocd login <server-fqdn> --sso --grpc-web
+```
+
+Then retry.
+
+## Examples
+
+```bash
+# Check out-of-sync apps in dev
+tempo-argocd dev-euw list | grep OutOfSync
+
+# Deploy workflow
+tempo-argocd dev-euw diff my-app
+tempo-argocd dev-euw sync my-app
+tempo-argocd dev-euw get my-app
+
+# Rollback in prod
+tempo-argocd prd-nae history my-app
+tempo-argocd prd-nae rollback my-app 5
+```

--- a/.claude/skills/tempo-ai-kubectl/SKILL.md
+++ b/.claude/skills/tempo-ai-kubectl/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: tempo-ai-kubectl
+description: Read-only kubectl operations on non-production Tailscale clusters. Use when asked about pods, deployments, logs, or cluster resources in dev/staging environments.
+---
+
+# Kubectl Read-Only Operations
+
+Query Kubernetes clusters via Tailscale. **Read-only operations only** - no create, delete, apply, or edit commands.
+
+## Prerequisites
+
+- Connected to Tailscale
+- kubectl installed
+
+## Setup Check
+
+First, check if kubeconfig is configured:
+
+```bash
+kubectl config get-contexts
+```
+
+If no Tailscale clusters appear (e.g., `dev-euw.tail388b2e.ts.net`), tell the user to configure:
+
+```bash
+tailscale configure kubeconfig <cluster-name>
+# Example: tailscale configure kubeconfig dev-euw
+```
+
+## Allowed Clusters
+
+**ONLY use these clusters** (exclude `prd-*` and `ic-2-*`):
+- `dev-euw.tail388b2e.ts.net` - Development EU West
+- `stg-nae.tail388b2e.ts.net` - Staging NA East
+- `ic-1-tailscale-operator.tail388b2e.ts.net` - IC-1 cluster
+
+If user asks about production (`prd-*`) or `ic-2-*`, **refuse** and explain these are excluded for safety.
+
+## Commands (Read-Only)
+
+**ALWAYS specify `--context`** on every command:
+
+```bash
+# List resources
+kubectl --context=dev-euw.tail388b2e.ts.net get pods -A
+kubectl --context=dev-euw.tail388b2e.ts.net get deployments -n <namespace>
+kubectl --context=dev-euw.tail388b2e.ts.net get services -n <namespace>
+kubectl --context=dev-euw.tail388b2e.ts.net get nodes
+
+# Describe resources
+kubectl --context=dev-euw.tail388b2e.ts.net describe pod <pod> -n <namespace>
+kubectl --context=dev-euw.tail388b2e.ts.net describe deployment <deploy> -n <namespace>
+
+# Logs
+kubectl --context=dev-euw.tail388b2e.ts.net logs <pod> -n <namespace>
+kubectl --context=dev-euw.tail388b2e.ts.net logs <pod> -n <namespace> --tail=100
+kubectl --context=dev-euw.tail388b2e.ts.net logs -l app=<label> -n <namespace>
+
+# Events
+kubectl --context=dev-euw.tail388b2e.ts.net get events -n <namespace> --sort-by='.lastTimestamp'
+
+# Resource details
+kubectl --context=dev-euw.tail388b2e.ts.net get pod <pod> -n <namespace> -o yaml
+kubectl --context=dev-euw.tail388b2e.ts.net top pods -n <namespace>
+kubectl --context=dev-euw.tail388b2e.ts.net top nodes
+```
+
+## Forbidden Commands
+
+**NEVER run these commands:**
+- `kubectl apply`
+- `kubectl create`
+- `kubectl delete`
+- `kubectl edit`
+- `kubectl patch`
+- `kubectl replace`
+- `kubectl scale`
+- `kubectl rollout restart`
+- `kubectl exec`
+- `kubectl port-forward`
+- Any command that modifies cluster state
+
+If user requests a write operation, explain this skill is read-only and suggest using ArgoCD for deployments.
+
+## Workflow
+
+1. Run `kubectl config get-contexts` to check available clusters
+2. If Tailscale clusters missing, prompt user to run `tailscale configure kubeconfig <cluster>`
+3. If user mentions "dev" → use `dev-euw.tail388b2e.ts.net`
+4. If user mentions "staging" → use `stg-nae.tail388b2e.ts.net`
+5. If user asks about "prod" or "ic-2" → **refuse**, explain exclusion
+
+## Examples
+
+```bash
+# Check pods in dev
+kubectl --context=dev-euw.tail388b2e.ts.net get pods -A | grep -v Running
+
+# Get logs from staging
+kubectl --context=stg-nae.tail388b2e.ts.net logs -l app=my-service -n default --tail=50
+
+# Describe failing pod
+kubectl --context=dev-euw.tail388b2e.ts.net describe pod crash-loop-pod -n my-namespace
+
+# Check node resources
+kubectl --context=dev-euw.tail388b2e.ts.net top nodes
+```

--- a/.claude/skills/tempo-fuzz/SKILL.md
+++ b/.claude/skills/tempo-fuzz/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: tempo-fuzz
+description: Running fuzz tests for Tempo precompiles using tempo-foundry. Use when testing Rust precompile implementations or syncing with Solidity implementations.
+---
+
+# Tempo Fuzz Testing
+
+## Overview
+
+Tempo uses a dual-testing approach to ensure Rust precompile implementations match Solidity reference implementations. The same test suite runs against both:
+
+1. **Solidity implementations** - Using standard Foundry (`forge`)
+2. **Rust precompile implementations** - Using tempo-foundry's custom `forge` binary
+
+## Repository Structure
+
+```
+Tempo/
+├── tempo/                    # Main Tempo node (Rust) - often has multiple git worktrees
+│   └── docs/specs/          # Solidity specs and fuzz tests
+│       ├── src/             # Solidity reference implementations
+│       ├── test/            # Test files (*.t.sol)
+│       ├── tempo-forge      # Script to run tempo-foundry's forge
+│       ├── tempo-cast       # Script to run tempo-foundry's cast
+│       └── foundry.toml     # Foundry configuration
+└── tempo-foundry/           # Foundry fork with Tempo's EVM (sibling directory)
+```
+
+## How the `isTempo` Flag Works
+
+The test suite uses an `isTempo` flag (defined in `BaseTest.t.sol`) to detect which implementation is being tested:
+
+```solidity
+isTempo = _TIP403REGISTRY.code.length + _TIP20FACTORY.code.length + _PATH_USD.code.length
+        + _STABLECOIN_DEX.code.length + _NONCE.code.length > 0;
+```
+
+- **`isTempo = false`**: No precompile code exists at expected addresses. Tests deploy Solidity implementations via `deployCodeTo()`. This is the default when using standard `forge`.
+- **`isTempo = true`**: Native precompile code exists at addresses like `0x403c...` (TIP403Registry), `0x20Fc...` (TIP20Factory). Tests run against Rust precompiles built into tempo-foundry's EVM.
+
+### Precompile Addresses
+
+| Precompile | Address | Notes |
+|------------|---------|-------|
+| TIP403Registry | `0x403c000000000000000000000000000000000000` | |
+| TIP20Factory | `0x20Fc000000000000000000000000000000000000` | |
+| PathUSD | `0x20C0000000000000000000000000000000000000` | TIP20 at token_id=0 |
+| StablecoinExchange | `0xDEc0000000000000000000000000000000000000` | |
+| FeeManager | `0xfeEC000000000000000000000000000000000000` | Also called FeeAMM |
+| Nonce | `0x4e4F4E4345000000000000000000000000000000` | |
+| ValidatorConfig | `0xCccCcCCC00000000000000000000000000000000` | |
+| AccountKeychain | `0xAAAAAAAA00000000000000000000000000000000` | Access key management |
+
+## Running Tests
+
+### Option 1: Test Against Solidity Implementations (Standard Foundry)
+
+```bash
+cd docs/specs
+
+# Run all tests
+forge test
+
+# Verbose output
+forge test -vvv
+
+# Run specific test
+forge test --match-test test_mint
+
+# Run tests in a specific file
+forge test --match-path test/TIP20.t.sol
+```
+
+### Option 2: Test Against Rust Precompiles (tempo-foundry)
+
+```bash
+cd docs/specs
+
+# Run all tests against Rust precompiles
+./tempo-forge test
+
+# Verbose output
+./tempo-forge test -vvv
+
+# Run specific test
+./tempo-forge test --match-test test_mint
+
+# Run tests in a specific file
+./tempo-forge test --match-path test/TIP20.t.sol
+
+# Build contracts only
+./tempo-forge build
+```
+
+## Setting Up tempo-foundry
+
+### Option 1: Clone as Sibling Directory (Recommended)
+
+```bash
+# From tempo repo root
+cd ..
+git clone git@github.com:tempoxyz/tempo-foundry.git
+```
+
+### Option 2: Set Environment Variable
+
+```bash
+export TEMPO_FOUNDRY_PATH=/path/to/tempo-foundry
+./tempo-forge test
+```
+
+### Building tempo-foundry Manually
+
+The `tempo-forge` script auto-builds on first run, but you can build manually:
+
+```bash
+cd /path/to/tempo-foundry
+cargo build -p forge --profile dev
+cargo build -p cast --profile dev
+```
+
+If you encounter build errors:
+
+```bash
+cargo clean
+cargo build -p forge --profile dev
+```
+
+## Using tempo-cast
+
+The `tempo-cast` script runs cast commands using tempo-foundry's custom cast binary:
+
+```bash
+# Get function signature
+./tempo-cast sig "transfer(address,uint256)"
+
+# Decode function selector
+./tempo-cast 4byte 0xa9059cbb
+
+# ABI encode
+./tempo-cast abi-encode "transfer(address,uint256)" 0x1234...5678 1000000
+```
+
+## Writing Tests
+
+### Test File Location
+
+All test files go in `docs/specs/test/` with the `.t.sol` extension.
+
+### Base Test Contract
+
+All tests should inherit from `BaseTest`:
+
+```solidity
+import { BaseTest } from "./BaseTest.t.sol";
+
+contract MyTest is BaseTest {
+    function setUp() public override {
+        super.setUp();
+        // Your setup code
+    }
+}
+```
+
+### Handling Implementation Differences
+
+Use `isTempo` to handle differences between Solidity and Rust implementations:
+
+```solidity
+function testTransfer() public {
+    // Some event expectations only work in Solidity mode
+    if (!isTempo) {
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, bob, amount);
+    }
+    
+    token.transfer(bob, amount);
+    
+    // Assertions work in both modes
+    assertEq(token.balanceOf(bob), amount);
+}
+```
+
+### Fuzz Tests
+
+Fuzz tests use the `testFuzz_` prefix:
+
+```solidity
+function testFuzz_setRewardRecipient(address recipient) public {
+    vm.prank(alice);
+    token.setRewardRecipient(recipient);
+    assertEq(token.rewardRecipient(alice), recipient);
+}
+```
+
+### Available Test Helpers
+
+From `BaseTest.t.sol`:
+
+- `admin`, `alice`, `bob`, `charlie` - Common test addresses
+- `factory` - TIP20Factory instance
+- `pathUSD` - PathUSD token instance
+- `exchange` - StablecoinExchange instance
+- `registry` - TIP403Registry instance
+- `nonce` - Nonce precompile instance
+- `validatorConfig` - ValidatorConfig instance
+- `amm` - FeeManager instance (at `_FEE_AMM` address)
+- `token1`, `token2` - Pre-created test tokens
+- Role constants: `_ISSUER_ROLE`, `_PAUSE_ROLE`, `_UNPAUSE_ROLE`, `_TRANSFER_ROLE`, `_RECEIVE_WITH_MEMO_ROLE`
+
+### Test Files
+
+Current test files in `docs/specs/test/`:
+- `AccountKeychain.t.sol` - Interface tests using mocks
+- `BaseTest.t.sol` - Base test framework
+- `FeeAMM.t.sol`, `FeeManager.t.sol` - Fee/AMM precompile tests
+- `Nonce.t.sol` - Nonce precompile tests
+- `StablecoinExchange.t.sol` - DEX precompile tests
+- `TIP20.t.sol`, `TIP20Factory.t.sol`, `TIP20RolesAuth.t.sol` - Token tests
+- `TIP403Registry.t.sol` - Registry tests
+- `ValidatorConfig.t.sol` - Validator config tests
+
+## CI Integration
+
+CI runs both test modes to ensure implementations stay in sync (see `.github/workflows/docs-specs.yml`):
+
+1. **Forge Build** - Builds Solidity contracts
+2. **Forge Fmt** - Checks Solidity formatting
+3. **Forge Test (Solidity)** - Validates Solidity implementations with `forge test -vvv`
+4. **Forge Test (Rust Precompiles)** - Validates Rust precompiles match Solidity specs
+
+### How Rust Precompile CI Works
+
+The CI automatically:
+1. Checks out both `tempo` and `tempo-foundry` repos
+2. Updates tempo-foundry's `Cargo.toml` to point to the PR's commit SHA
+3. Builds tempo-foundry's forge binary
+4. Runs tests with `isTempo=true`
+
+**Note:** The tempo-foundry-test job is in `allowed-failures` since it depends on external repo state. Failures don't block merge but should be investigated.
+
+## Troubleshooting
+
+### tempo-foundry not found
+
+```
+Error: Could not find tempo-foundry repository.
+```
+
+Either clone tempo-foundry as a sibling directory or set `TEMPO_FOUNDRY_PATH`.
+
+### Missing precompile errors
+
+```
+MissingPrecompile("TIP403Registry", 0x403c...)
+```
+
+This means you're running with tempo-foundry but a precompile is missing. Ensure tempo-foundry is up to date with the latest precompile implementations.
+
+### Build failures
+
+```bash
+cd /path/to/tempo-foundry
+cargo clean
+cargo build -p forge --profile dev
+```
+
+### Test passes in Solidity but fails in Rust
+
+This indicates an implementation mismatch - the exact purpose of this testing setup. Debug by:
+
+1. Running with `-vvv` for verbose output
+2. Checking if `isTempo` conditional logic is correct
+3. Comparing return values and state changes between modes

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ profile.json.gz
 !.envrc
 localnet/**
 
-.claude/
+.claude/settings.local.json
 !docs/.claude/
 
 # Docs


### PR DESCRIPTION
Adds project level skills that can be reused by people, using amp/claude for their workflows. 
Unlike Claude/Agent.md files, Skills don't use context until explicitly invoked.