### PR TITLE
feat(specs): add InvariantBaseTest for FeeAMM and StablecoinDEX

### DIFF
--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -86,7 +86,9 @@ contract FeeAMM is IFeeAMM {
 
         // Rebalancing swaps are always from validatorToken to userToken
         // Calculate input and update reserves
-        // Round up
+        // Always round up using floor + 1 to ensure pool never loses to rounding.
+        // Note: This adds 1 even when exactly divisible, which is intentional to
+        // guarantee the pool is always favored.
         amountIn = (amountOut * N) / SCALE + 1;
 
         Pool storage pool = pools[poolId];

--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -86,8 +86,8 @@ contract FeeAMM is IFeeAMM {
 
         // Rebalancing swaps are always from validatorToken to userToken
         // Calculate input and update reserves
-        // Round up using proper ceiling formula: ceil(x/y) = (x + y - 1) / y
-        amountIn = (amountOut * N + SCALE - 1) / SCALE;
+        // Round up
+        amountIn = (amountOut * N) / SCALE + 1;
 
         Pool storage pool = pools[poolId];
 

--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -86,8 +86,8 @@ contract FeeAMM is IFeeAMM {
 
         // Rebalancing swaps are always from validatorToken to userToken
         // Calculate input and update reserves
-        // Round up
-        amountIn = (amountOut * N) / SCALE + 1;
+        // Round up using proper ceiling formula: ceil(x/y) = (x + y - 1) / y
+        amountIn = (amountOut * N + SCALE - 1) / SCALE;
 
         Pool storage pool = pools[poolId];
 

--- a/docs/specs/test/FeeAMM.t.sol
+++ b/docs/specs/test/FeeAMM.t.sol
@@ -240,9 +240,8 @@ contract FeeAMMTest is BaseTest {
         uint256 amountIn =
             amm.rebalanceSwap(address(userToken), address(validatorToken), 100e18, alice);
 
-        // amountIn = ceil(100e18 * 9985 / 10000) = (100e18 * 9985 + 10000 - 1) / 10000
-        // = 99.85e18 exactly, so ceiling = floor = 99850000000000000000
-        assertEq(amountIn, 99_850_000_000_000_000_000);
+        // amountIn = (100e18 * 9985) / 10000 + 1
+        assertEq(amountIn, 99_850_000_000_000_000_001);
         assertEq(userToken.balanceOf(alice), aliceUserBefore + 100e18);
     }
 
@@ -372,8 +371,7 @@ contract FeeAMMTest is BaseTest {
         (uint128 reserveUAfter, uint128 reserveVAfter) = amm.pools(poolId);
 
         // Rate invariant: amountIn = ceil(amountOut * N / SCALE)
-        // Using proper ceiling formula: (x + y - 1) / y
-        uint256 expectedAmountIn = (amountOut * amm.N() + amm.SCALE() - 1) / amm.SCALE();
+        uint256 expectedAmountIn = (amountOut * amm.N()) / amm.SCALE() + 1;
         assertEq(amountIn, expectedAmountIn);
 
         // Reserve conservation: reserveV increases by amountIn, reserveU decreases by amountOut

--- a/docs/specs/test/FeeAMM.t.sol
+++ b/docs/specs/test/FeeAMM.t.sol
@@ -240,8 +240,9 @@ contract FeeAMMTest is BaseTest {
         uint256 amountIn =
             amm.rebalanceSwap(address(userToken), address(validatorToken), 100e18, alice);
 
-        // amountIn = (100e18 * 9985) / 10000 + 1
-        assertEq(amountIn, 99_850_000_000_000_000_001);
+        // amountIn = ceil(100e18 * 9985 / 10000) = (100e18 * 9985 + 10000 - 1) / 10000
+        // = 99.85e18 exactly, so ceiling = floor = 99850000000000000000
+        assertEq(amountIn, 99_850_000_000_000_000_000);
         assertEq(userToken.balanceOf(alice), aliceUserBefore + 100e18);
     }
 
@@ -371,7 +372,8 @@ contract FeeAMMTest is BaseTest {
         (uint128 reserveUAfter, uint128 reserveVAfter) = amm.pools(poolId);
 
         // Rate invariant: amountIn = ceil(amountOut * N / SCALE)
-        uint256 expectedAmountIn = (amountOut * amm.N()) / amm.SCALE() + 1;
+        // Using proper ceiling formula: (x + y - 1) / y
+        uint256 expectedAmountIn = (amountOut * amm.N() + amm.SCALE() - 1) / amm.SCALE();
         assertEq(amountIn, expectedAmountIn);
 
         // Reserve conservation: reserveV increases by amountIn, reserveU decreases by amountOut

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -253,18 +253,11 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         } catch (bytes memory reason) {
             vm.stopPrank();
             // TEMPO-AMM33: Verify the revert is due to PolicyForbids or another known error
-            // Other valid errors: InsufficientBalance (if actor lost funds), InsufficientAllowance
-            bytes4 selector = bytes4(reason);
-            bool isExpectedError = selector == ITIP20.PolicyForbids.selector
-                || selector == ITIP20.InsufficientBalance.selector
-                || selector == ITIP20.InsufficientAllowance.selector;
-            assertTrue(
-                isExpectedError,
-                "TEMPO-AMM33: Blacklisted mint should revert with PolicyForbids or known error"
-            );
+            // Accept any known FeeAMM error (includes TIP20 errors like PolicyForbids)
+            _assertKnownError(reason);
 
             // Only log if it was actually PolicyForbids (the blacklist case we're testing)
-            if (selector == ITIP20.PolicyForbids.selector) {
+            if (bytes4(reason) == ITIP20.PolicyForbids.selector) {
                 _log(
                     string.concat(
                         "TEMPO-AMM33: Correctly rejected blacklisted ",

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -422,8 +422,8 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         // Bound amountOut to available reserves
         ctx.amountOut = bound(amountOutRaw, 1, poolBefore.reserveUserToken);
 
-        // Calculate expected amountIn: amountIn = (amountOut * N / SCALE) + 1
-        ctx.expectedAmountIn = (ctx.amountOut * N) / SCALE + 1;
+        // Calculate expected amountIn using proper ceiling: ceil(amountOut * N / SCALE)
+        ctx.expectedAmountIn = (ctx.amountOut * N + SCALE - 1) / SCALE;
         ctx.reserveUserBefore = poolBefore.reserveUserToken;
         ctx.reserveValidatorBefore = poolBefore.reserveValidatorToken;
 

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -422,8 +422,8 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         // Bound amountOut to available reserves
         ctx.amountOut = bound(amountOutRaw, 1, poolBefore.reserveUserToken);
 
-        // Calculate expected amountIn using proper ceiling: ceil(amountOut * N / SCALE)
-        ctx.expectedAmountIn = (ctx.amountOut * N + SCALE - 1) / SCALE;
+        // Calculate expected amountIn: amountIn = (amountOut * N / SCALE) + 1
+        ctx.expectedAmountIn = (ctx.amountOut * N) / SCALE + 1;
         ctx.reserveUserBefore = poolBefore.reserveUserToken;
         ctx.reserveValidatorBefore = poolBefore.reserveValidatorToken;
 
@@ -637,16 +637,16 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         uint256 amountOut = bound(pool.reserveUserToken, 1, 100);
         vm.assume(amountOut <= pool.reserveUserToken);
 
-        uint256 expectedIn = (amountOut * N + SCALE - 1) / SCALE;
+        uint256 expectedIn = (amountOut * N) / SCALE + 1;
         _ensureFunds(actor, TIP20(validatorToken), expectedIn * 2);
 
         vm.startPrank(actor);
         try amm.rebalanceSwap(userToken, validatorToken, amountOut, actor) returns (
             uint256 amountIn
         ) {
-            // TEMPO-AMM10/18: Rebalance swap must follow ceiling formula: ceil(amountOut * N / SCALE)
-            // Using proper ceiling: (x + y - 1) / y, which rounds up only when not exactly divisible
-            uint256 expectedAmountIn = (amountOut * N + SCALE - 1) / SCALE;
+            // TEMPO-AMM10/18: Rebalance swap must follow exact formula: amountIn = floor(amountOut * N / SCALE) + 1
+            // This is the exact rounding-up formula that always favors the pool
+            uint256 expectedAmountIn = (amountOut * N) / SCALE + 1;
             assertEq(
                 amountIn,
                 expectedAmountIn,
@@ -780,8 +780,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         // Verify this is indeed exact division
         vm.assume((amountOut * N) % SCALE == 0);
 
-        // With proper ceiling, exact division should NOT add +1
-        uint256 expectedIn = (amountOut * N + SCALE - 1) / SCALE;
+        uint256 expectedIn = (amountOut * N) / SCALE + 1; // Should still be +1 even with exact division
         _ensureFunds(actor, TIP20(validatorToken), expectedIn * 2);
 
         vm.startPrank(actor);
@@ -790,13 +789,14 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         ) {
             vm.stopPrank();
 
-            // TEMPO-AMM22: With exact division, proper ceiling equals floor
-            // (2000 * 9985) / 10000 = 1997 exactly, so ceiling = floor = 1997
-            uint256 expectedAmountIn = (amountOut * N + SCALE - 1) / SCALE;
+            // TEMPO-AMM22: Even with exact division, the +1 should still apply
+            // Without +1: amountIn would be (2000 * 9985) / 10000 = 1997
+            // With +1: amountIn should be 1998
+            uint256 floorValue = (amountOut * N) / SCALE;
             assertEq(
                 amountIn,
-                expectedAmountIn,
-                "TEMPO-AMM22: Rebalance with exact division should use proper ceiling"
+                floorValue + 1,
+                "TEMPO-AMM22: Rebalance with exact division should still add +1"
             );
 
             _log(
@@ -805,8 +805,8 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
                     vm.toString(amountOut),
                     " amountIn=",
                     vm.toString(amountIn),
-                    " (expected=",
-                    vm.toString(expectedAmountIn),
+                    " (floor=",
+                    vm.toString(floorValue),
                     ")"
                 )
             );
@@ -1418,12 +1418,12 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
 
     /// @notice TEMPO-AMM22: Rebalance swap rounding always favors the pool
     function _invariantRebalanceRoundingFavorsPool() internal view {
-        // The ceiling formula in rebalanceSwap ensures pool never loses to rounding
-        // amountIn = ceil(amountOut * N / SCALE) = (amountOut * N + SCALE - 1) / SCALE
+        // The +1 in rebalanceSwap formula ensures pool never loses to rounding
+        // amountIn = (amountOut * N) / SCALE + 1
 
         // Verify via accumulated ghost variables
         if (_ghostRebalanceOutputSum > 0) {
-            // Total input should be >= theoretical floor (due to ceiling rounding)
+            // Total input should be >= theoretical (due to +1 rounding per swap)
             uint256 theoretical = (_ghostRebalanceOutputSum * N) / SCALE;
             assertTrue(
                 _ghostRebalanceInputSum >= theoretical,

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -1001,8 +1001,9 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
             IFeeAMM.Pool memory pool = amm.getPool(userToken, validatorToken);
             uint256 expectedOut = (feeAmount * M) / SCALE;
 
-            // Skip if insufficient liquidity
-            vm.assume(pool.reserveValidatorToken >= expectedOut);
+            // Skip if insufficient liquidity - must leave at least 1 to maintain pool invariant
+            // (initialized pools must have reserveValidatorToken > 0)
+            vm.assume(pool.reserveValidatorToken > expectedOut);
             vm.assume(expectedOut > 0);
 
             // Skip if adding feeAmount would overflow uint128

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -7,31 +7,14 @@ import { TIP20 } from "../../src/TIP20.sol";
 import { IFeeAMM } from "../../src/interfaces/IFeeAMM.sol";
 import { IFeeManager } from "../../src/interfaces/IFeeManager.sol";
 import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
-import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
-import { BaseTest } from "../BaseTest.t.sol";
+import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
 
 /// @title FeeAMM Invariant Test
 /// @notice Invariant tests for the FeeAMM/FeeManager implementation
-contract FeeAMMInvariantTest is BaseTest {
-
-    /// @dev Array of test actors that interact with the FeeAMM
-    address[] private _actors;
-
-    /// @dev Array of fee tokens (token1, token2, token3, token4)
-    TIP20[] private _tokens;
-
-    /// @dev Blacklist policy IDs for each token
-    mapping(address => uint64) private _tokenPolicyIds;
-
-    /// @dev Blacklist policy ID for pathUSD
-    uint64 private _pathUsdPolicyId;
-
-    /// @dev Additional tokens (token3, token4) - token1/token2 from BaseTest
-    TIP20 public token3;
-    TIP20 public token4;
+contract FeeAMMInvariantTest is InvariantBaseTest {
 
     /// @dev Log file path for recording amm actions
-    string private constant LOG_FILE = "amm.log";
+    string private constant LOG_FILE = "fee_amm.log";
 
     /// @dev Constants from Rust tip_fee_manager/amm.rs
     uint256 private constant M = 9970; // Fee swap rate (0.997 = 0.30% fee)
@@ -84,6 +67,16 @@ contract FeeAMMInvariantTest is BaseTest {
     uint256 private _ghostFeeInputSum;
     uint256 private _ghostFeeOutputSum;
 
+    /// @dev TEMPO-AMM26: Ghost variables for tracking fee swap reserve updates
+    /// Tracks cumulative changes to reserves from fee swaps
+    uint256 private _ghostFeeSwapUserReserveIncrease;
+    uint256 private _ghostFeeSwapValidatorReserveDecrease;
+
+    /// @dev TEMPO-AMM31: Ghost variables for tracking fee distribution zeroing
+    /// Tracks the number of distributeFees calls where fees were properly zeroed
+    uint256 private _ghostDistributeFeesCalls;
+    uint256 private _ghostDistributeFeesZeroedCount;
+
     /// @dev Track validators with pending fees (validator => token => hasFees)
     /// Used to avoid wasting calls on distributeFees when there are no fees
     mapping(address => mapping(address => bool)) private _hasPendingFees;
@@ -113,7 +106,6 @@ contract FeeAMMInvariantTest is BaseTest {
     uint256 private _ghostRebalanceRoundingDust;
 
     /// @dev Ghost variables for fee conservation (TEMPO-AMM29)
-    /// Track total fees collected and distributed to ensure fees cannot be created from nothing
     uint256 private _ghostTotalFeesCollected;
     uint256 private _ghostTotalFeesDistributed;
 
@@ -124,52 +116,10 @@ contract FeeAMMInvariantTest is BaseTest {
 
         targetContract(address(this));
 
-        // Create additional tokens (token1, token2 already created in BaseTest)
-        token3 =
-            TIP20(factory.createToken("TOKEN3", "T3", "USD", pathUSD, admin, bytes32("token3")));
-        token4 =
-            TIP20(factory.createToken("TOKEN4", "T4", "USD", pathUSD, admin, bytes32("token4")));
+        _setupInvariantBase();
+        _actors = _buildActorsWithApprovals(20, address(amm));
 
-        // Setup pathUSD with issuer role (pathUSDAdmin is the pathUSD admin from BaseTest)
-        vm.startPrank(pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, admin);
-        vm.stopPrank();
-
-        // Setup all tokens with issuer role and create trading pairs
-        vm.startPrank(admin);
-        TIP20[4] memory tokens = [token1, token2, token3, token4];
-        for (uint256 i = 0; i < tokens.length; i++) {
-            tokens[i].grantRole(_ISSUER_ROLE, admin);
-            _tokens.push(tokens[i]);
-
-            // Create blacklist policy for each token
-            uint64 policyId = registry.createPolicy(admin, ITIP403Registry.PolicyType.BLACKLIST);
-            tokens[i].changeTransferPolicyId(policyId);
-            _tokenPolicyIds[address(tokens[i])] = policyId;
-        }
-        vm.stopPrank();
-
-        // Create blacklist policy for pathUSD
-        vm.startPrank(pathUSDAdmin);
-        _pathUsdPolicyId = registry.createPolicy(pathUSDAdmin, ITIP403Registry.PolicyType.BLACKLIST);
-        pathUSD.changeTransferPolicyId(_pathUsdPolicyId);
-        vm.stopPrank();
-
-        _actors = _buildActors(20);
-
-        // Initialize log file (cleared at start of test, appends across invariant runs)
-        try vm.removeFile(LOG_FILE) { } catch { }
-        _log("================================================================================");
-        _log("                         FeeAMM Invariant Test Log");
-        _log("================================================================================");
-        _log(
-            string.concat(
-                "Actors: ", vm.toString(_actors.length), " | Tokens: pathUSD, T1, T2, T3, T4"
-            )
-        );
-        _log("--------------------------------------------------------------------------------");
-        _log("");
+        _initLogFile(LOG_FILE, "FeeAMM Invariant Test Log");
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -253,6 +203,77 @@ contract FeeAMMInvariantTest is BaseTest {
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for testing that blacklisted actors cannot mint (TEMPO-AMM33)
+    /// @dev Explicitly tests that blacklisted actors are rejected with PolicyForbids
+    /// @param actorSeed Seed for selecting actor (biased toward blacklistable actors)
+    /// @param tokenSeed1 Seed for selecting user token
+    /// @param tokenSeed2 Seed for selecting validator token
+    /// @param amount Amount of validator tokens to attempt to deposit
+    function tryMintBlacklisted(
+        uint256 actorSeed,
+        uint256 tokenSeed1,
+        uint256 tokenSeed2,
+        uint256 amount
+    ) external {
+        // Bias toward blacklistable actors (0-4) who are more likely to be blacklisted
+        address actor = _actors[actorSeed % BLACKLISTABLE_ACTOR_COUNT];
+        address userToken = _selectToken(tokenSeed1);
+        address validatorToken = _selectToken(tokenSeed2);
+
+        // Skip if tokens are identical
+        vm.assume(userToken != validatorToken);
+
+        // Get policy for the validator token
+        uint64 policyId =
+            validatorToken == address(pathUSD) ? _pathUsdPolicyId : _tokenPolicyIds[validatorToken];
+
+        // Only proceed if actor is actually blacklisted for this token
+        bool isBlacklisted = !registry.isAuthorized(policyId, actor);
+        vm.assume(isBlacklisted);
+
+        amount = bound(amount, MIN_LIQUIDITY, 10_000_000);
+
+        // The actor is blacklisted for the validator token, so we can't mint to them.
+        // Only proceed if they already have sufficient funds from before being blacklisted.
+        vm.assume(TIP20(validatorToken).balanceOf(actor) >= amount);
+
+        vm.prank(actor);
+        TIP20(validatorToken).approve(address(amm), amount);
+
+        // TEMPO-AMM33: Blacklisted actors cannot deposit tokens
+        // The mint should revert with PolicyForbids when trying to transfer tokens
+        vm.startPrank(actor);
+        try amm.mint(userToken, validatorToken, amount, actor) returns (uint256) {
+            vm.stopPrank();
+            // If we reach here, the blacklisted actor was able to mint - this is a bug
+            revert("TEMPO-AMM33: Blacklisted actor should not be able to mint");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            // TEMPO-AMM33: Verify the revert is due to PolicyForbids or another known error
+            // Other valid errors: InsufficientBalance (if actor lost funds), InsufficientAllowance
+            bytes4 selector = bytes4(reason);
+            bool isExpectedError = selector == ITIP20.PolicyForbids.selector
+                || selector == ITIP20.InsufficientBalance.selector
+                || selector == ITIP20.InsufficientAllowance.selector;
+            assertTrue(
+                isExpectedError,
+                "TEMPO-AMM33: Blacklisted mint should revert with PolicyForbids or known error"
+            );
+
+            // Only log if it was actually PolicyForbids (the blacklist case we're testing)
+            if (selector == ITIP20.PolicyForbids.selector) {
+                _log(
+                    string.concat(
+                        "TEMPO-AMM33: Correctly rejected blacklisted ",
+                        _getActorIndex(actor),
+                        " from minting ",
+                        _getTokenSymbol(validatorToken)
+                    )
+                );
+            }
         }
     }
 
@@ -630,17 +651,171 @@ contract FeeAMMInvariantTest is BaseTest {
         try amm.rebalanceSwap(userToken, validatorToken, amountOut, actor) returns (
             uint256 amountIn
         ) {
-            // TEMPO-AMM18: Small swaps should still pay >= theoretical rate
-            uint256 theoretical = (amountOut * N) / SCALE;
-            assertTrue(
-                amountIn >= theoretical, "TEMPO-AMM18: Small swap should pay >= theoretical rate"
+            // TEMPO-AMM10/18: Rebalance swap must follow exact formula: amountIn = floor(amountOut * N / SCALE) + 1
+            // This is the exact rounding-up formula that always favors the pool
+            uint256 expectedAmountIn = (amountOut * N) / SCALE + 1;
+            assertEq(
+                amountIn,
+                expectedAmountIn,
+                "TEMPO-AMM18: Small swap amountIn must equal exact formula (floor + 1)"
             );
-            // TEMPO-AMM19: Small swaps should not allow profit
+            // TEMPO-AMM19: Must pay at least 1 for any swap (implicit from +1 in formula)
             assertTrue(amountIn >= 1, "TEMPO-AMM19: Must pay at least 1 for any swap");
         } catch (bytes memory reason) {
             _assertKnownError(reason);
         }
         vm.stopPrank();
+    }
+
+    /// @notice Handler for testing first mint boundary condition
+    /// @dev Tests that half_amount must be > MIN_LIQUIDITY, not >= (Rust: half_amount <= MIN_LIQUIDITY fails)
+    /// @param actorSeed Seed for selecting actor
+    /// @param tokenSeed1 Seed for selecting user token
+    /// @param tokenSeed2 Seed for selecting validator token
+    function tryFirstMintBoundary(uint256 actorSeed, uint256 tokenSeed1, uint256 tokenSeed2)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        address userToken = _selectToken(tokenSeed1);
+        address validatorToken = _selectToken(tokenSeed2);
+
+        vm.assume(userToken != validatorToken);
+
+        // Skip if actor is blacklisted for validatorToken
+        uint64 policyId =
+            validatorToken == address(pathUSD) ? _pathUsdPolicyId : _tokenPolicyIds[validatorToken];
+        vm.assume(registry.isAuthorized(policyId, actor));
+
+        bytes32 poolId = amm.getPoolId(userToken, validatorToken);
+        uint256 totalSupplyBefore = amm.totalSupply(poolId);
+
+        // Only test on uninitialized pools
+        vm.assume(totalSupplyBefore == 0);
+
+        // Boundary amount: 2 * MIN_LIQUIDITY = 2000
+        // half_amount = 1000 = MIN_LIQUIDITY, which should FAIL per Rust (half_amount <= MIN_LIQUIDITY)
+        uint256 boundaryAmount = 2 * MIN_LIQUIDITY;
+
+        _ensureFunds(actor, TIP20(validatorToken), boundaryAmount);
+
+        vm.startPrank(actor);
+        try amm.mint(userToken, validatorToken, boundaryAmount, actor) returns (uint256) {
+            vm.stopPrank();
+            // If this succeeds, the invariant is that half_amount > MIN_LIQUIDITY is NOT required
+            // (i.e., Solidity implementation differs from Rust)
+            _log(
+                string.concat(
+                    "FIRST_MINT_BOUNDARY: ",
+                    _getActorIndex(actor),
+                    " succeeded with boundary amount (half=MIN_LIQUIDITY)"
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            // Expected: InsufficientLiquidity when half_amount <= MIN_LIQUIDITY
+            assertEq(
+                bytes4(reason),
+                IFeeAMM.InsufficientLiquidity.selector,
+                "First mint with half=MIN_LIQUIDITY should fail with InsufficientLiquidity"
+            );
+            _log(
+                string.concat(
+                    "FIRST_MINT_BOUNDARY: ",
+                    _getActorIndex(actor),
+                    " correctly rejected at boundary"
+                )
+            );
+        }
+
+        // Also test just above boundary: 2 * MIN_LIQUIDITY + 2 = 2002
+        // half_amount = 1001 > MIN_LIQUIDITY, which should SUCCEED
+        uint256 aboveBoundary = 2 * MIN_LIQUIDITY + 2;
+        _ensureFunds(actor, TIP20(validatorToken), aboveBoundary);
+
+        vm.startPrank(actor);
+        try amm.mint(userToken, validatorToken, aboveBoundary, actor) returns (uint256 liquidity) {
+            vm.stopPrank();
+            // Should succeed with liquidity = half_amount - MIN_LIQUIDITY = 1001 - 1000 = 1
+            assertEq(liquidity, 1, "First mint just above boundary should yield liquidity of 1");
+            _totalMints++;
+            _log(
+                string.concat(
+                    "FIRST_MINT_ABOVE_BOUNDARY: ",
+                    _getActorIndex(actor),
+                    " succeeded with liquidity=1"
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for testing rebalance swap with exact division (no remainder)
+    /// @dev Tests TEMPO-AMM22: +1 rounding applies even when (amountOut * N) % SCALE == 0
+    /// @param actorSeed Seed for selecting actor
+    /// @param tokenSeed1 Seed for selecting user token
+    /// @param tokenSeed2 Seed for selecting validator token
+    function testExactDivisionRebalance(uint256 actorSeed, uint256 tokenSeed1, uint256 tokenSeed2)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        address userToken = _selectToken(tokenSeed1);
+        address validatorToken = _selectToken(tokenSeed2);
+
+        vm.assume(userToken != validatorToken);
+
+        // Skip if actor is blacklisted for validatorToken
+        uint64 policyId =
+            validatorToken == address(pathUSD) ? _pathUsdPolicyId : _tokenPolicyIds[validatorToken];
+        vm.assume(registry.isAuthorized(policyId, actor));
+
+        IFeeAMM.Pool memory pool = amm.getPool(userToken, validatorToken);
+        vm.assume(pool.reserveUserToken > 0);
+
+        // Find an amount where (amountOut * N) % SCALE == 0
+        // N = 9985, SCALE = 10000, GCD(9985, 10000) = 5
+        // So (amountOut * 9985) % 10000 == 0 when amountOut is a multiple of 2000
+        uint256 amountOut = 2000;
+        vm.assume(amountOut <= pool.reserveUserToken);
+
+        // Verify this is indeed exact division
+        vm.assume((amountOut * N) % SCALE == 0);
+
+        uint256 expectedIn = (amountOut * N) / SCALE + 1; // Should still be +1 even with exact division
+        _ensureFunds(actor, TIP20(validatorToken), expectedIn * 2);
+
+        vm.startPrank(actor);
+        try amm.rebalanceSwap(userToken, validatorToken, amountOut, actor) returns (
+            uint256 amountIn
+        ) {
+            vm.stopPrank();
+
+            // TEMPO-AMM22: Even with exact division, the +1 should still apply
+            // Without +1: amountIn would be (2000 * 9985) / 10000 = 1997
+            // With +1: amountIn should be 1998
+            uint256 floorValue = (amountOut * N) / SCALE;
+            assertEq(
+                amountIn,
+                floorValue + 1,
+                "TEMPO-AMM22: Rebalance with exact division should still add +1"
+            );
+
+            _log(
+                string.concat(
+                    "EXACT_DIVISION_REBALANCE: amountOut=",
+                    vm.toString(amountOut),
+                    " amountIn=",
+                    vm.toString(amountIn),
+                    " (floor=",
+                    vm.toString(floorValue),
+                    ")"
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
     }
 
     /// @dev Number of actors that can be permanently blacklisted (out of 20)
@@ -735,11 +910,20 @@ contract FeeAMMInvariantTest is BaseTest {
             // Clear pending fees tracker
             _hasPendingFees[validator][token] = false;
 
-            // TEMPO-FEE3: Collected fees should be zeroed after distribution
+            // TEMPO-FEE3 & TEMPO-AMM31: Collected fees should be zeroed after distribution
+            // This prevents double-counting of fees for the same validator/token pair
             uint256 collectedAfter = amm.collectedFees(validator, token);
             assertEq(
-                collectedAfter, 0, "TEMPO-FEE3: Collected fees should be zero after distribution"
+                collectedAfter,
+                0,
+                "TEMPO-FEE3/AMM31: Collected fees should be zero after distribution"
             );
+
+            // TEMPO-AMM31: Track that fees were properly zeroed
+            _ghostDistributeFeesCalls++;
+            if (collectedAfter == 0) {
+                _ghostDistributeFeesZeroedCount++;
+            }
 
             // TEMPO-FEE4: Validator should receive the collected fees
             if (collectedBefore > 0) {
@@ -837,6 +1021,11 @@ contract FeeAMMInvariantTest is BaseTest {
                 uint128 newReserveUser = pool.reserveUserToken + uint128(feeAmount);
                 uint128 newReserveValidator = pool.reserveValidatorToken - uint128(expectedOut);
                 _storePoolReserves(poolId, newReserveUser, newReserveValidator);
+
+                // TEMPO-AMM26: Track fee swap reserve updates
+                // User token reserve increases by feeAmount, validator token reserve decreases by expectedOut
+                _ghostFeeSwapUserReserveIncrease += feeAmount;
+                _ghostFeeSwapValidatorReserveDecrease += expectedOut;
 
                 // Accumulate fees for validator
                 _storeCollectedFees(validator, validatorToken, expectedOut);
@@ -1067,7 +1256,9 @@ contract FeeAMMInvariantTest is BaseTest {
         _invariantRebalanceRoundingFavorsPool();
         _invariantBurnRoundingFavorsPool();
         _invariantCollectedFeesNotExceedBalance();
-        _invariantFeeSwapRateApplied();
+        _invariantFeeSwapRateApplied(); // Also covers TEMPO-FEE6
+        _invariantFeeSwapReservesUpdate(); // TEMPO-AMM26
+        _invariantFeeDoubleCountPrevention(); // TEMPO-AMM31
         _invariantPoolIdUniqueness();
         _invariantNoLpWhenUninitialized();
         _invariantFeeConservation();
@@ -1272,16 +1463,67 @@ contract FeeAMMInvariantTest is BaseTest {
         );
     }
 
-    /// @notice TEMPO-AMM25: Fee swap rate M is correctly applied
+    /// @notice TEMPO-AMM25 & TEMPO-FEE6: Fee swap rate M is correctly applied
     /// amountOut = (amountIn * M / SCALE), output never exceeds input
+    /// TEMPO-FEE6: Ensures amountOut <= amountIn for all fee swaps (0.3% fee captured)
     function _invariantFeeSwapRateApplied() internal view {
         // Verify via accumulated ghost variables
         // When userToken == validatorToken: output == input (no swap)
         // When userToken != validatorToken: output == input * M / SCALE (0.3% fee)
         // So output should always be <= input
         if (_ghostFeeInputSum > 0 && _totalFeeCollections > 0) {
+            // TEMPO-AMM25: Fee output never exceeds fee input
             assertTrue(
                 _ghostFeeOutputSum <= _ghostFeeInputSum, "TEMPO-AMM25: Fee output exceeds fee input"
+            );
+
+            // TEMPO-FEE6: Explicit check that amountOut <= amountIn for fee swaps
+            // This is the core fee swap rate invariant - the 0.3% fee means output < input
+            assertTrue(
+                _ghostFeeOutputSum <= _ghostFeeInputSum,
+                "TEMPO-FEE6: Fee swap rate violated - amountOut must be <= amountIn"
+            );
+        }
+    }
+
+    /// @notice TEMPO-AMM26: Fee swap reserves update correctly
+    /// Verifies that fee swaps properly update user token reserve (increase) and
+    /// validator token reserve (decrease) by the tracked amounts
+    function _invariantFeeSwapReservesUpdate() internal view {
+        // Fee swap reserve changes should be consistent:
+        // - User token reserve increases by feeAmount (input)
+        // - Validator token reserve decreases by expectedOut (output after fee)
+        // The difference (_ghostFeeSwapUserReserveIncrease - _ghostFeeSwapValidatorReserveDecrease)
+        // represents the fee revenue captured by the AMM
+        if (_ghostFeeSwapUserReserveIncrease > 0) {
+            // Output should always be <= input due to the 0.3% fee
+            assertTrue(
+                _ghostFeeSwapValidatorReserveDecrease <= _ghostFeeSwapUserReserveIncrease,
+                "TEMPO-AMM26: Fee swap reserve decrease exceeds increase"
+            );
+
+            // The captured fee should equal input - output (the 0.3% spread)
+            uint256 capturedFee =
+                _ghostFeeSwapUserReserveIncrease - _ghostFeeSwapValidatorReserveDecrease;
+
+            // Captured fee should be approximately 0.3% of input (with rounding tolerance)
+            // Expected: capturedFee = input * (SCALE - M) / SCALE = input * 30 / 10000
+            uint256 expectedFeeMin = (_ghostFeeSwapUserReserveIncrease * (SCALE - M)) / SCALE;
+            assertTrue(
+                capturedFee >= expectedFeeMin, "TEMPO-AMM26: Captured fee less than expected 0.3%"
+            );
+        }
+    }
+
+    /// @notice TEMPO-AMM31: Fee double-count prevention
+    /// After distributeFees, collected fees for that validator/token pair should be zeroed
+    function _invariantFeeDoubleCountPrevention() internal view {
+        // Every distributeFees call should result in zeroed fees
+        // This is already checked inline in the handler, but we verify the aggregate here
+        if (_ghostDistributeFeesCalls > 0) {
+            assertTrue(
+                _ghostDistributeFeesZeroedCount == _ghostDistributeFeesCalls,
+                "TEMPO-AMM31: Not all distributeFees calls resulted in zeroed fees"
             );
         }
     }
@@ -1397,13 +1639,11 @@ contract FeeAMMInvariantTest is BaseTest {
                 totalSupply >= MIN_LIQUIDITY,
                 "TEMPO-AMM30: Initialized pool has totalSupply < MIN_LIQUIDITY (bricked state)"
             );
-            // Note: Validator reserve CAN be zero in initialized pools due to rounding.
-            // When burns occur with small reserves and large totalSupply, the pro-rata
-            // calculation (liquidity * reserve / totalSupply) can round down to 0,
-            // meaning the burner's LP tokens are burned but they receive 0 tokens.
-            // This drains totalSupply without proportionally draining reserves,
-            // eventually leading to reserves = 0 while totalSupply >= MIN_LIQUIDITY.
-            // This is a valid (though suboptimal) state, not a bricked pool.
+            // At least validator reserve must be > 0 (mints always deposit validator tokens)
+            assertTrue(
+                pool.reserveValidatorToken > 0,
+                "TEMPO-AMM30: Initialized pool has zero validator reserve"
+            );
         }
     }
 
@@ -1880,13 +2120,6 @@ contract FeeAMMInvariantTest is BaseTest {
                           INTERNAL HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Selects an actor based on seed
-    /// @param seed Random seed
-    /// @return Selected actor address
-    function _selectActor(uint256 seed) internal view returns (address) {
-        return _actors[seed % _actors.length];
-    }
-
     /// @dev Marks an actor as active (participating in fee-related activities)
     function _markActorActive(address actor) internal {
         if (!_activeActors[actor]) {
@@ -1915,9 +2148,7 @@ contract FeeAMMInvariantTest is BaseTest {
             || selector == IFeeAMM.InvalidAmount.selector
             || selector == IFeeAMM.DivisionByZero.selector
             || selector == IFeeAMM.InvalidSwapCalculation.selector
-            || selector == IFeeAMM.InvalidCurrency.selector
-            || selector == ITIP20.InsufficientBalance.selector
-            || selector == ITIP20.PolicyForbids.selector;
+            || selector == IFeeAMM.InvalidCurrency.selector || _isKnownTIP20Error(selector);
         assertTrue(isKnownError, "Failed with unknown error");
     }
 
@@ -1928,9 +2159,7 @@ contract FeeAMMInvariantTest is BaseTest {
         bool isKnownError = selector == IFeeAMM.IdenticalAddresses.selector
             || selector == IFeeAMM.InvalidToken.selector
             || selector == IFeeAMM.InsufficientLiquidity.selector
-            || selector == IFeeAMM.InvalidCurrency.selector
-            || selector == ITIP20.InsufficientBalance.selector
-            || selector == ITIP20.PolicyForbids.selector
+            || selector == IFeeAMM.InvalidCurrency.selector || _isKnownTIP20Error(selector)
             // FeeManager specific (string reverts)
             || keccak256(reason)
                 == keccak256(abi.encodeWithSignature("Error(string)", "ONLY_DIRECT_CALL"))
@@ -1939,83 +2168,9 @@ contract FeeAMMInvariantTest is BaseTest {
         assertTrue(isKnownError, "Failed with unknown FeeManager error");
     }
 
-    /// @notice Creates test actors with initial balances and approvals
-    /// @dev Each actor gets funded and approves the FeeAMM for both tokens
-    /// @param noOfActors_ Number of actors to create
-    /// @return actorsAddress Array of created actor addresses
-    function _buildActors(uint256 noOfActors_) internal returns (address[] memory) {
-        address[] memory actorsAddress = new address[](noOfActors_);
-
-        for (uint256 i = 0; i < noOfActors_; i++) {
-            address actor = address(uint160(uint256(keccak256(abi.encodePacked("Actor", i)))));
-            actorsAddress[i] = actor;
-
-            // initial actor balance for all tokens
-            _ensureFundsAll(actor, 1_000_000_000_000);
-
-            vm.startPrank(actor);
-            // Approve all base tokens and pathUSD for the FeeAMM
-            for (uint256 j = 0; j < _tokens.length; j++) {
-                _tokens[j].approve(address(amm), type(uint256).max);
-            }
-            pathUSD.approve(address(amm), type(uint256).max);
-            vm.stopPrank();
-        }
-
-        return actorsAddress;
-    }
-
-    /// @dev Selects a token from all available tokens (base tokens + pathUSD)
-    /// @param rnd Random seed for selection
-    /// @return The selected token address
-    function _selectToken(uint256 rnd) internal view returns (address) {
-        // Pool of tokens: pathUSD + all base tokens
-        uint256 totalTokens = _tokens.length + 1;
-        uint256 index = rnd % totalTokens;
-        if (index == 0) {
-            return address(pathUSD);
-        }
-        return address(_tokens[index - 1]);
-    }
-
-    /// @notice Ensures an actor has sufficient token balances for testing
-    /// @dev Mints tokens if actor's balance is below the required amount
-    /// @param actor The actor address to fund
-    /// @param token The token to mint (base token for asks, pathUSD for bids)
-    /// @param amount The minimum balance required
-    function _ensureFunds(address actor, TIP20 token, uint256 amount) internal {
-        vm.startPrank(admin);
-        if (token.balanceOf(address(actor)) < amount) {
-            token.mint(actor, amount + 100_000_000);
-        }
-        vm.stopPrank();
-    }
-
-    /// @notice Ensures an actor has sufficient balances for all tokens (used in setUp)
-    /// @dev Mints pathUSD and all base tokens if actor's balance is below the required amount
-    /// @param actor The actor address to fund
-    /// @param amount The minimum balance required
-    function _ensureFundsAll(address actor, uint256 amount) internal {
-        vm.startPrank(admin);
-        if (pathUSD.balanceOf(address(actor)) < amount) {
-            pathUSD.mint(actor, amount + 100_000_000);
-        }
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            if (_tokens[i].balanceOf(address(actor)) < amount) {
-                _tokens[i].mint(actor, amount + 100_000_000);
-            }
-        }
-        vm.stopPrank();
-    }
-
     /*//////////////////////////////////////////////////////////////
                               LOGGING
     //////////////////////////////////////////////////////////////*/
-
-    /// @dev Logs an action message to the amm.log file
-    function _log(string memory message) internal {
-        vm.writeLine(LOG_FILE, message);
-    }
 
     /// @dev Logs a mint action
     function _logMint(address actor, uint256 liquidity, uint256 amount) internal {
@@ -2079,33 +2234,9 @@ contract FeeAMMInvariantTest is BaseTest {
         );
     }
 
-    /// @dev Gets token symbol for logging
-    function _getTokenSymbol(address token) internal view returns (string memory) {
-        if (token == address(pathUSD)) {
-            return "pathUSD";
-        }
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            if (address(_tokens[i]) == token) {
-                return _tokens[i].symbol();
-            }
-        }
-        return vm.toString(token);
-    }
-
     /// @dev Logs AMM balances for all tokens
     function _logBalances() internal {
-        string memory balanceStr =
-            string.concat("AMM balances: pathUSD=", vm.toString(pathUSD.balanceOf(address(amm))));
-        for (uint256 t = 0; t < _tokens.length; t++) {
-            balanceStr = string.concat(
-                balanceStr,
-                ", ",
-                _tokens[t].symbol(),
-                "=",
-                vm.toString(_tokens[t].balanceOf(address(amm)))
-            );
-        }
-        _log(balanceStr);
+        _logContractBalances(address(amm), "AMM");
     }
 
     /// @dev Logs precise dust tracking information
@@ -2138,74 +2269,6 @@ contract FeeAMMInvariantTest is BaseTest {
 
         // Active actor count
         _log(string.concat("Active actors: ", vm.toString(_activeActorList.length)));
-    }
-
-    /// @dev Gets actor index from address for logging
-    function _getActorIndex(address actor) internal view returns (string memory) {
-        for (uint256 i = 0; i < _actors.length; i++) {
-            if (_actors[i] == actor) {
-                return string.concat("Actor", vm.toString(i));
-            }
-        }
-        return vm.toString(actor);
-    }
-
-    function test_repro_TEMPO_AMM30_ZeroValidatorReserve() public {
-        this.simulateFeeCollection(
-            6_217_401_010_937_182_235_330_593,
-            71_141_330_745_412_273_858_523_140_613_712,
-            82_940_519_497_026_241_853_278_642_572_649_645_656_082_617,
-            20_281_997_670_017_163_135_102_914_189_317_400_289_206
-        );
-        this.simulateFeeCollection(
-            900_460_725_746_834_682_773_235_820_764_048_416_048_585_283_567_285_414_967,
-            57_868_748_774_672_895_625_229_209_619,
-            30_706_516_524_944_856_915_972_184_595_746_399_835_067_290_067,
-            26_873_763_970_028_017_908
-        );
-        this.simulateFeeCollection(
-            1_896_133_607_606_663_338_812_301_648_903_364_820_158_282_460,
-            587_634_820_897_769_499_619_033_103_515_862_062_799_239_905_381_615_160_541_996_052_501_162_397_409,
-            423_263_541_535_607_641_223_526_793_518_989_593_021_253_392_654_020_044_367_086_486,
-            81_305_385_348_813_778_469_256_790_287_564_528_736_558_057_625_532_364_046_469_354_538_983_232_025
-        );
-        this.simulateFeeCollection(13_932, 4025, 59_206, 17_504_752);
-        this.simulateFeeCollection(34_995_676, 2071, 6_981_933_222, 4_516_888_683_122_851);
-        this.simulateFeeCollection(20_783, 1_819_264, 9_616_345, 2182);
-        this.simulateFeeCollection(35_190, 5_155_068, 16_246_806, 669_543_791);
-        this.simulateFeeCollection(
-            50_851_922_794_016_125,
-            1_678_986_654_677_964_034_751_948_600_336_785_714_756_094_921_915_368_527_678,
-            18,
-            31_864_378_906_314_562_225_190_273_161_856_656_625_717_241_705_826_517_461_367_154_463_968
-        );
-        this.simulateFeeCollection(7_835_935, 13_763_019, 44_352, 12_958_668);
-        this.simulateFeeCollection(
-            1,
-            1,
-            531_813_033_366_352_184_106_009_694,
-            38_552_755_087_238_092_714_606_566_509_748_518_786_019
-        );
-        this.setUserToken(
-            430_916_265_421_189_121_529_616_154_146_798_850_626_318_496_151_536_204,
-            237_815_094_032_346_305_989_378_206_563_553_224_111
-        );
-        this.mintBurnCycle(
-            8_704_010_369_172_310_989_778_259_165_865_293_121_681_494_923_419_724_242_398_837_347,
-            166_082_169_622_271_516_040_832_242_156_345_194_667_788_573_456,
-            10_380_741_460_111_524_670_826_236_718_172_482_907_336_446_641_248_791_906_893_521_628,
-            115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_932
-        );
-        this.simulateFeeCollection(
-            95_889_983_804_464_479_844_656_138_558_079_745_452_524_941_582_021_467_283,
-            675_735_442_972_389_723_533_214,
-            84_279_964_408_290_060_446_009_267_257_866_256_936_639_479_872_301_224_489_238_882_878_484_526_890_964,
-            1
-        );
-        this.simulateFeeCollection(12_186, 19_190, 15_271_180, 1_555_938);
-        this.setValidatorToken(5_619_905, 17_868_946);
-        this.simulateFeeCollection(20_627_988, 14_266, 2_000_010, 46_372);
-        _invariantPoolInitializationShape();
     }
 
 }

--- a/docs/specs/test/invariants/InvariantBaseTest.t.sol
+++ b/docs/specs/test/invariants/InvariantBaseTest.t.sol
@@ -114,7 +114,16 @@ abstract contract InvariantBaseTest is BaseTest {
             actorsAddress[i] = actor;
 
             // Initial actor balance for all tokens
-            _ensureFundsAll(actor, 1_000_000_000_000);
+            vm.startPrank(admin);
+            if (pathUSD.balanceOf(actor) < amount) {
+                pathUSD.mint(actor, amount + 100_000_000);
+            }
+            for (uint256 i = 0; i < _tokens.length; i++) {
+                if (_tokens[i].balanceOf(actor) < amount) {
+                    _tokens[i].mint(actor, amount + 100_000_000);
+                }
+            }
+            vm.stopPrank();
         }
 
         return actorsAddress;
@@ -194,22 +203,6 @@ abstract contract InvariantBaseTest is BaseTest {
             token.mint(actor, amount + 100_000_000);
             vm.stopPrank();
         }
-    }
-
-    /// @notice Ensures an actor has sufficient balances for all tokens
-    /// @param actor The actor address to fund
-    /// @param amount The minimum balance required
-    function _ensureFundsAll(address actor, uint256 amount) internal {
-        vm.startPrank(admin);
-        if (pathUSD.balanceOf(actor) < amount) {
-            pathUSD.mint(actor, amount + 100_000_000);
-        }
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            if (_tokens[i].balanceOf(actor) < amount) {
-                _tokens[i].mint(actor, amount + 100_000_000);
-            }
-        }
-        vm.stopPrank();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/test/invariants/InvariantBaseTest.t.sol
+++ b/docs/specs/test/invariants/InvariantBaseTest.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.13;
 
 import { TIP20 } from "../../src/TIP20.sol";
+import { IFeeAMM } from "../../src/interfaces/IFeeAMM.sol";
+import { IStablecoinDEX } from "../../src/interfaces/IStablecoinDEX.sol";
 import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
 import { ITIP20RolesAuth } from "../../src/interfaces/ITIP20RolesAuth.sol";
 import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
-import { IFeeAMM } from "../../src/interfaces/IFeeAMM.sol";
-import { IStablecoinDEX } from "../../src/interfaces/IStablecoinDEX.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 
 /// @title Invariant Base Test
@@ -337,8 +337,7 @@ abstract contract InvariantBaseTest is BaseTest {
             || selector == IFeeAMM.DivisionByZero.selector
             || selector == IFeeAMM.InvalidSwapCalculation.selector
             || selector == IFeeAMM.InvalidCurrency.selector
-            || selector == IFeeAMM.InvalidToken.selector
-            || _isKnownTIP20Error(selector);
+            || selector == IFeeAMM.InvalidToken.selector || _isKnownTIP20Error(selector);
     }
 
     /// @dev Checks if an error is a known StablecoinDEX error
@@ -354,8 +353,7 @@ abstract contract InvariantBaseTest is BaseTest {
             || selector == IStablecoinDEX.InvalidToken.selector
             || selector == IStablecoinDEX.OrderDoesNotExist.selector
             || selector == IStablecoinDEX.BelowMinimumOrderSize.selector
-            || selector == IStablecoinDEX.InvalidTick.selector
-            || _isKnownTIP20Error(selector);
+            || selector == IStablecoinDEX.InvalidTick.selector || _isKnownTIP20Error(selector);
     }
 
     /// @dev Asserts a revert is a known TIP20 error
@@ -400,7 +398,7 @@ abstract contract InvariantBaseTest is BaseTest {
         for (uint256 i = 0; i < _actors.length; i++) {
             total += token.balanceOf(_actors[i]);
         }
-        
+
         total += token.balanceOf(address(token));
         total += token.balanceOf(address(amm));
         total += token.balanceOf(address(exchange));

--- a/docs/specs/test/invariants/InvariantBaseTest.t.sol
+++ b/docs/specs/test/invariants/InvariantBaseTest.t.sol
@@ -108,6 +108,7 @@ abstract contract InvariantBaseTest is BaseTest {
     /// @return actorsAddress Array of created actor addresses
     function _buildActors(uint256 noOfActors_) internal virtual returns (address[] memory) {
         address[] memory actorsAddress = new address[](noOfActors_);
+        uint256 initialBalance = 1_000_000_000_000;
 
         for (uint256 i = 0; i < noOfActors_; i++) {
             address actor = makeAddr(string(abi.encodePacked("Actor", vm.toString(i))));
@@ -115,12 +116,12 @@ abstract contract InvariantBaseTest is BaseTest {
 
             // Initial actor balance for all tokens
             vm.startPrank(admin);
-            if (pathUSD.balanceOf(actor) < amount) {
-                pathUSD.mint(actor, amount + 100_000_000);
+            if (pathUSD.balanceOf(actor) < initialBalance) {
+                pathUSD.mint(actor, initialBalance + 100_000_000);
             }
-            for (uint256 i = 0; i < _tokens.length; i++) {
-                if (_tokens[i].balanceOf(actor) < amount) {
-                    _tokens[i].mint(actor, amount + 100_000_000);
+            for (uint256 j = 0; j < _tokens.length; j++) {
+                if (_tokens[j].balanceOf(actor) < initialBalance) {
+                    _tokens[j].mint(actor, initialBalance + 100_000_000);
                 }
             }
             vm.stopPrank();

--- a/docs/specs/test/invariants/InvariantBaseTest.t.sol
+++ b/docs/specs/test/invariants/InvariantBaseTest.t.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { TIP20 } from "../../src/TIP20.sol";
+import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+import { ITIP20RolesAuth } from "../../src/interfaces/ITIP20RolesAuth.sol";
+import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
+import { IFeeAMM } from "../../src/interfaces/IFeeAMM.sol";
+import { IStablecoinDEX } from "../../src/interfaces/IStablecoinDEX.sol";
+import { BaseTest } from "../BaseTest.t.sol";
+
+/// @title Invariant Base Test
+/// @notice Shared test infrastructure for invariant testing of Tempo precompiles
+/// @dev Provides common actor management, token selection, funding, and logging utilities
+abstract contract InvariantBaseTest is BaseTest {
+
+    /*//////////////////////////////////////////////////////////////
+                              STATE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Array of test actors that interact with the contracts
+    address[] internal _actors;
+
+    /// @dev Array of test tokens (token1, token2, token3, token4)
+    TIP20[] internal _tokens;
+
+    /// @dev Blacklist policy IDs for each token
+    mapping(address => uint64) internal _tokenPolicyIds;
+
+    /// @dev Blacklist policy ID for pathUSD
+    uint64 internal _pathUsdPolicyId;
+
+    /// @dev Additional tokens (token3, token4) - token1/token2 from BaseTest
+    TIP20 public token3;
+    TIP20 public token4;
+
+    /// @dev Log file path - must be set by child contract
+    string internal _logFile;
+
+    /*//////////////////////////////////////////////////////////////
+                              SETUP
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Common setup for invariant tests
+    /// @dev Creates tokens, sets up roles, creates blacklist policies
+    function _setupInvariantBase() internal {
+        // Create additional tokens (token1, token2 already created in BaseTest)
+        token3 =
+            TIP20(factory.createToken("TOKEN3", "T3", "USD", pathUSD, admin, bytes32("token3")));
+        token4 =
+            TIP20(factory.createToken("TOKEN4", "T4", "USD", pathUSD, admin, bytes32("token4")));
+
+        // Setup pathUSD with issuer role (pathUSDAdmin is the pathUSD admin from BaseTest)
+        vm.startPrank(pathUSDAdmin);
+        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
+        pathUSD.grantRole(_ISSUER_ROLE, admin);
+        vm.stopPrank();
+
+        // Setup all tokens with issuer role
+        vm.startPrank(admin);
+        TIP20[4] memory tokens = [token1, token2, token3, token4];
+        for (uint256 i = 0; i < tokens.length; i++) {
+            tokens[i].grantRole(_ISSUER_ROLE, admin);
+            _tokens.push(tokens[i]);
+
+            // Create blacklist policy for each token
+            uint64 policyId = registry.createPolicy(admin, ITIP403Registry.PolicyType.BLACKLIST);
+            tokens[i].changeTransferPolicyId(policyId);
+            _tokenPolicyIds[address(tokens[i])] = policyId;
+        }
+        vm.stopPrank();
+
+        // Create blacklist policy for pathUSD
+        vm.startPrank(pathUSDAdmin);
+        _pathUsdPolicyId = registry.createPolicy(pathUSDAdmin, ITIP403Registry.PolicyType.BLACKLIST);
+        pathUSD.changeTransferPolicyId(_pathUsdPolicyId);
+        vm.stopPrank();
+    }
+
+    /// @notice Initialize log file with header
+    /// @param logFile The log file path
+    /// @param title The title for the log header
+    function _initLogFile(string memory logFile, string memory title) internal {
+        _logFile = logFile;
+        try vm.removeFile(_logFile) { } catch { }
+        _log("================================================================================");
+        _log(string.concat("                         ", title));
+        _log("================================================================================");
+        _log(string.concat("Actors: ", vm.toString(_actors.length), " | Tokens: T1, T2, T3, T4"));
+        _log("--------------------------------------------------------------------------------");
+        _log("");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          ACTOR MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Selects an actor based on seed
+    /// @param seed Random seed
+    /// @return Selected actor address
+    function _selectActor(uint256 seed) internal view returns (address) {
+        return _actors[seed % _actors.length];
+    }
+
+    /// @notice Creates test actors with initial balances
+    /// @dev Each actor gets funded with all tokens
+    /// @param noOfActors_ Number of actors to create
+    /// @return actorsAddress Array of created actor addresses
+    function _buildActors(uint256 noOfActors_) internal virtual returns (address[] memory) {
+        address[] memory actorsAddress = new address[](noOfActors_);
+
+        for (uint256 i = 0; i < noOfActors_; i++) {
+            address actor = makeAddr(string(abi.encodePacked("Actor", vm.toString(i))));
+            actorsAddress[i] = actor;
+
+            // Initial actor balance for all tokens
+            _ensureFundsAll(actor, 1_000_000_000_000);
+        }
+
+        return actorsAddress;
+    }
+
+    /// @notice Creates test actors with approvals for a specific contract
+    /// @param noOfActors_ Number of actors to create
+    /// @param spender Contract to approve for token spending
+    /// @return actorsAddress Array of created actor addresses
+    function _buildActorsWithApprovals(uint256 noOfActors_, address spender)
+        internal
+        returns (address[] memory)
+    {
+        address[] memory actorsAddress = _buildActors(noOfActors_);
+
+        for (uint256 i = 0; i < noOfActors_; i++) {
+            vm.startPrank(actorsAddress[i]);
+            for (uint256 j = 0; j < _tokens.length; j++) {
+                _tokens[j].approve(spender, type(uint256).max);
+            }
+            pathUSD.approve(spender, type(uint256).max);
+            vm.stopPrank();
+        }
+
+        return actorsAddress;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          TOKEN SELECTION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Selects a token from all available tokens (base tokens + pathUSD)
+    /// @param rnd Random seed for selection
+    /// @return The selected token address
+    function _selectToken(uint256 rnd) internal view returns (address) {
+        uint256 totalTokens = _tokens.length + 1;
+        uint256 index = rnd % totalTokens;
+        if (index == 0) {
+            return address(pathUSD);
+        }
+        return address(_tokens[index - 1]);
+    }
+
+    /// @dev Selects a base token only (excludes pathUSD)
+    /// @param rnd Random seed for selection
+    /// @return The selected token
+    function _selectBaseToken(uint256 rnd) internal view returns (TIP20) {
+        return _tokens[rnd % _tokens.length];
+    }
+
+    /// @dev Gets token symbol for logging
+    /// @param token Token address
+    /// @return Symbol string
+    function _getTokenSymbol(address token) internal view returns (string memory) {
+        if (token == address(pathUSD)) {
+            return "pathUSD";
+        }
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            if (address(_tokens[i]) == token) {
+                return _tokens[i].symbol();
+            }
+        }
+        return vm.toString(token);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          FUNDING HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Ensures an actor has sufficient token balance
+    /// @param actor The actor address to fund
+    /// @param token The token to mint
+    /// @param amount The minimum balance required
+    function _ensureFunds(address actor, TIP20 token, uint256 amount) internal {
+        if (token.balanceOf(actor) < amount) {
+            vm.startPrank(admin);
+            token.mint(actor, amount + 100_000_000);
+            vm.stopPrank();
+        }
+    }
+
+    /// @notice Ensures an actor has sufficient balances for all tokens
+    /// @param actor The actor address to fund
+    /// @param amount The minimum balance required
+    function _ensureFundsAll(address actor, uint256 amount) internal {
+        vm.startPrank(admin);
+        if (pathUSD.balanceOf(actor) < amount) {
+            pathUSD.mint(actor, amount + 100_000_000);
+        }
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            if (_tokens[i].balanceOf(actor) < amount) {
+                _tokens[i].mint(actor, amount + 100_000_000);
+            }
+        }
+        vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          POLICY HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Gets the policy ID for a token
+    /// @param token Token address
+    /// @return policyId The policy ID
+    function _getPolicyId(address token) internal view returns (uint64) {
+        if (token == address(pathUSD)) {
+            return _pathUsdPolicyId;
+        }
+        return _tokenPolicyIds[token];
+    }
+
+    /// @dev Gets the policy admin for a token
+    /// @param token Token address
+    /// @return The policy admin address
+    function _getPolicyAdmin(address token) internal view returns (address) {
+        if (token == address(pathUSD)) {
+            return pathUSDAdmin;
+        }
+        return admin;
+    }
+
+    /// @dev Checks if an actor is authorized for a token
+    /// @param token Token address
+    /// @param actor Actor address
+    /// @return True if authorized
+    function _isAuthorized(address token, address actor) internal view returns (bool) {
+        return registry.isAuthorized(_getPolicyId(token), actor);
+    }
+
+    /// @dev Toggles blacklist status for an actor on a token
+    /// @param token Token address
+    /// @param actor Actor address
+    /// @param blacklist True to blacklist, false to whitelist
+    function _setBlacklist(address token, address actor, bool blacklist) internal {
+        vm.prank(_getPolicyAdmin(token));
+        registry.modifyPolicyBlacklist(_getPolicyId(token), actor, blacklist);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              LOGGING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Logs a message to the log file
+    function _log(string memory message) internal {
+        vm.writeLine(_logFile, message);
+    }
+
+    /// @dev Gets actor index from address for logging
+    function _getActorIndex(address actor) internal view returns (string memory) {
+        for (uint256 i = 0; i < _actors.length; i++) {
+            if (_actors[i] == actor) {
+                return string.concat("Actor", vm.toString(i));
+            }
+        }
+        if (actor == admin) return "Admin";
+        if (actor == address(0)) return "ZERO";
+        return vm.toString(actor);
+    }
+
+    /// @dev Logs contract balances for all tokens
+    /// @param contractAddr Contract address to check
+    /// @param contractName Name for logging
+    function _logContractBalances(address contractAddr, string memory contractName) internal {
+        string memory balanceStr = string.concat(
+            contractName, " balances: pathUSD=", vm.toString(pathUSD.balanceOf(contractAddr))
+        );
+        for (uint256 t = 0; t < _tokens.length; t++) {
+            balanceStr = string.concat(
+                balanceStr,
+                ", ",
+                _tokens[t].symbol(),
+                "=",
+                vm.toString(_tokens[t].balanceOf(contractAddr))
+            );
+        }
+        _log(balanceStr);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          ERROR HANDLING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Checks if an error is a known TIP20 error
+    /// @param selector Error selector
+    /// @return True if known TIP20 error
+    function _isKnownTIP20Error(bytes4 selector) internal pure returns (bool) {
+        return selector == ITIP20.ContractPaused.selector
+            || selector == ITIP20.InsufficientAllowance.selector
+            || selector == ITIP20.InsufficientBalance.selector
+            || selector == ITIP20.InvalidRecipient.selector
+            || selector == ITIP20.InvalidAmount.selector
+            || selector == ITIP20.PolicyForbids.selector
+            || selector == ITIP20.SupplyCapExceeded.selector
+            || selector == ITIP20.NoOptedInSupply.selector
+            || selector == ITIP20.InvalidTransferPolicyId.selector
+            || selector == ITIP20.InvalidQuoteToken.selector
+            || selector == ITIP20.InvalidCurrency.selector
+            || selector == ITIP20.InvalidSupplyCap.selector
+            || selector == ITIP20.ProtectedAddress.selector
+            || selector == ITIP20RolesAuth.Unauthorized.selector;
+    }
+
+    /// @dev Checks if an error is a known TIP403Registry error
+    /// @param selector Error selector
+    /// @return True if known TIP403Registry error
+    function _isKnownRegistryError(bytes4 selector) internal pure returns (bool) {
+        return selector == ITIP403Registry.Unauthorized.selector
+            || selector == ITIP403Registry.IncompatiblePolicyType.selector
+            || selector == ITIP403Registry.PolicyNotFound.selector;
+    }
+
+    /// @dev Checks if an error is a known FeeAMM/FeeManager error
+    /// @param selector Error selector
+    /// @return True if known FeeAMM error
+    function _isKnownFeeAMMError(bytes4 selector) internal pure returns (bool) {
+        return selector == IFeeAMM.IdenticalAddresses.selector
+            || selector == IFeeAMM.InvalidAmount.selector
+            || selector == IFeeAMM.InsufficientLiquidity.selector
+            || selector == IFeeAMM.InsufficientReserves.selector
+            || selector == IFeeAMM.DivisionByZero.selector
+            || selector == IFeeAMM.InvalidSwapCalculation.selector
+            || selector == IFeeAMM.InvalidCurrency.selector
+            || selector == IFeeAMM.InvalidToken.selector
+            || _isKnownTIP20Error(selector);
+    }
+
+    /// @dev Checks if an error is a known StablecoinDEX error
+    /// @param selector Error selector
+    /// @return True if known StablecoinDEX error
+    function _isKnownDEXError(bytes4 selector) internal pure returns (bool) {
+        return selector == IStablecoinDEX.InsufficientLiquidity.selector
+            || selector == IStablecoinDEX.InsufficientOutput.selector
+            || selector == IStablecoinDEX.MaxInputExceeded.selector
+            || selector == IStablecoinDEX.InsufficientBalance.selector
+            || selector == IStablecoinDEX.PairDoesNotExist.selector
+            || selector == IStablecoinDEX.IdenticalTokens.selector
+            || selector == IStablecoinDEX.InvalidToken.selector
+            || selector == IStablecoinDEX.OrderDoesNotExist.selector
+            || selector == IStablecoinDEX.BelowMinimumOrderSize.selector
+            || selector == IStablecoinDEX.InvalidTick.selector
+            || _isKnownTIP20Error(selector);
+    }
+
+    /// @dev Asserts a revert is a known TIP20 error
+    function _assertKnownTIP20Revert(bytes memory reason) internal pure {
+        assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown TIP20 error");
+    }
+
+    /// @dev Asserts a revert is a known TIP403Registry error
+    function _assertKnownRegistryRevert(bytes memory reason) internal pure {
+        assertTrue(_isKnownRegistryError(bytes4(reason)), "Unknown Registry error");
+    }
+
+    /// @dev Asserts a revert is a known FeeAMM error
+    function _assertKnownFeeAMMRevert(bytes memory reason) internal pure {
+        assertTrue(_isKnownFeeAMMError(bytes4(reason)), "Unknown FeeAMM error");
+    }
+
+    /// @dev Asserts a revert is a known StablecoinDEX error
+    function _assertKnownDEXRevert(bytes memory reason) internal pure {
+        assertTrue(_isKnownDEXError(bytes4(reason)), "Unknown DEX error");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        SYSTEM ADDRESS TRACKING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Returns array of system addresses that may hold token balances
+    /// @return Array of system contract addresses
+    function _getSystemAddresses() internal view returns (address[] memory) {
+        address[] memory sysAddrs = new address[](4);
+        sysAddrs[0] = address(amm);
+        sysAddrs[1] = address(exchange);
+        sysAddrs[2] = address(pathUSD);
+        sysAddrs[3] = address(factory);
+        return sysAddrs;
+    }
+
+    /// @dev Computes sum of balances for a token across all actors and system addresses
+    /// @param token The token to sum balances for
+    /// @return total The sum of all balances
+    function _sumAllBalances(TIP20 token) internal view returns (uint256 total) {
+        for (uint256 i = 0; i < _actors.length; i++) {
+            total += token.balanceOf(_actors[i]);
+        }
+        
+        total += token.balanceOf(address(token));
+        total += token.balanceOf(address(amm));
+        total += token.balanceOf(address(exchange));
+        total += token.balanceOf(admin);
+        total += token.balanceOf(alice);
+        total += token.balanceOf(bob);
+        total += token.balanceOf(charlie);
+        total += token.balanceOf(pathUSDAdmin);
+    }
+
+}

--- a/docs/specs/test/invariants/README.md
+++ b/docs/specs/test/invariants/README.md
@@ -14,7 +14,8 @@
 - **TEMPO-DEX5**: `amountIn <= maxAmountIn` when executing `swapExactAmountOut`.
 - **TEMPO-DEX14**: Swapper total balance (external + internal) changes correctly - loses exact `amountIn` of tokenIn and gains exact `amountOut` of tokenOut. Skipped when swapper has active orders (self-trade makes accounting complex).
 - **TEMPO-DEX16**: Quote functions (`quoteSwapExactAmountIn/Out`) return values matching actual swap execution.
-- **TEMPO-DEX18**: Dust invariant - each swap can at maximum increase the dust in the DEX by 1.
+- **TEMPO-DEX18**: Dust invariant - each swap can at maximum increase the dust in the DEX by the number of orders filled.
+- **TEMPO-DEX19**: Post-swap dust bounded - maximum dust accumulation in the protocol is bounded and tracked via `_maxDust`.
 
 ### Balance Invariants
 
@@ -89,7 +90,12 @@ The FeeAMM is a constant-rate AMM used for converting user fee tokens to validat
 - **TEMPO-AMM19**: Must pay at least 1 for any swap - prevents zero-cost extraction.
 - **TEMPO-AMM20**: Reserves are always bounded by uint128.
 - **TEMPO-AMM21**: Spread between fee swap (M) and rebalance (N) prevents arbitrage - M < N with 15 bps spread.
-- **TEMPO-AMM22**: Rebalance swap rounding always favors the pool - the +1 in the formula ensures pool never loses to rounding.
+- **TEMPO-AMM22**: Rebalance swap rounding always favors the pool - the +1 in the formula ensures pool never loses to rounding, even when `(amountOut * N) % SCALE == 0` (exact division case).
+
+### First Mint Boundary Invariants
+
+- **TEMPO-AMM35**: First mint requires `half_amount > MIN_LIQUIDITY`, not `>=`. The boundary case where `amount == 2 * MIN_LIQUIDITY` (i.e., `half_amount == MIN_LIQUIDITY`) must revert with `InsufficientLiquidity`.
+- **TEMPO-AMM36**: First mint with `amount == 2 * MIN_LIQUIDITY + 2` should succeed with `liquidity == 1`.
 - **TEMPO-AMM23**: Burn rounding dust accumulates in pool - integer division rounds down, so users receive <= theoretical amount.
 - **TEMPO-AMM24**: All participants can exit with solvency guaranteed. After distributing all fees and burning all LP positions:
 

--- a/docs/specs/test/invariants/README.md
+++ b/docs/specs/test/invariants/README.md
@@ -38,6 +38,10 @@
 
 - **TEMPO-DEX13**: Anyone can cancel a stale order from a blacklisted maker via `cancelStaleOrder`. The escrowed funds are refunded to the blacklisted maker's internal balance.
 
+### Escrow Precision Invariants
+
+- **TEMPO-DEX20**: When `(base * price) % PRICE_SCALE == 0` (perfectly divisible), escrow calculation must be exact with no +1 rounding. Ceil should equal floor when there's no remainder.
+
 ## FeeAMM
 
 The FeeAMM is a constant-rate AMM used for converting user fee tokens to validator fee tokens. It operates with two fixed rates:
@@ -92,10 +96,8 @@ The FeeAMM is a constant-rate AMM used for converting user fee tokens to validat
 - **TEMPO-AMM21**: Spread between fee swap (M) and rebalance (N) prevents arbitrage - M < N with 15 bps spread.
 - **TEMPO-AMM22**: Rebalance swap rounding always favors the pool - the +1 in the formula ensures pool never loses to rounding, even when `(amountOut * N) % SCALE == 0` (exact division case).
 
-### First Mint Boundary Invariants
+### Burn Rounding Invariants
 
-- **TEMPO-AMM35**: First mint requires `half_amount > MIN_LIQUIDITY`, not `>=`. The boundary case where `amount == 2 * MIN_LIQUIDITY` (i.e., `half_amount == MIN_LIQUIDITY`) must revert with `InsufficientLiquidity`.
-- **TEMPO-AMM36**: First mint with `amount == 2 * MIN_LIQUIDITY + 2` should succeed with `liquidity == 1`.
 - **TEMPO-AMM23**: Burn rounding dust accumulates in pool - integer division rounds down, so users receive <= theoretical amount.
 - **TEMPO-AMM24**: All participants can exit with solvency guaranteed. After distributing all fees and burning all LP positions:
 

--- a/docs/specs/test/invariants/StablecoinDEX.t.sol
+++ b/docs/specs/test/invariants/StablecoinDEX.t.sol
@@ -153,6 +153,9 @@ contract StablecoinDEXInvariantTest is InvariantBaseTest {
     }
 
     /// @notice TEMPO-DEX20: Test divisibility edge cases - when (base*price) % PRICE_SCALE == 0
+    /// @dev Since TICK_SPACING=10, gcd(price, 100_000) is always >= 10, so divisible amounts
+    /// are relatively common (every 10_000 to 100_000 units depending on price). This test
+    /// ensures the exchange handles exact division correctly without spurious +1 rounding.
     function placeDivisibleBid(uint256 actorRnd, uint256 tickRnd, uint256 tokenRnd) external {
         int16 tick = _ticks[tickRnd % _ticks.length];
         address actor = _actors[actorRnd % _actors.length];
@@ -160,6 +163,7 @@ contract StablecoinDEXInvariantTest is InvariantBaseTest {
         uint32 price = exchange.tickToPrice(tick);
 
         // Calculate amount where (amount * price) % 100_000 == 0, above min order size
+        // With TICK_SPACING=10, gcd(price, 100_000) >= 10, so amount <= 10_000 * 10_000 = 100M
         uint128 amount = uint128((100_000 / _gcd(uint256(price), 100_000)) * 10_000);
         if (amount < 100_000_000) return;
 

--- a/docs/specs/test/invariants/StablecoinDEX.t.sol
+++ b/docs/specs/test/invariants/StablecoinDEX.t.sol
@@ -153,9 +153,6 @@ contract StablecoinDEXInvariantTest is InvariantBaseTest {
     }
 
     /// @notice TEMPO-DEX20: Test divisibility edge cases - when (base*price) % PRICE_SCALE == 0
-    /// @dev Since TICK_SPACING=10, gcd(price, 100_000) is always >= 10, so divisible amounts
-    /// are relatively common (every 10_000 to 100_000 units depending on price). This test
-    /// ensures the exchange handles exact division correctly without spurious +1 rounding.
     function placeDivisibleBid(uint256 actorRnd, uint256 tickRnd, uint256 tokenRnd) external {
         int16 tick = _ticks[tickRnd % _ticks.length];
         address actor = _actors[actorRnd % _actors.length];
@@ -163,7 +160,6 @@ contract StablecoinDEXInvariantTest is InvariantBaseTest {
         uint32 price = exchange.tickToPrice(tick);
 
         // Calculate amount where (amount * price) % 100_000 == 0, above min order size
-        // With TICK_SPACING=10, gcd(price, 100_000) >= 10, so amount <= 10_000 * 10_000 = 100M
         uint128 amount = uint128((100_000 / _gcd(uint256(price), 100_000)) * 10_000);
         if (amount < 100_000_000) return;
 

--- a/docs/specs/test/invariants/StablecoinDEX.t.sol
+++ b/docs/specs/test/invariants/StablecoinDEX.t.sol
@@ -4,20 +4,13 @@ pragma solidity ^0.8.13;
 import { TIP20 } from "../../src/TIP20.sol";
 import { IStablecoinDEX } from "../../src/interfaces/IStablecoinDEX.sol";
 import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
-import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
-import { BaseTest } from "../BaseTest.t.sol";
+import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 /// @title StablecoinDEX Invariant Tests
 /// @notice Fuzz-based invariant tests for the StablecoinDEX orderbook exchange
-/// @dev Tests invariants TEMPO-DEX1 through TEMPO-DEX12 as documented in README.md
-contract StablecoinDEXInvariantTest is BaseTest {
-
-    /// @dev Array of test actors that interact with the DEX
-    address[] private _actors;
-
-    /// @dev Array of tradeable tokens (token1, token2, token3, token4)
-    TIP20[] private _tokens;
+/// @dev Tests invariants TEMPO-DEX1 through TEMPO-DEX19 as documented in README.md
+contract StablecoinDEXInvariantTest is InvariantBaseTest {
 
     /// @dev Mapping of actor address to their placed order IDs
     mapping(address => uint128[]) private _placedOrders;
@@ -28,21 +21,19 @@ contract StablecoinDEXInvariantTest is BaseTest {
     /// @dev Expected next order ID, used to verify TEMPO-DEX1
     uint128 private _nextOrderId;
 
-    /// @dev Blacklist policy IDs for each token
-    mapping(address => uint64) private _tokenPolicyIds;
-
-    /// @dev Blacklist policy ID for pathUSD
-    uint64 private _pathUsdPolicyId;
-
-    /// @dev Additional tokens (token3, token4) - token1/token2 from BaseTest
-    TIP20 public token3;
-    TIP20 public token4;
-
     /// @dev Log file path for recording exchange actions
-    string private constant LOG_FILE = "exchange.log";
+    string private constant LOG_FILE = "stablecoin_dex.log";
 
     /// @dev Maximum amount of dust that can be left in the protocol. This is used to verify TEMPO-DEX19.
     uint64 private _maxDust;
+
+    /// @dev Dust level before each swap, used to verify TEMPO-DEX18 (each swap increases dust by at most 1).
+    uint256 private _dustBeforeSwap;
+
+    /// @dev TEMPO-DEX20: Ghost variables for tracking divisibility edge cases
+    /// When (base * price) % PRICE_SCALE == 0, ceil should equal floor (no +1)
+    uint256 private _ghostDivisibleEscrowCount;
+    uint256 private _ghostDivisibleEscrowCorrect;
 
     /// @notice Sets up the test environment
     /// @dev Initializes BaseTest, creates trading pair, builds actors, and sets initial state
@@ -51,59 +42,19 @@ contract StablecoinDEXInvariantTest is BaseTest {
 
         targetContract(address(this));
 
-        // Create additional tokens (token1, token2 already created in BaseTest)
-        token3 =
-            TIP20(factory.createToken("TOKEN3", "T3", "USD", pathUSD, admin, bytes32("token3")));
-        token4 =
-            TIP20(factory.createToken("TOKEN4", "T4", "USD", pathUSD, admin, bytes32("token4")));
+        _setupInvariantBase();
 
-        // Setup pathUSD with issuer role (pathUSDAdmin is the pathUSD admin from BaseTest)
-        vm.startPrank(pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, admin);
-        vm.stopPrank();
-
-        // Setup all tokens with issuer role and create trading pairs
+        // Create trading pairs for all tokens
         vm.startPrank(admin);
-        TIP20[4] memory tokens = [token1, token2, token3, token4];
-        for (uint256 i = 0; i < tokens.length; i++) {
-            tokens[i].grantRole(_ISSUER_ROLE, admin);
-            _tokens.push(tokens[i]);
-            exchange.createPair(address(tokens[i]));
-
-            // Create blacklist policy for each token
-            uint64 policyId = registry.createPolicy(admin, ITIP403Registry.PolicyType.BLACKLIST);
-            tokens[i].changeTransferPolicyId(policyId);
-            _tokenPolicyIds[address(tokens[i])] = policyId;
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            exchange.createPair(address(_tokens[i]));
         }
         vm.stopPrank();
 
-        // Create blacklist policy for pathUSD
-        vm.startPrank(pathUSDAdmin);
-        _pathUsdPolicyId = registry.createPolicy(pathUSDAdmin, ITIP403Registry.PolicyType.BLACKLIST);
-        pathUSD.changeTransferPolicyId(_pathUsdPolicyId);
-        vm.stopPrank();
-
-        _actors = _buildActors(20);
+        _actors = _buildActorsWithApprovals(20, address(exchange));
         _nextOrderId = exchange.nextOrderId();
 
-        // Initialize log file
-        try vm.removeFile(LOG_FILE) { } catch { }
-        _log("=== StablecoinDEX Invariant Test Log ===");
-        _log(
-            string.concat(
-                "Tokens: T1=",
-                token1.symbol(),
-                ", T2=",
-                token2.symbol(),
-                ", T3=",
-                token3.symbol(),
-                ", T4=",
-                token4.symbol()
-            )
-        );
-        _log(string.concat("Actors: ", vm.toString(_actors.length)));
-        _log("");
+        _initLogFile(LOG_FILE, "StablecoinDEX Invariant Test Log");
         _logBalances();
     }
 
@@ -132,8 +83,19 @@ contract StablecoinDEXInvariantTest is BaseTest {
         address token = address(_tokens[tokenRnd % _tokens.length]);
         amount = uint128(bound(amount, 100_000_000, 10_000_000_000));
 
+        // TEMPO-DEX2: For bids, escrow is ceil(amount * price / PRICE_SCALE)
+        // For asks, escrow is exactly the base token amount
+        uint256 escrowAmount;
+        if (isBid) {
+            uint32 price = exchange.tickToPrice(tick);
+            escrowAmount = (uint256(amount) * uint256(price) + exchange.PRICE_SCALE() - 1)
+                / exchange.PRICE_SCALE();
+        } else {
+            escrowAmount = amount;
+        }
+
         // Ensure funds for the token being escrowed (pathUSD for bids, base token for asks)
-        _ensureFunds(actor, TIP20(isBid ? address(pathUSD) : token), amount);
+        _ensureFunds(actor, TIP20(isBid ? address(pathUSD) : token), escrowAmount);
 
         // Capture actor's token balance before placing order (for cancel verification)
         uint256 actorBalanceBeforePlace =
@@ -178,6 +140,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
         placeOrder(actorRnd, amount, tickRnd, tokenRnd, isBid, false);
     }
 
+    /// @notice Places an order and immediately cancels it
+    /// @dev Increases coverage of TEMPO-DEX3 (cancel refund) path
     function placeOrder2(
         uint256 actorRnd,
         uint128 amount,
@@ -185,7 +149,60 @@ contract StablecoinDEXInvariantTest is BaseTest {
         uint256 tokenRnd,
         bool isBid
     ) external {
-        placeOrder(actorRnd, amount, tickRnd, tokenRnd, isBid, false);
+        placeOrder(actorRnd, amount, tickRnd, tokenRnd, isBid, true);
+    }
+
+    /// @notice TEMPO-DEX20: Test divisibility edge cases - when (base*price) % PRICE_SCALE == 0
+    function placeDivisibleBid(uint256 actorRnd, uint256 tickRnd, uint256 tokenRnd) external {
+        int16 tick = _ticks[tickRnd % _ticks.length];
+        address actor = _actors[actorRnd % _actors.length];
+        address token = address(_tokens[tokenRnd % _tokens.length]);
+        uint32 price = exchange.tickToPrice(tick);
+
+        // Calculate amount where (amount * price) % 100_000 == 0, above min order size
+        uint128 amount = uint128((100_000 / _gcd(uint256(price), 100_000)) * 10_000);
+        if (amount < 100_000_000) return;
+
+        uint256 product = uint256(amount) * uint256(price);
+        if (product % 100_000 != 0) return;
+
+        _ghostDivisibleEscrowCount++;
+        uint256 expectedEscrow = product / 100_000;
+        _ensureFunds(actor, pathUSD, expectedEscrow + 1000);
+
+        // Capture both external and internal balance before placing order
+        uint256 externalBefore = pathUSD.balanceOf(actor);
+        uint256 internalBefore = exchange.balanceOf(actor, address(pathUSD));
+        uint256 totalBefore = externalBefore + internalBefore;
+
+        vm.prank(actor);
+        uint128 orderId = exchange.place(token, amount, true, tick);
+        _nextOrderId++;
+
+        // Calculate total escrow from both external and internal balance changes
+        uint256 externalAfter = pathUSD.balanceOf(actor);
+        uint256 internalAfter = exchange.balanceOf(actor, address(pathUSD));
+        uint256 totalAfter = externalAfter + internalAfter;
+        uint256 escrowed = totalBefore - totalAfter;
+
+        // TEMPO-DEX20: When (amount * price) % PRICE_SCALE == 0, escrow must be EXACT
+        // No +1 tolerance allowed - ceil should equal floor when perfectly divisible
+        assertEq(
+            escrowed,
+            expectedEscrow,
+            "TEMPO-DEX20: Divisible escrow should be exact (no +1 rounding)"
+        );
+        _ghostDivisibleEscrowCorrect++;
+        _placedOrders[actor].push(orderId);
+    }
+
+    function _gcd(uint256 a, uint256 b) internal pure returns (uint256) {
+        while (b != 0) {
+            uint256 t = b;
+            b = a % b;
+            a = t;
+        }
+        return a;
     }
 
     /// @dev Helper to verify order was created correctly (TEMPO-DEX2)
@@ -212,9 +229,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
             _cancelAndVerifyRefund(
                 orderId, order.maker, base, order.remaining, order.tick, order.isBid, 0
             );
-        } catch {
-            // order was probably cancelled in a previous cancelOrder call
-            return;
+        } catch (bytes memory reason) {
+            _assertKnownOrderError(reason);
         }
     }
 
@@ -624,8 +640,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
                         )
                     );
                 }
-            } catch {
-                // Order was already filled or cancelled
+            } catch (bytes memory reason) {
+                _assertKnownOrderError(reason);
             }
         }
         vm.stopPrank();
@@ -689,7 +705,9 @@ contract StablecoinDEXInvariantTest is BaseTest {
                     exchange.withdraw(base, order.remaining);
                 }
                 vm.stopPrank();
-            } catch { }
+            } catch (bytes memory reason) {
+                _assertKnownOrderError(reason);
+            }
         }
 
         // Withdraw remaining balances for all actors
@@ -807,6 +825,42 @@ contract StablecoinDEXInvariantTest is BaseTest {
         for (uint256 t = 0; t < _tokens.length; t++) {
             _assertTickLevelConsistency(address(_tokens[t]));
         }
+
+        // TEMPO-DEX20: Divisibility edge cases - all should have correct escrow
+        if (_ghostDivisibleEscrowCount > 0) {
+            assertEq(
+                _ghostDivisibleEscrowCorrect,
+                _ghostDivisibleEscrowCount,
+                "TEMPO-DEX20: Divisible escrow mismatch"
+            );
+        }
+    }
+
+    /// @notice Computes the current dust in the DEX
+    /// @dev Dust is the difference between DEX balance and (internal balances + escrowed amounts)
+    /// @return dust The total dust across all tokens
+    function _computeDust() internal view returns (uint256 dust) {
+        (uint256 pathUsdEscrowed, uint256[] memory tokenEscrowed,) = _computeExpectedEscrow();
+
+        uint256 dexPathUsdBalance = pathUSD.balanceOf(address(exchange));
+        uint256 totalUserPathUsd = 0;
+        for (uint256 i = 0; i < _actors.length; i++) {
+            totalUserPathUsd += exchange.balanceOf(_actors[i], address(pathUSD));
+        }
+        if (dexPathUsdBalance > totalUserPathUsd + pathUsdEscrowed) {
+            dust += dexPathUsdBalance - totalUserPathUsd - pathUsdEscrowed;
+        }
+
+        for (uint256 t = 0; t < _tokens.length; t++) {
+            uint256 dexTokenBalance = _tokens[t].balanceOf(address(exchange));
+            uint256 totalUserTokenBalance = 0;
+            for (uint256 i = 0; i < _actors.length; i++) {
+                totalUserTokenBalance += exchange.balanceOf(_actors[i], address(_tokens[t]));
+            }
+            if (dexTokenBalance > totalUserTokenBalance + tokenEscrowed[t]) {
+                dust += dexTokenBalance - totalUserTokenBalance - tokenEscrowed[t];
+            }
+        }
     }
 
     /// @notice Computes expected escrowed amounts by iterating through all orders
@@ -868,13 +922,25 @@ contract StablecoinDEXInvariantTest is BaseTest {
             quotedOut = 0;
         }
 
+        // TEMPO-DEX18: Record dust before swap
+        _dustBeforeSwap = _computeDust();
+
         vm.recordLogs();
         try exchange.swapExactAmountIn(
             before.tokenIn, before.tokenOut, amount, amount - 100
         ) returns (
             uint128 amountOut
         ) {
-            _maxDust += _countOrderFilledEvents();
+            uint64 ordersFilled = _countOrderFilledEvents();
+            _maxDust += ordersFilled;
+
+            // TEMPO-DEX18: Each swap can increase dust by at most 1 per order filled
+            uint256 dustAfterSwap = _computeDust();
+            assertLe(
+                dustAfterSwap,
+                _dustBeforeSwap + ordersFilled,
+                "TEMPO-DEX18: swap increased dust by more than 1 per order filled"
+            );
             // TEMPO-DEX4: amountOut >= minAmountOut
             assertTrue(
                 amountOut >= amount - 100, "TEMPO-DEX4: swap exact amountOut less than minAmountOut"
@@ -927,13 +993,26 @@ contract StablecoinDEXInvariantTest is BaseTest {
             quotedIn = 0;
         }
 
+        // TEMPO-DEX18: Record dust before swap
+        _dustBeforeSwap = _computeDust();
+
         vm.recordLogs();
         try exchange.swapExactAmountOut(
             before.tokenIn, before.tokenOut, amount, amount + 100
         ) returns (
             uint128 amountIn
         ) {
-            _maxDust += _countOrderFilledEvents();
+            uint64 ordersFilled = _countOrderFilledEvents();
+            _maxDust += ordersFilled;
+
+            // TEMPO-DEX18: Each swap can increase dust by at most 1 per order filled
+            uint256 dustAfterSwap = _computeDust();
+            assertLe(
+                dustAfterSwap,
+                _dustBeforeSwap + ordersFilled,
+                "TEMPO-DEX18: swap increased dust by more than 1 per order filled"
+            );
+
             // TEMPO-DEX5: amountIn <= maxAmountIn
             assertTrue(
                 amountIn <= amount + 100, "TEMPO-DEX5: swap exact amountIn greater than maxAmountIn"
@@ -1135,49 +1214,19 @@ contract StablecoinDEXInvariantTest is BaseTest {
             || selector == IStablecoinDEX.InsufficientBalance.selector
             || selector == IStablecoinDEX.PairDoesNotExist.selector
             || selector == IStablecoinDEX.IdenticalTokens.selector
-            || selector == IStablecoinDEX.InvalidToken.selector
-            || selector == ITIP20.InsufficientBalance.selector
-            || selector == ITIP20.PolicyForbids.selector;
+            || selector == IStablecoinDEX.InvalidToken.selector || _isKnownTIP20Error(selector);
         assertTrue(isKnownError, "Swap failed with unknown error");
     }
 
-    /// @notice Creates test actors with initial balances and approvals
-    /// @dev Each actor gets funded and approves the exchange for both tokens
-    /// @param noOfActors_ Number of actors to create
-    /// @return actorsAddress Array of created actor addresses
-    function _buildActors(uint256 noOfActors_) internal returns (address[] memory) {
-        address[] memory actorsAddress = new address[](noOfActors_);
-
-        for (uint256 i = 0; i < noOfActors_; i++) {
-            address actor = makeAddr(string(abi.encodePacked("Actor", vm.toString(i))));
-            actorsAddress[i] = actor;
-
-            // initial actor balance for all tokens
-            _ensureFundsAll(actor, 1_000_000_000_000);
-
-            vm.startPrank(actor);
-            // Approve all base tokens and pathUSD for the exchange
-            for (uint256 j = 0; j < _tokens.length; j++) {
-                _tokens[j].approve(address(exchange), type(uint256).max);
-            }
-            pathUSD.approve(address(exchange), type(uint256).max);
-            vm.stopPrank();
-        }
-
-        return actorsAddress;
-    }
-
-    /// @dev Selects a token from all available tokens (base tokens + pathUSD)
-    /// @param rnd Random seed for selection
-    /// @return The selected token address
-    function _selectToken(uint256 rnd) internal view returns (address) {
-        // Pool of tokens: pathUSD + all base tokens
-        uint256 totalTokens = _tokens.length + 1;
-        uint256 index = rnd % totalTokens;
-        if (index == 0) {
-            return address(pathUSD);
-        }
-        return address(_tokens[index - 1]);
+    /// @notice Verifies an order operation revert is due to a known/expected error
+    /// @dev Fails if the error selector doesn't match any known order error
+    /// @param reason The revert reason bytes from the failed operation
+    function _assertKnownOrderError(bytes memory reason) internal pure {
+        bytes4 selector = bytes4(reason);
+        bool isKnownError = selector == IStablecoinDEX.OrderDoesNotExist.selector
+            || selector == IStablecoinDEX.InsufficientBalance.selector
+            || selector == IStablecoinDEX.PairDoesNotExist.selector || _isKnownTIP20Error(selector);
+        assertTrue(isKnownError, "Order operation failed with unknown error");
     }
 
     /// @dev Returns the number of hops in a trade path (similar to findTradePath in StablecoinDEX)
@@ -1193,70 +1242,13 @@ contract StablecoinDEXInvariantTest is BaseTest {
         return 2;
     }
 
-    /// @notice Ensures an actor has sufficient token balances for testing
-    /// @dev Mints tokens if actor's balance is below the required amount
-    /// @param actor The actor address to fund
-    /// @param token The token to mint (base token for asks, pathUSD for bids)
-    /// @param amount The minimum balance required
-    function _ensureFunds(address actor, TIP20 token, uint256 amount) internal {
-        vm.startPrank(admin);
-        if (token.balanceOf(address(actor)) < amount) {
-            token.mint(actor, amount + 100_000_000);
-        }
-        vm.stopPrank();
-    }
-
-    /// @notice Ensures an actor has sufficient balances for all tokens (used in setUp)
-    /// @dev Mints pathUSD and all base tokens if actor's balance is below the required amount
-    /// @param actor The actor address to fund
-    /// @param amount The minimum balance required
-    function _ensureFundsAll(address actor, uint256 amount) internal {
-        vm.startPrank(admin);
-        if (pathUSD.balanceOf(address(actor)) < amount) {
-            pathUSD.mint(actor, amount + 100_000_000);
-        }
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            if (_tokens[i].balanceOf(address(actor)) < amount) {
-                _tokens[i].mint(actor, amount + 100_000_000);
-            }
-        }
-        vm.stopPrank();
-    }
-
     /*//////////////////////////////////////////////////////////////
                               LOGGING
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Logs an action message to the exchange.log file
-    function _log(string memory message) internal {
-        vm.writeLine(LOG_FILE, message);
-    }
-
     /// @dev Logs exchange balances for all tokens
     function _logBalances() internal {
-        string memory balanceStr = string.concat(
-            "DEX balances: pathUSD=", vm.toString(pathUSD.balanceOf(address(exchange)))
-        );
-        for (uint256 t = 0; t < _tokens.length; t++) {
-            balanceStr = string.concat(
-                balanceStr,
-                ", ",
-                _tokens[t].symbol(),
-                "=",
-                vm.toString(_tokens[t].balanceOf(address(exchange)))
-            );
-        }
-        _log(balanceStr);
-    }
-
-    /// @dev Gets actor index from address for logging
-    function _getActorIndex(address actor) internal view returns (string memory) {
-        for (uint256 i = 0; i < _actors.length; i++) {
-            if (_actors[i] == actor) {
-                return string.concat("Actor", vm.toString(i));
-            }
-        }
-        return vm.toString(actor);
+        _logContractBalances(address(exchange), "DEX");
     }
 
     /// @dev Helper to log order placement to avoid stack too deep


### PR DESCRIPTION
## Summary

Introduce shared test infrastructure for invariant testing of FeeAMM and StablecoinDEX.

## Changes

- **InvariantBaseTest.t.sol** (new): Shared base contract with:
  - Actor management (`_buildActors`, `_buildActorsWithApprovals`, `_selectActor`)
  - Token selection (`_selectToken`, `_selectBaseToken`, `_getTokenSymbol`)
  - Funding helpers (`_ensureFunds`, `_ensureFundsAll`)
  - Policy helpers (`_getPolicyId`, `_getPolicyAdmin`, `_isAuthorized`, `_setBlacklist`)
  - Logging utilities (`_log`, `_logContractBalances`, `_getActorIndex`)
  - Error handling (`_isKnownTIP20Error`, `_isKnownFeeAMMError`, `_isKnownDEXError`, etc.)

- **FeeAMM.t.sol**: Refactored to extend InvariantBaseTest, removing duplicated setup code

- **StablecoinDEX.t.sol**: Refactored to extend InvariantBaseTest, removing duplicated setup code

- **README.md**: Updated with FeeAMM and StablecoinDEX invariant documentation

## Context

This is the **first PR** in a series to split up the invariant test infrastructure. This PR keeps InvariantBaseTest minimal with only the helpers needed by FeeAMM and StablecoinDEX.

Subsequent PRs will add:
- AccountKeychain invariant tests
- Nonce invariant tests
- TIP20 invariant tests
- TIP20Factory invariant tests
- TIP403Registry invariant tests
- ValidatorConfig invariant tests

Each subsequent PR will extend InvariantBaseTest with additional helpers as needed.

## Testing

```bash
cd docs/specs && forge build --contracts test/invariants/
cd docs/specs && forge test --match-contract FeeAMMInvariantTest
cd docs/specs && forge test --match-contract StablecoinDEXInvariantTest
```