### PR TITLE
fix(specs): update `isTIP20()` in `TempoUtils` to match `is_tip20` in precompiles

### DIFF
--- a/docs/specs/src/TempoUtilities.sol
+++ b/docs/specs/src/TempoUtilities.sol
@@ -14,14 +14,9 @@ library TempoUtilities {
     address internal constant _VALIDATOR_CONFIG = 0xCccCcCCC00000000000000000000000000000000;
 
     function isTIP20(address token) internal view returns (bool) {
-        bool isTempo = _TIP403REGISTRY.code.length + _TIP20FACTORY.code.length
-                + _PATH_USD.code.length + _STABLECOIN_DEX.code.length + _NONCE.code.length == 5;
-
-        // If this is tempo mainnet, we use code == 0xEF check
-        // Otherwise we just check that the address has code
-        return bytes12(bytes20(token)) == bytes12(0x20c000000000000000000000)
-            && ((isTempo && token.code.length == 1 && token.code[0] == hex"EF")
-                || (!isTempo && token.code.length > 0));
+        // Check if address has TIP20 prefix and non-empty code
+        return
+            bytes12(bytes20(token)) == bytes12(0x20c000000000000000000000) && token.code.length > 0;
     }
 
 }


### PR DESCRIPTION
This PR updates the `isTIP20()` implementation from the `TempoUtilities` lib to match the `is_tip20()` impl in the precompiles. Specifically, this updates the `isTIP20` function to check if `code size > 0`, rather than if `code == 0xef`