### PR TITLE
chore: bump msrv to 1.91

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.88" # MSRV
+          toolchain: "1.91" # MSRV
       - uses: rui314/setup-mold@v1
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build with MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.8.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 publish = false
 


### PR DESCRIPTION
Sets the workspace rust version to `1.91`. Required because commonware started using rust 1.91 features in https://github.com/commonwarexyz/monorepo/commit/45b0c9a62e8f643d8dc42a291a5c57631838293a (specifically, `std::time::Duration::from_hours` which only got stabilized in 1.91).