### PR TITLE
feat: add periodic spending limits to Access Keys

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -25,6 +25,7 @@ crate::sol! {
         struct TokenLimit {
             address token;
             uint256 amount;
+            uint64 period; // Period duration in seconds (0 = one-time limit, >0 = periodic limit)
         }
 
         /// Key information structure

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -248,6 +248,7 @@ fn create_signed_key_authorization(
                 .map(|_| TokenLimit {
                     token: Address::ZERO,
                     limit: U256::ZERO,
+                    period: None,
                 })
                 .collect(),
         )
@@ -688,6 +689,7 @@ fn create_default_token_limit() -> Vec<tempo_primitives::transaction::TokenLimit
     vec![TokenLimit {
         token: DEFAULT_FEE_TOKEN,
         limit: U256::from(100u64) * U256::from(10).pow(U256::from(18)),
+        period: None,
     }]
 }
 
@@ -3258,6 +3260,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
     let spending_limits = vec![TokenLimit {
         token: DEFAULT_FEE_TOKEN,
         limit: spending_limit_amount,
+        period: None,
     }];
 
     println!("\nCreating key authorization:");
@@ -3729,6 +3732,7 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
         Some(vec![TokenLimit {
             token: DEFAULT_FEE_TOKEN,
             limit: U256::from(10u64) * U256::from(10).pow(U256::from(18)),
+            period: None,
         }]),
     )?;
 
@@ -3853,6 +3857,7 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
         Some(vec![TokenLimit {
             token: DEFAULT_FEE_TOKEN,
             limit: U256::from(10u64) * U256::from(10).pow(U256::from(18)),
+            period: None,
         }]),
     )?;
 
@@ -4903,6 +4908,7 @@ async fn test_aa_keychain_rpc_validation() -> eyre::Result<()> {
     let spending_limits = vec![TokenLimit {
         token: DEFAULT_FEE_TOKEN,
         limit: U256::from(10u64) * U256::from(10).pow(U256::from(18)), // 10 tokens
+        period: None,
     }];
 
     let mock_p256_sig =

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -1607,6 +1607,7 @@ mod tests {
             limits: Some(vec![crate::transaction::TokenLimit {
                 token: address!("0000000000000000000000000000000000000003"),
                 limit: U256::from(10000),
+                period: None,
             }]),
             key_id: address!("0000000000000000000000000000000000000004"),
         }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -826,6 +826,8 @@ where
                             .map(|limit| TokenLimit {
                                 token: limit.token,
                                 amount: limit.limit,
+                                // Convert Option<u64> to u64: None = 0 (one-time limit), Some(x) = x (periodic limit)
+                                period: limit.period.unwrap_or(0),
                             })
                             .collect()
                     })
@@ -1799,10 +1801,12 @@ mod tests {
             TokenLimit {
                 token: Address::random(),
                 limit: U256::from(100),
+                period: None,
             },
             TokenLimit {
                 token: Address::random(),
                 limit: U256::from(200),
+                period: None,
             },
         ];
 
@@ -1931,6 +1935,7 @@ mod tests {
                         .map(|_| TokenLimit {
                             token: Address::random(),
                             limit: U256::from(1000),
+                            period: None,
                         })
                         .collect(),
                 )
@@ -2012,10 +2017,12 @@ mod tests {
                     TokenLimit {
                         token: Address::random(),
                         limit: U256::from(1000),
+                        period: None,
                     },
                     TokenLimit {
                         token: Address::random(),
                         limit: U256::from(2000),
+                        period: None,
                     },
                 ]),
             },

