### PR TITLE
commit biome fixes back when docs are not formatted correctly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,10 +40,14 @@ jobs:
         working-directory: docs
         run: bun install
 
-      - name: Check
-        continue-on-error: true
+      - name: Check and fix formatting
         working-directory: docs
-        run: bun run check:ci
+        run: bun run check
+
+      - name: Commit formatting fixes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: auto-fix formatting with biome"
 
       - name: Check types
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Clone repository

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "NODE_OPTIONS=\"--max-old-space-size=16384\" vocs build --searchIndex",
     "check": "biome check . --write --unsafe",
-    "check:ci": "biome check . --diagnostic-level=error",
     "check:types": "tsc --noEmit",
     "dev": "vocs dev",
     "gen:specs": "node scripts/gen-specs.ts",


### PR DESCRIPTION
## Context

From discussion on https://github.com/tempoxyz/tempo/pull/1922, does not fail on broken docs, now just commits diff back