### PR TITLE
perf!(precompiles): drop useless validator_count state var

### DIFF
--- a/crates/precompiles/src/validator_config/mod.rs
+++ b/crates/precompiles/src/validator_config/mod.rs
@@ -103,7 +103,7 @@ impl ValidatorConfig {
     /// Get all validators (view function)
     pub fn get_validators(&self) -> Result<Vec<IValidatorConfig::Validator>> {
         let count = self.validators_array.len()?;
-        let mut validators = Vec::new();
+        let mut validators = Vec::with_capacity(count);
 
         for i in 0..count {
             // Read validator address from the array at index i


### PR DESCRIPTION
This PR drops `validator_count`, as it is useless and redundant.

The variable 1:1 tracks the state of `validators_array`'s length slot. Thus, we can skip extra SLOAD/SSTOREs by simply reading the correct slot.

**IMPORTANT:** this PR changes the storage layout as it gets rid of one var