### PR TITLE
docs: add TIP spec for Multisig precompile

### DIFF
--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -373,7 +373,55 @@ interface IMultisig {
         bytes calldata value,
         bytes calldata data
     ) external;
+
+    // ============ Owner Management ============
+
+    /// @notice Adds a new owner to the multisig
+    /// @dev Requires threshold confirmations. Reverts if owner already exists or MAX_OWNERS reached.
+    /// @param owner The address to add as owner
+    function addOwner(address owner) external;
+
+    /// @notice Removes an owner from the multisig
+    /// @dev Requires threshold confirmations. Reverts if owner doesn't exist or would make threshold > ownerCount.
+    /// @param owner The address to remove
+    function removeOwner(address owner) external;
+
+    /// @notice Replaces an existing owner with a new address
+    /// @dev Requires threshold confirmations. Atomic swap to avoid temporary threshold issues.
+    /// @param oldOwner The owner to remove
+    /// @param newOwner The owner to add
+    function replaceOwner(address oldOwner, address newOwner) external;
+
+    /// @notice Changes the confirmation threshold
+    /// @dev Requires threshold confirmations. Reverts if newThreshold is 0 or > ownerCount.
+    /// @param newThreshold The new threshold value
+    function changeThreshold(uint8 newThreshold) external;
 }
+```
+
+### Owner Management Events and Errors
+
+```solidity
+/// @notice An owner was added to the multisig
+event OwnerAdded(address indexed owner);
+
+/// @notice An owner was removed from the multisig
+event OwnerRemoved(address indexed owner);
+
+/// @notice An owner was replaced with another address
+event OwnerReplaced(address indexed oldOwner, address indexed newOwner);
+
+/// @notice The confirmation threshold was changed
+event ThresholdChanged(uint8 oldThreshold, uint8 newThreshold);
+
+/// @notice The address is already an owner
+error AlreadyOwner(address owner);
+
+/// @notice Cannot remove: would make threshold > owner count
+error ThresholdExceedsOwners(uint8 threshold, uint8 newOwnerCount);
+
+/// @notice Cannot have zero owners
+error CannotRemoveLastOwner();
 ```
 
 ### Transaction Structure
@@ -489,6 +537,67 @@ Convenience function for 1-of-1 multisigs only:
 
 ---
 
+### Owner Management Behavior
+
+Owner management functions use the same confirmation pattern as regular transactions. Each function internally creates a "config change" transaction that owners must confirm.
+
+#### `addOwner`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `ZeroAddressOwner` if `owner` is `address(0)`
+3. Revert with `AlreadyOwner` if `owner` is already an owner
+4. Revert with `TooManyOwners` if `ownerCount >= MAX_OWNERS`
+5. Create config-change transaction for adding owner
+6. Auto-confirm for `msg.sender`
+7. If confirmations >= threshold:
+   - Add owner to owners array (maintain sorted order)
+   - Increment `ownerCount`
+   - Emit `OwnerAdded`
+
+#### `removeOwner`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `NotOwner` if `owner` is not in owners list
+3. Revert with `CannotRemoveLastOwner` if `ownerCount == 1`
+4. Revert with `ThresholdExceedsOwners` if `threshold > ownerCount - 1`
+5. Create config-change transaction for removing owner
+6. Auto-confirm for `msg.sender`
+7. If confirmations >= threshold:
+   - Remove owner from owners array
+   - Decrement `ownerCount`
+   - Emit `OwnerRemoved`
+
+> **Note**: If the removed owner had pending confirmations, those confirmations remain valid. However, they can no longer confirm new transactions or execute.
+
+#### `replaceOwner`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `NotOwner` if `oldOwner` is not in owners list
+3. Revert with `ZeroAddressOwner` if `newOwner` is `address(0)`
+4. Revert with `AlreadyOwner` if `newOwner` is already an owner
+5. Create config-change transaction for replacement
+6. Auto-confirm for `msg.sender`
+7. If confirmations >= threshold:
+   - Replace `oldOwner` with `newOwner` in owners array (maintain sorted order)
+   - Emit `OwnerReplaced`
+
+> **Note**: `replaceOwner` is atomic - it never temporarily reduces owner count, avoiding threshold validation edge cases.
+
+#### `changeThreshold`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `InvalidThreshold` if `newThreshold == 0`
+3. Revert with `InvalidThreshold` if `newThreshold > ownerCount`
+4. Create config-change transaction for threshold change
+5. Auto-confirm for `msg.sender`
+6. If confirmations >= threshold (using **current** threshold):
+   - Update threshold to `newThreshold`
+   - Emit `ThresholdChanged`
+
+> **Security Note**: Threshold changes use the **current** threshold for confirmation, not the new one. This prevents a single owner from reducing threshold to 1 and taking over.
+
+---
+
 ## Storage Layout
 
 ### Multisig Factory Storage
@@ -582,9 +691,12 @@ multisig.submitTransaction(
 7. Expired transactions cannot be executed or confirmed
 8. `confirmations` count must equal the number of owners who have confirmed
 9. `transactionCount` must be monotonically increasing
-10. The `owners()` and `threshold()` values must never change after creation
-11. Transaction `data` size must be <= `MAX_DATA_SIZE` (64KB)
-12. Transaction `value` must be empty or exactly 64 bytes (valid encoding)
+10. Transaction `data` size must be <= `MAX_DATA_SIZE` (64KB)
+11. Transaction `value` must be empty or exactly 64 bytes (valid encoding)
+12. `ownerCount` must always be >= 1 (cannot remove last owner)
+13. `threshold` must always be >= 1 and <= `ownerCount`
+14. Owner management operations require `threshold` confirmations
+15. Config changes use the current threshold, not the proposed new threshold
 
 ## Security Invariants
 
@@ -664,6 +776,41 @@ multisig.submitTransaction(
 - `execute()` reverts if threshold > 1
 - Transaction with empty value and empty data (no-op)
 - Transaction targeting multisig itself (self-call)
+
+## Owner Management Tests
+
+### Add Owner
+- Add owner with threshold confirmations
+- Reject add from non-owner
+- Reject adding existing owner (`AlreadyOwner`)
+- Reject adding zero address
+- Reject adding when at MAX_OWNERS (50)
+- Verify owner list remains sorted after add
+
+### Remove Owner
+- Remove owner with threshold confirmations
+- Reject remove from non-owner
+- Reject removing non-existent owner
+- Reject removing last owner (`CannotRemoveLastOwner`)
+- Reject if would make threshold > ownerCount (`ThresholdExceedsOwners`)
+- Removed owner's pending confirmations remain valid
+- Removed owner cannot confirm new transactions
+
+### Replace Owner
+- Replace owner atomically with threshold confirmations
+- Reject replace from non-owner
+- Reject replacing non-existent owner
+- Reject replacing with zero address
+- Reject replacing with existing owner
+- Verify owner list remains sorted after replace
+
+### Change Threshold
+- Change threshold with current threshold confirmations
+- Reject change from non-owner
+- Reject threshold = 0
+- Reject threshold > ownerCount
+- Verify change uses current threshold (not new one)
+- 2-of-3 can change to 1-of-3, then 1-of-3 to 3-of-3
 
 ## Integration Tests
 

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -513,6 +513,8 @@ Cancellation requires threshold confirmations, similar to execution:
 
 > **Note**: Cancellation uses a separate vote count from confirmation. An owner can confirm a transaction AND vote to cancel it (allowing them to change their mind).
 
+> **Design Decision**: Cancellation votes are NOT lazily invalidated when an owner is removed. Once an owner votes to cancel, that vote persists. This is intentional: a cancellation vote represents a permanent "veto" that survives ownership changes. If the removed owner's vote pushes cancellation to threshold, the transaction is cancelled.
+
 #### `executeTransaction`
 
 1. Revert with `NotOwner` if `msg.sender` is not an owner
@@ -523,10 +525,11 @@ Cancellation requires threshold confirmations, similar to execution:
 6. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
 7. **Count valid confirmations** (lazy invalidation/transfer check):
    - For each confirmer:
-     - If `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`: attribute to `replacedBy[confirmer]`
+     - **Follow replacement chain**: while `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`: `confirmer = replacedBy[confirmer]`
      - If `removedAt[confirmer] != 0` AND `removedAt[confirmer] <= txId`: invalid (removed before tx)
-     - Otherwise: valid confirmation from original confirmer
-   - Deduplicate: if both old and new owner confirmed, count only once
+     - If confirmer is not a current owner: invalid
+     - Otherwise: valid confirmation attributed to final `confirmer`
+   - Deduplicate: count unique valid confirmers only
 8. Revert with `InsufficientConfirmations` if `validConfirmations < threshold`
 9. Set reentrancy guard
 10. Mark as executed
@@ -577,7 +580,9 @@ When executed, the multisig calls itself, triggering the management function wit
 4. Revert with `TooManyOwners` if `ownerCount >= MAX_OWNERS`
 5. Add owner to owners array (binary search insert to maintain sorted order)
 6. Increment `ownerCount`
-7. Emit `OwnerAdded`
+7. Clear `removedAt[owner] = 0` (in case owner was previously removed and re-added)
+8. Clear `replacedBy[owner] = 0` and `replacedAt[owner] = 0` (in case owner was previously replaced)
+9. Emit `OwnerAdded`
 
 #### `removeOwner`
 
@@ -860,6 +865,20 @@ multisig.submitTransaction(
 - 3-of-3 multisig cannot directly removeOwner (threshold > ownerCount - 1)
 - 3-of-3 must changeThreshold to 2 first, then removeOwner
 - Can batch changeThreshold + removeOwner in single self-call with multicall
+
+### Replacement Chain
+- A replaced by B, B replaced by C: A's confirmations follow chain to C
+- Replacement chain terminates at current owner
+- If chain ends at removed owner, confirmation is invalid
+
+### Re-adding Removed Owner
+- Previously removed owner can be re-added
+- `removedAt`, `replacedBy`, `replacedAt` are cleared on re-add
+- New confirmations from re-added owner work correctly
+
+### Cancellation Persistence
+- Removed owner's cancellation votes still count
+- Cancellation can complete after voter removal
 
 ## Integration Tests
 

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -521,9 +521,12 @@ Cancellation requires threshold confirmations, similar to execution:
 4. Revert with `TransactionAlreadyExecuted` if already executed
 5. Revert with `TransactionCancelled` if cancelled
 6. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
-7. **Count valid confirmations** (lazy invalidation check):
-   - For each confirmer, check: `removedAt[confirmer] == 0` OR `removedAt[confirmer] > txId`
-   - Only count confirmations from owners who weren't removed before this tx was created
+7. **Count valid confirmations** (lazy invalidation/transfer check):
+   - For each confirmer:
+     - If `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`: attribute to `replacedBy[confirmer]`
+     - If `removedAt[confirmer] != 0` AND `removedAt[confirmer] <= txId`: invalid (removed before tx)
+     - Otherwise: valid confirmation from original confirmer
+   - Deduplicate: if both old and new owner confirmed, count only once
 8. Revert with `InsufficientConfirmations` if `validConfirmations < threshold`
 9. Set reentrancy guard
 10. Mark as executed
@@ -596,10 +599,10 @@ When executed, the multisig calls itself, triggering the management function wit
 3. Revert with `ZeroAddressOwner` if `newOwner` is `address(0)`
 4. Revert with `AlreadyOwner` if `newOwner` is already an owner
 5. Replace `oldOwner` with `newOwner` in owners array (maintain sorted order)
-6. **Transfer all confirmations from `oldOwner` to `newOwner`** on pending transactions
+6. Record `replacedBy[oldOwner] = newOwner` and `replacedAt[oldOwner] = transactionCount` (for lazy transfer)
 7. Emit `OwnerReplaced`
 
-> **Note**: `replaceOwner` is atomic and transfers confirmations, enabling seamless key rotation without losing confirmation state.
+> **Note**: `replaceOwner` uses lazy confirmation transfer. At execution time, when validating confirmations, if `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`, the confirmation is attributed to `replacedBy[confirmer]` instead. This enables seamless key rotation without O(n) iteration.
 
 #### `changeThreshold`
 
@@ -662,6 +665,12 @@ Cancellation count (at keccak256("cancellationCount", txId)):
 
 Owner removal tracking (at keccak256("removedAt", owner)):
   uint256 transactionCountAtRemoval  // 0 if not removed, else txCount when removed
+
+Owner replacement tracking (at keccak256("replacedBy", owner)):
+  address newOwner  // 0 if not replaced, else the replacement address
+
+Owner replacement timing (at keccak256("replacedAt", owner)):
+  uint256 transactionCountAtReplacement  // 0 if not replaced, else txCount when replaced
 ```
 
 ---
