### PR TITLE
feat: add order cancellation, random withdrawals to invariant testing

### DIFF
--- a/docs/specs/test/invariants/StablecoinDEX.t.sol
+++ b/docs/specs/test/invariants/StablecoinDEX.t.sol
@@ -774,10 +774,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
         }
 
         // Compute expected escrowed amounts from all orders (including flip-created orders)
-        (
-            uint256 expectedPathUsdEscrowed,
-            uint256[] memory expectedTokenEscrowed,
-        ) = _computeExpectedEscrow();
+        (uint256 expectedPathUsdEscrowed, uint256[] memory expectedTokenEscrowed,) =
+            _computeExpectedEscrow();
 
         // Assert escrowed amounts: DEX balance = user internal balances + escrowed in active orders
         // Allow tolerance for rounding during partial fills (can accumulate across multiple fills)
@@ -798,7 +796,7 @@ contract StablecoinDEXInvariantTest is BaseTest {
             assertApproxEqAbs(
                 dexTokenBalance,
                 totalUserTokenBalance + expectedTokenEscrowed[t],
-                tolerance,
+                _maxDust,
                 "TEMPO-DEX6: DEX token balance != user balances + escrowed"
             );
         }


### PR DESCRIPTION
1. Added `cancelOrder`, `withdraw` to invariant
2. Added 2 instances of `placeOrder` to better balance out order creation and removal
3. Improve bounds check for dust