### PR TITLE
chore(feeAMM): align spec with rust implementation, remove unused custom errors

### DIFF
--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -102,35 +102,15 @@ sol! {
         event Mint(address sender, address indexed to, address indexed userToken, address indexed validatorToken, uint256 amountValidatorToken, uint256 liquidity);
         event Burn(address indexed sender, address indexed userToken, address indexed validatorToken, uint256 amountUserToken, uint256 amountValidatorToken, uint256 liquidity, address to);
         event RebalanceSwap(address indexed userToken, address indexed validatorToken, address indexed swapper, uint256 amountIn, uint256 amountOut);
-        event FeeSwap(
-            address indexed userToken,
-            address indexed validatorToken,
-            uint256 amountIn,
-            uint256 amountOut
-        );
 
         // Errors
         error IdenticalAddresses();
-        error ZeroAddress();
-        error PoolExists();
-        error PoolDoesNotExist();
         error InvalidToken();
         error InsufficientLiquidity();
-        error OnlyProtocol();
-        error InsufficientPoolBalance();
         error InsufficientReserves();
-        error InsufficientLiquidityBalance();
-        error MustDepositLowerBalanceToken();
         error InvalidAmount();
-        error InvalidRebalanceState();
-        error InvalidRebalanceDirection();
-        error InvalidNewReserves();
-        error CannotSupportPendingSwaps();
         error DivisionByZero();
         error InvalidSwapCalculation();
-        error InsufficientLiquidityForPending();
-        error TokenTransferFailed();
-        error InternalError();
     }
 }
 
@@ -160,11 +140,6 @@ impl FeeManagerError {
         Self::InsufficientFeeTokenBalance(IFeeManager::InsufficientFeeTokenBalance {})
     }
 
-    /// Creates an error for internal errors.
-    pub const fn internal_error() -> Self {
-        Self::InternalError(IFeeManager::InternalError {})
-    }
-
     /// Creates an error for cannot change within block.
     pub const fn cannot_change_within_block() -> Self {
         Self::CannotChangeWithinBlock(IFeeManager::CannotChangeWithinBlock {})
@@ -187,21 +162,6 @@ impl TIPFeeAMMError {
         Self::IdenticalAddresses(ITIPFeeAMM::IdenticalAddresses {})
     }
 
-    /// Creates an error for zero address.
-    pub const fn zero_address() -> Self {
-        Self::ZeroAddress(ITIPFeeAMM::ZeroAddress {})
-    }
-
-    /// Creates an error when pool already exists.
-    pub const fn pool_exists() -> Self {
-        Self::PoolExists(ITIPFeeAMM::PoolExists {})
-    }
-
-    /// Creates an error when pool does not exist.
-    pub const fn pool_does_not_exist() -> Self {
-        Self::PoolDoesNotExist(ITIPFeeAMM::PoolDoesNotExist {})
-    }
-
     /// Creates an error for invalid token.
     pub const fn invalid_token() -> Self {
         Self::InvalidToken(ITIPFeeAMM::InvalidToken {})
@@ -212,34 +172,13 @@ impl TIPFeeAMMError {
         Self::InsufficientLiquidity(ITIPFeeAMM::InsufficientLiquidity {})
     }
 
-    /// Creates an error for insufficient pool balance.
-    pub const fn insufficient_pool_balance() -> Self {
-        Self::InsufficientPoolBalance(ITIPFeeAMM::InsufficientPoolBalance {})
-    }
-
     /// Creates an error for insufficient reserves.
     pub const fn insufficient_reserves() -> Self {
         Self::InsufficientReserves(ITIPFeeAMM::InsufficientReserves {})
     }
-
-    /// Creates an error for insufficient liquidity balance.
-    pub const fn insufficient_liquidity_balance() -> Self {
-        Self::InsufficientLiquidityBalance(ITIPFeeAMM::InsufficientLiquidityBalance {})
-    }
-
-    /// Creates an error when must deposit lower balance token.
-    pub const fn must_deposit_lower_balance_token() -> Self {
-        Self::MustDepositLowerBalanceToken(ITIPFeeAMM::MustDepositLowerBalanceToken {})
-    }
-
     /// Creates an error for invalid amount.
     pub const fn invalid_amount() -> Self {
         Self::InvalidAmount(ITIPFeeAMM::InvalidAmount {})
-    }
-
-    /// Creates an error for token transfer failure.
-    pub const fn token_transfer_failed() -> Self {
-        Self::TokenTransferFailed(ITIPFeeAMM::TokenTransferFailed {})
     }
 
     /// Creates an error for invalid swap calculation.
@@ -247,23 +186,8 @@ impl TIPFeeAMMError {
         Self::InvalidSwapCalculation(ITIPFeeAMM::InvalidSwapCalculation {})
     }
 
-    /// Creates an error for insufficient liquidity for pending operations.
-    pub const fn insufficient_liquidity_for_pending() -> Self {
-        Self::InsufficientLiquidityForPending(ITIPFeeAMM::InsufficientLiquidityForPending {})
-    }
-
     /// Creates an error for division by zero.
     pub const fn division_by_zero() -> Self {
         Self::DivisionByZero(ITIPFeeAMM::DivisionByZero {})
-    }
-
-    /// Creates an error for invalid new reserves.
-    pub const fn invalid_new_reserves() -> Self {
-        Self::InvalidNewReserves(ITIPFeeAMM::InvalidNewReserves {})
-    }
-
-    /// Creates an error for internal errors.
-    pub const fn internal_error() -> Self {
-        Self::InternalError(ITIPFeeAMM::InternalError {})
     }
 }

--- a/docs/specs/src/interfaces/IFeeAMM.sol
+++ b/docs/specs/src/interfaces/IFeeAMM.sol
@@ -3,9 +3,13 @@ pragma solidity ^0.8.13;
 
 interface IFeeAMM {
 
-    error InsufficientLiquidity();
     error IdenticalAddresses();
     error InvalidToken();
+    error InsufficientLiquidity();
+    error InsufficientReserves();
+    error InvalidAmount();
+    error DivisionByZero();
+    error InvalidSwapCalculation();
     error InvalidCurrency();
 
     event Burn(


### PR DESCRIPTION
Align specification with Rust implementation, specifically a number of cases are not covered in the specification:

- ensuring numbers fit in u128 before casting
- burn does not include `if (userToken == validatorToken) revert IdenticalAddresses()`
- spec should prefer custom errors rather than string reverts and the same as Rust implementation so the interface matches