### PR TITLE
refactor(executor): remove fill_holes backfill logic

### DIFF
--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -11,7 +11,7 @@ use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
 
 use commonware_runtime::{ContextCell, FutureExt, Handle, Metrics, Pacer, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
-use eyre::{OptionExt as _, Report, WrapErr as _, ensure, eyre};
+use eyre::{OptionExt as _, Report, WrapErr as _, ensure};
 use futures::{
     StreamExt as _,
     channel::{


### PR DESCRIPTION
The fill_holes function was originally added to handle cases where the entire network went down and the only blocks available were in local marshal/CL storage.

This is no longer necessary since PR #1781, which allows reth to sync blocks from other reth peers. Keeping fill_holes would cause big fast syncs to feed blocks one at a time instead of using efficient peer syncing (imagine syncing 100k blocks one by one).

Remove the hole detection logic in forward_finalized and the fill_holes method entirely.