--- a/docs/specs/src/interfaces/IAccountKeychain.sol
+++ b/docs/specs/src/interfaces/IAccountKeychain.sol
@@ -35,6 +35,7 @@ interface IAccountKeychain {
     struct TokenLimit {
         address token; // TIP20 token address
         uint256 amount; // Spending limit amount
+        uint64 period; // Period duration in seconds (0 = one-time limit, >0 = periodic limit)
     }
 
     /// @notice Key information structure

--- a/docs/specs/test/AccountKeychain.t.sol
+++ b/docs/specs/test/AccountKeychain.t.sol
@@ -35,7 +35,8 @@ contract AccountKeychainTest is BaseTest {
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](1);
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
-            amount: 1000e6 // 1000 USDC
+            amount: 1000e6, // 1000 USDC
+            period: 0 // One-time limit
         });
 
         keychain.authorizeKey(
@@ -65,11 +66,13 @@ contract AccountKeychainTest is BaseTest {
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](2);
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
-            amount: 1000e6 // 1000 USDC
+            amount: 1000e6, // 1000 USDC
+            period: 0 // One-time limit
         });
         limits[1] = IAccountKeychain.TokenLimit({
             token: USDT,
-            amount: 500e6 // 500 USDT
+            amount: 500e6, // 500 USDT
+            period: 0 // One-time limit
         });
 
         keychain.authorizeKey(
@@ -150,7 +153,7 @@ contract AccountKeychainTest is BaseTest {
 
         // First authorize a key with initial limits
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](1);
-        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
+        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
 
         keychain.authorizeKey(
             aliceAccessKey,
@@ -411,7 +414,7 @@ contract AccountKeychainTest is BaseTest {
 
         // Authorize a key with only USDC limit
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](1);
-        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
+        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
 
         keychain.authorizeKey(
             aliceAccessKey,
@@ -440,8 +443,8 @@ contract AccountKeychainTest is BaseTest {
 
         // Authorize key with enforceLimits=false but pass limits anyway
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](2);
-        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
-        limits[1] = IAccountKeychain.TokenLimit({ token: USDT, amount: 500e6 });
+        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
+        limits[1] = IAccountKeychain.TokenLimit({ token: USDT, amount: 500e6, period: 0 });
 
         keychain.authorizeKey(
             aliceAccessKey,
@@ -583,10 +586,10 @@ contract AccountKeychainTest is BaseTest {
 
     function test_KeyIsolationBetweenAccounts() public {
         IAccountKeychain.TokenLimit[] memory limits1 = new IAccountKeychain.TokenLimit[](1);
-        limits1[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
+        limits1[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
 
         IAccountKeychain.TokenLimit[] memory limits2 = new IAccountKeychain.TokenLimit[](1);
-        limits2[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 2000e6 });
+        limits2[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 2000e6, period: 0 });
 
         // Same keyId for two different accounts
         address sharedKeyId = address(0x9999);
@@ -710,7 +713,7 @@ contract AccountKeychainTest is BaseTest {
 
         // First authorize
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](1);
-        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
+        limits[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
         keychain.authorizeKey(
             aliceAccessKey,
             IAccountKeychain.SignatureType.P256,
@@ -774,8 +777,8 @@ contract AccountKeychainTest is BaseTest {
         vm.startPrank(alice);
 
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](2);
-        limits[0] = IAccountKeychain.TokenLimit({ token: token1, amount: amount1 });
-        limits[1] = IAccountKeychain.TokenLimit({ token: token2, amount: amount2 });
+        limits[0] = IAccountKeychain.TokenLimit({ token: token1, amount: amount1, period: 0 });
+        limits[1] = IAccountKeychain.TokenLimit({ token: token2, amount: amount2, period: 0 });
 
         keychain.authorizeKey(
             keyId,
@@ -804,7 +807,7 @@ contract AccountKeychainTest is BaseTest {
 
         // First authorize the key
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](1);
-        limits[0] = IAccountKeychain.TokenLimit({ token: token, amount: initialLimit });
+        limits[0] = IAccountKeychain.TokenLimit({ token: token, amount: initialLimit, period: 0 });
 
         keychain.authorizeKey(
             keyId,
@@ -879,10 +882,10 @@ contract AccountKeychainTest is BaseTest {
         vm.assume(keyId != address(0));
 
         IAccountKeychain.TokenLimit[] memory limits1 = new IAccountKeychain.TokenLimit[](1);
-        limits1[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6 });
+        limits1[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 1000e6, period: 0 });
 
         IAccountKeychain.TokenLimit[] memory limits2 = new IAccountKeychain.TokenLimit[](1);
-        limits2[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 2000e6 });
+        limits2[0] = IAccountKeychain.TokenLimit({ token: USDC, amount: 2000e6, period: 0 });
 
         // Authorize same keyId for two different accounts
         vm.prank(account1);


### PR DESCRIPTION
Implements periodic spending limits for Access Keys, enabling subscription-based access patterns where limits automatically reset after a configurable time period.

## Changes

- Add `period` field to `TokenLimit` struct (Rust: `Option<u64>`, Solidity: `uint64`)
- Add storage mappings for period tracking (`period_ends`, `period_limits`, `period_durations`)
- Update `verify_and_update_spending()` to auto-reset limits when period expires
- Update `authorize_key()`, `update_spending_limit()`, and `get_remaining_limit()` to support periodic limits

## Behavior

- `period = 0` (or `None` in Rust): one-time limit that depletes permanently
- `period > 0`: periodic limit that resets every `period` seconds
- Keys can have mixed limits (one-time and periodic for different tokens)

## Use Cases

- Subscription services: "up to X tokens per month"
- Recurring donations: "up to X tokens weekly"
- Payroll systems: monthly salary transfers
- Rate-limited APIs: per-period token budgets

Closes #1865