### PR TITLE
docs(node): add --chain testnet flag to RPC node examples

### DIFF
--- a/docs/pages/guide/node/rpc.mdx
+++ b/docs/pages/guide/node/rpc.mdx
@@ -13,10 +13,15 @@ tempo download
 
 # Run node
 tempo node \
+  --chain testnet \
   --follow \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace
 ```
+
+:::info
+When using testnet snapshots, you must specify `--chain testnet`. Without this flag, the node defaults to a different chain specification and will fail with a genesis hash mismatch error.
+:::
 
 ## Manually downloading snapshots
 
@@ -39,6 +44,7 @@ Group=$USER
 Environment=RUST_LOG=info
 WorkingDirectory=$HOME/tempo
 ExecStart=/usr/local/bin/tempo node \\
+  --chain testnet \\
   --datadir <datadir> \\
   --follow \\
   --port 30303 \\

--- a/docs/pages/guide/node/validator.mdx
+++ b/docs/pages/guide/node/validator.mdx
@@ -39,7 +39,8 @@ The process for running a validator node is very similar to [running a full node
 You should start by downloading the latest snapshot using `tempo download` and then running the validator node as such:
 
 ```bash
-tempo node --datadir <datadir> \
+tempo node --chain testnet \
+    --datadir <datadir> \
     --port 30303 \
     --discovery.addr 0.0.0.0 \
     --discovery.port 30303 \


### PR DESCRIPTION
## Summary

- Add the required `--chain testnet` flag to Quick Start and Systemd service examples in the RPC node documentation
- Add the required `--chain testnet` flag to validator node documentation
- Add an info callout explaining when and why this flag is needed

Without this flag, nodes using testnet snapshots fail with a genesis hash mismatch error, which can be confusing for new operators.

Closes #1937

## Test plan

- [ ] Verify docs build successfully with `bun run build`
- [ ] Check that the info callout renders correctly