### PR TITLE
fix(docs): use absolute URLs for og:image

### DIFF
--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -78,12 +78,12 @@ export default defineConfig({
     </>
   ),
   ogImageUrl: {
-    '/': '/og-docs.png',
-    '/learn': '/api/og?title=%title&description=%description',
-    '/quickstart': '/api/og?title=%title&description=%description',
-    '/guide': '/api/og?title=%title&description=%description',
-    '/protocol': '/api/og?title=%title&description=%description',
-    '/sdk': '/api/og?title=%title&description=%description',
+    '/': 'https://docs.tempo.xyz/og-docs.png',
+    '/learn': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
+    '/quickstart': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
+    '/guide': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
+    '/protocol': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
+    '/sdk': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
   },
   title: 'Tempo',
   titleTemplate: '%s | Tempo Docs',


### PR DESCRIPTION
Social platforms (Twitter, Slack, etc.) require absolute URLs in `og:image` meta tags.

Vocs wasn't prefixing relative paths with `baseUrl`, causing dynamic OG images to not load in link previews.

**Before:** `<meta property="og:image" content="/api/og?title=...">`
**After:** `<meta property="og:image" content="https://docs.tempo.xyz/api/og?title=...">`

Context: https://tempoxyz.slack.com/archives/C09K7873V4N/p1768391562113309