### PR TITLE
chore!(consensus): reindex p2p channels

### DIFF
--- a/crates/commonware-node/src/config.rs
+++ b/crates/commonware-node/src/config.rs
@@ -21,7 +21,7 @@ pub const RESOLVER_CHANNEL_IDENT: commonware_p2p::Channel = 2;
 pub const BROADCASTER_CHANNEL_IDENT: commonware_p2p::Channel = 3;
 pub const MARSHAL_CHANNEL_IDENT: commonware_p2p::Channel = 4;
 pub const DKG_CHANNEL_IDENT: commonware_p2p::Channel = 5;
-pub const SUBBLOCKS_CHANNEL_IDENT: commonware_p2p::Channel = 7;
+pub const SUBBLOCKS_CHANNEL_IDENT: commonware_p2p::Channel = 6;
 
 pub(crate) const NUMBER_CONCURRENT_FETCHES: usize = 4;
 


### PR DESCRIPTION
Removing the boundary cert channel left a hole. Not a big deal, but why not shift it by 1.