### PR TITLE
feat(txpool): add configurable limit for AA authorization list size

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -203,6 +203,12 @@ pub enum TempoPoolTransactionError {
         "Insufficient gas for AA transaction: gas limit {gas_limit} is less than intrinsic gas {intrinsic_gas}"
     )]
     InsufficientGasForAAIntrinsicCost { gas_limit: u64, intrinsic_gas: u64 },
+
+    /// Thrown when an AA transaction has too many authorizations in its authorization list.
+    #[error(
+        "Too many authorizations in AA transaction: {count} exceeds maximum allowed {max_allowed}"
+    )]
+    TooManyAuthorizations { count: usize, max_allowed: usize },
 }
 
 impl PoolTransactionError for TempoPoolTransactionError {
@@ -218,7 +224,8 @@ impl PoolTransactionError for TempoPoolTransactionError {
             | Self::InsufficientLiquidity(_) => false,
             Self::NonZeroValue
             | Self::SubblockNonceKey
-            | Self::InsufficientGasForAAIntrinsicCost { .. } => true,
+            | Self::InsufficientGasForAAIntrinsicCost { .. }
+            | Self::TooManyAuthorizations { .. } => true,
         }
     }
 


### PR DESCRIPTION
Closes CHAIN-454

## Summary

Adds a configurable limit for the number of authorizations allowed in AA transactions. The validation runs early in the transaction pool validation pipeline, before signature recovery operations, to efficiently reject transactions that exceed the limit.

**Changes:**
- Added `TooManyAuthorizations` error variant to `TempoPoolTransactionError`
- Added `DEFAULT_MAX_TEMPO_AUTHORIZATIONS` constant (default: 16)
- Added `--txpool.max-tempo-authorizations` CLI flag for configuration
- Added `ensure_authorization_list_size()` check in validator before signature recovery
- Added tests for authorization limit validation