### PR TITLE
refactor(revm): replace AccessKeyAuthorizationFailed with concrete error types

### DIFF
--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -103,13 +103,78 @@ pub enum TempoInvalidTransaction {
     #[error("value transfer in Tempo Transaction not allowed")]
     ValueTransferNotAllowedInAATx,
 
-    /// Access key authorization failed.
+    /// Failed to recover access key address from signature.
     ///
-    /// This error occurs when attempting to authorize an access key with the AccountKeychain
-    /// precompile fails (e.g., key already exists, invalid parameters, unauthorized caller).
-    #[error("access key authorization failed: {reason}")]
-    AccessKeyAuthorizationFailed {
-        /// Specific reason for failure.
+    /// This error occurs when attempting to recover the access key address from a Keychain signature fails.
+    #[error("failed to recover access key address from signature")]
+    AccessKeyRecoveryFailed,
+
+    /// Access keys cannot authorize other keys.
+    ///
+    /// Only the root key can authorize new access keys. An access key can only authorize itself
+    /// in a same-transaction authorization flow.
+    #[error("access keys cannot authorize other keys, only the root key can authorize new keys")]
+    AccessKeyCannotAuthorizeOtherKeys,
+
+    /// Failed to recover signer from KeyAuthorization signature.
+    ///
+    /// This error occurs when signature recovery from the KeyAuthorization fails.
+    #[error("failed to recover signer from KeyAuthorization signature")]
+    KeyAuthorizationSignatureRecoveryFailed,
+
+    /// KeyAuthorization not signed by root account.
+    ///
+    /// The KeyAuthorization must be signed by the root account (transaction caller),
+    /// but was signed by a different address.
+    #[error(
+        "KeyAuthorization must be signed by root account {expected}, but was signed by {actual}"
+    )]
+    KeyAuthorizationNotSignedByRoot {
+        /// The expected signer (root account).
+        expected: Address,
+        /// The actual signer recovered from the signature.
+        actual: Address,
+    },
+
+    /// Access key expiry is in the past.
+    ///
+    /// An access key cannot be authorized with an expiry timestamp that has already passed.
+    #[error("access key expiry {expiry} is in the past (current timestamp: {current_timestamp})")]
+    AccessKeyExpiryInPast {
+        /// The expiry timestamp from the KeyAuthorization.
+        expiry: u64,
+        /// The current block timestamp.
+        current_timestamp: u64,
+    },
+
+    /// AccountKeychain precompile error during key authorization.
+    ///
+    /// This error occurs when the AccountKeychain precompile rejects the key authorization
+    /// (e.g., key already exists, invalid parameters).
+    #[error("keychain precompile error: {reason}")]
+    KeychainPrecompileError {
+        /// The error message from the precompile.
+        reason: String,
+    },
+
+    /// Keychain user address does not match transaction caller.
+    ///
+    /// For Keychain signatures, the user_address field must match the transaction caller.
+    #[error("keychain user_address {user_address} does not match transaction caller {caller}")]
+    KeychainUserAddressMismatch {
+        /// The user_address from the Keychain signature.
+        user_address: Address,
+        /// The transaction caller.
+        caller: Address,
+    },
+
+    /// Keychain validation failed.
+    ///
+    /// The access key is not authorized in the AccountKeychain precompile for this user,
+    /// or the key has expired, or spending limits are exceeded.
+    #[error("keychain validation failed: {reason}")]
+    KeychainValidationFailed {
+        /// The validation error details.
         reason: String,
     },
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -762,18 +762,12 @@ where
                     // Get the access key address (recovered during Tx->TxEnv conversion and cached)
                     keychain_sig
                         .key_id(&tempo_tx_env.signature_hash)
-                        .map_err(|_| TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                            reason: "Failed to recover access key address from Keychain signature"
-                                .to_string(),
-                        })?
+                        .map_err(|_| TempoInvalidTransaction::AccessKeyRecoveryFailed)?
                 };
 
                 // Only allow if authorizing the same key that's being used (same-tx auth+use)
                 if access_key_addr != key_auth.key_id {
-                    return Err(
-                            TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                                reason: "Access keys cannot authorize other keys. Only the root key can authorize new keys.".to_string(),
-                            }.into());
+                    return Err(TempoInvalidTransaction::AccessKeyCannotAuthorizeOtherKeys.into());
                 }
             }
 
@@ -781,20 +775,17 @@ where
             let root_account = &tx.caller;
 
             // Recover the signer of the KeyAuthorization
