### PR TITLE
feat(rpc): add parent_view field to CertifiedBlock

### DIFF
--- a/crates/commonware-node/src/feed/actor.rs
+++ b/crates/commonware-node/src/feed/actor.rs
@@ -84,6 +84,7 @@ impl<TContext: Spawner> Actor<TContext> {
         &mut self,
         view: u64,
         epoch: u64,
+        parent_view: u64,
         digest: Digest,
         certificate: &impl Encode,
     ) -> CertifiedBlock {
@@ -97,6 +98,7 @@ impl<TContext: Spawner> Actor<TContext> {
         CertifiedBlock {
             epoch,
             view,
+            parent_view,
             height,
             digest: digest.0,
             certificate,
@@ -109,11 +111,13 @@ impl<TContext: Spawner> Actor<TContext> {
             Activity::Notarization(notarization) => {
                 let seen = now_millis();
                 let view = notarization.proposal.round.view().get();
+                let parent_view = notarization.proposal.parent.get();
 
                 let block = self
                     .create_certified_block(
                         view,
                         notarization.proposal.round.epoch().get(),
+                        parent_view,
                         notarization.proposal.payload,
                         &notarization.certificate,
                     )
@@ -142,11 +146,13 @@ impl<TContext: Spawner> Actor<TContext> {
             Activity::Finalization(finalization) => {
                 let seen = now_millis();
                 let view = finalization.proposal.round.view().get();
+                let parent_view = finalization.proposal.parent.get();
 
                 let block = self
                     .create_certified_block(
                         view,
                         finalization.proposal.round.epoch().get(),
+                        parent_view,
                         finalization.proposal.payload,
                         &finalization.certificate,
                     )

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -118,6 +118,7 @@ impl ConsensusFeed for FeedStateHandle {
                 Some(CertifiedBlock {
                     epoch: finalization.proposal.round.epoch().get(),
                     view: finalization.proposal.round.view().get(),
+                    parent_view: finalization.proposal.parent.get(),
                     height: Some(height),
                     digest: finalization.proposal.payload.0,
                     certificate: hex::encode(finalization.certificate.encode()),

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -11,9 +11,12 @@ use tokio::sync::broadcast;
 pub struct CertifiedBlock {
     pub epoch: u64,
     pub view: u64,
+    /// The view of the parent block this proposal builds on.
+    pub parent_view: u64,
     /// Block height, if known. May be `None` if the block hasn't been stored yet.
     pub height: Option<u64>,
     pub digest: B256,
+    /// Hex-encoded BLS threshold signature (vote_signature || seed_signature).
     pub certificate: String,
 }
 


### PR DESCRIPTION
Include the parent view in consensus events to allow clients to reconstruct the full Proposal for BLS certificate verification.

Amp-Thread-ID: https://ampcode.com/threads/T-019bbfb9-1e9f-74f5-b40c-a7f75f9014c4