### PR TITLE
fix(docs): use checksummed address for Account Keychain precompile

### DIFF
--- a/docs/pages/protocol/transactions/AccountKeychain.mdx
+++ b/docs/pages/protocol/transactions/AccountKeychain.mdx
@@ -5,7 +5,7 @@ description: Technical specification for the Account Keychain precompile managin
 
 # Account Keychain Precompile
 
-**Address:** `0xAAAAAAAA00000000000000000000000000000000`
+**Address:** `0xaAAAaaAA00000000000000000000000000000000`
 
 ## Overview
 

--- a/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/docs/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -588,7 +588,7 @@ Note: `expiry` and `limits` use RLP trailing field semantics - they can be omitt
 
 #### Keychain Precompile
 
-The Account Keychain precompile (deployed at address `0xAAAAAAAA00000000000000000000000000000000`) manages authorized access keys for accounts. It enables root keys to provision scoped access keys with expiry timestamps and per-TIP20 token spending limits.
+The Account Keychain precompile (deployed at address `0xaAAAaaAA00000000000000000000000000000000`) manages authorized access keys for accounts. It enables root keys to provision scoped access keys with expiry timestamps and per-TIP20 token spending limits.
 
 **See the [Account Keychain Specification](./AccountKeychain) for complete interface details, storage layout, and implementation.**
 

--- a/docs/specs/src/AccountKeychain.sol
+++ b/docs/specs/src/AccountKeychain.sol
@@ -6,7 +6,7 @@ import { IAccountKeychain } from "./interfaces/IAccountKeychain.sol";
 /// @title AccountKeychain - Access Key Manager Precompile
 /// @notice Manages authorized Access Keys for accounts, enabling Root Keys to provision
 ///         scoped secondary keys with expiry timestamps and per-TIP20 token spending limits.
-/// @dev This precompile is deployed at address `0xAAAAAAAA00000000000000000000000000000000`
+/// @dev This precompile is deployed at address `0xaAAAaaAA00000000000000000000000000000000`
 ///
 /// Storage Layout:
 /// ```solidity

--- a/docs/specs/src/interfaces/IAccountKeychain.sol
+++ b/docs/specs/src/interfaces/IAccountKeychain.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 /**
  * @title Account Keychain Precompile Interface
  * @notice Interface for the Account Keychain precompile that manages authorized access keys
- * @dev This precompile is deployed at address `0xAAAAAAAA00000000000000000000000000000000`
+ * @dev This precompile is deployed at address `0xaAAAaaAA00000000000000000000000000000000`
  *
  * The Account Keychain allows accounts to authorize secondary keys (Access Keys) that can sign
  * transactions on behalf of the account. Access Keys can be scoped by:


### PR DESCRIPTION
Updates the Account Keychain precompile address to use the correct EIP-55 checksummed format.

**Changes:**
- `0xAAAAAAAA00000000000000000000000000000000` → `0xaAAAaaAA00000000000000000000000000000000`

**Files updated:**
- docs/pages/protocol/transactions/AccountKeychain.mdx
- docs/pages/protocol/transactions/spec-tempo-transaction.mdx
- docs/specs/src/AccountKeychain.sol
- docs/specs/src/interfaces/IAccountKeychain.sol