### PR TITLE
feat: add tempo-bootnode for dynamic peer discovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (just)
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2
+        with:
+          tool: just
       - name: Build
         run: just build ${{ matrix.binary }} "--profile ${{ inputs.profile || 'dev' }}"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         binary: [tempo, tempo-bench, tempo-sidecar]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (just)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
       matrix:
         binary: [tempo, tempo-bench, tempo-sidecar]
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@c802b5ed6fc0b87c8c603a600ac1d864e6dc1cbe # just
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (just)
       - name: Build
         run: just build ${{ matrix.binary }} "--profile ${{ inputs.profile || 'dev' }}"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         id: binary_upload
         with:
           if-no-files-found: "error"

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -21,13 +21,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: depot/setup-action@v1
+      - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
 
       - name: Docker metadata for tempo-profiling
         id: meta-tempo
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/tempo
           bake-target: tempo
@@ -36,7 +36,7 @@ jobs:
             type=sha,prefix=${{ github.event.inputs.tag }}-sha-
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
         run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
-        uses: depot/bake-action@v1
+        uses: depot/bake-action@2ae2529115bba41de62b77b345de48d57eca7564 # v1.12.1
         with:
           files: |
             docker-bake.hcl

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,13 +31,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: depot/setup-action@v1
+      - uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
 
       - name: Docker metadata for tempo
         id: meta-tempo
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/tempo
           bake-target: tempo
@@ -55,7 +55,7 @@ jobs:
 
       - name: Docker metadata for tempo-bench
         id: meta-tempo-bench
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/tempo-bench
           bake-target: tempo-bench
@@ -73,7 +73,7 @@ jobs:
 
       - name: Docker metadata for tempo-sidecar
         id: meta-tempo-sidecar
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/tempo-sidecar
           bake-target: tempo-sidecar
@@ -91,7 +91,7 @@ jobs:
 
       - name: Docker metadata for tempo-xtask
         id: meta-tempo-xtask
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/tempo-xtask
           bake-target: tempo-xtask
@@ -108,7 +108,7 @@ jobs:
             type=ref,event=pr
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -118,7 +118,7 @@ jobs:
         run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
-        uses: depot/bake-action@v1
+        uses: depot/bake-action@2ae2529115bba41de62b77b345de48d57eca7564 # v1.12.1
         with:
           files: |
             docker-bake.hcl

--- a/.github/workflows/docs-specs.yml
+++ b/.github/workflows/docs-specs.yml
@@ -25,12 +25,12 @@ jobs:
     name: Forge Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
 
       - name: Show Forge version
         run: forge --version
@@ -43,12 +43,12 @@ jobs:
     name: Forge Fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
 
       - name: Run Forge fmt check
         working-directory: docs/specs
@@ -58,12 +58,12 @@ jobs:
     name: Forge Test (Solidity)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8b0419c685ef46cb79ec93fbdc131174afceb730 # v1.6.0
 
       - name: Run Forge tests
         working-directory: docs/specs
@@ -75,23 +75,23 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout tempo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
           path: tempo
 
       - name: Checkout tempo-foundry
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: tempoxyz/tempo-foundry
           path: tempo-foundry
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
 
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: Swatinem/rust-cache@v2
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           workspaces: tempo-foundry
 
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           allowed-failures: tempo-foundry-test
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/docs-specs.yml
+++ b/.github/workflows/docs-specs.yml
@@ -87,7 +87,7 @@ jobs:
           path: tempo-foundry
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "recursive"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
 
       - name: Install dependencies
         working-directory: docs

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -12,12 +12,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Label PRs
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const label_pr = require('./.github/assets/label_pr.js')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
         with:
           components: clippy
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --locked
         env:
@@ -37,8 +37,8 @@ jobs:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -52,11 +52,11 @@ jobs:
       matrix:
         partition: [1, 2]
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (cargo-hack)
       - run: cargo hack check --feature-powerset --depth 1 --partition ${{ matrix.partition }}/2
 
   docs:
@@ -64,22 +64,22 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
       - name: Setup Pages
         if: github.ref_name == 'main' && github.event_name == 'push'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
         with:
           enablement: true
       - name: Upload artifact
         if: github.ref_name == 'main' && github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./target/doc
 
@@ -97,14 +97,14 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   typos:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: crate-ci/typos@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: crate-ci/typos@bb4666ad77b539a6b4ce4eda7ebb6de553704021 # v1.42.0
 
   deny:
     uses: ithacaxyz/ci/.github/workflows/deny.yml@main
@@ -114,11 +114,11 @@ jobs:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/cache-cargo-install-action@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/cache-cargo-install-action@5b024fe3a0a2c7f2aaff0e47871acf0d14b07207 # v2.0.0
         with:
           tool: zepter
       - name: Eagerly pull dependencies
