### PR TITLE
fix: dead link in Chainalysis/Hexagate section

### DIFF
--- a/docs/pages/quickstart/developer-tools.mdx
+++ b/docs/pages/quickstart/developer-tools.mdx
@@ -253,7 +253,7 @@ Learn how Blockaid’s transaction scanning improves security by visiting their 
 
 [Chainalysis](https://www.chainalysis.com) delivers industry-leading onchain intelligence, compliance, and security infrastructure. Through Hexagate, Chainalysis supports Tempo with real-time monitoring, anomaly detection, and threat insights to help developers and platforms better understand and manage onchain risk as the ecosystem grows.
 
-Discover how Hexagate supports Tempo [here](https://www.hexagate.com), or request a dedicated walkthrough from the Chainalysis team through their [demo form](https://www.hexagate.com/request-demo).
+Discover how Hexagate supports Tempo on the [Hexagate product page](https://www.chainalysis.com/product/hexagate/), where you can also request a demo to get a dedicated walkthrough from the Chainalysis team.
 
 ## Issuance
 ### Brale


### PR DESCRIPTION
**Description:**
Updated the Hexagate demo request link in the Chainalysis section. The previous link (`https://www.hexagate.com/request-demo`) was broken. Replaced with the working Hexagate product page (`https://www.chainalysis.com/product/hexagate/`) where users can request a demo.