### PR TITLE
refactor(docs): remove any types and unsafe type casting

### DIFF
--- a/docs/biome.json
+++ b/docs/biome.json
@@ -21,6 +21,7 @@
         "useLiteralKeys": "off"
       },
       "suspicious": {
+        "noExplicitAny": "error",
         "noUnknownAtRules": "off"
       }
     }

--- a/docs/components/guides/steps/payments/AddFunds.tsx
+++ b/docs/components/guides/steps/payments/AddFunds.tsx
@@ -34,22 +34,18 @@ export function AddFunds(props: DemoStepProps) {
       if (!client) throw new Error('client not found')
 
       if (import.meta.env.VITE_ENVIRONMENT !== 'local')
-        await Actions.faucet.fundSync(
-          client as unknown as Client<Transport, Chain>,
-          { account: address },
-        )
+        await Actions.faucet.fundSync(client as Client<Transport, Chain>, {
+          account: address,
+        })
       else {
-        await Actions.token.transferSync(
-          client as unknown as Client<Transport, Chain>,
-          {
-            account: mnemonicToAccount(
-              'test test test test test test test test test test test junk',
-            ),
-            amount: parseUnits('10000', 6),
-            to: address,
-            token: alphaUsd,
-          },
-        )
+        await Actions.token.transferSync(client as Client<Transport, Chain>, {
+          account: mnemonicToAccount(
+            'test test test test test test test test test test test junk',
+          ),
+          amount: parseUnits('10000', 6),
+          to: address,
+          token: alphaUsd,
+        })
       }
       await new Promise((resolve) => setTimeout(resolve, 400))
       queryClient.refetchQueries({ queryKey: ['getBalance'] })

--- a/docs/components/guides/steps/payments/AddFundsToOthers.tsx
+++ b/docs/components/guides/steps/payments/AddFundsToOthers.tsx
@@ -50,12 +50,12 @@ export function AddFundsToOthers(props: DemoStepProps) {
       let receipts = null
       if (import.meta.env.VITE_ENVIRONMENT !== 'local')
         receipts = await Actions.faucet.fundSync(
-          client as unknown as Client<Transport, Chain>,
+          client as Client<Transport, Chain>,
           { account: targetAddress as Address },
         )
       else {
         const result = await Actions.token.transferSync(
-          client as unknown as Client<Transport, Chain>,
+          client as Client<Transport, Chain>,
           {
             account: mnemonicToAccount(
               'test test test test test test test test test test test junk',

--- a/docs/components/guides/steps/wallet/AddFundsToWallet.tsx
+++ b/docs/components/guides/steps/wallet/AddFundsToWallet.tsx
@@ -39,22 +39,18 @@ export function AddFundsToWallet(props: DemoStepProps) {
       if (!client) throw new Error('client not found')
 
       if (import.meta.env.VITE_ENVIRONMENT !== 'local')
-        await Actions.faucet.fundSync(
-          client as unknown as Client<Transport, Chain>,
-          { account: address },
-        )
+        await Actions.faucet.fundSync(client as Client<Transport, Chain>, {
+          account: address,
+        })
       else {
-        await Actions.token.transferSync(
-          client as unknown as Client<Transport, Chain>,
-          {
-            account: mnemonicToAccount(
-              'test test test test test test test test test test test junk',
-            ),
-            amount: parseUnits('10000', 6),
-            to: address,
-            token: alphaUsd,
-          },
-        )
+        await Actions.token.transferSync(client as Client<Transport, Chain>, {
+          account: mnemonicToAccount(
+            'test test test test test test test test test test test junk',
+          ),
+          amount: parseUnits('10000', 6),
+          to: address,
+          token: alphaUsd,
+        })
       }
       await new Promise((resolve) => setTimeout(resolve, 400))
       queryClient.refetchQueries({ queryKey: ['getBalance'] })

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -11,6 +11,7 @@
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "noImplicitAny": true,
 
     // Style Options
     "noImplicitReturns": true,


### PR DESCRIPTION
- Extract shared executeQuery function from Vercel handler to eliminate need for mocking
- Remove mock request/response objects from Vite dev middleware
- Replace 'as unknown as' double casts with single type assertions
- Add noImplicitAny to tsconfig.json
- Add noExplicitAny rule to biome.json
- All lint and typecheck gates pass
