### PR TITLE
fix: remove unnecessary checks on `TIPFeeManager.burn()`

### DIFF
--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -636,44 +636,6 @@ mod tests {
     }
 
     #[test]
-    fn test_burn_rejects_non_usd_tokens() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let eur_token = TIP20Setup::create("EuroToken", "EUR", admin)
-                .currency("EUR")
-                .apply()?;
-            let usd_token = TIP20Setup::create("USDToken", "USD", admin).apply()?;
-            let mut amm = TipFeeManager::new();
-
-            let result = amm.burn(
-                admin,
-                eur_token.address(),
-                usd_token.address(),
-                U256::from(1000),
-                admin,
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidCurrency(_)))
-            ));
-
-            let result = amm.burn(
-                admin,
-                usd_token.address(),
-                eur_token.address(),
-                U256::from(1000),
-                admin,
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::InvalidCurrency(_)))
-            ));
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_rebalance_swap_rejects_non_usd_tokens() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let admin = Address::random();


### PR DESCRIPTION
This PR updates `TIPFeeManager.burn()` to remove unnecessary USD checks to have parity with the spec implementation. We already validate that tokens are USD based when calling `mint()` which ensures all liquid pools are USD based.

```rust
    /// Mint LP tokens
    pub fn mint(
        &mut self,
        msg_sender: Address,
        user_token: Address,
        validator_token: Address,
        amount_validator_token: U256,
        to: Address,
    ) -> Result<U256> {
        if user_token == validator_token {
            return Err(TIPFeeAMMError::identical_addresses().into());
        }

        // Validate both tokens are USD currency
        validate_usd_currency(user_token)?;
        validate_usd_currency(validator_token)?;

// --snip--
```