### PR TITLE
feat(precompiles): add getFeeToken() for transaction fee token introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/.sonda
 _
 .vercel
 .env*.local
+.worktrees

--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -32,6 +32,11 @@ crate::sol! {
         // Fee functions
         function distributeFees(address validator, address token) external;
         function collectedFees(address validator, address token) external view returns (uint256);
+
+        // Transaction context
+        /// Returns the fee token being used for the current transaction.
+        /// This allows smart contracts to introspect which token is paying for gas fees.
+        function getFeeToken() external view returns (address);
         // NOTE: collectFeePreTx is a protocol-internal function called directly by the
         // execution handler, not exposed via the dispatch interface.
 

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -240,9 +240,6 @@ impl TipFeeManager {
         }
     }
 
-    // -----------------------------------------------------------------
-    // Transaction context methods
-    // -----------------------------------------------------------------
 
     /// Set the current transaction's fee token (transient storage)
     ///

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -244,13 +244,13 @@ impl TipFeeManager {
     // Transaction context methods
     // -----------------------------------------------------------------
 
-    /// Set the current transaction's fee token (transient storage).
+    /// Set the current transaction's fee token (transient storage)
     ///
-    /// This is called by the execution handler before transaction execution begins.
-    /// It allows smart contracts to introspect which token is paying for gas fees
-    /// by calling `getFeeToken()`.
+    /// NOTE: Thishis function is only called by the execution handler before 
+    /// transaction execution begins and allows smart contracts to introspect which 
+    /// token is paying for gas fees by calling `getFeeToken()`.
     ///
-    /// NOTE: This is a protocol-internal function, not exposed via the dispatch interface.
+    /// This is a protocol-internal function, not exposed via the dispatch interface.
     pub fn set_tx_fee_token(&mut self, fee_token: Address) -> Result<()> {
         self.tx_fee_token.t_write(fee_token)
     }

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -26,9 +26,7 @@ pub struct TipFeeManager {
     total_supply: Mapping<B256, U256>,
     liquidity_balances: Mapping<B256, Mapping<Address, U256>>,
 
-    // -----------------------------------------------------------------
-    // Transient fields - MUST remain at the end of the struct
-    // -----------------------------------------------------------------
+    // Transient fields MUST remain at the end of the struct
     /// Current transaction's fee token, set by the handler before execution.
     /// Allows smart contracts to introspect the fee token via `getFeeToken()`.
     tx_fee_token: Address,
@@ -266,17 +264,15 @@ impl TipFeeManager {
 
 #[cfg(test)]
 mod tests {
-    use alloy::sol_types::{SolCall, SolValue};
-    use tempo_contracts::precompiles::{IFeeManager, TIP20Error};
-
     use super::*;
     use crate::{
-        Precompile, TIP_FEE_MANAGER_ADDRESS,
+        TIP_FEE_MANAGER_ADDRESS,
         error::TempoPrecompileError,
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip20::{ITIP20, TIP20Token},
     };
+    use tempo_contracts::precompiles::{IFeeManager, TIP20Error};
 
     #[test]
     fn test_set_user_token() -> eyre::Result<()> {

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -240,11 +240,10 @@ impl TipFeeManager {
         }
     }
 
-
     /// Set the current transaction's fee token (transient storage)
     ///
-    /// NOTE: Thishis function is only called by the execution handler before 
-    /// transaction execution begins and allows smart contracts to introspect which 
+    /// NOTE: Thishis function is only called by the execution handler before
+    /// transaction execution begins and allows smart contracts to introspect which
     /// token is paying for gas fees by calling `getFeeToken()`.
     ///
     /// This is a protocol-internal function, not exposed via the dispatch interface.

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -648,6 +648,15 @@ where
         })
         .map_err(|e| EVMError::Custom(e.to_string()))?;
 
+        // Set the transaction fee token in the fee manager's transient storage
+        // so contracts can introspect it via IFeeManager.getFeeToken().
+        let fee_token = self.fee_token;
+        StorageCtx::enter_evm(journal, block, cfg, || {
+            let mut fee_manager = TipFeeManager::new();
+            fee_manager.set_tx_fee_token(fee_token)
+        })
+        .map_err(|e| EVMError::Custom(e.to_string()))?;
+
         // Load the fee payer balance
         let account_balance = get_token_balance(journal, self.fee_token, self.fee_payer)?;
 

--- a/docs/pages/protocol/tips/tip-1007.mdx
+++ b/docs/pages/protocol/tips/tip-1007.mdx
@@ -90,7 +90,8 @@ Reading the fee token costs the standard warm transient storage read cost (100 g
 | Normal transaction | The resolved fee token address |
 | Free transaction (zero gas price) | The resolved fee token (may still be set) |
 | `eth_call` simulation | `address(0)` (no transaction context) |
-| Before transaction execution | `address(0)` |
+
+The only case where `address(0)` is returned is in simulation contexts (e.g., `eth_call`) where the protocol handler does not execute.
 
 ## Example Usage
 
@@ -103,7 +104,7 @@ contract FeeTokenAware {
 
     function doSomething() external {
         address feeToken = FEE_MANAGER.getFeeToken();
-        
+
         if (feeToken == PATH_USD) {
             // User is paying fees in pathUSD
         } else if (feeToken != address(0)) {
@@ -163,7 +164,7 @@ interface IFeeManager {
 # Invariants
 
 - `getFeeToken()` must return a consistent value across all calls within the same transaction
-- `getFeeToken()` must return `address(0)` when called outside of a transaction context
+- `getFeeToken()` must return `address(0)` in simulation contexts (e.g., `eth_call`) where no transaction handler runs
 - `getFeeToken()` must be callable from `staticcall` contexts without reverting
 - The fee token returned must match the token used for actual fee deduction in `collectFeePreTx` and `collectFeePostTx`
 - Reading the fee token must not modify any state (view function)

--- a/docs/pages/protocol/tips/tip-1007.mdx
+++ b/docs/pages/protocol/tips/tip-1007.mdx
@@ -1,0 +1,181 @@
+# Fee Token Introspection
+
+This document specifies the addition of fee token introspection functionality to the FeeManager precompile, enabling smart contracts to query the fee token being used for the current transaction.
+
+- **TIP ID**: TIP-1007
+- **Authors/Owners**: Georgios Konstantopoulos
+- **Status**: Draft
+- **Related Specs/TIPs**: [Fee Manager](/protocol/fees/spec-fee), [TIP-20](/protocol/tip20/spec)
+- **Protocol Version**: TBD
+
+---
+
+# Overview
+
+## Abstract
+
+TIP-1007 adds a `getFeeToken()` view function to the FeeManager precompile that returns the fee token address being used for the current transaction. This enables smart contracts to introspect which TIP-20 token is paying for gas fees during execution, allowing for dynamic logic based on the fee token choice.
+
+## Motivation
+
+Tempo transactions support paying gas fees in any USD-denominated TIP-20 token via the fee token preference system. However, prior to this TIP, there was no way for a smart contract to determine which fee token is being used for the current transaction during execution.
+
+This capability is needed by protocols like LayerZero/Stargate that want to:
+
+- Adjust their internal logic based on which fee token is being used
+- Provide fee token-aware pricing or routing decisions
+- Emit events or logs that include the fee token for off-chain indexing
+- Implement fee token-specific behavior in cross-chain messaging
+
+### Request Context
+
+This feature was requested by the LayerZero team during their Stargate integration with Tempo:
+
+> Is there any way to access or read the selected `fee_token` from *inside a smart contract* during execution?
+
+---
+
+# Specification
+
+## New Function
+
+The following function is added to the `IFeeManager` interface:
+
+```solidity
+interface IFeeManager {
+    // ... existing functions ...
+
+    /// @notice Returns the fee token being used for the current transaction
+    /// @return The address of the TIP-20 token paying for gas fees
+    /// @dev This value is set by the protocol before transaction execution begins.
+    ///      Returns address(0) if no fee token has been set (e.g., free transactions
+    ///      or calls outside of a transaction context).
+    ///      This function reads from transient storage, so it is safe to call
+    ///      from staticcall contexts.
+    function getFeeToken() external view returns (address);
+}
+```
+
+## Behavior
+
+### Fee Token Resolution
+
+The fee token returned by `getFeeToken()` is the same token that was resolved by the protocol during transaction validation, following the fee token preference rules:
+
+1. **Transaction field**: If the transaction specifies a `fee_token` field, that token is used
+2. **User preference**: Otherwise, the fee payer's `userTokens` preference from FeeManager
+3. **TIP-20 inference**: For direct TIP-20 calls (`transfer`, `transferWithMemo`, `distributeReward`), the target token is used
+4. **Default**: Falls back to pathUSD (`0x20C0000000000000000000000000000000000000`)
+
+### Storage
+
+The fee token is stored in **transient storage** (EIP-1153) within the FeeManager precompile. This means:
+
+- The value is automatically cleared at the end of each transaction
+- No persistent storage writes occur, minimizing gas costs
+- The value is consistent across all calls within a transaction (including internal calls and subcalls)
+
+### Timing
+
+The fee token is set by the protocol in the `validate_against_state_and_deduct_caller` handler phase, before any user code executes. This ensures the value is available throughout the entire transaction execution.
+
+### Gas Cost
+
+Reading the fee token costs the standard warm transient storage read cost (100 gas for TLOAD).
+
+### Edge Cases
+
+| Scenario | Return Value |
+|----------|--------------|
+| Normal transaction | The resolved fee token address |
+| Free transaction (zero gas price) | The resolved fee token (may still be set) |
+| `eth_call` simulation | `address(0)` (no transaction context) |
+| Before transaction execution | `address(0)` |
+
+## Example Usage
+
+```solidity
+import { IFeeManager } from "./interfaces/IFeeManager.sol";
+
+contract FeeTokenAware {
+    IFeeManager constant FEE_MANAGER = IFeeManager(0xfeeC000000000000000000000000000000000000);
+    address constant PATH_USD = 0x20C0000000000000000000000000000000000000;
+
+    function doSomething() external {
+        address feeToken = FEE_MANAGER.getFeeToken();
+        
+        if (feeToken == PATH_USD) {
+            // User is paying fees in pathUSD
+        } else if (feeToken != address(0)) {
+            // User is paying fees in a different USD stablecoin
+        } else {
+            // No fee token context (e.g., eth_call simulation)
+        }
+    }
+}
+```
+
+## Interface Definition
+
+The complete updated `IFeeManager` interface:
+
+```solidity
+interface IFeeManager {
+    // Structs
+    struct FeeInfo {
+        uint128 amount;
+        bool hasBeenSet;
+    }
+
+    // User preferences
+    function userTokens(address user) external view returns (address);
+    function validatorTokens(address validator) external view returns (address);
+    function setUserToken(address token) external;
+    function setValidatorToken(address token) external;
+
+    // Fee functions
+    function distributeFees(address validator, address token) external;
+    function collectedFees(address validator, address token) external view returns (uint256);
+
+    // Transaction context (TIP-1007)
+    function getFeeToken() external view returns (address);
+
+    // Events
+    event UserTokenSet(address indexed user, address indexed token);
+    event ValidatorTokenSet(address indexed validator, address indexed token);
+    event FeesDistributed(address indexed validator, address indexed token, uint256 amount);
+
+    // Errors
+    error OnlyValidator();
+    error OnlySystemContract();
+    error InvalidToken();
+    error PoolDoesNotExist();
+    error InsufficientFeeTokenBalance();
+    error InternalError();
+    error CannotChangeWithinBlock();
+    error CannotChangeWithPendingFees();
+    error TokenPolicyForbids();
+}
+```
+
+---
+
+# Invariants
+
+- `getFeeToken()` must return a consistent value across all calls within the same transaction
+- `getFeeToken()` must return `address(0)` when called outside of a transaction context
+- `getFeeToken()` must be callable from `staticcall` contexts without reverting
+- The fee token returned must match the token used for actual fee deduction in `collectFeePreTx` and `collectFeePostTx`
+- Reading the fee token must not modify any state (view function)
+
+## Test Cases
+
+The test suite must cover:
+
+1. **Basic functionality**: `getFeeToken()` returns the correct fee token address
+2. **Zero when unset**: Returns `address(0)` when no fee token is set
+3. **Consistency**: Same value returned from nested calls within a transaction
+4. **Static call safety**: Works correctly when called via `staticcall`
+5. **Transient storage**: Value is cleared between transactions
+6. **Different fee tokens**: Works with various TIP-20 fee tokens (pathUSD, USDC, etc.)
+7. **Dispatch coverage**: Function selector is correctly dispatched by the precompile


### PR DESCRIPTION
## Summary

Add `IFeeManager.getFeeToken()` view function that allows smart contracts to read the fee token being used for the current transaction during execution.

**Requested by:** LayerZero/Stargate for their integration with Tempo's TIP-20 fee system.

**Context:** https://tempoxyz.slack.com/archives/C09GJBN2SEL/p1768415497871839?thread_ts=1767384201.823829&cid=C09GJBN2SEL

## Implementation

Uses the same transient storage pattern already established by `AccountKeychain` for storing `tx_origin`:

1. **Interface change**: Added `getFeeToken()` to `IFeeManager` interface in contracts crate
2. **Transient storage**: Added `tx_fee_token` field to `TipFeeManager` struct (at the end, as transient)
3. **Handler integration**: Set `tx_fee_token` in `TempoEvmHandler::validate_against_state_and_deduct_caller` before transaction execution
4. **Dispatch**: Wired `getFeeToken()` to read from transient storage

## Usage

From Solidity:
```solidity
interface IFeeManager {
    function getFeeToken() external view returns (address);
    // ... existing functions
}

contract MyContract {
    IFeeManager constant FEE_MANAGER = IFeeManager(0xfeec000000000000000000000000000000000000);

    function someFunction() external {
        address feeToken = FEE_MANAGER.getFeeToken();
        // Use feeToken to adjust logic, pricing, etc.
    }
}
```

## Testing

- Added unit tests for `set_tx_fee_token()` and `get_fee_token()` in mod.rs
- Added dispatch tests for `getFeeToken()` call via precompile interface  
- Verified selector coverage test still passes
- All 509 precompile tests pass

## Notes

- Returns `address(0)` if no fee token is set (e.g., during free transactions or if called outside transaction context)
- Safe for `staticcall` since it only reads transient storage
- Transient storage is automatically cleared between transactions