### PR TITLE
refactor(consensus): surface the executor actor

### DIFF
--- a/crates/commonware-node/src/consensus/application/mod.rs
+++ b/crates/commonware-node/src/consensus/application/mod.rs
@@ -1,4 +1,7 @@
-//! Drives the execution engine by forwarding consensus messages.
+//! The interface between the consensus layer and the execution layer.
+//!
+//! The application actor implements the [`commonware_consensus::Automaton`]
+//! trait to propose and verify blocks.
 
 use std::time::Duration;
 
@@ -8,8 +11,6 @@ use commonware_runtime::{Metrics, Pacer, Spawner, Storage};
 use eyre::WrapErr as _;
 use rand::{CryptoRng, Rng};
 use tempo_node::TempoFullNode;
-
-mod executor;
 
 mod actor;
 mod ingress;
@@ -39,15 +40,14 @@ pub(super) struct Config<TContext> {
     /// Used as PayloadAttributes.suggested_fee_recipient
     pub(super) fee_recipient: alloy_primitives::Address,
 
-    /// The last finalized height according to the consensus layer.
-    pub(super) last_finalized_height: u64,
-
     /// Number of messages from consensus to hold in our backlog
     /// before blocking.
     pub(super) mailbox_size: usize,
 
     /// For subscribing to blocks distributed via the consensus p2p network.
     pub(super) marshal: crate::alias::marshal::Mailbox,
+
+    pub(super) executor: crate::executor::Mailbox,
 
     /// A handle to the execution node to verify and create new payloads.
     pub(super) execution_node: TempoFullNode,

--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -1,0 +1,87 @@
+use commonware_consensus::{Reporter, marshal::Update};
+use eyre::WrapErr as _;
+use futures::{
+    SinkExt as _,
+    channel::{mpsc, oneshot},
+};
+use tracing::Span;
+
+use crate::consensus::{Digest, block::Block};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Mailbox {
+    pub(super) inner: mpsc::UnboundedSender<Message>,
+}
+
+impl Mailbox {
+    /// Requests the agent to update the head of the canonical chain to `digest`.
+    pub(crate) fn canonicalize_head(
+        &self,
+        height: u64,
+        digest: Digest,
+    ) -> eyre::Result<oneshot::Receiver<()>> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .unbounded_send(Message::in_current_span(CanonicalizeHead {
+                height,
+                digest,
+                ack: tx,
+            }))
+            .wrap_err("failed sending canonicalize request to agent, this means it exited")?;
+
+        Ok(rx)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Message {
+    pub(super) cause: Span,
+    pub(super) command: Command,
+}
+
+impl Message {
+    fn in_current_span(command: impl Into<Command>) -> Self {
+        Self {
+            cause: Span::current(),
+            command: command.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum Command {
+    /// Requests the agent to set the head of the canonical chain to `digest`.
+    CanonicalizeHead(CanonicalizeHead),
+    /// Requests the agent to forward a finalization event to the execution layer.
+    Finalize(Box<Update<Block>>),
+}
+
+#[derive(Debug)]
+pub(super) struct CanonicalizeHead {
+    pub(super) height: u64,
+    pub(super) digest: Digest,
+    pub(super) ack: oneshot::Sender<()>,
+}
+
+impl From<CanonicalizeHead> for Command {
+    fn from(value: CanonicalizeHead) -> Self {
+        Self::CanonicalizeHead(value)
+    }
+}
+
+impl From<Update<Block>> for Command {
+    fn from(value: Update<Block>) -> Self {
+        Self::Finalize(value.into())
+    }
+}
+
+impl Reporter for Mailbox {
+    type Activity = Update<Block>;
+
+    async fn report(&mut self, update: Self::Activity) {
+        self.inner
+            .send(Message::in_current_span(update))
+            .await
+            .expect("actor is present and ready to receive broadcasts");
+    }
+}

--- a/crates/commonware-node/src/executor/mod.rs
+++ b/crates/commonware-node/src/executor/mod.rs
@@ -1,0 +1,39 @@
+//! The executor is sending fork-choice-updates to the execution layer.
+use commonware_runtime::{Metrics, Pacer, Spawner};
+
+mod actor;
+mod ingress;
+
+pub(crate) use actor::Actor;
+use eyre::WrapErr as _;
+use futures::channel::mpsc;
+pub(crate) use ingress::Mailbox;
+use tempo_node::TempoFullNode;
+
+pub(crate) fn init<TContext>(
+    context: TContext,
+    config: Config,
+) -> eyre::Result<(Actor<TContext>, Mailbox)>
+where
+    TContext: Metrics + Pacer + Spawner,
+{
+    let (tx, rx) = mpsc::unbounded();
+    let mailbox = Mailbox { inner: tx };
+    let actor = Actor::init(context, config, rx).wrap_err("failed initializing actor")?;
+    Ok((actor, mailbox))
+}
+
+pub(crate) struct Config {
+    /// A handle to the execution node layer. Used to forward finalized blocks
+    /// and to update the canonical chain by sending forkchoice updates.
+    pub(crate) execution_node: TempoFullNode,
+
+    /// The last finalized height according to the consensus layer.
+    /// If on startup there is a mismatch between the execution layer and the
+    /// consensus, then the node will fill the gap by backfilling blocks to
+    /// the execution layer until `last_finalized_height` is reached.
+    pub(crate) last_finalized_height: u64,
+
+    /// The mailbox of the marshal actor. Used to backfill blocks.
+    pub(crate) marshal: crate::alias::marshal::Mailbox,
+}

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod config;
 pub mod consensus;
 pub(crate) mod dkg;
 pub(crate) mod epoch;
+pub(crate) mod executor;
 pub mod metrics;
 pub(crate) mod utils;
 


### PR DESCRIPTION
Moves the `executor` out of `consensus/application` to the top level of the crate. This is a refactor and does not come with new implementation details.

This is a first step in making it a free-standing actor that uses consensus activity as a trigger to send forkchoice-updates to the execution layer (that is, a notarization maps to a `fcu.head_block_hash` while a finalization maps to a `fcu.finalized_block_hash`). This is opposed to the current behavior, where notarizations are implicitly assumed when proposing and verifying.