### PR TITLE
feat: configure custom endpoints via cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11523,6 +11523,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-node-builder",
+ "reth-rpc-server-types",
  "tempo-chainspec",
  "tempo-commonware-node",
  "tempo-commonware-node-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11828,6 +11828,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "clap",
+ "derive_more",
  "eyre",
  "futures",
  "jsonrpsee",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -32,6 +32,7 @@ reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }
 reth-ethereum-cli.workspace = true
 reth-node-builder.workspace = true
+reth-rpc-server-types.workspace = true
 clap.workspace = true
 eyre.workspace = true
 tokio.workspace = true

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -46,7 +46,10 @@ use tempo_faucet::{
 use tempo_node::{
     TempoFullNode, TempoNodeArgs,
     node::TempoNode,
-    rpc::consensus::{TempoConsensusApiServer, TempoConsensusRpc},
+    rpc::{
+        TempoRpcModule,
+        consensus::{TempoConsensusApiServer, TempoConsensusRpc},
+    },
 };
 use tokio::sync::oneshot;
 use tracing::{info, info_span};
@@ -64,7 +67,7 @@ impl RpcModuleValidator for TempoRpcModuleParser {
         if let RpcModuleSelection::Selection(modules) = &selection {
             for module in modules {
                 if let RethRpcModule::Other(name) = module
-                    && !matches!(name.as_str(), "amm" | "dex" | "token" | "policy")
+                    && TempoRpcModule::from_str(name).is_err()
                 {
                     {
                         return Err(format!("Unknown RPC module: '{name}'"));

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -48,6 +48,7 @@ alloy-primitives.workspace = true
 
 async-trait.workspace = true
 clap.workspace = true
+derive_more.workspace = true
 eyre.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4,7 +4,7 @@ use crate::{
     rpc::{
         TempoAdminApi, TempoAdminApiServer, TempoAmm, TempoAmmApiServer, TempoDex,
         TempoDexApiServer, TempoEthApiBuilder, TempoEthExt, TempoEthExtApiServer, TempoPolicy,
-        TempoPolicyApiServer, TempoToken, TempoTokenApiServer,
+        TempoPolicyApiServer, TempoRpcModule, TempoToken, TempoTokenApiServer,
     },
 };
 use alloy_primitives::B256;
@@ -208,19 +208,19 @@ where
                 let admin = TempoAdminApi::new(self.validator_key);
 
                 modules.merge_if_module_configured(
-                    RethRpcModule::Other("dex".to_string()),
+                    RethRpcModule::Other(TempoRpcModule::Dex.to_string()),
                     dex.into_rpc(),
                 )?;
                 modules.merge_if_module_configured(
-                    RethRpcModule::Other("amm".to_string()),
+                    RethRpcModule::Other(TempoRpcModule::Amm.to_string()),
                     amm.into_rpc(),
                 )?;
                 modules.merge_if_module_configured(
-                    RethRpcModule::Other("token".to_string()),
+                    RethRpcModule::Other(TempoRpcModule::Token.to_string()),
                     token.into_rpc(),
                 )?;
                 modules.merge_if_module_configured(
-                    RethRpcModule::Other("policy".to_string()),
+                    RethRpcModule::Other(TempoRpcModule::Policy.to_string()),
                     policy.into_rpc(),
                 )?;
                 modules.merge_if_module_configured(RethRpcModule::Eth, eth_ext.into_rpc())?;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -207,11 +207,23 @@ where
                 let eth_ext = TempoEthExt::new(eth_api);
                 let admin = TempoAdminApi::new(self.validator_key);
 
-                modules.merge_configured(dex.into_rpc())?;
-                modules.merge_configured(amm.into_rpc())?;
-                modules.merge_configured(token.into_rpc())?;
-                modules.merge_configured(policy.into_rpc())?;
-                modules.merge_configured(eth_ext.into_rpc())?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Other("dex".to_string()),
+                    dex.into_rpc(),
+                )?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Other("amm".to_string()),
+                    amm.into_rpc(),
+                )?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Other("token".to_string()),
+                    token.into_rpc(),
+                )?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Other("policy".to_string()),
+                    policy.into_rpc(),
+                )?;
+                modules.merge_if_module_configured(RethRpcModule::Eth, eth_ext.into_rpc())?;
                 modules.merge_if_module_configured(RethRpcModule::Admin, admin.into_rpc())?;
                 modules.merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -488,3 +488,13 @@ where
         Ok(TempoEthApi::new(eth_api, self.validator_key))
     }
 }
+
+/// Enum representing custom Tempo RPC modules.
+#[derive(Debug, Clone, Copy, derive_more::FromStr, derive_more::Display)]
+#[display(rename_all = "lowercase")]
+pub enum TempoRpcModule {
+    Amm,
+    Dex,
+    Token,
+    Policy,
+}


### PR DESCRIPTION
Changes rpc code so that custom endpoints are enabled via `--http.api` arg vs being always enabled by default