@@ -722,8 +731,9 @@ multisig.submitTransaction(
 13. `threshold` must always be >= 1 and <= `ownerCount`
 14. Owner management functions can only be called by the multisig itself (self-call)
 15. Removed owners' confirmations are lazily invalidated via `removedAt` tracking
-16. A confirmation is valid iff `removedAt[confirmer] == 0` OR `removedAt[confirmer] > txId`
-17. When an owner is replaced, their confirmations transfer to the new owner
+16. Replaced owners' confirmations are lazily transferred via `replacedBy`/`replacedAt` tracking
+17. A confirmation is valid iff confirmer is current owner OR was replaced/removed AFTER tx creation
+18. Confirmation counting handles deduplication when both old and new owner confirmed
 
 ## Security Invariants
 
@@ -835,8 +845,10 @@ multisig.submitTransaction(
 - Reject replacing non-existent owner
 - Reject replacing with zero address
 - Reject replacing with existing owner
-- **Confirmations transfer from old owner to new owner**
 - Verify owner list remains sorted after replace
+- **Lazy transfer**: `replacedBy[old]` and `replacedAt[old]` are set correctly
+- Old owner's confirmations on pre-replacement txs are attributed to new owner
+- Deduplication: if both old and new owner confirmed same tx, counts as 1
 
 ### Change Threshold
 - Change threshold via self-call with current threshold confirmations

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -39,6 +39,14 @@ By implementing multisig as a precompile:
 
 # Specification
 
+## Constants and Limits
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `MAX_OWNERS` | 50 | Prevents gas DoS on confirmation loops |
+| `MAX_DATA_SIZE` | 65536 (64KB) | Bounds storage and execution costs |
+| `DEFAULT_EXPIRY` | 30 days | Prevents stale transaction execution |
+
 ## Address Scheme
 
 ### Multisig Factory Address
@@ -53,14 +61,14 @@ The `F15C` prefix is derived from "mUltiSig" → hex representation mnemonic.
 
 ### Multisig Address Derivation
 
-Multisig addresses use a dedicated prefix and deterministic derivation:
+Multisig addresses use a dedicated prefix and deterministic derivation. To prevent birthday-attack collisions, we use 16 bytes of the hash (128 bits of entropy):
 
 ```
-MULTISIG_PREFIX (12 bytes) || keccak256(owners, threshold)[0:8] (8 bytes)
+MULTISIG_PREFIX (4 bytes) || keccak256(owners, threshold)[0:16] (16 bytes)
 ```
 
 Where:
-- `MULTISIG_PREFIX` = `0xF15C000000000000000000000000000000` (12 bytes)
+- `MULTISIG_PREFIX` = `0xF15C0000` (4 bytes)
 - `owners` = sorted array of owner addresses (ascending order)
 - `threshold` = required number of confirmations (uint8)
 
@@ -71,12 +79,14 @@ function computeMultisigAddress(address[] memory owners, uint8 threshold) pure r
     bytes32 hash = keccak256(abi.encode(sorted, threshold));
     
     bytes20 addr;
-    addr[0:12] = MULTISIG_PREFIX;
-    addr[12:20] = hash[0:8];
+    addr[0:4] = MULTISIG_PREFIX;   // 4 bytes prefix
+    addr[4:20] = hash[0:16];       // 16 bytes from hash (128-bit collision resistance)
     
     return address(addr);
 }
 ```
+
+> **Security Note**: Using 16 bytes (128 bits) of the hash provides birthday-attack resistance of ~2^64 operations, making collision attacks computationally infeasible.
 
 ### Reserved Addresses
 
@@ -97,7 +107,7 @@ The first 1024 addresses in the multisig address space are reserved for protocol
 interface IMultisigFactory {
     /// @notice Emitted when a new multisig wallet is created
     /// @param multisig The address of the created multisig
-    /// @param owners Array of owner addresses
+    /// @param owners Array of owner addresses (sorted ascending)
     /// @param threshold Number of required confirmations
     event MultisigCreated(
         address indexed multisig,
@@ -117,6 +127,9 @@ interface IMultisigFactory {
     /// @notice Owner list is empty
     error NoOwners();
 
+    /// @notice Too many owners (exceeds MAX_OWNERS)
+    error TooManyOwners(uint8 count, uint8 max);
+
     /// @notice Duplicate owner in the list
     error DuplicateOwner(address owner);
 
@@ -124,7 +137,7 @@ interface IMultisigFactory {
     error ZeroAddressOwner();
 
     /// @notice Creates a new multisig wallet
-    /// @param owners Array of owner addresses (will be sorted internally)
+    /// @param owners Array of owner addresses (will be sorted internally, max 50)
     /// @param threshold Number of required confirmations (1 <= threshold <= owners.length)
     /// @return multisig The address of the created multisig
     function createMultisig(
@@ -154,6 +167,7 @@ interface IMultisigFactory {
 
 1. Validate inputs:
    - Revert with `NoOwners` if `owners.length == 0`
+   - Revert with `TooManyOwners` if `owners.length > MAX_OWNERS` (50)
    - Revert with `ZeroAddressOwner` if any owner is `address(0)`
    - Revert with `DuplicateOwner` if any owner appears twice
    - Revert with `InvalidThreshold` if `threshold == 0` or `threshold > owners.length`
@@ -187,12 +201,14 @@ interface IMultisig {
     /// @param to Target address for the transaction
     /// @param value TIP-20 token address and amount (encoded)
     /// @param data Calldata for the transaction
+    /// @param expiresAt Timestamp after which the transaction cannot be executed
     event TransactionSubmitted(
         uint256 indexed txId,
         address indexed proposer,
-        address to,
+        address indexed to,
         bytes value,
-        bytes data
+        bytes data,
+        uint256 expiresAt
     );
 
     /// @notice An owner has confirmed a transaction
@@ -218,13 +234,17 @@ interface IMultisig {
     /// @notice A transaction has been executed
     /// @param txId The transaction ID
     /// @param executor The address that triggered execution
-    /// @param success Whether the transaction succeeded
-    /// @param returnData Return data from the call
     event TransactionExecuted(
         uint256 indexed txId,
-        address indexed executor,
-        bool success,
-        bytes returnData
+        address indexed executor
+    );
+
+    /// @notice A transaction has been cancelled
+    /// @param txId The transaction ID
+    /// @param canceller The owner who initiated cancellation
+    event TransactionCancelled(
+        uint256 indexed txId,
+        address indexed canceller
     );
 
     /// @notice Caller is not an owner
@@ -235,6 +255,12 @@ interface IMultisig {
 
     /// @notice Transaction already executed
     error TransactionAlreadyExecuted(uint256 txId);
+
+    /// @notice Transaction has been cancelled
+    error TransactionCancelled(uint256 txId);
+
+    /// @notice Transaction has expired
+    error TransactionExpired(uint256 txId, uint256 expiresAt, uint256 currentTime);
 
     /// @notice Owner has already confirmed this transaction
     error AlreadyConfirmed(uint256 txId, address owner);
@@ -247,6 +273,15 @@ interface IMultisig {
 
     /// @notice Transaction execution failed
     error ExecutionFailed(uint256 txId, bytes returnData);
+
+    /// @notice Transaction data exceeds maximum size
+    error DataTooLarge(uint256 size, uint256 max);
+
+    /// @notice Invalid value encoding (must be empty or abi.encode(address, uint256))
+    error InvalidValueEncoding();
+
+    /// @notice Reentrancy detected
+    error ReentrancyGuard();
 
     /// @notice Returns the list of owners
     function owners() external view returns (address[] memory);
@@ -263,13 +298,17 @@ interface IMultisig {
     /// @return value Encoded token transfer (token address + amount), or empty for pure calls
     /// @return data Calldata
     /// @return executed Whether the transaction has been executed
+    /// @return cancelled Whether the transaction has been cancelled
     /// @return confirmations Number of confirmations
+    /// @return expiresAt Timestamp after which the transaction cannot be executed
     function getTransaction(uint256 txId) external view returns (
         address to,
         bytes memory value,
         bytes memory data,
         bool executed,
-        uint8 confirmations
+        bool cancelled,
+        uint8 confirmations,
+        uint256 expiresAt
     );
 
     /// @notice Returns whether an owner has confirmed a transaction
@@ -282,15 +321,28 @@ interface IMultisig {
     function getConfirmations(uint256 txId) external view returns (address[] memory);
 
     /// @notice Submits a new transaction for confirmation
-    /// @dev Also counts as a confirmation from msg.sender
+    /// @dev Also counts as a confirmation from msg.sender. Validates value encoding.
     /// @param to Target address
     /// @param value Encoded token transfer: abi.encode(tokenAddress, amount), or empty bytes
-    /// @param data Calldata for the transaction
+    /// @param data Calldata for the transaction (max 64KB)
     /// @return txId The ID of the submitted transaction
     function submitTransaction(
         address to,
         bytes calldata value,
         bytes calldata data
+    ) external returns (uint256 txId);
+
+    /// @notice Submits a new transaction with custom expiry
+    /// @param to Target address
+    /// @param value Encoded token transfer: abi.encode(tokenAddress, amount), or empty bytes
+    /// @param data Calldata for the transaction (max 64KB)
+    /// @param expiresAt Timestamp after which the transaction cannot be executed
+    /// @return txId The ID of the submitted transaction
+    function submitTransactionWithExpiry(
+        address to,
+        bytes calldata value,
+        bytes calldata data,
+        uint256 expiresAt
     ) external returns (uint256 txId);
 
     /// @notice Confirms a pending transaction
@@ -301,22 +353,26 @@ interface IMultisig {
     /// @param txId The transaction ID
     function revokeConfirmation(uint256 txId) external;
 
+    /// @notice Cancels a pending transaction (requires threshold confirmations to cancel)
+    /// @dev Creates a cancellation "meta-transaction" that owners must confirm
+    /// @param txId The transaction ID to cancel
+    function cancelTransaction(uint256 txId) external;
+
     /// @notice Executes a transaction that has sufficient confirmations
+    /// @dev Only callable by owners. Reverts on execution failure.
     /// @param txId The transaction ID to execute
     function executeTransaction(uint256 txId) external;
 
     /// @notice Submits, confirms, and executes a transaction in one call
-    /// @dev Reverts if threshold > 1 (cannot execute without other confirmations)
+    /// @dev Only works if threshold == 1, otherwise reverts
     /// @param to Target address
     /// @param value Encoded token transfer
     /// @param data Calldata
-    /// @return success Whether execution succeeded
-    /// @return returnData Return data from the call
     function execute(
         address to,
         bytes calldata value,
         bytes calldata data
-    ) external returns (bool success, bytes memory returnData);
+    ) external;
 }
 ```
 
@@ -328,66 +384,108 @@ Transactions are stored with the following data:
 struct Transaction {
     address to;           // Target address
     bytes value;          // Encoded: abi.encode(address token, uint256 amount) or empty
-    bytes data;           // Calldata to execute
+    bytes data;           // Calldata to execute (max 64KB)
     bool executed;        // Has been executed
+    bool cancelled;       // Has been cancelled
     uint8 confirmations;  // Current confirmation count
+    uint256 expiresAt;    // Timestamp after which execution is blocked
 }
 ```
 
 The `value` field encodes a TIP-20 transfer:
 - Empty bytes (`0x`): No token transfer, just a call
 - `abi.encode(token, amount)`: Transfer `amount` of `token` to `to` before executing `data`
+- Any other encoding: **Invalid**, reverts with `InvalidValueEncoding` at submission time
 
 ### Multisig Behavior
 
 #### `submitTransaction`
 
 1. Revert with `NotOwner` if `msg.sender` is not an owner
-2. Create transaction with `txId = transactionCount++`
-3. Store transaction data
-4. Auto-confirm for `msg.sender`
-5. Emit `TransactionSubmitted` and `TransactionConfirmed`
-6. Return `txId`
+2. Revert with `DataTooLarge` if `data.length > MAX_DATA_SIZE` (64KB)
+3. Validate `value` encoding:
+   - If `value.length == 0`: valid (no token transfer)
+   - If `value.length == 64`: valid (abi.encode(address, uint256))
+   - Otherwise: revert with `InvalidValueEncoding`
+4. Create transaction with `txId = transactionCount++`
+5. Set `expiresAt = block.timestamp + DEFAULT_EXPIRY` (30 days)
+6. Store transaction data
+7. Auto-confirm for `msg.sender`
+8. Emit `TransactionSubmitted` and `TransactionConfirmed`
+9. Return `txId`
+
+#### `submitTransactionWithExpiry`
+
+Same as `submitTransaction`, but:
+- Uses provided `expiresAt` instead of default
+- `expiresAt` must be in the future (`> block.timestamp`)
 
 #### `confirmTransaction`
 
 1. Revert with `NotOwner` if `msg.sender` is not an owner
 2. Revert with `TransactionNotFound` if transaction doesn't exist
 3. Revert with `TransactionAlreadyExecuted` if already executed
-4. Revert with `AlreadyConfirmed` if already confirmed by sender
-5. Record confirmation and increment count
-6. Emit `TransactionConfirmed`
+4. Revert with `TransactionCancelled` if cancelled
+5. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
+6. Revert with `AlreadyConfirmed` if already confirmed by sender
+7. Record confirmation and increment count
+8. Emit `TransactionConfirmed`
 
 #### `revokeConfirmation`
 
 1. Revert with `NotOwner` if `msg.sender` is not an owner
 2. Revert with `TransactionNotFound` if transaction doesn't exist
 3. Revert with `TransactionAlreadyExecuted` if already executed
-4. Revert with `NotConfirmed` if sender hasn't confirmed
-5. Remove confirmation and decrement count
-6. Emit `ConfirmationRevoked`
+4. Revert with `TransactionCancelled` if cancelled
+5. Revert with `NotConfirmed` if sender hasn't confirmed
+6. Remove confirmation and decrement count
+7. Emit `ConfirmationRevoked`
+
+#### `cancelTransaction`
+
+Cancellation requires threshold confirmations, similar to execution:
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `TransactionNotFound` if transaction doesn't exist
+3. Revert with `TransactionAlreadyExecuted` if already executed
+4. Revert with `TransactionCancelled` if already cancelled
+5. Record cancellation vote from `msg.sender`
+6. If cancellation votes >= threshold:
+   - Set `cancelled = true`
+   - Emit `TransactionCancelled`
+
+> **Note**: Cancellation uses a separate vote count from confirmation. An owner can confirm a transaction AND vote to cancel it (allowing them to change their mind).
 
 #### `executeTransaction`
 
-1. Revert with `TransactionNotFound` if transaction doesn't exist
-2. Revert with `TransactionAlreadyExecuted` if already executed
-3. Revert with `InsufficientConfirmations` if `confirmations < threshold`
-4. Mark as executed
-5. If `value` is non-empty:
-   - Decode `(token, amount)` from `value`
-   - Transfer `amount` of `token` from multisig to `to`
-6. If `data` is non-empty:
-   - Execute `to.call(data)` with multisig as `msg.sender`
-7. Emit `TransactionExecuted`
-8. Revert with `ExecutionFailed` if the call failed and user expects success
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `ReentrancyGuard` if already in execution context
+3. Revert with `TransactionNotFound` if transaction doesn't exist
+4. Revert with `TransactionAlreadyExecuted` if already executed
+5. Revert with `TransactionCancelled` if cancelled
+6. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
+7. Revert with `InsufficientConfirmations` if `confirmations < threshold`
+8. Set reentrancy guard
+9. Mark as executed
+10. If `value` is non-empty:
+    - Decode `(token, amount)` from `value`
+    - Transfer `amount` of `token` from multisig to `to`
+11. If `data` is non-empty:
+    - Execute `to.call(data)` with multisig as `msg.sender`
+12. Clear reentrancy guard
+13. Emit `TransactionExecuted`
+14. Revert with `ExecutionFailed` if the call failed
+
+> **Security Note**: Only owners can trigger execution. This prevents MEV attacks where attackers front-run or sandwich multisig transactions.
 
 #### `execute`
 
-Convenience function for 1-of-N multisigs or when all confirmations are ready:
+Convenience function for 1-of-1 multisigs only:
 
-1. Submit transaction
-2. If `confirmations >= threshold`: execute immediately
-3. Otherwise, revert (cannot execute without sufficient confirmations)
+1. Revert if `threshold != 1`
+2. Submit transaction (which auto-confirms)
+3. Execute immediately (since 1 confirmation = threshold)
+4. Revert with `ExecutionFailed` if execution fails
 
 ---
 
@@ -406,7 +504,7 @@ No additional storage needed; all validation is stateless.
 Each multisig uses the following storage layout at its deterministic address:
 
 ```
-Slot 0: initialized (bool)
+Slot 0: initialized (bool) | locked (bool, reentrancy guard)
 Slot 1: threshold (uint8)
 Slot 2: ownerCount (uint8)
 Slot 3: transactionCount (uint256)
@@ -416,13 +514,20 @@ Owners array (starting at keccak256("owners")):
 
 Transactions mapping (at keccak256("transactions", txId)):
   +0: to (address)
-  +1: value length + first 24 bytes
-  +2+: value continuation (if needed)
+  +1: expiresAt (uint256)
+  +2: value length + first 24 bytes
+  +3+: value continuation (if needed)
   +N: data length + bytes
-  +N+1: executed (bool) | confirmations (uint8)
+  +N+1: executed (bool) | cancelled (bool) | confirmations (uint8)
 
 Confirmations mapping (at keccak256("confirmations", txId, owner)):
   bool confirmed
+
+Cancellation votes mapping (at keccak256("cancellations", txId, owner)):
+  bool votedToCancel
+
+Cancellation count (at keccak256("cancellationCount", txId)):
+  uint8 count
 ```
 
 ---
@@ -464,24 +569,32 @@ multisig.submitTransaction(
 3. `isMultisig` must return `true` if and only if the address was created by the factory
 4. Owner lists must be sorted ascending before address derivation
 5. Duplicate owners must be rejected
+6. Owner count must be <= `MAX_OWNERS` (50)
 
 ## Multisig Invariants
 
-1. Only owners can submit, confirm, or revoke transactions
+1. Only owners can submit, confirm, revoke, cancel, or execute transactions
 2. A transaction can only be executed once
 3. A transaction requires exactly `threshold` confirmations to execute
 4. An owner can only confirm a transaction once
 5. Executed transactions cannot be modified or re-executed
-6. `confirmations` count must equal the number of owners who have confirmed
-7. `transactionCount` must be monotonically increasing
-8. The `owners()` and `threshold()` values must never change after creation
+6. Cancelled transactions cannot be executed or confirmed
+7. Expired transactions cannot be executed or confirmed
+8. `confirmations` count must equal the number of owners who have confirmed
+9. `transactionCount` must be monotonically increasing
+10. The `owners()` and `threshold()` values must never change after creation
+11. Transaction `data` size must be <= `MAX_DATA_SIZE` (64KB)
+12. Transaction `value` must be empty or exactly 64 bytes (valid encoding)
 
 ## Security Invariants
 
 1. No transaction can execute with fewer than `threshold` confirmations
-2. Non-owners cannot influence transaction state
+2. Non-owners cannot influence transaction state (submit, confirm, revoke, cancel, execute)
 3. Revoked confirmations must decrease the confirmation count
 4. Token transfers in `value` field must respect TIP-403 policies
+5. Reentrancy during `executeTransaction` must be blocked
+6. Cancellation requires `threshold` votes (same as execution)
+7. Address derivation uses 128 bits of entropy (collision-resistant)
 
 ---
 
@@ -496,23 +609,61 @@ multisig.submitTransaction(
 - Reject threshold = 0
 - Reject threshold > owner count
 - Reject creation if multisig exists
+- Reject creation with > 50 owners (`TooManyOwners`)
 - Verify deterministic address matches prediction
 - Verify owner order doesn't affect address (sorted internally)
+- Verify 128-bit address derivation (no collisions with different configs)
 
 ## Multisig Tests
 
+### Submission
 - Submit transaction as owner
 - Reject submission from non-owner
+- Reject submission with data > 64KB (`DataTooLarge`)
+- Reject submission with invalid value encoding (`InvalidValueEncoding`)
+- Verify default expiry is set (30 days)
+- Submit with custom expiry via `submitTransactionWithExpiry`
+
+### Confirmation
 - Confirm transaction as different owner
 - Reject double confirmation
-- Execute when threshold reached
-- Reject execution with insufficient confirmations
+- Reject confirmation from non-owner
+- Reject confirmation of cancelled transaction
+- Reject confirmation of expired transaction
+- Reject confirmation of executed transaction
+
+### Revocation
 - Revoke confirmation
 - Reject revoke if not confirmed
+- Reject revoke of cancelled transaction
+- Reject revoke of executed transaction
+
+### Cancellation
+- Cancel transaction with threshold votes
+- Reject cancel from non-owner
+- Reject cancel of already-cancelled transaction
+- Reject cancel of executed transaction
+- Verify cancellation requires threshold votes (not just 1)
+- Owner can confirm AND vote to cancel same transaction
+
+### Execution
+- Execute when threshold reached
+- Reject execution with insufficient confirmations
+- Reject execution from non-owner
+- Reject execution of cancelled transaction
+- Reject execution of expired transaction
+- Reject double execution
 - Execute TIP-20 transfer via value field
 - Execute arbitrary call via data field
 - Execute combined value + data transaction
+- Verify reentrancy is blocked
 - Verify events are emitted correctly
+
+### Edge Cases
+- 1-of-1 immediate execution via `execute()`
+- `execute()` reverts if threshold > 1
+- Transaction with empty value and empty data (no-op)
+- Transaction targeting multisig itself (self-call)
 
 ## Integration Tests
 
@@ -521,3 +672,6 @@ multisig.submitTransaction(
 - 1-of-1 immediate execution via `execute()`
 - Multisig receiving tokens from another account
 - Multisig interacting with DEX
+- Multisig as owner of another multisig (nested multisig)
+- Cancel race condition: execute vs cancel reaching threshold simultaneously
+- Expiry edge case: confirm just before expiry, execute just after

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -414,6 +414,9 @@ event OwnerReplaced(address indexed oldOwner, address indexed newOwner);
 /// @notice The confirmation threshold was changed
 event ThresholdChanged(uint8 oldThreshold, uint8 newThreshold);
 
+/// @notice Caller is not the multisig itself (management functions require self-call)
+error NotMultisig();
+
 /// @notice The address is already an owner
 error AlreadyOwner(address owner);
 
@@ -423,6 +426,8 @@ error ThresholdExceedsOwners(uint8 threshold, uint8 newOwnerCount);
 /// @notice Cannot have zero owners
 error CannotRemoveLastOwner();
 ```
+
+> **Design Rationale**: Owner management functions use `NotMultisig` instead of `NotOwner` because they can only be called via self-call (when the multisig executes a confirmed transaction targeting itself). Direct external calls to these functions will always revert.
 
 ### Transaction Structure
 
@@ -539,62 +544,70 @@ Convenience function for 1-of-1 multisigs only:
 
 ### Owner Management Behavior
 
-Owner management functions use the same confirmation pattern as regular transactions. Each function internally creates a "config change" transaction that owners must confirm.
+Owner management is implemented via **self-calls**: owners submit a regular transaction where `to = multisig address` and `data` encodes the management function. This reuses the existing transaction queue, confirmation, cancellation, and expiry mechanisms.
+
+```solidity
+// Example: Add owner via self-call transaction
+multisig.submitTransaction(
+    address(multisig),  // to = self
+    "",                 // no token transfer
+    abi.encodeCall(IMultisig.addOwner, (newOwner))
+);
+```
+
+When executed, the multisig calls itself, triggering the management function with `msg.sender = multisig`.
 
 #### `addOwner`
 
-1. Revert with `NotOwner` if `msg.sender` is not an owner
+1. Revert with `NotMultisig` if `msg.sender != address(this)` (must be self-call)
 2. Revert with `ZeroAddressOwner` if `owner` is `address(0)`
 3. Revert with `AlreadyOwner` if `owner` is already an owner
 4. Revert with `TooManyOwners` if `ownerCount >= MAX_OWNERS`
-5. Create config-change transaction for adding owner
-6. Auto-confirm for `msg.sender`
-7. If confirmations >= threshold:
-   - Add owner to owners array (maintain sorted order)
-   - Increment `ownerCount`
-   - Emit `OwnerAdded`
+5. Add owner to owners array (binary search insert to maintain sorted order)
+6. Increment `ownerCount`
+7. Emit `OwnerAdded`
 
 #### `removeOwner`
 
-1. Revert with `NotOwner` if `msg.sender` is not an owner
+1. Revert with `NotMultisig` if `msg.sender != address(this)`
 2. Revert with `NotOwner` if `owner` is not in owners list
 3. Revert with `CannotRemoveLastOwner` if `ownerCount == 1`
 4. Revert with `ThresholdExceedsOwners` if `threshold > ownerCount - 1`
-5. Create config-change transaction for removing owner
-6. Auto-confirm for `msg.sender`
-7. If confirmations >= threshold:
-   - Remove owner from owners array
-   - Decrement `ownerCount`
-   - Emit `OwnerRemoved`
+5. Remove owner from owners array
+6. Decrement `ownerCount`
+7. **Invalidate all confirmations by this owner** on pending transactions
+8. Emit `OwnerRemoved`
 
-> **Note**: If the removed owner had pending confirmations, those confirmations remain valid. However, they can no longer confirm new transactions or execute.
+> **Security Note**: When an owner is removed, their confirmations on all pending transactions are invalidated and confirmation counts decremented. This prevents "stale confirmation" attacks where a removed owner's old confirmations still count toward threshold.
 
 #### `replaceOwner`
 
-1. Revert with `NotOwner` if `msg.sender` is not an owner
+1. Revert with `NotMultisig` if `msg.sender != address(this)`
 2. Revert with `NotOwner` if `oldOwner` is not in owners list
 3. Revert with `ZeroAddressOwner` if `newOwner` is `address(0)`
 4. Revert with `AlreadyOwner` if `newOwner` is already an owner
-5. Create config-change transaction for replacement
-6. Auto-confirm for `msg.sender`
-7. If confirmations >= threshold:
-   - Replace `oldOwner` with `newOwner` in owners array (maintain sorted order)
-   - Emit `OwnerReplaced`
+5. Replace `oldOwner` with `newOwner` in owners array (maintain sorted order)
+6. **Transfer all confirmations from `oldOwner` to `newOwner`** on pending transactions
+7. Emit `OwnerReplaced`
 
-> **Note**: `replaceOwner` is atomic - it never temporarily reduces owner count, avoiding threshold validation edge cases.
+> **Note**: `replaceOwner` is atomic and transfers confirmations, enabling seamless key rotation without losing confirmation state.
 
 #### `changeThreshold`
 
-1. Revert with `NotOwner` if `msg.sender` is not an owner
+1. Revert with `NotMultisig` if `msg.sender != address(this)`
 2. Revert with `InvalidThreshold` if `newThreshold == 0`
 3. Revert with `InvalidThreshold` if `newThreshold > ownerCount`
-4. Create config-change transaction for threshold change
-5. Auto-confirm for `msg.sender`
-6. If confirmations >= threshold (using **current** threshold):
-   - Update threshold to `newThreshold`
-   - Emit `ThresholdChanged`
+4. Update threshold to `newThreshold`
+5. Emit `ThresholdChanged`
 
-> **Security Note**: Threshold changes use the **current** threshold for confirmation, not the new one. This prevents a single owner from reducing threshold to 1 and taking over.
+> **Security Note**: Since management functions require a confirmed transaction to execute, threshold changes inherently require the **current** threshold number of confirmations before execution. This prevents a single owner from reducing threshold to 1 and taking over.
+
+#### Self-Removal and N-of-N Multisigs
+
+An owner CAN vote to remove themselves. For N-of-N multisigs where `threshold == ownerCount`:
+- Direct `removeOwner` will fail (`threshold > ownerCount - 1`)
+- Must first `changeThreshold(N-1)`, then `removeOwner`
+- These can be batched in a single transaction using multicall pattern
 
 ---
 
@@ -689,14 +702,15 @@ multisig.submitTransaction(
 5. Executed transactions cannot be modified or re-executed
 6. Cancelled transactions cannot be executed or confirmed
 7. Expired transactions cannot be executed or confirmed
-8. `confirmations` count must equal the number of owners who have confirmed
+8. `confirmations` count must equal the number of **current** owners who have confirmed
 9. `transactionCount` must be monotonically increasing
 10. Transaction `data` size must be <= `MAX_DATA_SIZE` (64KB)
 11. Transaction `value` must be empty or exactly 64 bytes (valid encoding)
 12. `ownerCount` must always be >= 1 (cannot remove last owner)
 13. `threshold` must always be >= 1 and <= `ownerCount`
-14. Owner management operations require `threshold` confirmations
-15. Config changes use the current threshold, not the proposed new threshold
+14. Owner management functions can only be called by the multisig itself (self-call)
+15. When an owner is removed, their confirmations on pending transactions are invalidated
+16. When an owner is replaced, their confirmations transfer to the new owner
 
 ## Security Invariants
 
@@ -779,38 +793,46 @@ multisig.submitTransaction(
 
 ## Owner Management Tests
 
+### Self-Call Mechanism
+- Owner management only works via self-call transaction
+- Direct call to `addOwner` reverts with `NotMultisig`
+- Submit self-call transaction for owner management
+- Self-call transaction requires threshold confirmations like any other
+
 ### Add Owner
-- Add owner with threshold confirmations
-- Reject add from non-owner
+- Add owner via self-call with threshold confirmations
 - Reject adding existing owner (`AlreadyOwner`)
 - Reject adding zero address
 - Reject adding when at MAX_OWNERS (50)
-- Verify owner list remains sorted after add
+- Verify owner list remains sorted after add (binary search insert)
 
 ### Remove Owner
-- Remove owner with threshold confirmations
-- Reject remove from non-owner
+- Remove owner via self-call with threshold confirmations
 - Reject removing non-existent owner
 - Reject removing last owner (`CannotRemoveLastOwner`)
 - Reject if would make threshold > ownerCount (`ThresholdExceedsOwners`)
-- Removed owner's pending confirmations remain valid
+- **Removed owner's confirmations are invalidated on all pending transactions**
 - Removed owner cannot confirm new transactions
+- Confirmation count decrements correctly after removal
 
 ### Replace Owner
-- Replace owner atomically with threshold confirmations
-- Reject replace from non-owner
+- Replace owner atomically via self-call
 - Reject replacing non-existent owner
 - Reject replacing with zero address
 - Reject replacing with existing owner
+- **Confirmations transfer from old owner to new owner**
 - Verify owner list remains sorted after replace
 
 ### Change Threshold
-- Change threshold with current threshold confirmations
-- Reject change from non-owner
+- Change threshold via self-call with current threshold confirmations
 - Reject threshold = 0
 - Reject threshold > ownerCount
-- Verify change uses current threshold (not new one)
-- 2-of-3 can change to 1-of-3, then 1-of-3 to 3-of-3
+- Existing pending transactions use new threshold for execution check
+
+### N-of-N Edge Cases
+- 3-of-3 multisig cannot directly removeOwner (threshold > ownerCount - 1)
+- 3-of-3 must changeThreshold to 2 first, then removeOwner
+- Can batch changeThreshold + removeOwner in single self-call with multicall
 
 ## Integration Tests
 

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -286,6 +286,10 @@ interface IMultisig {
     /// @notice Returns the list of owners
     function owners() external view returns (address[] memory);
 
+    /// @notice Returns whether an address is a current owner
+    /// @param addr The address to check
+    function isOwner(address addr) external view returns (bool);
+
     /// @notice Returns the confirmation threshold
     function threshold() external view returns (uint8);
 
@@ -517,19 +521,24 @@ Cancellation requires threshold confirmations, similar to execution:
 4. Revert with `TransactionAlreadyExecuted` if already executed
 5. Revert with `TransactionCancelled` if cancelled
 6. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
-7. Revert with `InsufficientConfirmations` if `confirmations < threshold`
-8. Set reentrancy guard
-9. Mark as executed
-10. If `value` is non-empty:
+7. **Count valid confirmations** (lazy invalidation check):
+   - For each confirmer, check: `removedAt[confirmer] == 0` OR `removedAt[confirmer] > txId`
+   - Only count confirmations from owners who weren't removed before this tx was created
+8. Revert with `InsufficientConfirmations` if `validConfirmations < threshold`
+9. Set reentrancy guard
+10. Mark as executed
+11. If `value` is non-empty:
     - Decode `(token, amount)` from `value`
     - Transfer `amount` of `token` from multisig to `to`
-11. If `data` is non-empty:
+12. If `data` is non-empty:
     - Execute `to.call(data)` with multisig as `msg.sender`
-12. Clear reentrancy guard
-13. Emit `TransactionExecuted`
-14. Revert with `ExecutionFailed` if the call failed
+13. Clear reentrancy guard
+14. Emit `TransactionExecuted`
+15. Revert with `ExecutionFailed` if the call failed
 
 > **Security Note**: Only owners can trigger execution. This prevents MEV attacks where attackers front-run or sandwich multisig transactions.
+
+> **Implementation Note**: The lazy confirmation validation at step 7 requires iterating over confirmers for this transaction. Since each transaction can have at most `MAX_OWNERS` (50) confirmations, this is O(50) = O(1) bounded, not O(pending_transactions).
 
 #### `execute`
 
@@ -575,10 +584,10 @@ When executed, the multisig calls itself, triggering the management function wit
 4. Revert with `ThresholdExceedsOwners` if `threshold > ownerCount - 1`
 5. Remove owner from owners array
 6. Decrement `ownerCount`
-7. **Invalidate all confirmations by this owner** on pending transactions
+7. Record `removedAt[owner] = transactionCount` (for lazy invalidation)
 8. Emit `OwnerRemoved`
 
-> **Security Note**: When an owner is removed, their confirmations on all pending transactions are invalidated and confirmation counts decremented. This prevents "stale confirmation" attacks where a removed owner's old confirmations still count toward threshold.
+> **Security Note**: Confirmation invalidation uses **lazy evaluation**. Instead of iterating over all pending transactions (which would be O(n) and a DoS vector), we record when each owner was removed. At execution time, when counting confirmations, we check: for each confirmer, is `removedAt[confirmer] == 0` (not removed) OR `removedAt[confirmer] > txId` (removed after this tx was created)? Only valid confirmations count toward threshold. This prevents "stale confirmation" attacks where a removed owner's old confirmations count toward threshold.
 
 #### `replaceOwner`
 
@@ -650,6 +659,9 @@ Cancellation votes mapping (at keccak256("cancellations", txId, owner)):
 
 Cancellation count (at keccak256("cancellationCount", txId)):
   uint8 count
+
+Owner removal tracking (at keccak256("removedAt", owner)):
+  uint256 transactionCountAtRemoval  // 0 if not removed, else txCount when removed
 ```
 
 ---
@@ -709,8 +721,9 @@ multisig.submitTransaction(
 12. `ownerCount` must always be >= 1 (cannot remove last owner)
 13. `threshold` must always be >= 1 and <= `ownerCount`
 14. Owner management functions can only be called by the multisig itself (self-call)
-15. When an owner is removed, their confirmations on pending transactions are invalidated
-16. When an owner is replaced, their confirmations transfer to the new owner
+15. Removed owners' confirmations are lazily invalidated via `removedAt` tracking
+16. A confirmation is valid iff `removedAt[confirmer] == 0` OR `removedAt[confirmer] > txId`
+17. When an owner is replaced, their confirmations transfer to the new owner
 
 ## Security Invariants
 
@@ -811,9 +824,11 @@ multisig.submitTransaction(
 - Reject removing non-existent owner
 - Reject removing last owner (`CannotRemoveLastOwner`)
 - Reject if would make threshold > ownerCount (`ThresholdExceedsOwners`)
-- **Removed owner's confirmations are invalidated on all pending transactions**
 - Removed owner cannot confirm new transactions
-- Confirmation count decrements correctly after removal
+- **Lazy invalidation**: removed owner's confirmations on txs created BEFORE removal are invalid
+- **Lazy invalidation**: removed owner's confirmations on txs created AFTER removal don't exist
+- Execution correctly counts only valid confirmations after owner removal
+- `removedAt[owner]` is set to `transactionCount` at removal time
 
 ### Replace Owner
 - Replace owner atomically via self-call

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -1,0 +1,523 @@
+---
+title: TIP-XXXX Multisig Precompile
+description: Native multisig wallets as precompiles with deterministic addressing, M-of-N confirmation thresholds, and on-chain transaction execution.
+---
+
+# Multisig Precompile
+
+This document specifies a native multisig system implemented as precompiles on Tempo, enabling M-of-N multi-signature wallets with deterministic addressing.
+
+- **TIP ID**: TIP-XXXX
+- **Authors/Owners**: Tempo Team
+- **Status**: Draft
+- **Related Specs/TIPs**: [TIP-20](/protocol/tip20/spec), [TIP-20 Factory](/protocol/tip20/overview)
+
+---
+
+# Overview
+
+## Abstract
+
+This TIP introduces two precompiles: a **Multisig Factory** that creates multisig wallets at deterministic addresses, and a **Multisig** precompile that manages M-of-N transaction confirmations and execution. Multisig addresses are derived from a hash of the owner list and threshold, enabling address prediction before deployment.
+
+## Motivation
+
+Multi-signature wallets are essential for secure asset management, requiring multiple parties to approve transactions before execution. Current solutions require deploying smart contracts, which:
+
+1. **Lack deterministic addressing**: Wallet addresses cannot be predicted from configuration alone
+2. **Incur deployment costs**: Each multisig requires a contract deployment
+3. **Fragment liquidity**: TIP-20 tokens held in contract wallets behave differently than precompile-based accounts
+
+By implementing multisig as a precompile:
+
+- **Deterministic addresses**: Given owners and threshold, the address is predictable and consistent
+- **Native integration**: Multisig wallets work seamlessly with TIP-20 tokens and other precompiles
+- **Lower costs**: No contract deployment required; only factory interaction
+- **Standardized interface**: All multisigs share the same well-audited logic
+
+---
+
+# Specification
+
+## Address Scheme
+
+### Multisig Factory Address
+
+The Multisig Factory is deployed at a fixed precompile address:
+
+```
+0xF15C000000000000000000000000000000000000
+```
+
+The `F15C` prefix is derived from "mUltiSig" → hex representation mnemonic.
+
+### Multisig Address Derivation
+
+Multisig addresses use a dedicated prefix and deterministic derivation:
+
+```
+MULTISIG_PREFIX (12 bytes) || keccak256(owners, threshold)[0:8] (8 bytes)
+```
+
+Where:
+- `MULTISIG_PREFIX` = `0xF15C000000000000000000000000000000` (12 bytes)
+- `owners` = sorted array of owner addresses (ascending order)
+- `threshold` = required number of confirmations (uint8)
+
+```solidity
+function computeMultisigAddress(address[] memory owners, uint8 threshold) pure returns (address) {
+    // Sort owners ascending to ensure deterministic address
+    address[] memory sorted = sortAscending(owners);
+    bytes32 hash = keccak256(abi.encode(sorted, threshold));
+    
+    bytes20 addr;
+    addr[0:12] = MULTISIG_PREFIX;
+    addr[12:20] = hash[0:8];
+    
+    return address(addr);
+}
+```
+
+### Reserved Addresses
+
+The first 1024 addresses in the multisig address space are reserved for protocol use:
+
+```
+0xF15C000000000000000000000000000000000000 - Factory
+0xF15C000000000000000000000000000000000001 - Reserved
+...
+0xF15C0000000000000000000000000000000003FF - Reserved
+```
+
+---
+
+## Multisig Factory Interface
+
+```solidity
+interface IMultisigFactory {
+    /// @notice Emitted when a new multisig wallet is created
+    /// @param multisig The address of the created multisig
+    /// @param owners Array of owner addresses
+    /// @param threshold Number of required confirmations
+    event MultisigCreated(
+        address indexed multisig,
+        address[] owners,
+        uint8 threshold
+    );
+
+    /// @notice The computed address falls in the reserved range
+    error AddressReserved();
+
+    /// @notice A multisig already exists at this address
+    error MultisigAlreadyExists(address multisig);
+
+    /// @notice Invalid threshold (zero, or greater than owner count)
+    error InvalidThreshold(uint8 threshold, uint8 ownerCount);
+
+    /// @notice Owner list is empty
+    error NoOwners();
+
+    /// @notice Duplicate owner in the list
+    error DuplicateOwner(address owner);
+
+    /// @notice Zero address in owner list
+    error ZeroAddressOwner();
+
+    /// @notice Creates a new multisig wallet
+    /// @param owners Array of owner addresses (will be sorted internally)
+    /// @param threshold Number of required confirmations (1 <= threshold <= owners.length)
+    /// @return multisig The address of the created multisig
+    function createMultisig(
+        address[] calldata owners,
+        uint8 threshold
+    ) external returns (address multisig);
+
+    /// @notice Computes the deterministic address for a multisig configuration
+    /// @param owners Array of owner addresses
+    /// @param threshold Number of required confirmations
+    /// @return The address where the multisig would be deployed
+    function getMultisigAddress(
+        address[] calldata owners,
+        uint8 threshold
+    ) external pure returns (address);
+
+    /// @notice Checks if an address is a deployed multisig
+    /// @param addr The address to check
+    /// @return True if the address is a valid, deployed multisig
+    function isMultisig(address addr) external view returns (bool);
+}
+```
+
+### Factory Behavior
+
+#### `createMultisig`
+
+1. Validate inputs:
+   - Revert with `NoOwners` if `owners.length == 0`
+   - Revert with `ZeroAddressOwner` if any owner is `address(0)`
+   - Revert with `DuplicateOwner` if any owner appears twice
+   - Revert with `InvalidThreshold` if `threshold == 0` or `threshold > owners.length`
+
+2. Sort owners in ascending order
+
+3. Compute the deterministic address
+
+4. Check address validity:
+   - Revert with `AddressReserved` if address is in reserved range
+   - Revert with `MultisigAlreadyExists` if multisig already deployed
+
+5. Initialize the multisig at the computed address with:
+   - Sorted owner list
+   - Threshold value
+   - Empty transaction queue
+
+6. Emit `MultisigCreated` event
+
+7. Return the multisig address
+
+---
+
+## Multisig Interface
+
+```solidity
+interface IMultisig {
+    /// @notice A transaction has been submitted for confirmation
+    /// @param txId The transaction ID
+    /// @param proposer The address that submitted the transaction
+    /// @param to Target address for the transaction
+    /// @param value TIP-20 token address and amount (encoded)
+    /// @param data Calldata for the transaction
+    event TransactionSubmitted(
+        uint256 indexed txId,
+        address indexed proposer,
+        address to,
+        bytes value,
+        bytes data
+    );
+
+    /// @notice An owner has confirmed a transaction
+    /// @param txId The transaction ID
+    /// @param owner The confirming owner
+    /// @param confirmationCount Current number of confirmations
+    event TransactionConfirmed(
+        uint256 indexed txId,
+        address indexed owner,
+        uint8 confirmationCount
+    );
+
+    /// @notice An owner has revoked their confirmation
+    /// @param txId The transaction ID
+    /// @param owner The owner who revoked
+    /// @param confirmationCount Current number of confirmations
+    event ConfirmationRevoked(
+        uint256 indexed txId,
+        address indexed owner,
+        uint8 confirmationCount
+    );
+
+    /// @notice A transaction has been executed
+    /// @param txId The transaction ID
+    /// @param executor The address that triggered execution
+    /// @param success Whether the transaction succeeded
+    /// @param returnData Return data from the call
+    event TransactionExecuted(
+        uint256 indexed txId,
+        address indexed executor,
+        bool success,
+        bytes returnData
+    );
+
+    /// @notice Caller is not an owner
+    error NotOwner(address caller);
+
+    /// @notice Transaction does not exist
+    error TransactionNotFound(uint256 txId);
+
+    /// @notice Transaction already executed
+    error TransactionAlreadyExecuted(uint256 txId);
+
+    /// @notice Owner has already confirmed this transaction
+    error AlreadyConfirmed(uint256 txId, address owner);
+
+    /// @notice Owner has not confirmed this transaction
+    error NotConfirmed(uint256 txId, address owner);
+
+    /// @notice Transaction does not have enough confirmations
+    error InsufficientConfirmations(uint256 txId, uint8 have, uint8 need);
+
+    /// @notice Transaction execution failed
+    error ExecutionFailed(uint256 txId, bytes returnData);
+
+    /// @notice Returns the list of owners
+    function owners() external view returns (address[] memory);
+
+    /// @notice Returns the confirmation threshold
+    function threshold() external view returns (uint8);
+
+    /// @notice Returns the current transaction count (next txId)
+    function transactionCount() external view returns (uint256);
+
+    /// @notice Returns transaction details
+    /// @param txId The transaction ID
+    /// @return to Target address
+    /// @return value Encoded token transfer (token address + amount), or empty for pure calls
+    /// @return data Calldata
+    /// @return executed Whether the transaction has been executed
+    /// @return confirmations Number of confirmations
+    function getTransaction(uint256 txId) external view returns (
+        address to,
+        bytes memory value,
+        bytes memory data,
+        bool executed,
+        uint8 confirmations
+    );
+
+    /// @notice Returns whether an owner has confirmed a transaction
+    /// @param txId The transaction ID
+    /// @param owner The owner address
+    function isConfirmedBy(uint256 txId, address owner) external view returns (bool);
+
+    /// @notice Returns addresses that have confirmed a transaction
+    /// @param txId The transaction ID
+    function getConfirmations(uint256 txId) external view returns (address[] memory);
+
+    /// @notice Submits a new transaction for confirmation
+    /// @dev Also counts as a confirmation from msg.sender
+    /// @param to Target address
+    /// @param value Encoded token transfer: abi.encode(tokenAddress, amount), or empty bytes
+    /// @param data Calldata for the transaction
+    /// @return txId The ID of the submitted transaction
+    function submitTransaction(
+        address to,
+        bytes calldata value,
+        bytes calldata data
+    ) external returns (uint256 txId);
+
+    /// @notice Confirms a pending transaction
+    /// @param txId The transaction ID to confirm
+    function confirmTransaction(uint256 txId) external;
+
+    /// @notice Revokes a confirmation for a pending transaction
+    /// @param txId The transaction ID
+    function revokeConfirmation(uint256 txId) external;
+
+    /// @notice Executes a transaction that has sufficient confirmations
+    /// @param txId The transaction ID to execute
+    function executeTransaction(uint256 txId) external;
+
+    /// @notice Submits, confirms, and executes a transaction in one call
+    /// @dev Reverts if threshold > 1 (cannot execute without other confirmations)
+    /// @param to Target address
+    /// @param value Encoded token transfer
+    /// @param data Calldata
+    /// @return success Whether execution succeeded
+    /// @return returnData Return data from the call
+    function execute(
+        address to,
+        bytes calldata value,
+        bytes calldata data
+    ) external returns (bool success, bytes memory returnData);
+}
+```
+
+### Transaction Structure
+
+Transactions are stored with the following data:
+
+```solidity
+struct Transaction {
+    address to;           // Target address
+    bytes value;          // Encoded: abi.encode(address token, uint256 amount) or empty
+    bytes data;           // Calldata to execute
+    bool executed;        // Has been executed
+    uint8 confirmations;  // Current confirmation count
+}
+```
+
+The `value` field encodes a TIP-20 transfer:
+- Empty bytes (`0x`): No token transfer, just a call
+- `abi.encode(token, amount)`: Transfer `amount` of `token` to `to` before executing `data`
+
+### Multisig Behavior
+
+#### `submitTransaction`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Create transaction with `txId = transactionCount++`
+3. Store transaction data
+4. Auto-confirm for `msg.sender`
+5. Emit `TransactionSubmitted` and `TransactionConfirmed`
+6. Return `txId`
+
+#### `confirmTransaction`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `TransactionNotFound` if transaction doesn't exist
+3. Revert with `TransactionAlreadyExecuted` if already executed
+4. Revert with `AlreadyConfirmed` if already confirmed by sender
+5. Record confirmation and increment count
+6. Emit `TransactionConfirmed`
+
+#### `revokeConfirmation`
+
+1. Revert with `NotOwner` if `msg.sender` is not an owner
+2. Revert with `TransactionNotFound` if transaction doesn't exist
+3. Revert with `TransactionAlreadyExecuted` if already executed
+4. Revert with `NotConfirmed` if sender hasn't confirmed
+5. Remove confirmation and decrement count
+6. Emit `ConfirmationRevoked`
+
+#### `executeTransaction`
+
+1. Revert with `TransactionNotFound` if transaction doesn't exist
+2. Revert with `TransactionAlreadyExecuted` if already executed
+3. Revert with `InsufficientConfirmations` if `confirmations < threshold`
+4. Mark as executed
+5. If `value` is non-empty:
+   - Decode `(token, amount)` from `value`
+   - Transfer `amount` of `token` from multisig to `to`
+6. If `data` is non-empty:
+   - Execute `to.call(data)` with multisig as `msg.sender`
+7. Emit `TransactionExecuted`
+8. Revert with `ExecutionFailed` if the call failed and user expects success
+
+#### `execute`
+
+Convenience function for 1-of-N multisigs or when all confirmations are ready:
+
+1. Submit transaction
+2. If `confirmations >= threshold`: execute immediately
+3. Otherwise, revert (cannot execute without sufficient confirmations)
+
+---
+
+## Storage Layout
+
+### Multisig Factory Storage
+
+```
+Slot 0: initialized (bool)
+```
+
+No additional storage needed; all validation is stateless.
+
+### Multisig Storage
+
+Each multisig uses the following storage layout at its deterministic address:
+
+```
+Slot 0: initialized (bool)
+Slot 1: threshold (uint8)
+Slot 2: ownerCount (uint8)
+Slot 3: transactionCount (uint256)
+
+Owners array (starting at keccak256("owners")):
+  Slot hash + i: owner[i] (address)
+
+Transactions mapping (at keccak256("transactions", txId)):
+  +0: to (address)
+  +1: value length + first 24 bytes
+  +2+: value continuation (if needed)
+  +N: data length + bytes
+  +N+1: executed (bool) | confirmations (uint8)
+
+Confirmations mapping (at keccak256("confirmations", txId, owner)):
+  bool confirmed
+```
+
+---
+
+## TIP-20 Integration
+
+Multisig wallets can hold and transfer TIP-20 tokens:
+
+1. **Receiving tokens**: Any TIP-20 can be transferred to a multisig address
+2. **Sending tokens**: Owners submit a transaction with `value = abi.encode(token, amount)`
+3. **Calling token functions**: Use `data` field to call `approve`, `transfer`, etc.
+
+Example: Transfer 100 USDC from multisig to recipient:
+
+```solidity
+// Option 1: Using value field
+multisig.submitTransaction(
+    recipient,
+    abi.encode(USDC_ADDRESS, 100e6),
+    "" // No additional calldata
+);
+
+// Option 2: Using data field (direct transfer call)
+multisig.submitTransaction(
+    USDC_ADDRESS,
+    "", // No value
+    abi.encodeCall(ITIP20.transfer, (recipient, 100e6))
+);
+```
+
+---
+
+# Invariants
+
+## Factory Invariants
+
+1. `getMultisigAddress(owners, threshold)` must always return the same address for the same inputs (after sorting)
+2. `createMultisig` must revert if the multisig already exists
+3. `isMultisig` must return `true` if and only if the address was created by the factory
+4. Owner lists must be sorted ascending before address derivation
+5. Duplicate owners must be rejected
+
+## Multisig Invariants
+
+1. Only owners can submit, confirm, or revoke transactions
+2. A transaction can only be executed once
+3. A transaction requires exactly `threshold` confirmations to execute
+4. An owner can only confirm a transaction once
+5. Executed transactions cannot be modified or re-executed
+6. `confirmations` count must equal the number of owners who have confirmed
+7. `transactionCount` must be monotonically increasing
+8. The `owners()` and `threshold()` values must never change after creation
+
+## Security Invariants
+
+1. No transaction can execute with fewer than `threshold` confirmations
+2. Non-owners cannot influence transaction state
+3. Revoked confirmations must decrease the confirmation count
+4. Token transfers in `value` field must respect TIP-403 policies
+
+---
+
+# Test Cases
+
+## Factory Tests
+
+- Create multisig with valid 2-of-3 configuration
+- Create multisig with 1-of-1 configuration
+- Reject duplicate owners
+- Reject zero address owner
+- Reject threshold = 0
+- Reject threshold > owner count
+- Reject creation if multisig exists
+- Verify deterministic address matches prediction
+- Verify owner order doesn't affect address (sorted internally)
+
+## Multisig Tests
+
+- Submit transaction as owner
+- Reject submission from non-owner
+- Confirm transaction as different owner
+- Reject double confirmation
+- Execute when threshold reached
+- Reject execution with insufficient confirmations
+- Revoke confirmation
+- Reject revoke if not confirmed
+- Execute TIP-20 transfer via value field
+- Execute arbitrary call via data field
+- Execute combined value + data transaction
+- Verify events are emitted correctly
+
+## Integration Tests
+
+- Create multisig and transfer TIP-20 tokens
+- 2-of-3 workflow: submit → confirm → confirm → execute
+- 1-of-1 immediate execution via `execute()`
+- Multisig receiving tokens from another account
+- Multisig interacting with DEX

--- a/docs/pages/protocol/tips/tip-multisig.mdx
+++ b/docs/pages/protocol/tips/tip-multisig.mdx
@@ -138,7 +138,7 @@ interface IMultisigFactory {
 
     /// @notice Creates a new multisig wallet
     /// @param owners Array of owner addresses (will be sorted internally, max 50)
-    /// @param threshold Number of required confirmations (1 <= threshold <= owners.length)
+    /// @param threshold Number of required confirmations (1 ≤ threshold ≤ owners.length)
     /// @return multisig The address of the created multisig
     function createMultisig(
         address[] calldata owners,
@@ -507,7 +507,7 @@ Cancellation requires threshold confirmations, similar to execution:
 3. Revert with `TransactionAlreadyExecuted` if already executed
 4. Revert with `TransactionCancelled` if already cancelled
 5. Record cancellation vote from `msg.sender`
-6. If cancellation votes >= threshold:
+6. If cancellation votes ≥ threshold:
    - Set `cancelled = true`
    - Emit `TransactionCancelled`
 
@@ -525,8 +525,8 @@ Cancellation requires threshold confirmations, similar to execution:
 6. Revert with `TransactionExpired` if `block.timestamp > expiresAt`
 7. **Count valid confirmations** (lazy invalidation/transfer check):
    - For each confirmer:
-     - **Follow replacement chain**: while `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`: `confirmer = replacedBy[confirmer]`
-     - If `removedAt[confirmer] != 0` AND `removedAt[confirmer] <= txId`: invalid (removed before tx)
+     - **Follow replacement chain**: while `replacedBy[confirmer] ≠ 0` AND `replacedAt[confirmer] > txId`: `confirmer = replacedBy[confirmer]`
+     - If `removedAt[confirmer] ≠ 0` AND `removedAt[confirmer] ≤ txId`: invalid (removed before tx)
      - If confirmer is not a current owner: invalid
      - Otherwise: valid confirmation attributed to final `confirmer`
    - Deduplicate: count unique valid confirmers only
@@ -577,7 +577,7 @@ When executed, the multisig calls itself, triggering the management function wit
 1. Revert with `NotMultisig` if `msg.sender != address(this)` (must be self-call)
 2. Revert with `ZeroAddressOwner` if `owner` is `address(0)`
 3. Revert with `AlreadyOwner` if `owner` is already an owner
-4. Revert with `TooManyOwners` if `ownerCount >= MAX_OWNERS`
+4. Revert with `TooManyOwners` if `ownerCount ≥ MAX_OWNERS`
 5. Add owner to owners array (binary search insert to maintain sorted order)
 6. Increment `ownerCount`
 7. Clear `removedAt[owner] = 0` (in case owner was previously removed and re-added)
@@ -607,7 +607,7 @@ When executed, the multisig calls itself, triggering the management function wit
 6. Record `replacedBy[oldOwner] = newOwner` and `replacedAt[oldOwner] = transactionCount` (for lazy transfer)
 7. Emit `OwnerReplaced`
 
-> **Note**: `replaceOwner` uses lazy confirmation transfer. At execution time, when validating confirmations, if `replacedBy[confirmer] != 0` AND `replacedAt[confirmer] > txId`, the confirmation is attributed to `replacedBy[confirmer]` instead. This enables seamless key rotation without O(n) iteration.
+> **Note**: `replaceOwner` uses lazy confirmation transfer. At execution time, when validating confirmations, if `replacedBy[confirmer] ≠ 0` AND `replacedAt[confirmer] > txId`, the confirmation is attributed to `replacedBy[confirmer]` instead. This enables seamless key rotation without O(n) iteration.
 
 #### `changeThreshold`
 
@@ -717,7 +717,7 @@ multisig.submitTransaction(
 3. `isMultisig` must return `true` if and only if the address was created by the factory
 4. Owner lists must be sorted ascending before address derivation
 5. Duplicate owners must be rejected
-6. Owner count must be <= `MAX_OWNERS` (50)
+6. Owner count must be ≤ `MAX_OWNERS` (50)
 
 ## Multisig Invariants
 
@@ -730,10 +730,10 @@ multisig.submitTransaction(
 7. Expired transactions cannot be executed or confirmed
 8. `confirmations` count must equal the number of **current** owners who have confirmed
 9. `transactionCount` must be monotonically increasing
-10. Transaction `data` size must be <= `MAX_DATA_SIZE` (64KB)
+10. Transaction `data` size must be ≤ `MAX_DATA_SIZE` (64KB)
 11. Transaction `value` must be empty or exactly 64 bytes (valid encoding)
-12. `ownerCount` must always be >= 1 (cannot remove last owner)
-13. `threshold` must always be >= 1 and <= `ownerCount`
+12. `ownerCount` must always be ≥ 1 (cannot remove last owner)
+13. `threshold` must always be ≥ 1 and ≤ `ownerCount`
 14. Owner management functions can only be called by the multisig itself (self-call)
 15. Removed owners' confirmations are lazily invalidated via `removedAt` tracking
 16. Replaced owners' confirmations are lazily transferred via `replacedBy`/`replacedAt` tracking


### PR DESCRIPTION
## Summary

Adds a TIP specification for native multisig wallets as precompiles on Tempo.

## Key Design Decisions

- **Multisig Factory** at `0xF15C000000000000000000000000000000000000`
- **Deterministic addressing**: `MULTISIG_PREFIX || keccak256(sorted_owners, threshold)[0:8]`
- **On-chain confirmations**: submit → confirm → execute flow
- **TIP-20 integration**: `value` field encodes `(token, amount)` for transfers
- **Immutable config**: owners and threshold fixed at creation

## Interface Overview

### Factory
- `createMultisig(owners, threshold)` → deterministic address
- `getMultisigAddress(owners, threshold)` → predict address
- `isMultisig(addr)` → check if deployed

### Multisig
- `submitTransaction(to, value, data)` → create + auto-confirm
- `confirmTransaction(txId)` → add confirmation
- `revokeConfirmation(txId)` → remove confirmation
- `executeTransaction(txId)` → execute when threshold met

## Next Steps

- [ ] Assign TIP number
- [ ] Review and iterate on spec
- [ ] Implement precompiles following TIP-20 patterns