### PR TITLE
fix(consensus/p2p): enable private ip connections

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -117,6 +117,11 @@ pub struct Args {
     #[arg(long = "consensus.bypass-ip-check", default_value_t = false)]
     pub bypass_ip_check: bool,
 
+    /// Reduces security by enabling connections from private IPs.
+    /// Only enable in trusted network environments.
+    #[arg(long = "consensus.allow-private-ips", default_value_t = false)]
+    pub allow_private_ips: bool,
+
     /// The interval at which to broadcast subblocks to the next proposer.
     /// Each built subblock is immediately broadcasted to the next proposer (if it's known).
     /// We broadcast subblock every `subblock-broadcast-interval` to ensure the next

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -66,6 +66,7 @@ pub async fn run_consensus_stack(
         config.mailbox_size,
         config.max_message_size_bytes,
         config.bypass_ip_check,
+        config.allow_private_ips,
     )
     .await
     .wrap_err("failed to start network")?;
@@ -175,6 +176,7 @@ async fn instantiate_network(
     mailbox_size: usize,
     max_message_size: u32,
     bypass_ip_check: bool,
+    allow_private_ips: bool,
 ) -> eyre::Result<(
     lookup::Network<commonware_runtime::tokio::Context, PrivateKey>,
     lookup::Oracle<PublicKey>,
@@ -186,6 +188,7 @@ async fn instantiate_network(
         mailbox_size,
         tracked_peer_sets: PEERSETS_TO_TRACK,
         bypass_ip_check,
+        allow_private_ips,
         ..lookup::Config::recommended(signing_key, &p2p_namespace, listen_addr, max_message_size)
     };
 


### PR DESCRIPTION
Since we switched to `recommended` p2p configuration, we inadvertently disabled private IP connections. This PR enables us to enable them using a CLI flag