### PR TITLE
fix(docs): correct stablecoin DEX reference implementation link

### DIFF
--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -454,7 +454,7 @@ export default defineConfig({
               },
               {
                 text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinExchange.sol',
+                link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol',
               },
               {
                 text: 'Rust Implementation',


### PR DESCRIPTION
The reference implementation link for the stablecoin DEX in the docs sidebar pointed to `StablecoinExchange.sol` which doesn't exist. The correct file is `StablecoinDEX.sol`.

Reported via Slack: https://tempoxyz.slack.com/archives/C09F2UTPEJY/p1768400825647779