### PR TITLE
fix(specs): update bestBidTick/bestAskTick when cancelling last order at best tick

### DIFF
--- a/docs/specs/src/StablecoinDEX.sol
+++ b/docs/specs/src/StablecoinDEX.sol
@@ -421,6 +421,17 @@ contract StablecoinDEX is IStablecoinDEX {
 
         if (level.head == 0) {
             _clearTickBit(order.bookKey, order.tick, isBid);
+
+            // If this was the best tick, find the next best tick
+            if (isBid && book.bestBidTick == order.tick) {
+                (int16 nextTick, bool hasLiquidity) =
+                    nextInitializedBidTick(order.bookKey, order.tick);
+                book.bestBidTick = hasLiquidity ? nextTick : type(int16).min;
+            } else if (!isBid && book.bestAskTick == order.tick) {
+                (int16 nextTick, bool hasLiquidity) =
+                    nextInitializedAskTick(order.bookKey, order.tick);
+                book.bestAskTick = hasLiquidity ? nextTick : type(int16).max;
+            }
         }
 
         // Credit escrow amount to user's withdrawable balance - must match the escrow calculation


### PR DESCRIPTION
When the last order at the best bid/ask tick is cancelled, the contract now scans for the next initialized tick and updates the best tick pointer. Previously, the pointer was left stale, causing swaps to start at an empty tick and potentially loop infinitely or lock liquidity at other ticks.

Matches the Rust implementation:
https://github.com/tempoxyz/tempo/blob/eb2effcaa18629e66856ac02fe5debf867919dc7/crates/precompiles/src/stablecoin_dex/mod.rs#L991-L1014

Note that `cancel_active_order` is called within `cancel_stale_order`, so the `bestBidTick` and `bestAskTick` are both updated when cancelling stale orders, too:

https://github.com/tempoxyz/tempo/blob/eb2effcaa18629e66856ac02fe5debf867919dc7/crates/precompiles/src/stablecoin_dex/mod.rs#L1076