### PR TITLE
feat: Add info note on fee atomicity

### DIFF
--- a/docs/pages/protocol/fees/spec-fee.mdx
+++ b/docs/pages/protocol/fees/spec-fee.mdx
@@ -32,6 +32,10 @@ After the execution of each transaction:
 * Credit the `fee_payer`'s address with `refund_amount` of `fee_token`.
 * Log a `Transfer` event from the user to the [fee manager contract](/protocol/fees/spec-fee-amm) for the net amount of the fee payment.
 
+:::info[Atomic fee handling]
+The protocol executes the max fee deduction and refund atomically. If insufficient liquidity is encountered at any point during fee calculation (for example, if a previous transaction by the same sender in the same block exhausted the fee token reserves), the entire transaction reverts.
+:::
+
 ## Fee payer
 
 Tempo supports *sponsored transactions* in which the `fee_payer` is a different address from the `tx.origin` of the transaction. This is supported by Tempo's [new transaction type](/protocol/transactions/spec-tempo-transaction.mdx), which has a `fee_payer_signature` field.


### PR DESCRIPTION
Adds blurb on fee atomicity (see blue part)

<img width="1534" height="1372" alt="image" src="https://github.com/user-attachments/assets/d761bfcc-51b2-46f0-ab95-f457636972ae" />
