### PR TITLE
docs: remove deadlink from nav

### DIFF
--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -383,10 +383,6 @@ export default defineConfig({
                 link: "/protocol/transactions/AccountKeychain",
               },
               {
-                text: "Default Delegation Specification",
-                link: "/protocol/transactions/spec-default-delegation",
-              },
-              {
                 text: "Rust Implementation",
                 link: "https://github.com/tempoxyz/tempo/blob/main/crates/primitives/src/transaction/tempo_transaction.rs",
               },


### PR DESCRIPTION
This PR removes a deadlink from the navigation sidebar. The link to '/protocol/transactions/spec-default-delegation' was pointing to a non-existent page and has been removed.