### PR TITLE
fix(specs): cache order values before calling `_clearTickBit`

### DIFF
--- a/docs/specs/src/StablecoinDEX.sol
+++ b/docs/specs/src/StablecoinDEX.sol
@@ -577,11 +577,14 @@ contract StablecoinDEX is IStablecoinDEX {
                 );
             }
 
+            bytes32 bookKey = order.bookKey;
+            int16 tick = order.tick;
+
             delete orders[orderId];
 
             // Check if tick is exhausted and return 0 if so
             if (level.head == 0) {
-                _clearTickBit(order.bookKey, order.tick, isBid);
+                _clearTickBit(bookKey, tick, isBid);
                 return 0;
             }
         } else {


### PR DESCRIPTION
The delete on L580 zeroes out the storage values, so on L584 `order.bookKey` and `order.tick` are zero leading to bitmap corruption. Caching the values before calling `_clearTickBit` fixes this.

This bug is not present in the Rust implementation.