@@ -139,6 +139,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/cache-cargo-install-action@5b024fe3a0a2c7f2aaff0e47871acf0d14b07207 # v2.0.0
+      - uses: taiki-e/cache-cargo-install-action@34ce5120836e5f9f1508d8713d7fdea0e8facd6f # v3.0.1
         with:
           tool: zepter
       - name: Eagerly pull dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (cargo-hack)
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2
+        with:
+          tool: cargo-hack
       - run: cargo hack check --feature-powerset --depth 1 --partition ${{ matrix.partition }}/2
 
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -53,7 +53,7 @@ jobs:
         partition: [1, 2]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (cargo-hack)
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build documentation
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/cache-cargo-install-action@5b024fe3a0a2c7f2aaff0e47871acf0d14b07207 # v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
     needs: get-version
     if: ${{ github.event.inputs.dry_run != 'true' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
         # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
@@ -60,7 +60,7 @@ jobs:
           tag="${{ needs.get-version.outputs.version }}"
           tag=${tag#v}
           cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn’t match the Cargo version $cargo_ver"; exit 1; }
+          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn't match the Cargo version $cargo_ver"; exit 1; }
 
   build-release:
     name: Build Release Binaries
@@ -86,18 +86,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
         with:
           targets: ${{ matrix.platform.target }}
 
       - name: Setup mold linker
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Get build profile
         id: profile
@@ -141,7 +141,7 @@ jobs:
           shasum -a 256 "${{ steps.prepare.outputs.archive_path }}" > "${{ steps.prepare.outputs.archive_name }}.sha256"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.binary.name }}-${{ matrix.platform.target }}
           path: |
@@ -160,12 +160,12 @@ jobs:
       # This is necessary for generating the changelog.
       # It has to come before "Download Artifacts" or else it deletes the artifacts.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
@@ -195,12 +195,12 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
@@ -211,7 +211,7 @@ jobs:
           mkdir $VERSION
           mv artifacts/**/* $VERSION/
 
-      - uses: shallwefootball/s3-upload-action@master
+      - uses: shallwefootball/s3-upload-action@4350529f410221787ccf424e50133cbc1b52704e # v1.3.3
         with:
           aws_key_id: ${{ secrets.R2_BINARIES_KEY_ID }}
           aws_secret_access_key: ${{ secrets.R2_BINARIES_SECRET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ github.event.inputs.dry_run != 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
         # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform.target }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Generate genesis
         run: |
           cargo xtask generate-genesis \
@@ -48,11 +48,11 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/install-action@nextest
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (nextest)
       - name: Build and compile tests
         run: cargo nextest run --no-run -j num-cpus
       - name: Run tests
@@ -63,12 +63,12 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # master
         with:
           toolchain: "1.91" # MSRV
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build with MSRV
         run: cargo build --bin tempo
         env:
@@ -79,10 +79,10 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Get latest filename from API
         id: latest
         run: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Restore cached file
         id: cache-file
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .cache/snapshots
           key: snapshots-${{ steps.latest.outputs.filename }}
@@ -134,6 +134,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (nextest)
+      - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2
+        with:
+          tool: nextest
       - name: Build and compile tests
         run: cargo nextest run --no-run -j num-cpus
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Generate genesis
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@03ef6f57d573ca4522fb02950f326083373b85bf # v2.66.2 (nextest)
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.91" # MSRV
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Get latest filename from API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11673,6 +11673,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-bootnode"
+version = "1.0.0-rc.5"
+dependencies = [
+ "axum",
+ "const-hex",
+ "eyre",
+ "futures",
+ "parking_lot",
+ "rand 0.8.5",
+ "reqwest",
+ "reth-discv4",
+ "reth-network-peers",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "tempo-bootnode-bin"
+version = "1.0.0-rc.5"
+dependencies = [
+ "clap",
+ "const-hex",
+ "eyre",
+ "tempo-bootnode",
+ "tempo-eyre",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "tempo-chainspec"
 version = "1.0.0-rc.6"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11674,7 +11674,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-bootnode"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "axum",
  "const-hex",
@@ -11696,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-bootnode-bin"
-version = "1.0.0-rc.5"
+version = "1.0.0-rc.6"
 dependencies = [
  "clap",
  "const-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 members = [
   "bin/tempo",
   "bin/tempo-bench",
+  "bin/tempo-bootnode",
   "bin/tempo-sidecar",
   "crates/alloy",
+  "crates/bootnode",
   "crates/chainspec",
   "crates/commonware-node",
   "crates/commonware-node-config",

--- a/bin/tempo-bootnode/Cargo.toml
+++ b/bin/tempo-bootnode/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tempo-bootnode-bin"
+description = "Internal bootnode binary with dynamic peer registration for Kubernetes deployments"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tempo-bootnode = { path = "../../crates/bootnode" }
+tempo-eyre.workspace = true
+
+clap.workspace = true
+const-hex.workspace = true
+eyre.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[[bin]]
+name = "tempo-bootnode"
+path = "src/main.rs"

--- a/bin/tempo-bootnode/README.md
+++ b/bin/tempo-bootnode/README.md
@@ -1,0 +1,212 @@
+# tempo-bootnode
+
+Internal bootnode with dynamic peer registration for Kubernetes deployments.
+
+The core logic is in the `tempo-bootnode` crate at `crates/bootnode/`.
+
+## Overview
+
+This binary runs a lightweight discv4 bootnode that:
+
+1. **Maintains a stable identity** via a persistent node key
+2. **Exposes an HTTP API** for dynamic peer registration/deregistration
+3. **Advertises registered peers** to any connecting node via discv4
+
+Designed for Kubernetes where nodes can call the bootnode API during startup (preStart hook) and shutdown (preStop hook).
+
+## Usage
+
+```bash
+# Run with ephemeral key (for testing)
+tempo-bootnode --discovery-addr 0.0.0.0:30303 --http-addr 0.0.0.0:8080
+
+# Run with persistent key
+tempo-bootnode --node-key /data/node.key --external-ip 10.0.0.1
+
+# Full options
+tempo-bootnode \
+  --discovery-addr 0.0.0.0:30303 \
+  --http-addr 0.0.0.0:8080 \
+  --node-key /data/node.key \
+  --external-ip 10.0.0.1 \
+  --lookup-interval-secs 30
+```
+
+## HTTP API
+
+### `GET /`
+
+Returns bootnode info:
+
+```json
+{
+  "enode": "enode://abcd...@10.0.0.1:30303",
+  "peer_id": "0xabcd...",
+  "discovery_addr": "10.0.0.1:30303",
+  "http_addr": "0.0.0.0:8080",
+  "registered_peers": 5,
+  "discovered_peers": 12
+}
+```
+
+### `GET /health`
+
+Returns 200 OK if healthy.
+
+### `GET /peers`
+
+List all registered peers:
+
+```json
+[
+  {
+    "id": "0x1234...",
+    "ip": "10.0.1.5",
+    "tcp_port": 30303,
+    "udp_port": 30303,
+    "enode": "enode://1234...@10.0.1.5:30303"
+  }
+]
+```
+
+### `POST /peers`
+
+Register a new peer:
+
+```bash
+curl -X POST http://bootnode:8080/peers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "secret_key": "0xabcd1234...",
+    "ip": "10.0.1.5",
+    "tcp_port": 30303,
+    "udp_port": 30303
+  }'
+```
+
+Response:
+
+```json
+{
+  "id": "0x1234...",
+  "ip": "10.0.1.5",
+  "tcp_port": 30303,
+  "udp_port": 30303,
+  "enode": "enode://1234...@10.0.1.5:30303"
+}
+```
+
+### `GET /peers/{peer_id}`
+
+Get a specific peer by ID.
+
+### `DELETE /peers/{peer_id}`
+
+Deregister a peer:
+
+```bash
+curl -X DELETE http://bootnode:8080/peers/1234abcd...
+```
+
+### `GET /discovered`
+
+List all peers discovered via discv4 (from network):
+
+```json
+[
+  {
+    "id": "0x5678...",
+    "ip": "192.168.1.10",
+    "tcp_port": 30303,
+    "udp_port": 30303,
+    "enode": "enode://5678...@192.168.1.10:30303"
+  }
+]
+```
+
+## Kubernetes Integration
+
+### Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo-bootnode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tempo-bootnode
+  template:
+    metadata:
+      labels:
+        app: tempo-bootnode
+    spec:
+      containers:
+      - name: bootnode
+        image: tempo-bootnode:latest
+        args:
+          - --node-key=/data/node.key
+          - --external-ip=$(POD_IP)
+          - --discovery-addr=0.0.0.0:30303
+          - --http-addr=0.0.0.0:8080
+        env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        ports:
+          - containerPort: 30303
+            protocol: UDP
+            name: discovery
+          - containerPort: 8080
+            protocol: TCP
+            name: http
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: bootnode-data
+```
+
+### Node Registration Hooks
+
+In your tempo node deployment:
+
+```yaml
+spec:
+  containers:
+  - name: tempo
+    lifecycle:
+      postStart:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              curl -X POST http://tempo-bootnode:8080/peers \
+                -H "Content-Type: application/json" \
+                -d "{\"secret_key\": \"$(cat /data/node.key)\", \"ip\": \"${POD_IP}\", \"tcp_port\": 30303}"
+      preStop:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              curl -X DELETE "http://tempo-bootnode:8080/peers/$(cat /data/peer_id)"
+```
+
+## Environment Variables
+
+- `RUST_LOG` - Configure logging (e.g., `RUST_LOG=info,reth_discv4=debug`)

--- a/bin/tempo-bootnode/src/main.rs
+++ b/bin/tempo-bootnode/src/main.rs
@@ -1,0 +1,64 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+};
+
+use clap::Parser;
+use eyre::Result;
+use tempo_bootnode::{BootnodeConfig, BootnodeServer, load_or_generate_key};
+use tracing::info;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "tempo-bootnode",
+    about = "Internal bootnode with dynamic peer registration"
+)]
+struct Args {
+    /// Address to bind the discovery UDP socket.
+    #[arg(long, default_value = "0.0.0.0:30303")]
+    discovery_addr: SocketAddr,
+
+    /// Address to bind the HTTP API.
+    #[arg(long, default_value = "0.0.0.0:8080")]
+    http_addr: SocketAddr,
+
+    /// Path to the node key file (hex-encoded 32-byte secret key).
+    /// If not provided, generates a new key.
+    /// If path doesn't exist, generates and saves a new key.
+    #[arg(long)]
+    node_key: Option<PathBuf>,
+
+    /// External IP address to advertise (for NAT traversal).
+    /// If not provided, will not perform NAT resolution.
+    #[arg(long)]
+    external_ip: Option<IpAddr>,
+
+    /// Lookup interval in seconds.
+    #[arg(long, default_value = "30")]
+    lookup_interval_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tempo_eyre::install()?;
+    tracing_subscriber::fmt::init();
+
+    let args = Args::parse();
+
+    let secret_key = load_or_generate_key(args.node_key.as_deref())?;
+
+    let mut config = BootnodeConfig::new(args.discovery_addr, args.http_addr)
+        .with_secret_key(secret_key)
+        .with_lookup_interval_secs(args.lookup_interval_secs);
+
+    if let Some(ip) = args.external_ip {
+        config = config.with_external_ip(ip);
+    }
+
+    info!("Starting bootnode...");
+    info!("Discovery address: {}", args.discovery_addr);
+    info!("HTTP API address: {}", args.http_addr);
+
+    let server = BootnodeServer::new(config).await?;
+    server.run().await
+}

--- a/crates/bootnode/Cargo.toml
+++ b/crates/bootnode/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tempo-bootnode"
+description = "Internal bootnode with dynamic peer registration for Kubernetes deployments"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+axum.workspace = true
+const-hex.workspace = true
+eyre.workspace = true
+futures.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+secp256k1.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", rev = "d76babb2f17773f79c9cf1eda497c539bd5cf553" }
+reth-network-peers.workspace = true
+
+[dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+tracing-subscriber.workspace = true
+
+[features]
+default = []

--- a/crates/bootnode/src/lib.rs
+++ b/crates/bootnode/src/lib.rs
@@ -1,0 +1,132 @@
+//! Internal bootnode with dynamic peer registration.
+//!
+//! This crate provides a lightweight discv4 bootnode that can dynamically
+//! register and deregister peers via an HTTP API. Designed for Kubernetes
+//! deployments where nodes register on startup and deregister on shutdown.
+
+mod server;
+mod state;
+
+pub use server::{BootnodeConfig, BootnodeHandle, BootnodeServer};
+pub use state::{BootnodeInfo, BootnodeState, PeerInfo, RegisterRequest};
+
+use eyre::Result;
+use rand::Rng;
+use secp256k1::SecretKey;
+use std::path::Path;
+use tracing::{info, warn};
+
+/// Load a secret key from a file or generate a new one.
+///
+/// If the path exists, reads and decodes the hex-encoded key.
+/// If the path doesn't exist, generates a new key and saves it.
+/// If no path is provided, generates an ephemeral key (not persisted).
+pub fn load_or_generate_key(path: Option<&Path>) -> Result<SecretKey> {
+    match path {
+        Some(path) if path.exists() => {
+            let contents = std::fs::read_to_string(path)?;
+            let bytes = const_hex::decode(contents.trim().trim_start_matches("0x"))?;
+            let key = SecretKey::from_slice(&bytes)?;
+            info!("Loaded node key from {:?}", path);
+            Ok(key)
+        }
+        Some(path) => {
+            let key = generate_secret_key();
+            let hex_key = const_hex::encode(key.secret_bytes());
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(path, hex_key)?;
+            info!("Generated and saved new node key to {:?}", path);
+            Ok(key)
+        }
+        None => {
+            let key = generate_secret_key();
+            warn!("Generated ephemeral node key (not persisted)");
+            Ok(key)
+        }
+    }
+}
+
+/// Generate a random secp256k1 secret key.
+pub fn generate_secret_key() -> SecretKey {
+    let mut rng = rand::thread_rng();
+    loop {
+        let bytes: [u8; 32] = rng.r#gen();
+        if let Ok(key) = SecretKey::from_slice(&bytes) {
+            return key;
+        }
+    }
+}
+
+/// Parse a hex-encoded peer ID (64 bytes / 128 hex chars).
+pub fn parse_peer_id(s: &str) -> Result<reth_network_peers::PeerId, String> {
+    let s = s.trim_start_matches("0x");
+    let bytes = const_hex::decode(s).map_err(|e| format!("Invalid hex: {e}"))?;
+    if bytes.len() != 64 {
+        return Err(format!("Expected 64 bytes, got {}", bytes.len()));
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(&bytes);
+    Ok(reth_network_peers::PeerId::from(arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_generate_secret_key() {
+        let key1 = generate_secret_key();
+        let key2 = generate_secret_key();
+        assert_ne!(key1.secret_bytes(), key2.secret_bytes());
+    }
+
+    #[test]
+    fn test_load_or_generate_key_new_file() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("node.key");
+
+        let key1 = load_or_generate_key(Some(&key_path)).unwrap();
+        assert!(key_path.exists());
+
+        let key2 = load_or_generate_key(Some(&key_path)).unwrap();
+        assert_eq!(key1.secret_bytes(), key2.secret_bytes());
+    }
+
+    #[test]
+    fn test_load_or_generate_key_ephemeral() {
+        let key = load_or_generate_key(None).unwrap();
+        assert_eq!(key.secret_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_parse_peer_id_valid() {
+        let hex = "a".repeat(128);
+        let result = parse_peer_id(&hex);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_peer_id_with_prefix() {
+        let hex = format!("0x{}", "b".repeat(128));
+        let result = parse_peer_id(&hex);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_peer_id_invalid_length() {
+        let hex = "a".repeat(64);
+        let result = parse_peer_id(&hex);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Expected 64 bytes"));
+    }
+
+    #[test]
+    fn test_parse_peer_id_invalid_hex() {
+        let result = parse_peer_id("zzzz");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid hex"));
+    }
+}

--- a/crates/bootnode/src/server.rs
+++ b/crates/bootnode/src/server.rs
@@ -1,0 +1,400 @@
+//! HTTP server and bootnode lifecycle management.
+
+use crate::{
+    parse_peer_id,
+    state::{BootnodeState, RegisterRequest},
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+};
+use eyre::Result;
+use futures::StreamExt;
+use reth_discv4::{Discv4, Discv4Config, NatResolver};
+use reth_network_peers::NodeRecord;
+use secp256k1::SecretKey;
+use std::net::{IpAddr, SocketAddr};
+use tracing::{error, info};
+
+/// Configuration for the bootnode server.
+#[derive(Debug, Clone)]
+pub struct BootnodeConfig {
+    /// Address to bind the discovery UDP socket.
+    pub discovery_addr: SocketAddr,
+    /// Address to bind the HTTP API.
+    pub http_addr: SocketAddr,
+    /// Node secret key.
+    pub secret_key: SecretKey,
+    /// External IP for NAT traversal.
+    pub external_ip: Option<IpAddr>,
+    /// Lookup interval in seconds.
+    pub lookup_interval_secs: u64,
+}
+
+impl Default for BootnodeConfig {
+    fn default() -> Self {
+        Self {
+            discovery_addr: ([0, 0, 0, 0], 30303).into(),
+            http_addr: ([0, 0, 0, 0], 8080).into(),
+            secret_key: crate::generate_secret_key(),
+            external_ip: None,
+            lookup_interval_secs: 30,
+        }
+    }
+}
+
+impl BootnodeConfig {
+    /// Create a new config with the given discovery and HTTP addresses.
+    pub fn new(discovery_addr: SocketAddr, http_addr: SocketAddr) -> Self {
+        Self {
+            discovery_addr,
+            http_addr,
+            ..Default::default()
+        }
+    }
+
+    /// Set the secret key.
+    pub fn with_secret_key(mut self, key: SecretKey) -> Self {
+        self.secret_key = key;
+        self
+    }
+
+    /// Set the external IP.
+    pub fn with_external_ip(mut self, ip: IpAddr) -> Self {
+        self.external_ip = Some(ip);
+        self
+    }
+
+    /// Set the lookup interval.
+    pub fn with_lookup_interval_secs(mut self, secs: u64) -> Self {
+        self.lookup_interval_secs = secs;
+        self
+    }
+}
+
+/// The bootnode server combining discv4 discovery and HTTP API.
+pub struct BootnodeServer {
+    config: BootnodeConfig,
+    local_enr: NodeRecord,
+}
+
+impl BootnodeServer {
+    /// Create a new bootnode server with the given configuration.
+    pub async fn new(config: BootnodeConfig) -> Result<Self> {
+        let local_enr = NodeRecord::from_secret_key(config.discovery_addr, &config.secret_key);
+
+        info!("Bootnode created with enode: {}", local_enr);
+        info!("Peer ID: {:?}", local_enr.id);
+
+        Ok(Self { config, local_enr })
+    }
+
+    /// Get the local ENR.
+    pub fn local_enr(&self) -> &NodeRecord {
+        &self.local_enr
+    }
+
+    /// Build the axum router with the given state.
+    fn router(state: BootnodeState) -> axum::Router {
+        axum::Router::new()
+            .route("/", get(get_info))
+            .route("/health", get(health))
+            .route("/peers", get(list_peers))
+            .route("/peers", post(register_peer))
+            .route("/peers/{peer_id}", get(get_peer))
+            .route("/peers/{peer_id}", delete(deregister_peer))
+            .route("/discovered", get(list_discovered))
+            .with_state(state)
+    }
+
+    /// Create and bind the discv4 service.
+    async fn create_discv4(&self) -> Result<(Discv4, reth_discv4::Discv4Service)> {
+        let nat_resolver = self
+            .config
+            .external_ip
+            .map(NatResolver::ExternalIp)
+            .unwrap_or(NatResolver::None);
+
+        let discv4_config = Discv4Config::builder()
+            .external_ip_resolver(Some(nat_resolver))
+            .lookup_interval(std::time::Duration::from_secs(
+                self.config.lookup_interval_secs,
+            ))
+            .build();
+
+        let (discv4, discv4_service) = Discv4::bind(
+            self.config.discovery_addr,
+            self.local_enr,
+            self.config.secret_key,
+            discv4_config,
+        )
+        .await?;
+
+        Ok((discv4, discv4_service))
+    }
+
+    /// Run the bootnode server.
+    ///
+    /// This spawns the discv4 service and HTTP server, then processes
+    /// discovery updates until shutdown.
+    pub async fn run(self) -> Result<()> {
+        let (discv4, mut discv4_service) = self.create_discv4().await?;
+        let state = BootnodeState::new(discv4, self.local_enr, self.config.http_addr);
+
+        let mut updates = discv4_service.update_stream();
+        discv4_service.spawn();
+
+        let app = Self::router(state.clone());
+        let listener = tokio::net::TcpListener::bind(self.config.http_addr).await?;
+        info!("HTTP API listening on {}", self.config.http_addr);
+
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, app).await {
+                error!("HTTP server error: {}", e);
+            }
+        });
+
+        loop {
+            tokio::select! {
+                Some(update) = updates.next() => {
+                    state.handle_discovery_update(update);
+                }
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Shutting down...");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Run the bootnode server with a shutdown signal.
+    pub async fn run_until<F>(self, shutdown: F) -> Result<()>
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let (discv4, mut discv4_service) = self.create_discv4().await?;
+        let state = BootnodeState::new(discv4, self.local_enr, self.config.http_addr);
+
+        let mut updates = discv4_service.update_stream();
+        discv4_service.spawn();
+
+        let app = Self::router(state.clone());
+        let listener = tokio::net::TcpListener::bind(self.config.http_addr).await?;
+        info!("HTTP API listening on {}", self.config.http_addr);
+
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, app).await {
+                error!("HTTP server error: {}", e);
+            }
+        });
+
+        tokio::pin!(shutdown);
+
+        loop {
+            tokio::select! {
+                Some(update) = updates.next() => {
+                    state.handle_discovery_update(update);
+                }
+                _ = &mut shutdown => {
+                    info!("Shutdown signal received");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Start the server in background and return a handle.
+    pub async fn start(self) -> Result<BootnodeHandle> {
+        let (discv4, mut discv4_service) = self.create_discv4().await?;
+        let state = BootnodeState::new(discv4, self.local_enr, self.config.http_addr);
+
+        let mut updates = discv4_service.update_stream();
+        discv4_service.spawn();
+
+        let app = Self::router(state.clone());
+        let listener = tokio::net::TcpListener::bind(self.config.http_addr).await?;
+        let http_addr = listener.local_addr()?;
+        info!("HTTP API listening on {}", http_addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, app).await {
+                error!("HTTP server error: {}", e);
+            }
+        });
+
+        let state_clone = state.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(update) = updates.next() => {
+                        state_clone.handle_discovery_update(update);
+                    }
+                    _ = &mut shutdown_rx => {
+                        info!("Shutdown signal received");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(BootnodeHandle {
+            state,
+            http_addr,
+            shutdown_tx: Some(shutdown_tx),
+        })
+    }
+}
+
+/// Handle to a running bootnode server.
+pub struct BootnodeHandle {
+    state: BootnodeState,
+    http_addr: SocketAddr,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl BootnodeHandle {
+    /// Get the HTTP API address.
+    pub fn http_addr(&self) -> SocketAddr {
+        self.http_addr
+    }
+
+    /// Get the bootnode state.
+    pub fn state(&self) -> &BootnodeState {
+        &self.state
+    }
+
+    /// Get the base URL for the HTTP API.
+    pub fn base_url(&self) -> String {
+        format!("http://{}", self.http_addr)
+    }
+
+    /// Shutdown the bootnode.
+    pub fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+impl Drop for BootnodeHandle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+// HTTP Handlers
+
+async fn health() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+async fn get_info(State(state): State<BootnodeState>) -> impl IntoResponse {
+    Json(state.info())
+}
+
+async fn list_peers(State(state): State<BootnodeState>) -> impl IntoResponse {
+    Json(state.list_registered())
+}
+
+async fn list_discovered(State(state): State<BootnodeState>) -> impl IntoResponse {
+    Json(state.list_discovered())
+}
+
+async fn register_peer(
+    State(state): State<BootnodeState>,
+    Json(req): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    let secret_bytes = match const_hex::decode(req.secret_key.trim_start_matches("0x")) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("Invalid secret key hex: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    let secret_key = match SecretKey::from_slice(&secret_bytes) {
+        Ok(key) => key,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("Invalid secret key: {}", e) })),
+            )
+                .into_response();
+        }
+    };
+
+    let udp_port = req.udp_port.unwrap_or(req.tcp_port);
+    let socket_addr = SocketAddr::new(req.ip, udp_port);
+    let mut record = NodeRecord::from_secret_key(socket_addr, &secret_key);
+    record.tcp_port = req.tcp_port;
+
+    let info = state.register_peer(record);
+    (
+        StatusCode::CREATED,
+        Json(serde_json::to_value(info).unwrap()),
+    )
+        .into_response()
+}
+
+async fn get_peer(
+    State(state): State<BootnodeState>,
+    Path(peer_id): Path<String>,
+) -> impl IntoResponse {
+    let peer_id = match parse_peer_id(&peer_id) {
+        Ok(id) => id,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e })),
+            )
+                .into_response();
+        }
+    };
+
+    match state.get_peer(&peer_id) {
+        Some(info) => Json(serde_json::to_value(info).unwrap()).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Peer not found" })),
+        )
+            .into_response(),
+    }
+}
+
+async fn deregister_peer(
+    State(state): State<BootnodeState>,
+    Path(peer_id): Path<String>,
+) -> impl IntoResponse {
+    let peer_id = match parse_peer_id(&peer_id) {
+        Ok(id) => id,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": e })),
+            );
+        }
+    };
+
+    if state.deregister_peer(peer_id) {
+        (StatusCode::OK, Json(serde_json::json!({ "removed": true })))
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Peer not found in registered peers" })),
+        )
+    }
+}

--- a/crates/bootnode/src/state.rs
+++ b/crates/bootnode/src/state.rs
@@ -1,0 +1,216 @@
+//! Bootnode state management.
+
+use parking_lot::RwLock;
+use reth_discv4::{DiscoveryUpdate, Discv4};
+use reth_network_peers::{NodeRecord, PeerId};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use tracing::{info, warn};
+
+/// Information about a registered or discovered peer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PeerInfo {
+    pub id: String,
+    pub ip: String,
+    pub tcp_port: u16,
+    pub udp_port: u16,
+    pub enode: String,
+}
+
+impl From<&NodeRecord> for PeerInfo {
+    fn from(record: &NodeRecord) -> Self {
+        Self {
+            id: format!("{:?}", record.id),
+            ip: record.address.to_string(),
+            tcp_port: record.tcp_port,
+            udp_port: record.udp_port,
+            enode: record.to_string(),
+        }
+    }
+}
+
+/// Request to register a new peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    /// Hex-encoded 32-byte secret key for the node.
+    pub secret_key: String,
+    /// IP address of the node.
+    pub ip: std::net::IpAddr,
+    /// TCP port (defaults to 30303).
+    #[serde(default = "default_port")]
+    pub tcp_port: u16,
+    /// UDP port (defaults to tcp_port).
+    pub udp_port: Option<u16>,
+}
+
+fn default_port() -> u16 {
+    30303
+}
+
+/// Bootnode status information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BootnodeInfo {
+    pub enode: String,
+    pub peer_id: String,
+    pub discovery_addr: String,
+    pub http_addr: String,
+    pub registered_peers: usize,
+    pub discovered_peers: usize,
+}
+
+/// Shared state for the bootnode.
+#[derive(Clone)]
+pub struct BootnodeState {
+    /// The discv4 frontend for managing peers.
+    pub discv4: Discv4,
+    /// This node's ENR record.
+    pub local_enr: NodeRecord,
+    /// HTTP API address.
+    pub http_addr: SocketAddr,
+    /// Peers explicitly registered via the API.
+    pub registered_peers: Arc<RwLock<HashMap<PeerId, NodeRecord>>>,
+    /// Peers discovered via discv4 protocol.
+    pub discovered_peers: Arc<RwLock<HashMap<PeerId, NodeRecord>>>,
+}
+
+impl BootnodeState {
+    /// Create a new bootnode state.
+    pub fn new(discv4: Discv4, local_enr: NodeRecord, http_addr: SocketAddr) -> Self {
+        Self {
+            discv4,
+            local_enr,
+            http_addr,
+            registered_peers: Arc::new(RwLock::new(HashMap::new())),
+            discovered_peers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get bootnode info.
+    pub fn info(&self) -> BootnodeInfo {
+        BootnodeInfo {
+            enode: self.local_enr.to_string(),
+            peer_id: format!("{:?}", self.local_enr.id),
+            discovery_addr: self.local_enr.udp_addr().to_string(),
+            http_addr: self.http_addr.to_string(),
+            registered_peers: self.registered_peers.read().len(),
+            discovered_peers: self.discovered_peers.read().len(),
+        }
+    }
+
+    /// List all registered peers.
+    pub fn list_registered(&self) -> Vec<PeerInfo> {
+        self.registered_peers
+            .read()
+            .values()
+            .map(PeerInfo::from)
+            .collect()
+    }
+
+    /// List all discovered peers.
+    pub fn list_discovered(&self) -> Vec<PeerInfo> {
+        self.discovered_peers
+            .read()
+            .values()
+            .map(PeerInfo::from)
+            .collect()
+    }
+
+    /// Register a peer with the bootnode.
+    pub fn register_peer(&self, record: NodeRecord) -> PeerInfo {
+        self.discv4.add_node(record);
+        self.registered_peers.write().insert(record.id, record);
+        info!("Registered peer: {:?} at {}", record.id, record.address);
+        PeerInfo::from(&record)
+    }
+
+    /// Deregister a peer from the bootnode.
+    pub fn deregister_peer(&self, peer_id: PeerId) -> bool {
+        let removed = self.registered_peers.write().remove(&peer_id);
+        if removed.is_some() {
+            self.discv4.remove_peer(peer_id);
+            info!("Deregistered peer: {:?}", peer_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get a peer by ID (checks registered first, then discovered).
+    pub fn get_peer(&self, peer_id: &PeerId) -> Option<PeerInfo> {
+        if let Some(record) = self.registered_peers.read().get(peer_id) {
+            return Some(PeerInfo::from(record));
+        }
+        if let Some(record) = self.discovered_peers.read().get(peer_id) {
+            return Some(PeerInfo::from(record));
+        }
+        None
+    }
+
+    /// Handle a discovery update from the discv4 service.
+    pub fn handle_discovery_update(&self, update: DiscoveryUpdate) {
+        match update {
+            DiscoveryUpdate::Added(record) => {
+                info!("Discovered peer: {:?} at {}", record.id, record.address);
+                self.discovered_peers.write().insert(record.id, record);
+            }
+            DiscoveryUpdate::Removed(peer_id) => {
+                info!("Peer removed: {:?}", peer_id);
+                self.discovered_peers.write().remove(&peer_id);
+            }
+            DiscoveryUpdate::DiscoveredAtCapacity(record) => {
+                warn!(
+                    "Discovery at capacity, ignoring peer: {:?} at {}",
+                    record.id, record.address
+                );
+            }
+            DiscoveryUpdate::EnrForkId(record, fork_id) => {
+                info!("Peer {:?} has fork_id: {:?}", record.id, fork_id);
+            }
+            DiscoveryUpdate::Batch(updates) => {
+                for update in updates {
+                    self.handle_discovery_update(update);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_node_record(port: u16) -> NodeRecord {
+        let key = crate::generate_secret_key();
+        let addr =
+            std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port);
+        NodeRecord::from_secret_key(addr, &key)
+    }
+
+    #[test]
+    fn test_peer_info_from_node_record() {
+        let record = mock_node_record(30303);
+        let info = PeerInfo::from(&record);
+
+        assert_eq!(info.ip, "127.0.0.1");
+        assert_eq!(info.tcp_port, 30303);
+        assert_eq!(info.udp_port, 30303);
+        assert!(info.enode.starts_with("enode://"));
+    }
+
+    #[test]
+    fn test_register_request_default_port() {
+        let json = r#"{"secret_key": "0x1234", "ip": "10.0.0.1"}"#;
+        let req: RegisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.tcp_port, 30303);
+        assert!(req.udp_port.is_none());
+    }
+
+    #[test]
+    fn test_register_request_custom_ports() {
+        let json =
+            r#"{"secret_key": "0x1234", "ip": "10.0.0.1", "tcp_port": 30304, "udp_port": 30305}"#;
+        let req: RegisterRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.tcp_port, 30304);
+        assert_eq!(req.udp_port, Some(30305));
+    }
+}

--- a/crates/bootnode/tests/integration.rs
+++ b/crates/bootnode/tests/integration.rs
@@ -1,0 +1,387 @@
+//! Integration tests for the bootnode server.
+
+use reqwest::Client;
+use serde_json::Value;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tempo_bootnode::{BootnodeConfig, BootnodeServer, PeerInfo, generate_secret_key};
+
+/// Find an available port for testing.
+fn find_available_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Create a test bootnode config with random ports.
+fn test_config() -> BootnodeConfig {
+    let discovery_port = find_available_port();
+    let http_port = find_available_port();
+
+    BootnodeConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), discovery_port),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), http_port),
+    )
+    .with_lookup_interval_secs(60)
+}
+
+#[tokio::test]
+async fn test_bootnode_health_endpoint() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let resp = client
+        .get(format!("{}/health", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_bootnode_info_endpoint() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let expected_enode = server.local_enr().to_string();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let resp = client
+        .get(format!("{}/", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+
+    let info: Value = resp.json().await.unwrap();
+    assert_eq!(info["enode"], expected_enode);
+    assert_eq!(info["registered_peers"], 0);
+    assert_eq!(info["discovered_peers"], 0);
+}
+
+#[tokio::test]
+async fn test_register_peer() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let peer_key = generate_secret_key();
+    let secret_hex = const_hex::encode(peer_key.secret_bytes());
+
+    let resp = client
+        .post(format!("{}/peers", handle.base_url()))
+        .json(&serde_json::json!({
+            "secret_key": secret_hex,
+            "ip": "10.0.0.5",
+            "tcp_port": 30303
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 201);
+
+    let peer: PeerInfo = resp.json().await.unwrap();
+    assert_eq!(peer.ip, "10.0.0.5");
+    assert_eq!(peer.tcp_port, 30303);
+    assert!(peer.enode.starts_with("enode://"));
+
+    let info_resp = client
+        .get(format!("{}/", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+    let info: Value = info_resp.json().await.unwrap();
+    assert_eq!(info["registered_peers"], 1);
+}
+
+#[tokio::test]
+async fn test_list_peers_empty() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let resp = client
+        .get(format!("{}/peers", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+
+    let peers: Vec<PeerInfo> = resp.json().await.unwrap();
+    assert!(peers.is_empty());
+}
+
+#[tokio::test]
+async fn test_register_and_list_peers() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    for i in 1..=3 {
+        let peer_key = generate_secret_key();
+        let secret_hex = const_hex::encode(peer_key.secret_bytes());
+
+        let resp = client
+            .post(format!("{}/peers", handle.base_url()))
+            .json(&serde_json::json!({
+                "secret_key": secret_hex,
+                "ip": format!("10.0.0.{}", i),
+                "tcp_port": 30303 + i
+            }))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 201);
+    }
+
+    let resp = client
+        .get(format!("{}/peers", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    let peers: Vec<PeerInfo> = resp.json().await.unwrap();
+    assert_eq!(peers.len(), 3);
+}
+
+#[tokio::test]
+async fn test_deregister_peer() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let peer_key = generate_secret_key();
+    let secret_hex = const_hex::encode(peer_key.secret_bytes());
+
+    let resp = client
+        .post(format!("{}/peers", handle.base_url()))
+        .json(&serde_json::json!({
+            "secret_key": secret_hex,
+            "ip": "10.0.0.10",
+            "tcp_port": 30303
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 201);
+    let peer: PeerInfo = resp.json().await.unwrap();
+
+    let peer_id = peer.id.trim_start_matches("0x");
+
+    let delete_resp = client
+        .delete(format!("{}/peers/{}", handle.base_url(), peer_id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(delete_resp.status(), 200);
+    let result: Value = delete_resp.json().await.unwrap();
+    assert_eq!(result["removed"], true);
+
+    let list_resp = client
+        .get(format!("{}/peers", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+    let peers: Vec<PeerInfo> = list_resp.json().await.unwrap();
+    assert!(peers.is_empty());
+}
+
+#[tokio::test]
+async fn test_deregister_nonexistent_peer() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let fake_peer_id = "a".repeat(128);
+
+    let resp = client
+        .delete(format!("{}/peers/{}", handle.base_url(), fake_peer_id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn test_register_invalid_secret_key() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{}/peers", handle.base_url()))
+        .json(&serde_json::json!({
+            "secret_key": "invalid_hex",
+            "ip": "10.0.0.1",
+            "tcp_port": 30303
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 400);
+    let error: Value = resp.json().await.unwrap();
+    assert!(error["error"].as_str().unwrap().contains("Invalid"));
+}
+
+#[tokio::test]
+async fn test_register_with_custom_udp_port() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let peer_key = generate_secret_key();
+    let secret_hex = const_hex::encode(peer_key.secret_bytes());
+
+    let resp = client
+        .post(format!("{}/peers", handle.base_url()))
+        .json(&serde_json::json!({
+            "secret_key": secret_hex,
+            "ip": "10.0.0.20",
+            "tcp_port": 30303,
+            "udp_port": 30304
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 201);
+
+    let peer: PeerInfo = resp.json().await.unwrap();
+    assert_eq!(peer.tcp_port, 30303);
+    assert_eq!(peer.udp_port, 30304);
+}
+
+#[tokio::test]
+async fn test_get_peer_by_id() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let peer_key = generate_secret_key();
+    let secret_hex = const_hex::encode(peer_key.secret_bytes());
+
+    let resp = client
+        .post(format!("{}/peers", handle.base_url()))
+        .json(&serde_json::json!({
+            "secret_key": secret_hex,
+            "ip": "10.0.0.30",
+            "tcp_port": 30303
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 201);
+    let peer: PeerInfo = resp.json().await.unwrap();
+    let peer_id = peer.id.trim_start_matches("0x");
+
+    let get_resp = client
+        .get(format!("{}/peers/{}", handle.base_url(), peer_id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(get_resp.status(), 200);
+    let fetched_peer: PeerInfo = get_resp.json().await.unwrap();
+    assert_eq!(fetched_peer.ip, "10.0.0.30");
+}
+
+#[tokio::test]
+async fn test_get_nonexistent_peer() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+
+    let fake_peer_id = "b".repeat(128);
+
+    let resp = client
+        .get(format!("{}/peers/{}", handle.base_url(), fake_peer_id))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn test_discovered_peers_endpoint() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let resp = client
+        .get(format!("{}/discovered", handle.base_url()))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+
+    let peers: Vec<PeerInfo> = resp.json().await.unwrap();
+    assert!(peers.is_empty());
+}
+
+#[tokio::test]
+async fn test_state_direct_access() {
+    let config = test_config();
+    let server = BootnodeServer::new(config).await.unwrap();
+    let handle = server.start().await.unwrap();
+
+    assert!(handle.state().list_registered().is_empty());
+    assert!(handle.state().list_discovered().is_empty());
+
+    let info = handle.state().info();
+    assert_eq!(info.registered_peers, 0);
+    assert_eq!(info.discovered_peers, 0);
+}


### PR DESCRIPTION
## Summary

Add internal bootnode with dynamic peer registration for Kubernetes deployments.

## Features

- Lightweight discv4 bootnode with stable identity via persistent node key
- HTTP API for dynamic peer registration/deregistration
- Designed for k8s startup/shutdown hooks (postStart/preStop)

## HTTP Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/health` | GET | Health check |
| `/` | GET | Bootnode info (enode, peer counts) |
| `/peers` | GET | List registered peers |
| `/peers` | POST | Register a new peer |
| `/peers/{id}` | GET | Get peer by ID |
| `/peers/{id}` | DELETE | Deregister a peer |
| `/discovered` | GET | List discovered peers |

## Structure

- `crates/bootnode`: Core library with BootnodeServer, BootnodeState, BootnodeHandle
- `bin/tempo-bootnode`: CLI binary with clap args

## Usage

```bash
# Run with ephemeral key (testing)
tempo-bootnode --discovery-addr 0.0.0.0:30303 --http-addr 0.0.0.0:8080

# Run with persistent key
tempo-bootnode --node-key /data/node.key --external-ip 10.0.0.1
```

## Testing

23 tests (10 unit + 13 integration):
```bash
cargo test -p tempo-bootnode
```