### PR TITLE
docs(precompiles): remove stale comment in `set_validator_token`

### DIFF
--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -61,10 +61,6 @@ impl TipFeeManager {
             return Err(FeeManagerError::invalid_token().into());
         }
 
-        // FIXME: Either ensure that there are no pending fees for a given
-        // validator before updating the fee token, or update the pending fees structure
-        // to a mapping so that a validator can have multiple fee balances for tokens
-
         // Prevent changing within the validator's own block
         if sender == beneficiary {
             return Err(FeeManagerError::cannot_change_within_block().into());


### PR DESCRIPTION
This PR removes a stale `FIXME` comment in the `TIPFeeManager`. Pending fees have been removed with #1537. Further, collected fees are now tracked via a mapping with #1798, allowing validators to switch fee tokens while they still have a collected fees balance for a given token.