### PR TITLE
TIP: DEX minimum order enforcement on partial fills

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -4332,8 +4332,15 @@ mod tests {
 
             // Alice places $200 flip bid order (buy base at tick 0, flip to sell at tick 100)
             let order_amount = 200_000_000u128;
-            let order_id =
-                exchange.place_flip(alice, base_token, order_amount, true, tick, flip_tick, false)?;
+            let order_id = exchange.place_flip(
+                alice,
+                base_token,
+                order_amount,
+                true,
+                tick,
+                flip_tick,
+                false,
+            )?;
             assert_eq!(order_id, 1);
 
             // Bob sells $110 base, leaving $90 remaining (below minimum)
@@ -4350,13 +4357,21 @@ mod tests {
             // A proportional flip order ($110) should have been created
             // The flip order should be order_id = 2
             let flip_order = exchange.orders[2].read()?;
-            assert!(
-                !flip_order.maker().is_zero(),
-                "Flip order should exist"
+            assert!(!flip_order.maker().is_zero(), "Flip order should exist");
+            assert_eq!(
+                flip_order.maker(),
+                alice,
+                "Flip order maker should be Alice"
             );
-            assert_eq!(flip_order.maker(), alice, "Flip order maker should be Alice");
-            assert!(flip_order.is_ask(), "Flip order should be an ask (flipped from bid)");
-            assert_eq!(flip_order.tick(), flip_tick, "Flip order should be at flip_tick");
+            assert!(
+                flip_order.is_ask(),
+                "Flip order should be an ask (flipped from bid)"
+            );
+            assert_eq!(
+                flip_order.tick(),
+                flip_tick,
+                "Flip order should be at flip_tick"
+            );
             assert_eq!(
                 flip_order.amount(),
                 200_000_000,
@@ -4367,7 +4382,10 @@ mod tests {
                 110_000_000,
                 "Flip order remaining should equal filled portion"
             );
-            assert!(flip_order.is_flip(), "Flip order should also be a flip order");
+            assert!(
+                flip_order.is_flip(),
+                "Flip order should also be a flip order"
+            );
 
             // Alice should have $90 quote tokens refunded (bid orders escrow quote)
             let alice_quote_balance = exchange.balance_of(alice, quote_token)?;
@@ -4408,8 +4426,15 @@ mod tests {
 
             // Alice places $150 flip bid order
             let order_amount = 150_000_000u128;
-            let order_id =
-                exchange.place_flip(alice, base_token, order_amount, true, tick, flip_tick, false)?;
+            let order_id = exchange.place_flip(
+                alice,
+                base_token,
+                order_amount,
+                true,
+                tick,
+                flip_tick,
+                false,
+            )?;
 
             // Bob sells $60 base, leaving $90 remaining (below minimum)
             // Filled amount = $60, which is also below minimum
@@ -4469,8 +4494,15 @@ mod tests {
 
             // Alice places $190 flip bid order
             let order_amount = 190_000_000u128;
-            let order_id =
-                exchange.place_flip(alice, base_token, order_amount, true, tick, flip_tick, false)?;
+            let order_id = exchange.place_flip(
+                alice,
+                base_token,
+                order_amount,
+                true,
+                tick,
+                flip_tick,
+                false,
+            )?;
 
             // Bob sells $100 base, leaving $90 remaining (below minimum)
             // Filled amount = $100, exactly at minimum

--- a/docs/specs/TIP-DEX-MIN-ORDER.md
+++ b/docs/specs/TIP-DEX-MIN-ORDER.md
@@ -13,7 +13,12 @@ This document specifies a protocol change to prevent DoS attacks on the Stableco
 
 ## Abstract
 
-When a partial fill on the Stablecoin DEX leaves an order with remaining amount below `MIN_ORDER_AMOUNT` ($100), the order is automatically cancelled and remaining tokens are refunded to the maker. This prevents DoS attacks where malicious users create arbitrarily small orders by self-matching.
+When a partial fill on the Stablecoin DEX leaves an order with remaining amount below `MIN_ORDER_AMOUNT` ($100), the order is automatically completed:
+
+- **Non-flip orders**: Cancelled with remaining tokens refunded to maker
+- **Flip orders**: Force-completed with a proportional flip (flip amount = filled amount)
+
+This prevents DoS attacks where malicious users create arbitrarily small orders by self-matching, while preserving flip order functionality.
 
 ## Motivation
 
@@ -33,7 +38,10 @@ By stacking many tiny orders on the orderbook, an attacker can:
 
 ### Solution
 
-Extend the minimum order size enforcement to partial fills. When a partial fill would leave `remaining < MIN_ORDER_AMOUNT`, the order is automatically cancelled with the remaining amount refunded to the maker's internal balance.
+Extend the minimum order size enforcement to partial fills:
+
+1. **Non-flip orders**: Auto-cancel when `remaining < MIN_ORDER_AMOUNT`, refunding remaining tokens to maker
+2. **Flip orders**: Force-complete with proportional flip - the flip order amount equals the filled amount (not the original amount), preserving the flip functionality while preventing tiny orders
 
 ---
 
@@ -46,6 +54,19 @@ No new constants. Uses existing:
 ```solidity
 uint128 public constant MIN_ORDER_AMOUNT = 100_000_000; // $100 with 6 decimals
 ```
+
+## Key Insight: Proportional Flipping
+
+For flip orders, we can compute the filled amount without additional storage:
+
+```
+filled = order.amount - order.remaining
+```
+
+When a flip order is force-completed, the flip order is created with `amount = filled`, not the original amount. This ensures:
+- The flip is proportional to actual execution
+- No new storage fields needed
+- Fair treatment of flip order users
 
 ## Behavior Change
 
@@ -60,17 +81,23 @@ After computing `new_remaining = order.remaining - fill_amount`:
 1. If `new_remaining >= MIN_ORDER_AMOUNT` OR `new_remaining == 0`:
    - Continue with normal partial fill logic (no change)
 
-2. If `0 < new_remaining < MIN_ORDER_AMOUNT`:
+2. If `0 < new_remaining < MIN_ORDER_AMOUNT` AND **order is NOT a flip order**:
    - Credit the filled amount to maker (normal settlement)
-   - Refund remaining tokens to maker's internal balance:
-     - Bid orders: refund quote tokens (using `RoundingDirection::Up` to match escrow)
-     - Ask orders: refund base tokens
-   - Remove order from orderbook linked list
-   - Update tick level liquidity (subtract full `order.remaining`, not just `fill_amount`)
-   - If tick becomes empty, clear bitmap bit and update best tick
-   - Delete order from storage
-   - Emit `OrderFilled` event (with `partialFill: true`)
-   - Emit `OrderCancelled` event
+   - Refund remaining tokens to maker's internal balance
+   - Remove order from orderbook, delete from storage
+   - Emit `OrderFilled` + `OrderCancelled`
+
+3. If `0 < new_remaining < MIN_ORDER_AMOUNT` AND **order IS a flip order**:
+   - Credit the filled amount to maker (normal settlement)
+   - Refund remaining tokens to maker's internal balance
+   - Calculate `total_filled = order.amount - new_remaining`
+   - Remove order from orderbook, delete from storage
+   - If `total_filled >= MIN_ORDER_AMOUNT`:
+     - Create flip order with `amount = total_filled` (proportional flip)
+     - Flip order placed at `flip_tick`, with `is_flip = true`
+   - If `total_filled < MIN_ORDER_AMOUNT`:
+     - No flip order created (filled amount too small)
+   - Emit `OrderFilled` + `OrderCancelled` (+ `OrderPlaced` if flip created)
 
 ## Interface Changes
 
@@ -86,9 +113,17 @@ event OrderFilled(
 );
 
 event OrderCancelled(uint128 indexed orderId);
-```
 
-When auto-cancellation occurs, both events are emitted in sequence.
+event OrderPlaced(
+    uint128 indexed orderId,
+    address indexed maker,
+    address indexed base,
+    uint128 amount,
+    bool isBid,
+    int16 tick,
+    bool isFlip
+);
+```
 
 ## Affected Functions
 
@@ -106,12 +141,12 @@ fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_
     settle_maker(order, fill_amount);
     
     if new_remaining > 0 && new_remaining < MIN_ORDER_AMOUNT {
-        // Auto-cancel: refund remaining to maker
+        // Refund remaining to maker
         refund_remaining_to_maker(order, new_remaining);
         
         // Remove from orderbook
         remove_from_linked_list(order, level);
-        update_tick_level_liquidity(level, order.remaining()); // Full remaining
+        update_tick_level_liquidity(level, order.remaining());
         
         if level.head == 0 {
             clear_tick_bitmap(order);
@@ -119,6 +154,24 @@ fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_
         }
         
         delete_order(order);
+        
+        // Handle flip orders: create proportional flip if filled amount >= minimum
+        if order.is_flip() {
+            let total_filled = order.amount() - new_remaining;
+            if total_filled >= MIN_ORDER_AMOUNT {
+                // Create flip order with proportional amount
+                place_flip(
+                    order.maker(),
+                    orderbook.base,
+                    total_filled,        // Proportional flip amount
+                    !order.is_bid(),     // Flip side
+                    order.flip_tick(),   // New tick
+                    order.tick(),        // New flip_tick
+                    true,                // is_flip
+                );
+            }
+            // If total_filled < MIN_ORDER_AMOUNT, no flip (too small)
+        }
         
         emit_order_filled(order, fill_amount, partial_fill: true);
         emit_order_cancelled(order);
@@ -139,24 +192,78 @@ fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_
 
 1. **No orders below minimum**: After any swap, no active order has `0 < remaining < MIN_ORDER_AMOUNT`
 
-2. **Maker made whole**: When auto-cancelled, maker receives:
+2. **Maker made whole**: When force-completed, maker receives:
    - Settlement for filled portion (normal)
    - Full refund of remaining escrowed tokens
+   - Proportional flip order (for flip orders with sufficient filled amount)
 
-3. **Accounting consistency**: Total liquidity at tick level equals sum of remaining amounts of all orders at that tick
+3. **Proportional flip**: Flip orders create flips with `amount = total_filled`, not original amount
 
-4. **Event ordering**: `OrderFilled` always emitted before `OrderCancelled` for auto-cancellations
+4. **Accounting consistency**: Total liquidity at tick level equals sum of remaining amounts of all orders at that tick
+
+5. **Event ordering**: `OrderFilled` → `OrderCancelled` → `OrderPlaced` (if flip created)
 
 ## Test Cases
 
+### Non-Flip Orders
 1. **Auto-cancel triggers**: Place $150 order, swap $60 → order cancelled, $90 refunded
 2. **Boundary - at minimum**: Place $200 order, swap $100 → order remains with $100
 3. **Boundary - just below**: Place $199 order, swap $100 → order cancelled, $99 refunded
-4. **Full fill unaffected**: Place $100 order, swap $100 → normal full fill, no cancellation
-5. **Bid order refund**: Verify quote tokens refunded with correct rounding
-6. **Ask order refund**: Verify base tokens refunded exactly
-7. **Linked list integrity**: Multiple orders at tick, middle order auto-cancelled
-8. **Best tick updates**: Auto-cancel last order at best tick
+4. **Full fill unaffected**: Place $100 order, swap $100 → normal full fill
+
+### Flip Orders
+5. **Flip with sufficient filled**: Place $200 flip order, swap $110 → cancelled, $90 refunded, $110 flip created
+6. **Flip with insufficient filled**: Place $150 flip order, swap $60 → cancelled, $90 refunded, NO flip (filled < $100)
+7. **Flip at exact minimum filled**: Place $190 flip order, swap $100 → cancelled, $90 refunded, $100 flip created
+8. **Flip chain termination**: Flip order → force-complete → proportional flip → force-complete → no flip (amounts shrink naturally)
+
+### Edge Cases
+9. **Bid order refund**: Verify quote tokens refunded with correct rounding
+10. **Ask order refund**: Verify base tokens refunded exactly
+11. **Linked list integrity**: Multiple orders at tick, middle order force-completed
+12. **Best tick updates**: Force-complete last order at best tick
+
+---
+
+# Examples
+
+## Example 1: Non-Flip Order Auto-Cancel
+
+```
+1. Alice places $150 ask order at tick 0
+2. Bob swaps $60 quote for base (fills $60 of Alice's order)
+3. Remaining = $90 < $100 minimum
+4. Order auto-cancelled:
+   - Alice receives $60 base settlement (from fill)
+   - Alice receives $90 base refund (remaining)
+   - OrderFilled + OrderCancelled emitted
+```
+
+## Example 2: Flip Order with Proportional Flip
+
+```
+1. Alice places $200 flip ask at tick 10, flip_tick 0
+2. Bob swaps $110 quote for base (fills $110)
+3. Remaining = $90 < $100 minimum
+4. Order force-completed:
+   - Alice receives $110 quote settlement
+   - Alice receives $90 base refund
+   - Flip order created: $110 bid at tick 0 (flip_tick 10)
+   - OrderFilled + OrderCancelled + OrderPlaced emitted
+```
+
+## Example 3: Flip Order with Insufficient Filled Amount
+
+```
+1. Alice places $150 flip ask at tick 10, flip_tick 0
+2. Bob swaps $60 quote for base (fills $60)
+3. Remaining = $90 < $100 minimum
+4. Order force-completed:
+   - Alice receives $60 quote settlement
+   - Alice receives $90 base refund
+   - NO flip order created ($60 < $100 minimum)
+   - OrderFilled + OrderCancelled emitted
+```
 
 ---
 
@@ -164,6 +271,8 @@ fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_
 
 This change requires a **hard fork** as it modifies consensus-critical behavior:
 
-- Existing orders below minimum (if any exist from edge cases) will be cancelled on next interaction
+- Existing orders below minimum (if any exist from edge cases) will be force-completed on next interaction
 - No state migration needed - change is forward-only
-- Clients should handle receiving `OrderCancelled` events for orders they didn't explicitly cancel
+- Clients should handle:
+  - Receiving `OrderCancelled` events for orders they didn't explicitly cancel
+  - Flip orders completing with proportional (not original) amounts

--- a/docs/specs/TIP-DEX-MIN-ORDER.md
+++ b/docs/specs/TIP-DEX-MIN-ORDER.md
@@ -1,0 +1,169 @@
+# DEX Minimum Order Enforcement on Partial Fills
+
+This document specifies a protocol change to prevent DoS attacks on the Stablecoin DEX by enforcing minimum order size after partial fills.
+
+- **Spec ID**: TIP-DEX-MIN-ORDER
+- **Authors/Owners**: @georgios, @dan
+- **Status**: Draft
+- **Related Specs**: Stablecoin DEX Specification
+
+---
+
+# Overview
+
+## Abstract
+
+When a partial fill on the Stablecoin DEX leaves an order with remaining amount below `MIN_ORDER_AMOUNT` ($100), the order is automatically cancelled and remaining tokens are refunded to the maker. This prevents DoS attacks where malicious users create arbitrarily small orders by self-matching.
+
+## Motivation
+
+### Problem
+
+The current DEX enforces a $100 minimum order size at placement time, but not after partial fills. This creates a vulnerability:
+
+1. User places a $100+ order (e.g., $150)
+2. User trades against their own order to partially fill it (e.g., buy $60)
+3. Order now has $90 remaining, below the minimum
+4. Repeat to create arbitrarily small orders (e.g., $0.000001)
+
+By stacking many tiny orders on the orderbook, an attacker can:
+- Increase gas costs for legitimate swaps (more orders to iterate)
+- Bloat storage with dust orders
+- Degrade orderbook performance
+
+### Solution
+
+Extend the minimum order size enforcement to partial fills. When a partial fill would leave `remaining < MIN_ORDER_AMOUNT`, the order is automatically cancelled with the remaining amount refunded to the maker's internal balance.
+
+---
+
+# Specification
+
+## Constants
+
+No new constants. Uses existing:
+
+```solidity
+uint128 public constant MIN_ORDER_AMOUNT = 100_000_000; // $100 with 6 decimals
+```
+
+## Behavior Change
+
+### Current Behavior
+
+`partial_fill_order` updates `order.remaining` and leaves the order active regardless of the new remaining amount.
+
+### New Behavior
+
+After computing `new_remaining = order.remaining - fill_amount`:
+
+1. If `new_remaining >= MIN_ORDER_AMOUNT` OR `new_remaining == 0`:
+   - Continue with normal partial fill logic (no change)
+
+2. If `0 < new_remaining < MIN_ORDER_AMOUNT`:
+   - Credit the filled amount to maker (normal settlement)
+   - Refund remaining tokens to maker's internal balance:
+     - Bid orders: refund quote tokens (using `RoundingDirection::Up` to match escrow)
+     - Ask orders: refund base tokens
+   - Remove order from orderbook linked list
+   - Update tick level liquidity (subtract full `order.remaining`, not just `fill_amount`)
+   - If tick becomes empty, clear bitmap bit and update best tick
+   - Delete order from storage
+   - Emit `OrderFilled` event (with `partialFill: true`)
+   - Emit `OrderCancelled` event
+
+## Interface Changes
+
+No interface changes. Existing events are reused:
+
+```solidity
+event OrderFilled(
+    uint128 indexed orderId,
+    address indexed maker,
+    address indexed taker,
+    uint128 fillAmount,
+    bool partialFill
+);
+
+event OrderCancelled(uint128 indexed orderId);
+```
+
+When auto-cancellation occurs, both events are emitted in sequence.
+
+## Affected Functions
+
+- `partial_fill_order` (internal) - Primary change location
+- `fill_orders_exact_in` - Calls `partial_fill_order`
+- `fill_orders_exact_out` - Calls `partial_fill_order`
+
+## Pseudocode
+
+```rust
+fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_amount: u128, taker: Address) -> Result<u128> {
+    let new_remaining = order.remaining() - fill_amount;
+    
+    // Normal maker settlement for filled portion
+    settle_maker(order, fill_amount);
+    
+    if new_remaining > 0 && new_remaining < MIN_ORDER_AMOUNT {
+        // Auto-cancel: refund remaining to maker
+        refund_remaining_to_maker(order, new_remaining);
+        
+        // Remove from orderbook
+        remove_from_linked_list(order, level);
+        update_tick_level_liquidity(level, order.remaining()); // Full remaining
+        
+        if level.head == 0 {
+            clear_tick_bitmap(order);
+            update_best_tick_if_needed(order);
+        }
+        
+        delete_order(order);
+        
+        emit_order_filled(order, fill_amount, partial_fill: true);
+        emit_order_cancelled(order);
+    } else {
+        // Normal partial fill
+        order.remaining = new_remaining;
+        update_tick_level_liquidity(level, fill_amount);
+        emit_order_filled(order, fill_amount, partial_fill: true);
+    }
+    
+    Ok(amount_out)
+}
+```
+
+---
+
+# Invariants
+
+1. **No orders below minimum**: After any swap, no active order has `0 < remaining < MIN_ORDER_AMOUNT`
+
+2. **Maker made whole**: When auto-cancelled, maker receives:
+   - Settlement for filled portion (normal)
+   - Full refund of remaining escrowed tokens
+
+3. **Accounting consistency**: Total liquidity at tick level equals sum of remaining amounts of all orders at that tick
+
+4. **Event ordering**: `OrderFilled` always emitted before `OrderCancelled` for auto-cancellations
+
+## Test Cases
+
+1. **Auto-cancel triggers**: Place $150 order, swap $60 → order cancelled, $90 refunded
+2. **Boundary - at minimum**: Place $200 order, swap $100 → order remains with $100
+3. **Boundary - just below**: Place $199 order, swap $100 → order cancelled, $99 refunded
+4. **Full fill unaffected**: Place $100 order, swap $100 → normal full fill, no cancellation
+5. **Bid order refund**: Verify quote tokens refunded with correct rounding
+6. **Ask order refund**: Verify base tokens refunded exactly
+7. **Linked list integrity**: Multiple orders at tick, middle order auto-cancelled
+8. **Best tick updates**: Auto-cancel last order at best tick
+
+---
+
+# Migration
+
+This change requires a **hard fork** as it modifies consensus-critical behavior:
+
+- Existing orders below minimum (if any exist from edge cases) will be cancelled on next interaction
+- No state migration needed - change is forward-only
+- Clients should handle receiving `OrderCancelled` events for orders they didn't explicitly cancel

--- a/docs/specs/TIP-DEX-MIN-ORDER.md
+++ b/docs/specs/TIP-DEX-MIN-ORDER.md
@@ -280,6 +280,21 @@ fn partial_fill_order(&mut self, order: &mut Order, level: &mut TickLevel, fill_
 
 ---
 
+# Maker Considerations
+
+Makers should understand that orders can be early-completed when remaining falls below `MIN_ORDER_AMOUNT` ($100). This affects smaller orders more significantly:
+
+| Order Size | Min Fill Before Early Completion | % That Must Fill |
+|------------|----------------------------------|------------------|
+| $200 | $100 | 50% |
+| $500 | $400 | 80% |
+| $1,000 | $900 | 90% |
+| $10,000 | $9,900 | 99% |
+
+**Recommendation:** Makers who want full order execution should place orders significantly larger than `MIN_ORDER_AMOUNT`. For market making strategies, this behavior is generally acceptable since the filled portion is settled normally and the dust is refunded.
+
+---
+
 # Migration
 
 This change requires a **hard fork** as it modifies consensus-critical behavior:

--- a/docs/specs/test/StablecoinDEX.t.sol
+++ b/docs/specs/test/StablecoinDEX.t.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IStablecoinDEX } from "../src/interfaces/IStablecoinDEX.sol";
-import { ITIP20 } from "../src/interfaces/ITIP20.sol";
-import { ITIP403Registry } from "../src/interfaces/ITIP403Registry.sol";
-import { BaseTest } from "./BaseTest.t.sol";
-import { MockTIP20 } from "./mocks/MockTIP20.sol";
+import {IStablecoinDEX} from "../src/interfaces/IStablecoinDEX.sol";
+import {ITIP20} from "../src/interfaces/ITIP20.sol";
+import {ITIP403Registry} from "../src/interfaces/ITIP403Registry.sol";
+import {BaseTest} from "./BaseTest.t.sol";
+import {MockTIP20} from "./mocks/MockTIP20.sol";
 
 contract StablecoinDEXTest is BaseTest {
-
     bytes32 pairKey;
     uint128 constant INITIAL_BALANCE = 10_000e18;
 
@@ -26,11 +25,7 @@ contract StablecoinDEXTest is BaseTest {
     event OrderCancelled(uint128 indexed orderId);
 
     event OrderFilled(
-        uint128 indexed orderId,
-        address indexed maker,
-        address indexed taker,
-        uint128 amountFilled,
-        bool partialFill
+        uint128 indexed orderId, address indexed maker, address indexed taker, uint128 amountFilled, bool partialFill
     );
 
     event PairCreated(bytes32 indexed key, address indexed base, address indexed quote);
@@ -87,13 +82,9 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     function test_CreatePair() public {
-        ITIP20 newQuote = ITIP20(
-            factory.createToken("New Quote", "NQUOTE", "USD", pathUSD, admin, bytes32("newquote"))
-        );
+        ITIP20 newQuote = ITIP20(factory.createToken("New Quote", "NQUOTE", "USD", pathUSD, admin, bytes32("newquote")));
 
-        ITIP20 newBase = ITIP20(
-            factory.createToken("New Base", "NBASE", "USD", newQuote, admin, bytes32("newbase"))
-        );
+        ITIP20 newBase = ITIP20(factory.createToken("New Base", "NBASE", "USD", newQuote, admin, bytes32("newbase")));
         bytes32 expectedKey = exchange.pairKey(address(newBase), address(newQuote));
 
         vm.expectEmit(true, true, true, true);
@@ -107,11 +98,8 @@ contract StablecoinDEXTest is BaseTest {
     function test_OrderbookPairs_AreOrderSensitive_AcrossQuoteUpdates() public {
         // Create a dedicated base token and two possible quote tokens, all USD-denominated.
         vm.startPrank(admin);
-        ITIP20 base =
-            ITIP20(factory.createToken("OBBase", "OBB", "USD", pathUSD, admin, bytes32(0)));
-        ITIP20 quote1 = ITIP20(
-            factory.createToken("OBQuote1", "OBQ1", "USD", pathUSD, admin, bytes32(uint256(1)))
-        );
+        ITIP20 base = ITIP20(factory.createToken("OBBase", "OBB", "USD", pathUSD, admin, bytes32(0)));
+        ITIP20 quote1 = ITIP20(factory.createToken("OBQuote1", "OBQ1", "USD", pathUSD, admin, bytes32(uint256(1))));
         vm.stopPrank();
 
         // Initial state: base quotes pathUSD
@@ -177,14 +165,13 @@ contract StablecoinDEXTest is BaseTest {
 
         uint32 price = exchange.tickToPrice(100);
         // Escrow rounds UP to favor protocol
-        uint256 expectedEscrow = (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1)
-            / uint256(exchange.PRICE_SCALE());
+        uint256 expectedEscrow =
+            (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1) / uint256(exchange.PRICE_SCALE());
         assertEq(pathUSD.balanceOf(alice), uint256(INITIAL_BALANCE) - expectedEscrow);
         assertEq(pathUSD.balanceOf(address(exchange)), expectedEscrow);
 
         // Verify order is immediately active in orderbook
-        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) =
-            exchange.getTickLevel(address(token1), 100, true);
+        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) = exchange.getTickLevel(address(token1), 100, true);
         assertEq(bidHead, orderId);
         assertEq(bidTail, orderId);
         assertEq(bidLiquidity, 1e18);
@@ -219,17 +206,11 @@ contract StablecoinDEXTest is BaseTest {
         // Verify the contract used ceiling division
         uint256 actualEscrow = uint256(INITIAL_BALANCE) - pathUSD.balanceOf(alice);
         assertEq(actualEscrow, ceilEscrow, "Escrow should use ceiling division (round UP)");
-        assertEq(
-            pathUSD.balanceOf(address(exchange)),
-            ceilEscrow,
-            "Exchange should receive ceiling amount"
-        );
+        assertEq(pathUSD.balanceOf(address(exchange)), ceilEscrow, "Exchange should receive ceiling amount");
     }
 
     /// @notice Fuzz test that escrow always rounds UP for bid orders
-    function testFuzz_PlaceBidOrder_EscrowAlwaysRoundsUp(uint128 amount, int16 tickMultiplier)
-        public
-    {
+    function testFuzz_PlaceBidOrder_EscrowAlwaysRoundsUp(uint128 amount, int16 tickMultiplier) public {
         // Constrain amount to be >= MIN_ORDER_AMOUNT and reasonable for our balance
         uint128 minAmount = exchange.MIN_ORDER_AMOUNT();
         vm.assume(amount >= minAmount && amount <= INITIAL_BALANCE / 2);
@@ -266,8 +247,7 @@ contract StablecoinDEXTest is BaseTest {
         assertEq(token1.balanceOf(address(exchange)), 1e18);
 
         // Verify order is immediately active in orderbook
-        (uint128 askHead, uint128 askTail, uint128 askLiquidity) =
-            exchange.getTickLevel(address(token1), 100, false);
+        (uint128 askHead, uint128 askTail, uint128 askLiquidity) = exchange.getTickLevel(address(token1), 100, false);
         assertEq(askHead, orderId);
         assertEq(askTail, orderId);
         assertEq(askLiquidity, 1e18);
@@ -284,14 +264,13 @@ contract StablecoinDEXTest is BaseTest {
 
         uint32 price = exchange.tickToPrice(100);
         // Escrow rounds UP to favor protocol
-        uint256 expectedEscrow = (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1)
-            / uint256(exchange.PRICE_SCALE());
+        uint256 expectedEscrow =
+            (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1) / uint256(exchange.PRICE_SCALE());
         assertEq(pathUSD.balanceOf(alice), uint256(INITIAL_BALANCE) - expectedEscrow);
         assertEq(pathUSD.balanceOf(address(exchange)), expectedEscrow);
 
         // Verify order is immediately active in orderbook
-        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) =
-            exchange.getTickLevel(address(token1), 100, true);
+        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) = exchange.getTickLevel(address(token1), 100, true);
         assertEq(bidHead, orderId);
         assertEq(bidTail, orderId);
         assertEq(bidLiquidity, 1e18);
@@ -311,8 +290,7 @@ contract StablecoinDEXTest is BaseTest {
         assertEq(token1.balanceOf(address(exchange)), 1e18);
 
         // Verify order is immediately active in orderbook
-        (uint128 askHead, uint128 askTail, uint128 askLiquidity) =
-            exchange.getTickLevel(address(token1), 100, false);
+        (uint128 askHead, uint128 askTail, uint128 askLiquidity) = exchange.getTickLevel(address(token1), 100, false);
         assertEq(askHead, orderId);
         assertEq(askTail, orderId);
         assertEq(askLiquidity, 1e18);
@@ -348,15 +326,13 @@ contract StablecoinDEXTest is BaseTest {
         assertEq(exchange.nextOrderId(), 5);
 
         // Verify liquidity at tick levels - orders are immediately active
-        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) =
-            exchange.getTickLevel(address(token1), 100, true);
+        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) = exchange.getTickLevel(address(token1), 100, true);
 
         assertEq(bidHead, bid0);
         assertEq(bidTail, bid1);
         assertEq(bidLiquidity, 3e18);
 
-        (uint128 askHead, uint128 askTail, uint128 askLiquidity) =
-            exchange.getTickLevel(address(token1), 150, false);
+        (uint128 askHead, uint128 askTail, uint128 askLiquidity) = exchange.getTickLevel(address(token1), 150, false);
         assertEq(askHead, ask0);
         assertEq(askTail, ask1);
         assertEq(askLiquidity, 3e18);
@@ -373,13 +349,12 @@ contract StablecoinDEXTest is BaseTest {
 
         // Verify tokens were returned to balance - escrow rounds UP to favor protocol
         uint32 price = exchange.tickToPrice(100);
-        uint256 escrowAmount = (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1)
-            / uint256(exchange.PRICE_SCALE());
+        uint256 escrowAmount =
+            (uint256(1e18) * uint256(price) + exchange.PRICE_SCALE() - 1) / uint256(exchange.PRICE_SCALE());
         assertEq(exchange.balanceOf(alice, address(pathUSD)), escrowAmount);
 
         // Verify order removed from orderbook
-        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) =
-            exchange.getTickLevel(address(token1), 100, true);
+        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) = exchange.getTickLevel(address(token1), 100, true);
         assertEq(bidHead, 0);
         assertEq(bidTail, 0);
         assertEq(bidLiquidity, 0);
@@ -406,8 +381,7 @@ contract StablecoinDEXTest is BaseTest {
         // Orders are immediately active
 
         uint128 amountOut = 500e18;
-        uint128 amountIn =
-            exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), amountOut);
+        uint128 amountIn = exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), amountOut);
 
         uint32 price = exchange.tickToPrice(100);
         uint128 expectedAmountIn = (amountOut * price) / exchange.PRICE_SCALE();
@@ -430,8 +404,7 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(askOrderId, bob, alice, amountOut, true);
 
         vm.prank(alice);
-        uint128 amountIn =
-            exchange.swapExactAmountOut(address(pathUSD), address(token1), amountOut, maxAmountIn);
+        uint128 amountIn = exchange.swapExactAmountOut(address(pathUSD), address(token1), amountOut, maxAmountIn);
 
         assertEq(amountIn, expectedAmountIn);
         assertEq(token1.balanceOf(alice), initialBaseBalance + amountOut);
@@ -444,9 +417,7 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(askOrderId, bob, alice, remainingAmount, false);
 
         vm.prank(alice);
-        uint128 amountIn2 = exchange.swapExactAmountOut(
-            address(pathUSD), address(token1), remainingAmount, maxAmountIn
-        );
+        uint128 amountIn2 = exchange.swapExactAmountOut(address(pathUSD), address(token1), remainingAmount, maxAmountIn);
 
         assertEq(amountIn2, expectedAmountIn2);
         assertEq(token1.balanceOf(alice), initialBaseBalance + amountOut + remainingAmount);
@@ -482,8 +453,7 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(order3, bob, alice, 5e17, true);
 
         vm.prank(alice);
-        uint128 amountIn =
-            exchange.swapExactAmountOut(address(pathUSD), address(token1), buyAmount, maxIn);
+        uint128 amountIn = exchange.swapExactAmountOut(address(pathUSD), address(token1), buyAmount, maxIn);
 
         assertEq(amountIn, totalCost);
         assertEq(token1.balanceOf(alice), initBalance + buyAmount);
@@ -495,8 +465,7 @@ contract StablecoinDEXTest is BaseTest {
         // Orders are immediately active
 
         uint128 amountIn = 500e18;
-        uint128 amountOut =
-            exchange.quoteSwapExactAmountIn(address(token1), address(pathUSD), amountIn);
+        uint128 amountOut = exchange.quoteSwapExactAmountIn(address(token1), address(pathUSD), amountIn);
 
         uint32 price = exchange.tickToPrice(100);
         uint128 expectedProceeds = (amountIn * price) / exchange.PRICE_SCALE();
@@ -519,8 +488,7 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(bidOrderId, bob, alice, amountIn, true);
 
         vm.prank(alice);
-        uint128 amountOut =
-            exchange.swapExactAmountIn(address(token1), address(pathUSD), amountIn, minAmountOut);
+        uint128 amountOut = exchange.swapExactAmountIn(address(token1), address(pathUSD), amountIn, minAmountOut);
 
         assertEq(amountOut, expectedAmountOut);
         assertEq(pathUSD.balanceOf(alice), initialQuoteBalance + amountOut);
@@ -534,9 +502,8 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(bidOrderId, bob, alice, remainingAmount, false);
 
         vm.prank(alice);
-        uint128 amountOut2 = exchange.swapExactAmountIn(
-            address(token1), address(pathUSD), remainingAmount, minAmountOut2
-        );
+        uint128 amountOut2 =
+            exchange.swapExactAmountIn(address(token1), address(pathUSD), remainingAmount, minAmountOut2);
 
         assertEq(amountOut2, expectedAmountOut2);
         assertEq(pathUSD.balanceOf(alice), initialQuoteBalance + amountOut + amountOut2);
@@ -572,8 +539,7 @@ contract StablecoinDEXTest is BaseTest {
         emit OrderFilled(order3, bob, alice, 5e17, true);
 
         vm.prank(alice);
-        uint128 amountOut =
-            exchange.swapExactAmountIn(address(token1), address(pathUSD), sellAmount, minOut);
+        uint128 amountOut = exchange.swapExactAmountIn(address(token1), address(pathUSD), sellAmount, minOut);
 
         assertEq(amountOut, totalOut);
         assertEq(pathUSD.balanceOf(alice), initBalance + totalOut);
@@ -657,8 +623,7 @@ contract StablecoinDEXTest is BaseTest {
             expectedError = abi.encodeWithSelector(IStablecoinDEX.InvalidTick.selector);
         } else if (amount < exchange.MIN_ORDER_AMOUNT()) {
             shouldRevert = true;
-            expectedError =
-                abi.encodeWithSelector(IStablecoinDEX.BelowMinimumOrderSize.selector, amount);
+            expectedError = abi.encodeWithSelector(IStablecoinDEX.BelowMinimumOrderSize.selector, amount);
         }
 
         // Execute and verify
@@ -681,12 +646,7 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     // Test flip order validation rules
-    function testFuzz_PlaceFlipOrder_ValidationRules(
-        uint128 amount,
-        int16 tick,
-        int16 flipTick,
-        bool isBid
-    ) public {
+    function testFuzz_PlaceFlipOrder_ValidationRules(uint128 amount, int16 tick, int16 flipTick, bool isBid) public {
         tick = int16(bound(int256(tick), type(int16).min, type(int16).max));
         flipTick = int16(bound(int256(flipTick), type(int16).min, type(int16).max));
 
@@ -738,8 +698,7 @@ contract StablecoinDEXTest is BaseTest {
     // Test pair creation validation
     function test_CreatePair_RevertIf_NonUsdToken() public {
         // Create a non-USD token
-        ITIP20 eurToken =
-            ITIP20(factory.createToken("EUR Token", "EUR", "EUR", pathUSD, admin, bytes32("eur")));
+        ITIP20 eurToken = ITIP20(factory.createToken("EUR Token", "EUR", "EUR", pathUSD, admin, bytes32("eur")));
 
         try exchange.createPair(address(eurToken)) {
             revert CallShouldHaveReverted();
@@ -792,9 +751,7 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     // Test withdraw validation
-    function testFuzz_Withdraw_RevertIf_InsufficientBalance(uint128 balance, uint128 withdrawAmount)
-        public
-    {
+    function testFuzz_Withdraw_RevertIf_InsufficientBalance(uint128 balance, uint128 withdrawAmount) public {
         vm.assume(balance < type(uint128).max); // Avoid overflow in balance + 1
         withdrawAmount = uint128(bound(withdrawAmount, balance + 1, type(uint128).max));
 
@@ -820,8 +777,7 @@ contract StablecoinDEXTest is BaseTest {
     // Test swap validation
     function test_Swap_RevertIf_PairNotExists() public {
         // Try to swap between two tokens that don't have a trading pair
-        ITIP20 token3 =
-            ITIP20(factory.createToken("Token3", "TK3", "USD", pathUSD, admin, bytes32("token3")));
+        ITIP20 token3 = ITIP20(factory.createToken("Token3", "TK3", "USD", pathUSD, admin, bytes32("token3")));
 
         try exchange.swapExactAmountIn(address(token3), address(token2), 100, 0) {
             revert CallShouldHaveReverted();
@@ -886,10 +842,7 @@ contract StablecoinDEXTest is BaseTest {
             try exchange.priceToTick(price) {
                 revert CallShouldHaveReverted();
             } catch (bytes memory err) {
-                assertEq(
-                    err,
-                    abi.encodeWithSelector(IStablecoinDEX.TickOutOfBounds.selector, expectedTick)
-                );
+                assertEq(err, abi.encodeWithSelector(IStablecoinDEX.TickOutOfBounds.selector, expectedTick));
             }
         } else {
             // Valid price range - should succeed
@@ -1021,8 +974,7 @@ contract StablecoinDEXTest is BaseTest {
             // Orders are immediately active
 
             // Should find direct path
-            uint128 amountOut =
-                exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), minOrderAmount);
+            uint128 amountOut = exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), minOrderAmount);
             assertGt(amountOut, 0);
         } else if (scenario == 1) {
             // Sibling tokens through pathUSD
@@ -1045,8 +997,7 @@ contract StablecoinDEXTest is BaseTest {
             // Orders are immediately active
 
             // Should route token1 -> pathUSD -> token2
-            uint128 amountOut =
-                exchange.quoteSwapExactAmountIn(address(token1), address(token2), minOrderAmount);
+            uint128 amountOut = exchange.quoteSwapExactAmountIn(address(token1), address(token2), minOrderAmount);
             assertGt(amountOut, 0);
         } else {
             // Reverse direction
@@ -1056,8 +1007,7 @@ contract StablecoinDEXTest is BaseTest {
             // Orders are immediately active
 
             // Should find path in reverse
-            uint128 amountOut =
-                exchange.quoteSwapExactAmountIn(address(token1), address(pathUSD), minOrderAmount);
+            uint128 amountOut = exchange.quoteSwapExactAmountIn(address(token1), address(pathUSD), minOrderAmount);
             assertGt(amountOut, 0);
         }
     }
@@ -1068,18 +1018,15 @@ contract StablecoinDEXTest is BaseTest {
         // The path algorithm will find token1 -> pathUSD -> isolatedToken
         // But the swap will fail because the isolatedToken pair doesn't exist
 
-        ITIP20 isolatedToken = ITIP20(
-            factory.createToken("Isolated", "ISO", "USD", pathUSD, admin, bytes32("isolated"))
-        );
+        ITIP20 isolatedToken =
+            ITIP20(factory.createToken("Isolated", "ISO", "USD", pathUSD, admin, bytes32("isolated")));
 
         // Don't create a pair for isolatedToken - this means the orderbook doesn't exist
 
         // Try to swap token1 -> isolatedToken
         // Path exists in token tree, but orderbook pair doesn't exist
         // Expect any revert (specifically PairDoesNotExist but exact error encoding varies)
-        try exchange.quoteSwapExactAmountIn(
-            address(token1), address(isolatedToken), exchange.MIN_ORDER_AMOUNT()
-        ) {
+        try exchange.quoteSwapExactAmountIn(address(token1), address(isolatedToken), exchange.MIN_ORDER_AMOUNT()) {
             revert CallShouldHaveReverted();
         } catch {
             // Successfully reverted as expected
@@ -1087,11 +1034,7 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     // Fuzz test: routing handles various token pair combinations
-    function testFuzz_Routing_TokenPairCombinations(
-        bool useToken1,
-        bool useToken2,
-        bool swapDirection
-    ) public {
+    function testFuzz_Routing_TokenPairCombinations(bool useToken1, bool useToken2, bool swapDirection) public {
         // Setup both token pairs
         exchange.createPair(address(token2));
 
@@ -1121,9 +1064,7 @@ contract StablecoinDEXTest is BaseTest {
         address tokenOut = swapDirection ? address(pathUSD) : address(token1);
 
         // Always use try/catch since liquidity setup varies and may not support this direction
-        try exchange.quoteSwapExactAmountIn(tokenIn, tokenOut, minOrderAmount) returns (
-            uint128 amountOut
-        ) {
+        try exchange.quoteSwapExactAmountIn(tokenIn, tokenOut, minOrderAmount) returns (uint128 amountOut) {
             // Success - verify output
             assertGt(amountOut, 0);
         } catch {
@@ -1151,18 +1092,14 @@ contract StablecoinDEXTest is BaseTest {
         // Test with non-TIP20 token (should fail when trying to get quote token)
         address invalidToken = address(0x123456);
 
-        try exchange.quoteSwapExactAmountIn(
-            invalidToken, address(token1), exchange.MIN_ORDER_AMOUNT()
-        ) {
+        try exchange.quoteSwapExactAmountIn(invalidToken, address(token1), exchange.MIN_ORDER_AMOUNT()) {
             revert CallShouldHaveReverted();
         } catch {
             // Successfully reverted - exact error depends on whether token implements interface
         }
 
         // Test swap to non-TIP20 token
-        try exchange.quoteSwapExactAmountIn(
-            address(token1), invalidToken, exchange.MIN_ORDER_AMOUNT()
-        ) {
+        try exchange.quoteSwapExactAmountIn(address(token1), invalidToken, exchange.MIN_ORDER_AMOUNT()) {
             revert CallShouldHaveReverted();
         } catch {
             // Successfully reverted
@@ -1278,8 +1215,7 @@ contract StablecoinDEXTest is BaseTest {
         int16 flipTick = 200;
 
         vm.prank(alice);
-        uint128 flipOrderId =
-            exchange.placeFlip(address(token1), orderAmount, true, bidTick, flipTick);
+        uint128 flipOrderId = exchange.placeFlip(address(token1), orderAmount, true, bidTick, flipTick);
         assertEq(flipOrderId, 1);
 
         vm.prank(admin);
@@ -1290,8 +1226,7 @@ contract StablecoinDEXTest is BaseTest {
         uint256 bobInitialPathUSD = pathUSD.balanceOf(bob);
 
         vm.prank(bob);
-        uint128 amountOut =
-            exchange.swapExactAmountIn(address(token1), address(pathUSD), orderAmount, 0);
+        uint128 amountOut = exchange.swapExactAmountIn(address(token1), address(pathUSD), orderAmount, 0);
 
         assertGt(amountOut, 0);
         assertEq(token1.balanceOf(bob), bobInitialToken1 - orderAmount);
@@ -1302,8 +1237,7 @@ contract StablecoinDEXTest is BaseTest {
 
         assertEq(exchange.nextOrderId(), 2);
 
-        (uint128 askHead,, uint128 askLiquidity) =
-            exchange.getTickLevel(address(token1), flipTick, false);
+        (uint128 askHead,, uint128 askLiquidity) = exchange.getTickLevel(address(token1), flipTick, false);
         assertEq(askHead, 0);
         assertEq(askLiquidity, 0);
     }
@@ -1331,22 +1265,12 @@ contract StablecoinDEXTest is BaseTest {
         exchange.withdraw(address(token1), aliceBaseBalance);
 
         // Verify Alice's internal balance is now 0
-        assertEq(
-            exchange.balanceOf(alice, address(token1)), 0, "Alice's internal balance should be 0"
-        );
+        assertEq(exchange.balanceOf(alice, address(token1)), 0, "Alice's internal balance should be 0");
 
         // Verify Alice still has sufficient external token balance and approval for a flip order
         // For a flip ask at tick 200, she would need to escrow base tokens
-        assertGt(
-            token1.balanceOf(alice),
-            orderAmount,
-            "Alice should have sufficient external token balance"
-        );
-        assertGt(
-            token1.allowance(alice, address(exchange)),
-            orderAmount,
-            "Alice should have sufficient approval"
-        );
+        assertGt(token1.balanceOf(alice), orderAmount, "Alice should have sufficient external token balance");
+        assertGt(token1.allowance(alice, address(exchange)), orderAmount, "Alice should have sufficient approval");
 
         uint128 nextOrderIdBefore = exchange.nextOrderId();
 
@@ -1422,9 +1346,7 @@ contract StablecoinDEXTest is BaseTest {
         registry.modifyPolicyBlacklist(policyId, alice, true);
 
         // Verify alice is blacklisted in pathUSD
-        assertFalse(
-            registry.isAuthorized(policyId, alice), "Alice should be blacklisted in pathUSD"
-        );
+        assertFalse(registry.isAuthorized(policyId, alice), "Alice should be blacklisted in pathUSD");
 
         // Alice tries to place an ask order to SELL token1 for pathUSD
         // Even though alice is authorized in token1 (the escrow token), she is blacklisted in pathUSD
@@ -1506,8 +1428,7 @@ contract StablecoinDEXTest is BaseTest {
         exchange.cancelStaleOrder(orderId);
 
         // Verify order is removed from orderbook
-        (uint128 askHead, uint128 askTail, uint128 askLiquidity) =
-            exchange.getTickLevel(address(token1), 100, false);
+        (uint128 askHead, uint128 askTail, uint128 askLiquidity) = exchange.getTickLevel(address(token1), 100, false);
         assertEq(askHead, 0);
         assertEq(askTail, 0);
         assertEq(askLiquidity, 0);
@@ -1536,8 +1457,7 @@ contract StablecoinDEXTest is BaseTest {
         // Calculate expected escrow - rounds UP to favor protocol
         uint32 price = exchange.tickToPrice(100);
         uint128 expectedEscrow = uint128(
-            (uint256(orderAmount) * uint256(price) + exchange.PRICE_SCALE() - 1)
-                / uint256(exchange.PRICE_SCALE())
+            (uint256(orderAmount) * uint256(price) + exchange.PRICE_SCALE() - 1) / uint256(exchange.PRICE_SCALE())
         );
 
         // Blacklist alice
@@ -1552,8 +1472,7 @@ contract StablecoinDEXTest is BaseTest {
         exchange.cancelStaleOrder(orderId);
 
         // Verify order is removed from orderbook
-        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) =
-            exchange.getTickLevel(address(token1), 100, true);
+        (uint128 bidHead, uint128 bidTail, uint128 bidLiquidity) = exchange.getTickLevel(address(token1), 100, true);
         assertEq(bidHead, 0);
         assertEq(bidTail, 0);
         assertEq(bidLiquidity, 0);
@@ -1633,11 +1552,7 @@ contract StablecoinDEXTest is BaseTest {
         exchange.cancelStaleOrder(orderId);
 
         // Verify escrow is refunded
-        assertEq(
-            exchange.balanceOf(alice, address(token1)),
-            orderAmount,
-            "Alice should have escrow refunded"
-        );
+        assertEq(exchange.balanceOf(alice, address(token1)), orderAmount, "Alice should have escrow refunded");
     }
 
     /// @notice Test that the order maker can also cancel their own stale order
@@ -1662,11 +1577,7 @@ contract StablecoinDEXTest is BaseTest {
         exchange.cancelStaleOrder(orderId);
 
         // Verify escrow is refunded
-        assertEq(
-            exchange.balanceOf(alice, address(token1)),
-            orderAmount,
-            "Alice should have escrow refunded"
-        );
+        assertEq(exchange.balanceOf(alice, address(token1)), orderAmount, "Alice should have escrow refunded");
     }
 
     /// @notice Test canceling stale order in the middle of a tick level's linked list
@@ -1684,8 +1595,7 @@ contract StablecoinDEXTest is BaseTest {
         uint128 order3 = _placeAskOrder(alice, exchange.MIN_ORDER_AMOUNT(), 100);
 
         // Verify tick has all three orders
-        (uint128 head, uint128 tail, uint128 liquidity) =
-            exchange.getTickLevel(address(token1), 100, false);
+        (uint128 head, uint128 tail, uint128 liquidity) = exchange.getTickLevel(address(token1), 100, false);
         assertEq(head, order1);
         assertEq(tail, order3);
         assertEq(liquidity, exchange.MIN_ORDER_AMOUNT() * 3);
@@ -1719,30 +1629,20 @@ contract StablecoinDEXTest is BaseTest {
                         HELPER FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function _placeBidOrder(address user, uint128 amount, int16 tick)
-        internal
-        returns (uint128 orderId)
-    {
+    function _placeBidOrder(address user, uint128 amount, int16 tick) internal returns (uint128 orderId) {
         if (!isTempo) {
             vm.expectEmit(true, true, true, true);
-            emit OrderPlaced(
-                exchange.nextOrderId(), user, address(token1), amount, true, tick, false, 0
-            );
+            emit OrderPlaced(exchange.nextOrderId(), user, address(token1), amount, true, tick, false, 0);
         }
 
         vm.prank(user);
         orderId = exchange.place(address(token1), amount, true, tick);
     }
 
-    function _placeAskOrder(address user, uint128 amount, int16 tick)
-        internal
-        returns (uint128 orderId)
-    {
+    function _placeAskOrder(address user, uint128 amount, int16 tick) internal returns (uint128 orderId) {
         if (!isTempo) {
             vm.expectEmit(true, true, true, true);
-            emit OrderPlaced(
-                exchange.nextOrderId(), user, address(token1), amount, false, tick, false, 0
-            );
+            emit OrderPlaced(exchange.nextOrderId(), user, address(token1), amount, false, tick, false, 0);
         }
 
         vm.prank(user);
@@ -1754,7 +1654,8 @@ contract StablecoinDEXTest is BaseTest {
     ///         which may leave dust in the order.
     function test_BidExactOutRounding_CeilingOnly() public {
         // Values that trigger the rounding difference between floor and ceil
-        uint128 baseAmount = 100_000_051;
+        // Use a larger order amount so dust remaining is above MIN_ORDER_AMOUNT
+        uint128 baseAmount = 200_000_051;
         int16 tick = -2000; // price = 98000, p = 0.98
 
         uint32 price = exchange.tickToPrice(tick);
@@ -1763,32 +1664,35 @@ contract StablecoinDEXTest is BaseTest {
         uint128 release = uint128((uint256(baseAmount) * uint256(price)) / exchange.PRICE_SCALE());
 
         // Calculate expected baseIn: ceil(release * SCALE / price)
-        uint128 expectedBaseIn =
-            uint128((uint256(release) * exchange.PRICE_SCALE() + price - 1) / price);
+        uint128 expectedBaseIn = uint128((uint256(release) * exchange.PRICE_SCALE() + price - 1) / price);
 
         // Alice places a bid for baseAmount base tokens
         vm.prank(alice);
         uint128 orderId = exchange.place(address(token1), baseAmount, true, tick);
 
-        // Bob does exactOut for the full release amount
+        // Bob does exactOut for a partial amount that leaves remaining above MIN_ORDER_AMOUNT
+        // We'll swap half the release amount
+        uint128 partialRelease = release / 2;
+        uint128 partialBaseIn = uint128((uint256(partialRelease) * exchange.PRICE_SCALE() + price - 1) / price);
+
         vm.prank(bob);
         uint128 baseIn = exchange.swapExactAmountOut(
             address(token1), // tokenIn = base
             address(pathUSD), // tokenOut = quote
-            release, // amountOut
+            partialRelease, // amountOut
             type(uint128).max // maxAmountIn
         );
 
-        // baseIn equals the ceiling, which may be less than the full order amount
-        assertEq(baseIn, expectedBaseIn, "baseIn should be ceil(release * SCALE / price)");
+        // baseIn equals the ceiling for partial swap
+        assertEq(baseIn, partialBaseIn, "baseIn should be ceil(release * SCALE / price)");
 
-        // The order may have dust remaining (this is correct behavior)
-        uint128 dustRemaining = baseAmount - expectedBaseIn;
-        assertGt(dustRemaining, 0, "There should be dust remaining in the order");
+        // The remaining amount should be above MIN_ORDER_AMOUNT
+        uint128 remaining = baseAmount - partialBaseIn;
+        assertGt(remaining, exchange.MIN_ORDER_AMOUNT(), "Remaining should be above minimum");
 
-        // Verify order still exists with dust
+        // Verify order still exists with remaining amount
         IStablecoinDEX.Order memory order = exchange.getOrder(orderId);
-        assertEq(order.remaining, dustRemaining, "Order should have dust remaining");
+        assertEq(order.remaining, remaining, "Order should have remaining amount");
     }
 
     function testFuzz_BidExactOutRounding_CeilingOnly(uint128 amount, int16 tick) public {
@@ -1804,8 +1708,7 @@ contract StablecoinDEXTest is BaseTest {
         if (release == 0) return; // skip if no quote to release
 
         // Calculate expected baseIn: ceil(release * SCALE / price)
-        uint128 expectedBaseIn =
-            uint128((uint256(release) * exchange.PRICE_SCALE() + price - 1) / price);
+        uint128 expectedBaseIn = uint128((uint256(release) * exchange.PRICE_SCALE() + price - 1) / price);
 
         // Alice places a bid
         vm.prank(alice);
@@ -1813,9 +1716,7 @@ contract StablecoinDEXTest is BaseTest {
 
         // Bob takes all available quote
         vm.prank(bob);
-        uint128 baseIn = exchange.swapExactAmountOut(
-            address(token1), address(pathUSD), release, type(uint128).max
-        );
+        uint128 baseIn = exchange.swapExactAmountOut(address(token1), address(pathUSD), release, type(uint128).max);
 
         // baseIn should be the ceiling (may be less than or equal to amount)
         assertEq(baseIn, expectedBaseIn, "baseIn should be ceil(release * SCALE / price)");
@@ -1831,10 +1732,8 @@ contract StablecoinDEXTest is BaseTest {
 
         uint32 price = exchange.tickToPrice(tick);
         // Escrow rounds UP to favor protocol
-        uint128 escrow = uint128(
-            (uint256(amount) * uint256(price) + exchange.PRICE_SCALE() - 1)
-                / uint256(exchange.PRICE_SCALE())
-        );
+        uint128 escrow =
+            uint128((uint256(amount) * uint256(price) + exchange.PRICE_SCALE() - 1) / uint256(exchange.PRICE_SCALE()));
 
         // Give charlie base tokens so they can pay `amountIn` at the end of swapExactAmountOut.
         vm.startPrank(admin);
@@ -1866,11 +1765,7 @@ contract StablecoinDEXTest is BaseTest {
 
     /// @notice Fuzz test: splitting a trade into smaller pieces should never give the taker a better price.
     /// With ceiling rounding on asks, the taker pays at least as much (usually more) when splitting.
-    function testFuzz_AskRounding_SplittingNeverCheaper(
-        uint128 totalBaseOut,
-        uint8 numSplits,
-        int16 tick
-    ) public {
+    function testFuzz_AskRounding_SplittingNeverCheaper(uint128 totalBaseOut, uint8 numSplits, int16 tick) public {
         // Bound inputs
         totalBaseOut = uint128(bound(totalBaseOut, exchange.MIN_ORDER_AMOUNT() * 2, 1e18));
         numSplits = uint8(bound(numSplits, 2, 10));
@@ -1900,18 +1795,12 @@ contract StablecoinDEXTest is BaseTest {
                 thisAmount += remainder; // last split gets the remainder
             }
             if (thisAmount > 0) {
-                totalSplitQuote += exchange.quoteSwapExactAmountOut(
-                    address(pathUSD), address(token1), thisAmount
-                );
+                totalSplitQuote += exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), thisAmount);
             }
         }
 
         // Splitting should never be cheaper (ceiling rounding means splits cost >= single)
-        assertGe(
-            totalSplitQuote,
-            singleTradeQuote,
-            "Splitting trades should never give taker a better price"
-        );
+        assertGe(totalSplitQuote, singleTradeQuote, "Splitting trades should never give taker a better price");
     }
 
     /// @notice PoC: Without the fix, at price < 1.0, trading 1 base at a time costs 0 quote each.
@@ -1926,14 +1815,12 @@ contract StablecoinDEXTest is BaseTest {
         exchange.place(address(token1), askAmount, false, tick);
 
         // Quote for single trade of 100 base
-        uint128 singleTradeQuote =
-            exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), 100);
+        uint128 singleTradeQuote = exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), 100);
 
         // Quote for 100 trades of 1 base each
         uint128 totalOneAtATime = 0;
         for (uint256 i = 0; i < 100; i++) {
-            uint128 quoteFor1 =
-                exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), 1);
+            uint128 quoteFor1 = exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), 1);
             totalOneAtATime += quoteFor1;
 
             // With ceiling rounding, each 1-base trade costs at least 1 quote
@@ -1941,9 +1828,39 @@ contract StablecoinDEXTest is BaseTest {
         }
 
         // With the fix, 100 trades of 1 base costs MORE than single trade (ceiling rounds up)
-        assertGe(
-            totalOneAtATime, singleTradeQuote, "Splitting into 1-unit trades should not be cheaper"
-        );
+        assertGe(totalOneAtATime, singleTradeQuote, "Splitting into 1-unit trades should not be cheaper");
     }
 
+    /// @notice Verifies that orders with remaining below MIN_ORDER_AMOUNT are early-completed
+    ///         and the maker is refunded the dust amount.
+    function test_OrderEarlyCompletedWhenRemainingBelowMinimum() public {
+        // Alice places an order just above minimum
+        uint128 orderAmount = 150_000_000; // $150
+        int16 tick = 0; // price = 1.0
+
+        vm.prank(alice);
+        uint128 orderId = exchange.place(address(token1), orderAmount, false, tick);
+
+        // Get alice's balance before
+        uint256 aliceBalanceBefore = exchange.balanceOf(alice, address(token1));
+
+        // Bob buys $60 worth, leaving $90 remaining (below $100 minimum)
+        uint128 swapAmount = 60_000_000;
+        vm.prank(bob);
+        exchange.swapExactAmountIn(
+            address(pathUSD), // tokenIn = quote (buying base)
+            address(token1), // tokenOut = base
+            swapAmount,
+            0 // minAmountOut
+        );
+
+        // The order should be deleted because remaining ($90) < MIN_ORDER_AMOUNT ($100)
+        vm.expectRevert(IStablecoinDEX.OrderDoesNotExist.selector);
+        exchange.getOrder(orderId);
+
+        // Alice should have received the dust refund to her internal balance
+        uint256 aliceBalanceAfter = exchange.balanceOf(alice, address(token1));
+        uint128 expectedRefund = orderAmount - swapAmount; // $90
+        assertEq(aliceBalanceAfter - aliceBalanceBefore, expectedRefund, "Alice should receive dust refund");
+    }
 }


### PR DESCRIPTION
## Summary
Proposes a protocol change to prevent DoS attacks on the Stablecoin DEX by enforcing minimum order size after partial fills.

## Problem
Users can create arbitrarily small orders by placing a $100+ order and trading against themselves to reduce it below the minimum.

## Solution
Auto-cancel orders when partial fills leave `remaining < MIN_ORDER_AMOUNT`, refunding remaining tokens to the maker.

## Contents
- TIP specification document: `docs/specs/TIP-DEX-MIN-ORDER.md`
- Reference implementation (for review, not to be merged until TIP approved)

## Hard Fork Required
This change modifies consensus-critical behavior and requires a coordinated network upgrade.

Related: PROTO-39