### PR TITLE
chore: remove unused modular-bitfield dependency

### DIFF
--- a/crates/dkg-onchain-artifacts/Cargo.toml
+++ b/crates/dkg-onchain-artifacts/Cargo.toml
@@ -12,7 +12,6 @@ commonware-codec.workspace = true
 commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
 commonware-utils.workspace = true
-modular-bitfield = { version = "0.11.2", optional = true }
 
 [dev-dependencies]
 commonware-math.workspace = true


### PR DESCRIPTION
Removes unused modular-bitfield dependency