### PR TITLE
fix: update default hardfork

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -40,8 +40,8 @@ hardfork!(
     #[derive(Default)]
     TempoHardfork {
         /// Genesis hardfork
-        Genesis,
         #[default]
+        Genesis,
         /// T0 hardfork (default)
         T0,
     }


### PR DESCRIPTION
This PR updates the default hardfork from `T0` to `Genesis`.