### PR TITLE
feat!(precompiles): remove `TIPFeeManager.get_fee_token_balance()`

### DIFF
--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -30,7 +30,6 @@ crate::sol! {
         function setValidatorToken(address token) external;
 
         // Fee functions
-        function getFeeTokenBalance(address sender, address validator) external view returns (address, uint256);
         function distributeFees(address validator, address token) external;
         function collectedFees(address validator, address token) external view returns (uint256);
         // NOTE: collectFeePreTx is a protocol-internal function called directly by the

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -34,11 +34,6 @@ impl Precompile for TipFeeManager {
                     self.validator_tokens(call)
                 })
             }
-            IFeeManager::getFeeTokenBalanceCall::SELECTOR => {
-                view::<IFeeManager::getFeeTokenBalanceCall>(calldata, |call| {
-                    self.get_fee_token_balance(call)
-                })
-            }
             ITIPFeeAMM::getPoolIdCall::SELECTOR => {
                 view::<ITIPFeeAMM::getPoolIdCall>(calldata, |call| {
                     Ok(self.pool_id(call.userToken, call.validatorToken))

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -236,25 +236,6 @@ impl TipFeeManager {
             Ok(token)
         }
     }
-
-    pub fn get_fee_token_balance(
-        &self,
-        call: IFeeManager::getFeeTokenBalanceCall,
-    ) -> Result<IFeeManager::getFeeTokenBalanceReturn> {
-        let mut token = self.user_tokens[call.sender].read()?;
-        if token.is_zero() {
-            token = DEFAULT_FEE_TOKEN;
-        }
-
-        let token_balance = TIP20Token::from_address(token)?.balance_of(ITIP20::balanceOfCall {
-            account: call.sender,
-        })?;
-
-        Ok(IFeeManager::getFeeTokenBalanceReturn {
-            _0: token,
-            _1: token_balance,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -783,34 +764,6 @@ mod tests {
             let fee_manager = TipFeeManager::new();
             let remaining = fee_manager.collected_fees[validator][token.address()].read()?;
             assert_eq!(remaining, U256::ZERO);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_get_fee_token_balance_fallback() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let user = Address::random();
-        let validator = Address::random();
-        let admin = Address::random();
-
-        StorageCtx::enter(&mut storage, || {
-            let balance = U256::from(1000);
-            let _path_usd = TIP20Setup::path_usd(admin)
-                .with_issuer(admin)
-                .with_mint(user, balance)
-                .apply()?;
-
-            let fee_manager = TipFeeManager::new();
-            let call = IFeeManager::getFeeTokenBalanceCall {
-                sender: user,
-                validator,
-            };
-            let result = fee_manager.get_fee_token_balance(call)?;
-
-            assert_eq!(result._0, DEFAULT_FEE_TOKEN);
-            assert_eq!(result._1, balance);
 
             Ok(())
         })


### PR DESCRIPTION
This PR updates the `TIPFeeManager` by removing the `get_fee_token_balance()` function to align with the specification. This function could potentially be misleading, as a user might check their fee token balance via this call and then submit a transaction where the fee token is inferred, resulting in a different balance than the one originally returned.

Users can still check fee tokens via the `TIPFeeManager` and call `balanceOf` directly on the corresponding `TIP20` to check their balance.
