### PR TITLE
feat(specs): remove `FeeSwap` event to align with precompile impl

### DIFF
--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -68,8 +68,6 @@ contract FeeAMM is IFeeAMM {
 
         pool.reserveUserToken += uint128(amountIn);
         pool.reserveValidatorToken -= uint128(amountOut);
-
-        emit FeeSwap(userToken, validatorToken, amountIn, amountOut);
     }
 
     function rebalanceSwap(address userToken, address validatorToken, uint256 amountOut, address to)
@@ -152,7 +150,9 @@ contract FeeAMM is IFeeAMM {
 
         Pool storage pool = pools[poolId];
 
-        if (liquidityBalances[poolId][msg.sender] < liquidity) revert InsufficientLiquidity();
+        if (liquidityBalances[poolId][msg.sender] < liquidity) {
+            revert InsufficientLiquidity();
+        }
 
         // Calculate amounts
         (amountUserToken, amountValidatorToken) = _calculateBurnAmounts(pool, poolId, liquidity);

--- a/docs/specs/src/interfaces/IFeeAMM.sol
+++ b/docs/specs/src/interfaces/IFeeAMM.sol
@@ -17,12 +17,6 @@ interface IFeeAMM {
         uint256 liquidity,
         address to
     );
-    event FeeSwap(
-        address indexed userToken,
-        address indexed validatorToken,
-        uint256 amountIn,
-        uint256 amountOut
-    );
     event Mint(
         address sender,
         address indexed to,


### PR DESCRIPTION
This PR removes the `FeeSwap` event from the Solidity TIPFeeManager spec implementation to align with the precompile impl.