### PR TITLE
chore: simplify size functions

### DIFF
--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -252,9 +252,9 @@ mod tests {
     #[test]
     fn test_slot_size() {
         // slot (U256) 32 bytes + LayoutCtx (usize) 8 bytes + Address 20 bytes (+4 for byte alignment)
-        assert_eq!(std::mem::size_of::<Slot<U256>>(), 64);
-        assert_eq!(std::mem::size_of::<Slot<Address>>(), 64);
-        assert_eq!(std::mem::size_of::<Slot<bool>>(), 64);
+        assert_eq!(size_of::<Slot<U256>>(), 64);
+        assert_eq!(size_of::<Slot<Address>>(), 64);
+        assert_eq!(size_of::<Slot<bool>>(), 64);
     }
 
     #[test]

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -292,7 +292,7 @@ impl reth_primitives_traits::SignedTransaction for TempoTxEnvelope {}
 #[cfg(feature = "reth")]
 impl reth_primitives_traits::InMemorySize for TempoTxType {
     fn size(&self) -> usize {
-        core::mem::size_of::<Self>()
+        size_of::<Self>()
     }
 }
 

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -1,17 +1,14 @@
+use crate::{
+    subblock::{PartialValidatorKey, has_sub_block_nonce_key_prefix},
+    transaction::{
+        AASigned, TempoSignature, TempoSignedAuthorization,
+        key_authorization::SignedKeyAuthorization,
+    },
+};
 use alloy_consensus::{SignableTransaction, Transaction, crypto::RecoveryError};
 use alloy_eips::{Typed2718, eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxKind, U256, keccak256};
 use alloy_rlp::{Buf, BufMut, Decodable, EMPTY_STRING_CODE, Encodable};
-use core::mem;
-
-use crate::transaction::{
-    AASigned, TempoSignature, TempoSignedAuthorization, key_authorization::SignedKeyAuthorization,
-};
-
-use crate::{
-    subblock::{PartialValidatorKey, has_sub_block_nonce_key_prefix},
-    transaction::KeyAuthorization,
-};
 
 /// Tempo transaction type byte (0x76)
 pub const TEMPO_TX_TYPE_ID: u8 = 0x76;
@@ -105,6 +102,10 @@ impl Call {
             list: true,
             payload_length,
         }
+    }
+
+    fn size(&self) -> usize {
+        size_of::<Self>() + self.input.len()
     }
 }
 