-            let auth_signer = key_auth.recover_signer().map_err(|_| {
-                TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                    reason: "Failed to recover signer from KeyAuthorization signature".to_string(),
-                }
-            })?;
+            let auth_signer = key_auth
+                .recover_signer()
+                .map_err(|_| TempoInvalidTransaction::KeyAuthorizationSignatureRecoveryFailed)?;
 
             // Verify the KeyAuthorization is signed by the root account
             if auth_signer != *root_account {
-                return Err(
-                    TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                        reason: format!(
-                            "KeyAuthorization must be signed by root account {root_account}, but was signed by {auth_signer}",
-                        ),
-                    }.into());
+                return Err(TempoInvalidTransaction::KeyAuthorizationNotSignedByRoot {
+                    expected: *root_account,
+                    actual: auth_signer,
+                }
+                .into());
             }
 
             // Validate KeyAuthorization chain_id (following EIP-7702 pattern)
@@ -826,11 +817,11 @@ where
                 // Validate expiry is not in the past
                 let current_timestamp = block.timestamp().saturating_to::<u64>();
                 if expiry <= current_timestamp {
-                    return Err(TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                        reason: format!(
-                            "Key expiry {expiry} is in the past (current timestamp: {current_timestamp})"
-                        ),
-                    }.into());
+                    return Err(TempoInvalidTransaction::AccessKeyExpiryInPast {
+                        expiry,
+                        current_timestamp,
+                    }
+                    .into());
                 }
 
                 // Handle limits: None means unlimited spending (enforce_limits=false)
@@ -865,7 +856,7 @@ where
                     .authorize_key(*root_account, authorize_call)
                     .map_err(|err| match err {
                         TempoPrecompileError::Fatal(err) => EVMError::Custom(err),
-                        err => TempoInvalidTransaction::AccessKeyAuthorizationFailed {
+                        err => TempoInvalidTransaction::KeychainPrecompileError {
                             reason: err.to_string(),
                         }
                         .into(),
@@ -888,11 +879,9 @@ where
 
                 // Sanity check: user_address should match tx.caller
                 if *user_address != tx.caller {
-                    return Err(TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                        reason: format!(
-                            "Keychain user_address {} does not match transaction caller {}",
-                            user_address, tx.caller
-                        ),
+                    return Err(TempoInvalidTransaction::KeychainUserAddressMismatch {
+                        user_address: *user_address,
+                        caller: tx.caller,
                     }
                     .into());
                 }
@@ -900,10 +889,7 @@ where
                 // Get the access key address (recovered during pool validation and cached)
                 keychain_sig
                     .key_id(&tempo_tx_env.signature_hash)
-                    .map_err(|_| TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                        reason: "Failed to recover access key address from inner signature"
-                            .to_string(),
-                    })?
+                    .map_err(|_| TempoInvalidTransaction::AccessKeyRecoveryFailed)?
             };
 
             // Check if this transaction includes a KeyAuthorization for the same key
@@ -926,8 +912,8 @@ where
                             access_key_addr,
                             block.timestamp().to::<u64>(),
                         )
-                        .map_err(|e| TempoInvalidTransaction::AccessKeyAuthorizationFailed {
-                            reason: format!("Keychain validation failed: {e:?}"),
+                        .map_err(|e| TempoInvalidTransaction::KeychainValidationFailed {
+                            reason: format!("{e:?}"),
                         })?;
                 }
 


### PR DESCRIPTION
## Summary

Replaces the generic `TempoInvalidTransaction::AccessKeyAuthorizationFailed` error variant with 8 concrete, specific error types for better error reporting and debugging.

### New Error Types

- **AccessKeyRecoveryFailed** - Failed to recover access key address from signature
- **AccessKeyCannotAuthorizeOtherKeys** - Access keys cannot authorize other keys (only root can)
- **KeyAuthorizationSignatureRecoveryFailed** - Failed to recover signer from KeyAuthorization signature
- **KeyAuthorizationNotSignedByRoot** - KeyAuthorization signed by wrong address (includes expected/actual addresses)
- **AccessKeyExpiryInPast** - Access key expiry timestamp has already passed (includes expiry/current_timestamp)
- **KeychainPrecompileError** - AccountKeychain precompile rejected authorization
- **KeychainUserAddressMismatch** - Keychain user_address doesn't match tx caller (includes both addresses)
- **KeychainValidationFailed** - Access key validation failed in precompile

### Changes

- Updated `crates/revm/src/error.rs` with 8 new concrete error variants
- Updated all 9 usages in `crates/revm/src/handler.rs` to use appropriate concrete types
- All error types include relevant context fields (addresses, timestamps, etc.) for better debugging
- Removed the generic `AccessKeyAuthorizationFailed` variant

## Benefits

- **Better error messages** - Each error type has a specific, descriptive message
- **Type safety** - Compiler enforces correct error context for each case
- **Easier debugging** - Structured fields (addresses, timestamps) instead of formatted strings
- **Better error handling** - Consumers can match on specific error types

## Test plan

- [x] Verify code compiles (`cargo check --package revm`)
- [ ] Run existing tests to ensure no regressions
- [ ] Test error reporting in various failure scenarios