### PR TITLE
chore: add `--max-concurrent-requests` flag to `tempo.nu bench`

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -400,6 +400,7 @@ def "main bench" [
     --tps: int = 10000                              # Target TPS
     --duration: int = 30                            # Duration in seconds
     --accounts: int = 1000                          # Number of accounts
+    --max-concurrent-requests: int = 100            # Max concurrent requests
     --nodes: int = 3                                # Number of consensus nodes (consensus mode only)
     --genesis: string = ""                          # Custom genesis file path (skips generation)
     --samply                                        # Profile nodes with samply
@@ -491,6 +492,7 @@ def "main bench" [
         "--tps" $"($tps)"
         "--duration" $"($duration)"
         "--accounts" $"($accounts)"
+        "--max-concurrent-requests" $"($max_concurrent_requests)"
         "--target-urls" ($rpc_urls | str join ",")
         "--faucet"
         "--clear-txpool"
@@ -587,6 +589,7 @@ def main [] {
     print "  --tps <N>                Target TPS (default: 10000)"
     print "  --duration <N>           Duration in seconds (default: 30)"
     print "  --accounts <N>           Number of accounts (default: 1000)"
+    print "  --max-concurrent-requests <N>  Max concurrent requests (default: 100)"
     print "  --nodes <N>              Number of consensus nodes (default: 3, consensus mode only)"
     print "  --samply                 Profile nodes with samply"
     print "  --samply-args <ARGS>     Additional samply arguments (space-separated)"


### PR DESCRIPTION
### Motivation
- Make `tempo.nu bench` forward a concurrency limit to `tempo-bench` so users can tune request parallelism without editing scripts.

### Description
- Add `--max-concurrent-requests: int = 100` to the `main bench` signature in `tempo.nu` with a default of `100`.
- Pass `--max-concurrent-requests` through to the `tempo-bench` invocation (`run-max-tps` command) when building `bench_cmd`.
- Document the new flag in the bench help output printed by `tempo.nu`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695fe0f8ad5c832190d5ace98c25c482)