### PR TITLE
fix(precompiles): array packing never spans slot boundary

### DIFF
--- a/crates/precompiles/src/storage/packing.rs
+++ b/crates/precompiles/src/storage/packing.rs
@@ -355,10 +355,7 @@ mod tests {
                 let offset = calc_element_offset(idx, elem_bytes);
                 assert!(
                     offset + elem_bytes <= 32,
-                    "elem_bytes={}, idx={}, offset={} would cross slot boundary",
-                    elem_bytes,
-                    idx,
-                    offset
+                    "elem_bytes={elem_bytes}, idx={idx}, offset={offset} would cross slot boundary"
                 );
             }
         }
@@ -1166,7 +1163,7 @@ mod tests {
         ) {
             let slot_count = calc_packed_slot_count(n, elem_bytes);
             let elems_per_slot = 32 / elem_bytes;
-            let expected = n.div_ceil(per_slot);
+            let expected = n.div_ceil(elems_per_slot);
 
             // Verify the calculated slot count is correct
             prop_assert_eq!(slot_count, expected);


### PR DESCRIPTION
## Motivation

The math in functions `calc_packed_slot_count()`, `calc_element_slot()`, `calc_element_offset()` [is incorrect](https://github.com/tempoxyz/tempo/blob/d9d05f07247417a99a951b15d0eb45c5541a1207/crates/precompiles/src/storage/packing.rs#L170-L194) for elements smaller than 16 bytes that do not fit exactly in 32 bytes.

As such, when these elements are packed in a vector, their packing constants are incorrect which results in errors. For example, a `Vec<FixedBytes<11>>` will have its third element assigned to offset 22, crossing the slot boundary.

## Solution

Account the the maximum amount of elements that fit in 32 bytes in all of these calculations.

---

**NOTE:** Despite this would be a breaking change, this PR doesn't require a hardfork cause none of the precompiles use `Vec<T>` where `T::BYTES < 16`