@@ -288,23 +289,15 @@ impl TempoTransaction {
     /// Calculates a heuristic for the in-memory size of the transaction
     #[inline]
     pub fn size(&self) -> usize {
-        mem::size_of::<ChainId>() + // chain_id
-        mem::size_of::<Option<Address>>() + // fee_token
-        mem::size_of::<u128>() + // max_priority_fee_per_gas
-        mem::size_of::<u128>() + // max_fee_per_gas
-        mem::size_of::<u64>() + // gas_limit
-        self.calls.iter().map(|call| {
-            mem::size_of::<TxKind>() + mem::size_of::<U256>() + call.input.len()
-        }).sum::<usize>() + // calls
-        self.access_list.size() + // access_list
-        mem::size_of::<U256>() + // nonce_key
-        mem::size_of::<u64>() + // nonce
-        mem::size_of::<Option<Signature>>() + // fee_payer_signature
-        mem::size_of::<Option<u64>>() + // valid_before
-        mem::size_of::<Option<u64>>() + // valid_after
-        // key_authorization (optional)
-        self.key_authorization.as_ref().map(|k| k.size()).unwrap_or(mem::size_of::<Option<KeyAuthorization>>()) +
-        self.tempo_authorization_list.iter().map(|auth| auth.size()).sum::<usize>() // authorization_list
+        size_of::<Self>()
+            + self.calls.iter().map(|call| call.size()).sum::<usize>()
+            + self.access_list.size()
+            + self.key_authorization.as_ref().map_or(0, |k| k.size())
+            + self
+                .tempo_authorization_list
+                .iter()
+                .map(|auth| auth.size())
+                .sum::<usize>()
     }
 
     /// Convert the transaction into a signed transaction
@@ -920,7 +913,7 @@ mod serde_input {
 mod tests {
     use super::*;
     use crate::transaction::{
-        TempoSignedAuthorization,
+        KeyAuthorization, TempoSignedAuthorization,
         tt_signature::{PrimitiveSignature, TempoSignature, derive_p256_address},
     };
     use alloy_eips::eip7702::Authorization;
@@ -1828,62 +1821,6 @@ mod tests {
         );
         assert_eq!(call.value, U256::ONE);
         assert_eq!(call.input, bytes!("0x1234"));
-    }
-
-    #[test]
-    fn test_size_accounts_for_all_fields() {
-        // This test ensures the size() function correctly accounts for all field types.
-        // If you add a new field to TempoTransaction or change a field's type,
-        // you must update both this test AND the size() function.
-        //
-        // The test calculates expected size by summing the size of each field type,
-        // which should match what size() computes for a minimal transaction.
-
-        let dummy_call = Call {
-            to: TxKind::Create,
-            value: U256::ZERO,
-            input: Bytes::new(),
-        };
-
-        let tx = TempoTransaction {
-            chain_id: 1,
-            fee_token: None,
-            max_priority_fee_per_gas: 0,
-            max_fee_per_gas: 0,
-            gas_limit: 0,
-            calls: vec![dummy_call],
-            access_list: Default::default(),
-            nonce_key: U256::ZERO,
-            nonce: 0,
-            fee_payer_signature: None,
-            valid_before: None,
-            valid_after: None,
-            key_authorization: None,
-            tempo_authorization_list: vec![],
-        };
-
-        // Calculate expected size by manually summing field sizes
-        // This acts as a specification that the size() function must match
-        let expected_size = mem::size_of::<ChainId>() + // chain_id: u64
-            mem::size_of::<Option<Address>>() + // fee_token: Option<Address>
-            mem::size_of::<u128>() + // max_priority_fee_per_gas: u128
-            mem::size_of::<u128>() + // max_fee_per_gas: u128
-            mem::size_of::<u64>() + // gas_limit: u64
-            (mem::size_of::<TxKind>() + mem::size_of::<U256>()) + // calls: one call with empty input
-            tx.access_list.size() + // access_list: AccessList
-            mem::size_of::<U256>() + // nonce_key: U256
-            mem::size_of::<u64>() + // nonce: u64
-            mem::size_of::<Option<Signature>>() + // fee_payer_signature: Option<Signature>
-            mem::size_of::<Option<u64>>() + // valid_before: Option<u64>
-            mem::size_of::<Option<u64>>() + // valid_after: Option<u64>
-            mem::size_of::<Option<KeyAuthorization>>(); // key_authorization + empty tempo_authorization_list
-
-        assert_eq!(
-            tx.size(),
-            expected_size,
-            "size() calculation doesn't match expected field sizes. \
-             If you added/changed a field in TempoTransaction, update both size() and this test."
-        );
     }
 
     #[test]

--- a/crates/primitives/src/transaction/tt_authorization.rs
+++ b/crates/primitives/src/transaction/tt_authorization.rs
@@ -108,7 +108,7 @@ impl TempoSignedAuthorization {
 
     /// Calculates a heuristic for the in-memory size of this authorization
     pub fn size(&self) -> usize {
-        core::mem::size_of::<Authorization>() + self.signature.size()
+        size_of::<Self>()
     }
 }
 

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -230,11 +230,11 @@ impl PrimitiveSignature {
 
     /// Get the in-memory size of the signature
     pub fn size(&self) -> usize {
-        match self {
-            Self::Secp256k1(_) => SECP256K1_SIGNATURE_LENGTH,
-            Self::P256(_) => 1 + P256_SIGNATURE_LENGTH,
-            Self::WebAuthn(webauthn_sig) => 1 + webauthn_sig.webauthn_data.len() + 128,
-        }
+        size_of::<Self>()
+            + match self {
+                Self::Secp256k1(_) | Self::P256(_) => 0,
+                Self::WebAuthn(webauthn_sig) => webauthn_sig.webauthn_data.len(),
+            }
     }
 
     /// Recover the signer address from the signature

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -305,10 +305,7 @@ impl Eq for AASigned {}
 #[cfg(feature = "reth")]
 impl reth_primitives_traits::InMemorySize for AASigned {
     fn size(&self) -> usize {
-        core::mem::size_of::<Self>()
-            + self.tx.size()
-            + self.signature.encoded_length()
-            + core::mem::size_of::<B256>()
+        size_of::<Self>() + self.tx.size() + self.signature.size()
     }
 }
 


### PR DESCRIPTION
Use `size_of::<Self>()` instead of manually summing field sizes for in-memory size calculations. This is simpler and more maintainable.

Re-opening #1690
https://github.com/alloy-rs/alloy/pull/3403