### PR TITLE
chore(precompiles): add `FixedBytes` storage test

### DIFF
--- a/crates/precompiles/tests/storage_tests/solidity/primitives.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/primitives.rs
@@ -80,6 +80,28 @@ fn test_arrays_layout() {
 }
 
 #[test]
+fn test_fixed_bytes_layout() {
+    #[contract]
+    struct FixedBytesStruct {
+        field_a: U256,
+        bytes4_field: FixedBytes<4>,
+        bytes16_field: FixedBytes<16>,
+        bytes10_field: FixedBytes<10>,
+        field_b: U256,
+    }
+
+    let rust_layout = layout_fields!(field_a, bytes4_field, bytes16_field, bytes10_field, field_b);
+
+    // Compare against expected layout from Solidity
+    let sol_path = testdata("fixed_bytes.sol");
+    let solc_layout = load_solc_layout(&sol_path);
+
+    if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
+        panic_layout_mismatch("Layout", errors, &sol_path);
+    }
+}
+
+#[test]
 fn test_mappings_layout() {
     #[contract]
     struct Mappings {

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/fixed_bytes.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/fixed_bytes.layout.json
@@ -1,0 +1,73 @@
+{
+  "contracts": {
+    "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout": {
+      "storage-layout": {
+        "storage": [
+          {
+            "astId": 3,
+            "contract": "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout",
+            "label": "fieldA",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256"
+          },
+          {
+            "astId": 5,
+            "contract": "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout",
+            "label": "bytes4Field",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_bytes4"
+          },
+          {
+            "astId": 7,
+            "contract": "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout",
+            "label": "bytes16Field",
+            "offset": 4,
+            "slot": "1",
+            "type": "t_bytes16"
+          },
+          {
+            "astId": 9,
+            "contract": "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout",
+            "label": "bytes10Field",
+            "offset": 20,
+            "slot": "1",
+            "type": "t_bytes10"
+          },
+          {
+            "astId": 11,
+            "contract": "tests/storage_tests/solidity/testdata/fixed_bytes.sol:FixedBytesLayout",
+            "label": "fieldB",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_uint256"
+          }
+        ],
+        "types": {
+          "t_bytes10": {
+            "encoding": "inplace",
+            "label": "bytes10",
+            "numberOfBytes": "10"
+          },
+          "t_bytes16": {
+            "encoding": "inplace",
+            "label": "bytes16",
+            "numberOfBytes": "16"
+          },
+          "t_bytes4": {
+            "encoding": "inplace",
+            "label": "bytes4",
+            "numberOfBytes": "4"
+          },
+          "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        }
+      }
+    }
+  },
+  "version": "0.8.30+commit.73712a01.Linux.g++"
+}

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/fixed_bytes.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/fixed_bytes.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract FixedBytesLayout {
+    uint256 fieldA; // slot 0
+    bytes4 bytes4Field; // slot 1 (first 4 bytes)
+    bytes16 bytes16Field; // slot 1 (next 16 bytes)
+    bytes10 bytes10Field; // slot 1 (last 10 bytes, 2 leftover bytes)
+    uint256 fieldB; // slot 2
+}


### PR DESCRIPTION
This was not explicitly tested, additionally shows the mapping of Solidity's `bytes*` fields <> `FixedBytes<*>`

Artifact from an investigation into alignment of various types during packing

cc @0xrusowsky for visibility