### PR TITLE
feat(chainspec/node): add follow defaults based on chainspec

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -52,13 +52,9 @@ use tracing::{info, info_span};
 // TODO: migrate this to tempo_node eventually.
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 struct TempoArgs {
-    /// Follow this specific RPC node for block hashes
-    #[arg(
-        long,
-        value_name = "URL",
-        default_missing_value = "wss://rpc.testnet.tempo.xyz",
-        num_args(0..=1)
-    )]
+    /// Follow this specific RPC node for block hashes.
+    /// If provided without a value, defaults to the RPC URL for the selected chain.
+    #[arg(long, value_name = "URL", default_missing_value = "auto", num_args(0..=1))]
     pub follow: Option<String>,
 
     #[command(flatten)]
@@ -145,6 +141,7 @@ fn main() -> eyre::Result<()> {
         )?;
 
         let ret = if node.config.dev.dev || args.follow.is_some() {
+            // When --follow is used (with or without a URL), skip consensus stack
             futures::executor::block_on(async move {
                 shutdown_token_clone.cancelled().await;
                 Ok(())
@@ -263,8 +260,20 @@ fn main() -> eyre::Result<()> {
         } = builder
             .node(TempoNode::new(&args.node_args, validator_key))
             .apply(|mut builder: WithLaunchContext<_>| {
-                if let Some(follow_url) = &args.follow {
-                    builder.config_mut().debug.rpc_consensus_url = Some(follow_url.clone());
+                // Resolve the follow URL:
+                // --follow or --follow=auto -> use chain-specific default
+                // --follow=URL -> use provided URL
+                if let Some(follow) = &args.follow {
+                    let follow_url = if follow == "auto" {
+                        builder
+                            .config()
+                            .chain
+                            .default_follow_url()
+                            .map(|s| s.to_string())
+                    } else {
+                        Some(follow.clone())
+                    };
+                    builder.config_mut().debug.rpc_consensus_url = follow_url;
                 }
 
                 builder

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -80,13 +80,17 @@ impl reth_cli::chainspec::ChainSpecParser for TempoChainSpecParser {
 pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/andantino.json"))
         .expect("`./genesis/andantino.json` must be present and deserializable");
-    TempoChainSpec::from_genesis(genesis).into()
+    TempoChainSpec::from_genesis(genesis)
+        .with_default_follow_url("wss://rpc.testnet.tempo.xyz")
+        .into()
 });
 
 pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/moderato.json"))
         .expect("`./genesis/moderato.json` must be present and deserializable");
-    TempoChainSpec::from_genesis(genesis).into()
+    TempoChainSpec::from_genesis(genesis)
+        .with_default_follow_url("wss://rpc.moderato.tempo.xyz")
+        .into()
 });
 
 /// Development chainspec with funded dev accounts and activated tempo hardforks
@@ -104,9 +108,16 @@ pub struct TempoChainSpec {
     /// [`ChainSpec`].
     pub inner: ChainSpec<TempoHeader>,
     pub info: TempoGenesisInfo,
+    /// Default RPC URL for following this chain.
+    pub default_follow_url: Option<&'static str>,
 }
 
 impl TempoChainSpec {
+    /// Returns the default RPC URL for following this chain.
+    pub fn default_follow_url(&self) -> Option<&'static str> {
+        self.default_follow_url
+    }
+
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].
     pub fn from_genesis(genesis: Genesis) -> Self {
         // Extract Tempo genesis info from extra_fields
@@ -128,7 +139,14 @@ impl TempoChainSpec {
                 inner,
             }),
             info,
+            default_follow_url: None,
         }
+    }
+
+    /// Sets the default follow URL for this chain spec.
+    pub fn with_default_follow_url(mut self, url: &'static str) -> Self {
+        self.default_follow_url = Some(url);
+        self
     }
 }
 
@@ -144,6 +162,7 @@ impl From<ChainSpec> for TempoChainSpec {
                 shared_gas_limit: 0,
             }),
             info: TempoGenesisInfo::default(),
+            default_follow_url: None,
         }
     }
 }


### PR DESCRIPTION
This makes the follow argument default to the correct URL based on the chainspec you are using.

The only thing I don't like is the `auto` sentinel, but the alternative is making the arg `Option<Option<String>>` which seemed unclean too.