### PR TITLE
fix(tempo.nu): ulimit unlimited is a bash-ism

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -509,7 +509,7 @@ def "main bench" [
 
     print $"Running benchmark: ($bench_cmd | str join ' ')"
     try {
-        sh -c $"ulimit -Sn unlimited && ($bench_cmd | str join ' ')"
+        bash -c $"ulimit -Sn unlimited && ($bench_cmd | str join ' ')"
     } catch {
         print "Benchmark interrupted or failed."
     }


### PR DESCRIPTION
ulimit unlimited doesn't work in sh since it's a builtin.