### PR TITLE
feat(specs): add TIP20 and TIP20Factory invariant tests

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ ignore = [
   "RUSTSEC-2026-0002",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0003 cmov timing on ARM32 - we don't target ARM32
+  "RUSTSEC-2026-0003",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/docs/specs/test/BaseTest.t.sol
+++ b/docs/specs/test/BaseTest.t.sol
@@ -32,6 +32,7 @@ contract BaseTest is Test {
     bytes32 internal constant _ISSUER_ROLE = keccak256("ISSUER_ROLE");
     bytes32 internal constant _PAUSE_ROLE = keccak256("PAUSE_ROLE");
     bytes32 internal constant _UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+    bytes32 internal constant _BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
     bytes32 internal constant _TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
     bytes32 internal constant _RECEIVE_WITH_MEMO_ROLE = keccak256("RECEIVE_WITH_MEMO_ROLE");
 

--- a/docs/specs/test/invariants/README.md
+++ b/docs/specs/test/invariants/README.md
@@ -136,3 +136,85 @@ The FeeManager extends FeeAMM and handles fee token preferences and distribution
 
 - **TEMPO-FEE5**: Collected fees should not exceed AMM token balance for any token.
 - **TEMPO-FEE6**: Fee swap rate M is correctly applied - fee output should always be <= fee input.
+
+## TIP20
+
+TIP20 is the Tempo token standard that extends ERC-20 with transfer policies, memo support, pause functionality, and reward distribution.
+
+### Transfer Invariants
+
+- **TEMPO-TIP1**: Balance conservation - sender balance decreases by exactly `amount`, recipient balance increases by exactly `amount`. Transfer returns `true` on success.
+- **TEMPO-TIP2**: Total supply unchanged after transfer - transfers only move tokens between accounts.
+- **TEMPO-TIP3**: Allowance consumption - `transferFrom` decreases allowance by exactly `amount` transferred.
+- **TEMPO-TIP4**: Infinite allowance preserved - `type(uint256).max` allowance remains infinite after `transferFrom`.
+- **TEMPO-TIP9**: Memo transfers behave identically to regular transfers for balance accounting.
+
+### Approval Invariants
+
+- **TEMPO-TIP5**: Allowance setting - `approve` sets exact allowance amount, returns `true`.
+
+### Mint/Burn Invariants
+
+- **TEMPO-TIP6**: Minting increases total supply and recipient balance by exactly `amount`.
+- **TEMPO-TIP7**: Supply cap enforcement - minting reverts if `totalSupply + amount > supplyCap`.
+- **TEMPO-TIP8**: Burning decreases total supply and burner balance by exactly `amount`.
+- **TEMPO-TIP23**: Burn blocked - `burnBlocked` decreases target balance and total supply by exactly `amount` when target is blacklisted.
+
+### Reward Distribution Invariants
+
+- **TEMPO-TIP10**: Reward recipient setting - `setRewardRecipient` updates the stored recipient correctly.
+- **TEMPO-TIP11**: Opted-in supply tracking - `optedInSupply` increases when opting in (by holder's balance) and decreases when opting out.
+- **TEMPO-TIP25**: Reward delegation - users can delegate their rewards to another address via `setRewardRecipient`.
+- **TEMPO-TIP12**: Global reward per token updates - `distributeReward` increases `globalRewardPerToken` by `(amount * ACC_PRECISION) / optedInSupply`.
+- **TEMPO-TIP13**: Reward token custody - distributed rewards are transferred to the token contract.
+- **TEMPO-TIP14**: Reward claiming - `claimRewards` transfers owed amount from contract to caller, updates balances correctly.
+- **TEMPO-TIP15**: Claim bounded by available - claimed amount cannot exceed contract's token balance.
+
+### Policy Invariants
+
+- **TEMPO-TIP16**: Blacklist enforcement - transfers to/from blacklisted addresses revert with `PolicyForbids`.
+- **TEMPO-TIP17**: Pause enforcement - transfers revert with `ContractPaused` when paused.
+
+### Global Invariants
+
+- **TEMPO-TIP18**: Supply conservation - `totalSupply = initialSupply + totalMints - totalBurns`.
+- **TEMPO-TIP19**: Opted-in supply bounded - `optedInSupply <= totalSupply`.
+- **TEMPO-TIP20**: Balance sum equals supply - sum of all holder balances equals `totalSupply`.
+- **TEMPO-TIP21**: Decimals constant - `decimals()` always returns 6.
+- **TEMPO-TIP22**: Supply cap enforced - `totalSupply <= supplyCap` always holds.
+
+### Protected Address Invariants
+
+- **TEMPO-TIP24**: Protected address enforcement - `burnBlocked` cannot be called on FeeManager or DEX addresses (reverts with `ProtectedAddress`).
+
+### Access Control Invariants
+
+- **TEMPO-TIP26**: Issuer-only minting - only accounts with `ISSUER_ROLE` can call `mint` (non-issuers revert with `Unauthorized`).
+- **TEMPO-TIP27**: Pause-role enforcement - only accounts with `PAUSE_ROLE` can call `pause` (non-role holders revert with `Unauthorized`).
+- **TEMPO-TIP28**: Unpause-role enforcement - only accounts with `UNPAUSE_ROLE` can call `unpause` (non-role holders revert with `Unauthorized`).
+- **TEMPO-TIP29**: Burn-blocked-role enforcement - only accounts with `BURN_BLOCKED_ROLE` can call `burnBlocked` (non-role holders revert with `Unauthorized`).
+
+## TIP20Factory
+
+The TIP20Factory is the factory contract for creating TIP-20 compliant tokens with deterministic addresses.
+
+### Token Creation Invariants
+
+- **TEMPO-FAC1**: Deterministic addresses - `createToken` deploys to the exact address returned by `getTokenAddress` for the same sender/salt combination.
+- **TEMPO-FAC2**: TIP20 recognition - all tokens created by the factory are recognized as TIP-20 by `isTIP20()`.
+- **TEMPO-FAC3**: Address uniqueness - attempting to create a token at an existing address reverts with `TokenAlreadyExists`.
+- **TEMPO-FAC4**: Quote token validation - `createToken` reverts with `InvalidQuoteToken` if the quote token is not a valid TIP-20.
+- **TEMPO-FAC5**: Reserved address enforcement - addresses in the reserved range (lower 64 bits < 1024) revert with `AddressReserved`.
+- **TEMPO-FAC6**: Token properties - created tokens have correct name, symbol, and currency as specified.
+- **TEMPO-FAC7**: Currency consistency - USD tokens must have USD quote tokens; non-USD tokens can have any valid quote token.
+
+### Address Prediction Invariants
+
+- **TEMPO-FAC8**: isTIP20 consistency - created tokens return true, non-TIP20 addresses return false.
+- **TEMPO-FAC9**: Address determinism - `getTokenAddress(sender, salt)` always returns the same address for the same inputs.
+- **TEMPO-FAC10**: Sender differentiation - different senders with the same salt produce different token addresses.
+
+### Global Invariants
+
+- **TEMPO-FAC11**: Address format - all created tokens have addresses with the correct TIP-20 prefix (`0x20C0...`).
+- **TEMPO-FAC12**: Salt-to-token consistency - ghost mappings `saltToToken` and `tokenToSalt` match factory's `getTokenAddress` for all tracked sender/salt combinations.

--- a/docs/specs/test/invariants/TIP20.t.sol
+++ b/docs/specs/test/invariants/TIP20.t.sol
@@ -1,0 +1,1339 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { TIP20 } from "../../src/TIP20.sol";
+import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
+
+/// @title TIP20 Invariant Tests
+/// @notice Fuzz-based invariant tests for the TIP20 token implementation
+/// @dev Tests invariants TEMPO-TIP1 through TEMPO-TIP22 as documented in README.md
+contract TIP20InvariantTest is InvariantBaseTest {
+
+    /// @dev Log file path for recording actions
+    string private constant LOG_FILE = "tip20.log";
+
+    /// @dev Ghost variables for tracking operations
+    uint256 private _totalTransfers;
+    uint256 private _totalMints;
+    uint256 private _totalBurns;
+    uint256 private _totalApprovals;
+
+    /// @dev Ghost variables for reward distribution tracking
+    uint256 private _totalRewardsDistributed;
+    uint256 private _totalRewardsClaimed;
+    uint256 private _ghostRewardInputSum;
+    uint256 private _ghostRewardClaimSum;
+
+    /// @dev Track total supply changes for conservation check
+    mapping(address => uint256) private _tokenMintSum;
+    mapping(address => uint256) private _tokenBurnSum;
+
+    /// @dev Track rewards distributed per token for conservation invariant
+    mapping(address => uint256) private _tokenRewardsDistributed;
+    mapping(address => uint256) private _tokenRewardsClaimed;
+
+    /// @dev Track distribution count and opted-in holder count for tighter dust bounds
+    mapping(address => uint256) private _tokenDistributionCount;
+    mapping(address => uint256) private _tokenOptedInHolderCount;
+
+    /// @dev Track all addresses that have held tokens (per token)
+    mapping(address => mapping(address => bool)) private _tokenHolderSeen;
+    mapping(address => address[]) private _tokenHolders;
+
+    /// @dev Constants
+    uint256 internal constant ACC_PRECISION = 1e18;
+
+    /// @dev Register an address as a potential token holder
+    function _registerHolder(address token, address holder) internal {
+        if (!_tokenHolderSeen[token][holder]) {
+            _tokenHolderSeen[token][holder] = true;
+            _tokenHolders[token].push(holder);
+        }
+    }
+
+    /// @notice Sets up the test environment
+    function setUp() public override {
+        super.setUp();
+
+        targetContract(address(this));
+
+        _setupInvariantBase();
+        _actors = _buildActors(20);
+
+        // Track initial mints from _buildActors
+        // _ensureFundsAll mints (amount + 100_000_000) per actor when balance < amount
+        // = 1_000_000_000_000 + 100_000_000 = 1_000_100_000_000 per actor
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            _tokenMintSum[address(_tokens[i])] = 20 * 1_000_100_000_000;
+        }
+
+        // Register all initially known addresses for each token
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            address tokenAddr = address(_tokens[i]);
+
+            // Register actors
+            for (uint256 j = 0; j < _actors.length; j++) {
+                _registerHolder(tokenAddr, _actors[j]);
+            }
+
+            // Register system addresses
+            _registerHolder(tokenAddr, admin);
+            _registerHolder(tokenAddr, tokenAddr); // token contract itself
+            _registerHolder(tokenAddr, address(amm));
+            _registerHolder(tokenAddr, address(exchange));
+            _registerHolder(tokenAddr, address(pathUSD));
+            _registerHolder(tokenAddr, alice);
+            _registerHolder(tokenAddr, bob);
+            _registerHolder(tokenAddr, charlie);
+            _registerHolder(tokenAddr, pathUSDAdmin);
+        }
+
+        _initLogFile(LOG_FILE, "TIP20 Invariant Test Log");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            FUZZ HANDLERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Handler for token transfers
+    /// @dev Tests TEMPO-TIP1 (balance conservation), TEMPO-TIP2 (transfer events)
+    function transfer(uint256 actorSeed, uint256 tokenSeed, uint256 recipientSeed, uint256 amount)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        address recipient = _selectActor(recipientSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(actor != recipient);
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance > 0);
+
+        amount = bound(amount, 1, actorBalance);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(_isAuthorized(address(token), recipient));
+        vm.assume(!token.paused());
+
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+        uint256 totalSupplyBefore = token.totalSupply();
+
+        vm.startPrank(actor);
+        try token.transfer(recipient, amount) returns (bool success) {
+            vm.stopPrank();
+            assertTrue(success, "TEMPO-TIP1: Transfer should return true");
+
+            _totalTransfers++;
+            _registerHolder(address(token), actor);
+            _registerHolder(address(token), recipient);
+
+            // TEMPO-TIP1: Balance conservation
+            assertEq(
+                token.balanceOf(actor),
+                actorBalance - amount,
+                "TEMPO-TIP1: Sender balance not decreased correctly"
+            );
+            assertEq(
+                token.balanceOf(recipient),
+                recipientBalanceBefore + amount,
+                "TEMPO-TIP1: Recipient balance not increased correctly"
+            );
+
+            // TEMPO-TIP2: Total supply unchanged
+            assertEq(
+                token.totalSupply(),
+                totalSupplyBefore,
+                "TEMPO-TIP2: Total supply changed during transfer"
+            );
+
+            _log(
+                string.concat(
+                    "TRANSFER: ",
+                    _getActorIndex(actor),
+                    " -> ",
+                    _getActorIndex(recipient),
+                    " ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol()
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for transferFrom with allowance
+    /// @dev Tests TEMPO-TIP3 (allowance consumption), TEMPO-TIP4 (infinite allowance)
+    function transferFrom(
+        uint256 actorSeed,
+        uint256 tokenSeed,
+        uint256 ownerSeed,
+        uint256 recipientSeed,
+        uint256 amount
+    ) external {
+        address spender = _selectActor(actorSeed);
+        address owner = _selectActor(ownerSeed);
+        address recipient = _selectActor(recipientSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(owner != spender);
+        vm.assume(owner != recipient);
+
+        uint256 ownerBalance = token.balanceOf(owner);
+        vm.assume(ownerBalance > 0);
+
+        uint256 allowance = token.allowance(owner, spender);
+        vm.assume(allowance > 0);
+
+        amount = bound(amount, 1, ownerBalance < allowance ? ownerBalance : allowance);
+
+        vm.assume(_isAuthorized(address(token), owner));
+        vm.assume(_isAuthorized(address(token), recipient));
+        vm.assume(!token.paused());
+
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+        bool isInfiniteAllowance = allowance == type(uint256).max;
+
+        vm.startPrank(spender);
+        try token.transferFrom(owner, recipient, amount) returns (bool success) {
+            vm.stopPrank();
+            assertTrue(success, "TEMPO-TIP3: TransferFrom should return true");
+
+            _totalTransfers++;
+            _registerHolder(address(token), owner);
+            _registerHolder(address(token), recipient);
+
+            // TEMPO-TIP3/TIP4: Allowance handling
+            if (isInfiniteAllowance) {
+                assertEq(
+                    token.allowance(owner, spender),
+                    type(uint256).max,
+                    "TEMPO-TIP4: Infinite allowance should remain infinite"
+                );
+            } else {
+                assertEq(
+                    token.allowance(owner, spender),
+                    allowance - amount,
+                    "TEMPO-TIP3: Allowance not decreased correctly"
+                );
+            }
+
+            assertEq(
+                token.balanceOf(owner),
+                ownerBalance - amount,
+                "TEMPO-TIP3: Owner balance not decreased"
+            );
+            assertEq(
+                token.balanceOf(recipient),
+                recipientBalanceBefore + amount,
+                "TEMPO-TIP3: Recipient balance not increased"
+            );
+
+            _log(
+                string.concat(
+                    "TRANSFER_FROM: ",
+                    _getActorIndex(owner),
+                    " -> ",
+                    _getActorIndex(recipient),
+                    " via ",
+                    _getActorIndex(spender),
+                    " ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol()
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for approvals
+    /// @dev Tests TEMPO-TIP5 (allowance setting)
+    function approve(uint256 actorSeed, uint256 tokenSeed, uint256 spenderSeed, uint256 amount)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        address spender = _selectActor(spenderSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        amount = bound(amount, 0, type(uint128).max);
+
+        vm.startPrank(actor);
+        try token.approve(spender, amount) returns (bool success) {
+            vm.stopPrank();
+            assertTrue(success, "TEMPO-TIP5: Approve should return true");
+
+            _totalApprovals++;
+
+            assertEq(
+                token.allowance(actor, spender), amount, "TEMPO-TIP5: Allowance not set correctly"
+            );
+
+            _log(
+                string.concat(
+                    "APPROVE: ",
+                    _getActorIndex(actor),
+                    " approved ",
+                    _getActorIndex(spender),
+                    " for ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol()
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for minting tokens
+    /// @dev Tests TEMPO-TIP6 (supply increase), TEMPO-TIP7 (supply cap)
+    function mint(uint256 tokenSeed, uint256 recipientSeed, uint256 amount) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+        address recipient = _selectActor(recipientSeed);
+
+        uint256 currentSupply = token.totalSupply();
+        uint256 supplyCap = token.supplyCap();
+        uint256 remaining = supplyCap > currentSupply ? supplyCap - currentSupply : 0;
+
+        vm.assume(remaining > 0);
+        amount = bound(amount, 1, remaining);
+
+        vm.assume(_isAuthorized(address(token), recipient));
+
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+
+        vm.startPrank(admin);
+        try token.mint(recipient, amount) {
+            vm.stopPrank();
+
+            _totalMints++;
+            _tokenMintSum[address(token)] += amount;
+            _registerHolder(address(token), recipient);
+
+            // TEMPO-TIP6: Total supply should increase
+            assertEq(
+                token.totalSupply(),
+                currentSupply + amount,
+                "TEMPO-TIP6: Total supply not increased correctly"
+            );
+
+            // TEMPO-TIP7: Total supply should not exceed cap
+            assertLe(token.totalSupply(), supplyCap, "TEMPO-TIP7: Total supply exceeds supply cap");
+
+            assertEq(
+                token.balanceOf(recipient),
+                recipientBalanceBefore + amount,
+                "TEMPO-TIP6: Recipient balance not increased"
+            );
+
+            _log(
+                string.concat(
+                    "MINT: ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol(),
+                    " to ",
+                    _getActorIndex(recipient)
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for burning tokens
+    /// @dev Tests TEMPO-TIP8 (supply decrease)
+    function burn(uint256 tokenSeed, uint256 amount) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        uint256 adminBalance = token.balanceOf(admin);
+        vm.assume(adminBalance > 0);
+
+        amount = bound(amount, 1, adminBalance);
+
+        uint256 totalSupplyBefore = token.totalSupply();
+
+        vm.startPrank(admin);
+        try token.burn(amount) {
+            vm.stopPrank();
+
+            _totalBurns++;
+            _tokenBurnSum[address(token)] += amount;
+            _registerHolder(address(token), admin);
+
+            // TEMPO-TIP8: Total supply should decrease
+            assertEq(
+                token.totalSupply(),
+                totalSupplyBefore - amount,
+                "TEMPO-TIP8: Total supply not decreased correctly"
+            );
+
+            assertEq(
+                token.balanceOf(admin),
+                adminBalance - amount,
+                "TEMPO-TIP8: Admin balance not decreased"
+            );
+
+            _log(string.concat("BURN: ", vm.toString(amount), " ", token.symbol()));
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for transfer with memo
+    /// @dev Tests TEMPO-TIP9 (memo transfers work like regular transfers)
+    function transferWithMemo(
+        uint256 actorSeed,
+        uint256 tokenSeed,
+        uint256 recipientSeed,
+        uint256 amount,
+        bytes32 memo
+    ) external {
+        address actor = _selectActor(actorSeed);
+        address recipient = _selectActor(recipientSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(actor != recipient);
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance > 0);
+
+        amount = bound(amount, 1, actorBalance);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(_isAuthorized(address(token), recipient));
+        vm.assume(!token.paused());
+
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+        uint256 totalSupplyBefore = token.totalSupply();
+
+        vm.startPrank(actor);
+        try token.transferWithMemo(recipient, amount, memo) {
+            vm.stopPrank();
+
+            _totalTransfers++;
+            _registerHolder(address(token), actor);
+            _registerHolder(address(token), recipient);
+
+            // TEMPO-TIP9: Balance changes same as regular transfer
+            assertEq(
+                token.balanceOf(actor),
+                actorBalance - amount,
+                "TEMPO-TIP9: Sender balance not decreased"
+            );
+            assertEq(
+                token.balanceOf(recipient),
+                recipientBalanceBefore + amount,
+                "TEMPO-TIP9: Recipient balance not increased"
+            );
+            assertEq(token.totalSupply(), totalSupplyBefore, "TEMPO-TIP9: Total supply changed");
+
+            _log(
+                string.concat(
+                    "TRANSFER_WITH_MEMO: ",
+                    _getActorIndex(actor),
+                    " -> ",
+                    _getActorIndex(recipient),
+                    " ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol()
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for setting reward recipient (opt-in, opt-out, or delegate)
+    /// @dev Tests TEMPO-TIP10 (opted-in supply), TEMPO-TIP11 (supply updates), TEMPO-TIP25 (delegation)
+    function setRewardRecipient(uint256 actorSeed, uint256 tokenSeed, uint256 recipientSeed)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // 0 = opt-out, 1 = opt-in to self, 2+ = delegate to another actor
+        uint256 choice = recipientSeed % 3;
+        address newRecipient;
+        if (choice == 0) {
+            newRecipient = address(0);
+        } else if (choice == 1) {
+            newRecipient = actor;
+        } else {
+            newRecipient = _selectActor(recipientSeed);
+            if (newRecipient == actor) newRecipient = _selectActor(recipientSeed + 1);
+        }
+
+        vm.assume(_isAuthorized(address(token), actor));
+        if (newRecipient != address(0)) {
+            vm.assume(_isAuthorized(address(token), newRecipient));
+        }
+        vm.assume(!token.paused());
+
+        (address currentRecipient,,) = token.userRewardInfo(actor);
+        uint256 actorBalance = token.balanceOf(actor);
+        uint128 optedInSupplyBefore = token.optedInSupply();
+        bool isDelegation = newRecipient != address(0) && newRecipient != actor;
+
+        vm.startPrank(actor);
+        try token.setRewardRecipient(newRecipient) {
+            vm.stopPrank();
+
+            _registerHolder(address(token), actor);
+            if (newRecipient != address(0)) {
+                _registerHolder(address(token), newRecipient);
+            }
+
+            (address storedRecipient,,) = token.userRewardInfo(actor);
+
+            assertEq(storedRecipient, newRecipient, "Reward recipient not set correctly");
+
+            // Opted-in supply should update correctly
+            uint128 optedInSupplyAfter = token.optedInSupply();
+            if (currentRecipient == address(0) && newRecipient != address(0)) {
+                assertEq(
+                    optedInSupplyAfter,
+                    optedInSupplyBefore + uint128(actorBalance),
+                    "Opted-in supply not increased"
+                );
+                _tokenOptedInHolderCount[address(token)]++;
+            } else if (currentRecipient != address(0) && newRecipient == address(0)) {
+                assertEq(
+                    optedInSupplyAfter,
+                    optedInSupplyBefore - uint128(actorBalance),
+                    "Opted-in supply not decreased"
+                );
+                if (_tokenOptedInHolderCount[address(token)] > 0) {
+                    _tokenOptedInHolderCount[address(token)]--;
+                }
+            }
+
+            if (isDelegation) {
+                _log(
+                    string.concat(
+                        "DELEGATE_REWARDS: ",
+                        _getActorIndex(actor),
+                        " delegated to ",
+                        _getActorIndex(newRecipient),
+                        " on ",
+                        token.symbol()
+                    )
+                );
+            } else {
+                _log(
+                    string.concat(
+                        "SET_REWARD_RECIPIENT: ",
+                        _getActorIndex(actor),
+                        " -> ",
+                        newRecipient != address(0) ? _getActorIndex(newRecipient) : "NONE",
+                        " on ",
+                        token.symbol()
+                    )
+                );
+            }
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for distributing rewards
+    /// @dev Tests TEMPO-TIP12, TEMPO-TIP13
+    function distributeReward(uint256 actorSeed, uint256 tokenSeed, uint256 amount) external {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance > 0);
+
+        amount = bound(amount, 1, actorBalance);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(!token.paused());
+
+        uint128 optedInSupply = token.optedInSupply();
+        vm.assume(optedInSupply > 0);
+
+        uint256 globalRPTBefore = token.globalRewardPerToken();
+        uint256 tokenBalanceBefore = token.balanceOf(address(token));
+
+        vm.startPrank(actor);
+        try token.distributeReward(amount) {
+            vm.stopPrank();
+
+            _totalRewardsDistributed++;
+            _ghostRewardInputSum += amount;
+            _tokenRewardsDistributed[address(token)] += amount;
+            _tokenDistributionCount[address(token)]++;
+            _registerHolder(address(token), actor);
+            _registerHolder(address(token), address(token));
+
+            // TEMPO-TIP12: Global reward per token should increase by exact floor division
+            // Formula: delta = floor(amount * ACC_PRECISION / optedInSupply)
+            uint256 globalRPTAfter = token.globalRewardPerToken();
+            uint256 expectedDelta = (amount * ACC_PRECISION) / optedInSupply;
+            assertEq(
+                globalRPTAfter,
+                globalRPTBefore + expectedDelta,
+                "TEMPO-TIP12: globalRewardPerToken delta must equal floor(amount * ACC_PRECISION / optedInSupply)"
+            );
+
+            // TEMPO-TIP13: Tokens should be transferred to the token contract
+            assertEq(
+                token.balanceOf(address(token)),
+                tokenBalanceBefore + amount,
+                "TEMPO-TIP13: Tokens not transferred to contract"
+            );
+
+            _log(
+                string.concat(
+                    "DISTRIBUTE_REWARD: ",
+                    _getActorIndex(actor),
+                    " distributed ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol()
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for distributing tiny rewards where delta == 0
+    /// @dev Tests TEMPO-TIP12 edge case: when amount << optedInSupply, delta is 0
+    function distributeRewardTiny(uint256 actorSeed, uint256 tokenSeed) external {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(!token.paused());
+
+        uint128 optedInSupply = token.optedInSupply();
+        vm.assume(optedInSupply > ACC_PRECISION); // Ensure division will result in 0
+
+        // Use amount = 1 where delta = floor(1 * ACC_PRECISION / optedInSupply) = 0
+        uint256 amount = 1;
+        uint256 expectedDelta = (amount * ACC_PRECISION) / optedInSupply;
+        vm.assume(expectedDelta == 0); // Confirm this is indeed a zero-delta case
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance >= amount);
+
+        uint256 globalRPTBefore = token.globalRewardPerToken();
+
+        vm.startPrank(actor);
+        try token.distributeReward(amount) {
+            vm.stopPrank();
+
+            _registerHolder(address(token), actor);
+            _registerHolder(address(token), address(token));
+
+            // TEMPO-TIP12: When delta == 0, globalRewardPerToken must stay constant
+            uint256 globalRPTAfter = token.globalRewardPerToken();
+            assertEq(
+                globalRPTAfter,
+                globalRPTBefore,
+                "TEMPO-TIP12: Zero-delta distribution should not change globalRewardPerToken"
+            );
+
+            _log(
+                string.concat(
+                    "DISTRIBUTE_REWARD_TINY: ",
+                    _getActorIndex(actor),
+                    " distributed 1 ",
+                    token.symbol(),
+                    " (delta=0)"
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for attempting to distribute rewards when optedInSupply == 0
+    /// @dev Tests TEMPO-TIP12 edge case: must revert with NoOptedInSupply when nobody is opted in
+    function distributeRewardZeroOptedIn(uint256 actorSeed, uint256 tokenSeed) external {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(!token.paused());
+
+        uint128 optedInSupply = token.optedInSupply();
+        vm.assume(optedInSupply == 0); // Only test when nobody is opted in
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance >= 1000);
+
+        vm.startPrank(actor);
+        try token.distributeReward(1000) {
+            vm.stopPrank();
+            revert("TEMPO-TIP12: distributeReward should revert when optedInSupply == 0");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            assertEq(
+                bytes4(reason),
+                ITIP20.NoOptedInSupply.selector,
+                "TEMPO-TIP12: Should revert with NoOptedInSupply when optedInSupply == 0"
+            );
+        }
+
+        _log(
+            string.concat(
+                "DISTRIBUTE_REWARD_ZERO_OPTED: ",
+                _getActorIndex(actor),
+                " correctly rejected on ",
+                token.symbol()
+            )
+        );
+    }
+
+    /// @notice Handler for claiming rewards
+    /// @dev Tests TEMPO-TIP14, TEMPO-TIP15
+    function claimRewards(uint256 actorSeed, uint256 tokenSeed) external {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(_isAuthorized(address(token), actor));
+        vm.assume(_isAuthorized(address(token), address(token)));
+        vm.assume(!token.paused());
+
+        (,, uint256 rewardBalance) = token.userRewardInfo(actor);
+        uint256 actorBalanceBefore = token.balanceOf(actor);
+        uint256 contractBalanceBefore = token.balanceOf(address(token));
+
+        vm.startPrank(actor);
+        try token.claimRewards() returns (uint256 claimed) {
+            vm.stopPrank();
+
+            _registerHolder(address(token), actor);
+
+            if (rewardBalance > 0 || claimed > 0) {
+                _totalRewardsClaimed++;
+                _ghostRewardClaimSum += claimed;
+                _tokenRewardsClaimed[address(token)] += claimed;
+            }
+
+            // TEMPO-TIP14: Actor should receive claimed amount
+            assertEq(
+                token.balanceOf(actor),
+                actorBalanceBefore + claimed,
+                "TEMPO-TIP14: Actor balance not increased by claimed amount"
+            );
+
+            assertEq(
+                token.balanceOf(address(token)),
+                contractBalanceBefore - claimed,
+                "TEMPO-TIP14: Contract balance not decreased"
+            );
+
+            // TEMPO-TIP15: Claimed amount should not exceed available
+            assertLe(
+                claimed, contractBalanceBefore, "TEMPO-TIP15: Claimed more than contract balance"
+            );
+
+            if (claimed > 0) {
+                _log(
+                    string.concat(
+                        "CLAIM_REWARDS: ",
+                        _getActorIndex(actor),
+                        " claimed ",
+                        vm.toString(claimed),
+                        " ",
+                        token.symbol()
+                    )
+                );
+            }
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for burning tokens from blocked accounts
+    /// @dev Tests TEMPO-TIP23 (burnBlocked functionality)
+    function burnBlocked(uint256 tokenSeed, uint256 targetSeed, uint256 amount) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+        address target = _selectActor(targetSeed);
+
+        // Ensure target is blacklisted for this test
+        uint64 policyId = _tokenPolicyIds[address(token)];
+        bool isBlacklisted = !registry.isAuthorized(policyId, target);
+        vm.assume(isBlacklisted);
+
+        uint256 targetBalance = token.balanceOf(target);
+        vm.assume(targetBalance > 0);
+
+        amount = bound(amount, 1, targetBalance);
+
+        uint256 totalSupplyBefore = token.totalSupply();
+
+        vm.startPrank(admin);
+        token.grantRole(_BURN_BLOCKED_ROLE, admin);
+        try token.burnBlocked(target, amount) {
+            vm.stopPrank();
+
+            _totalBurns++;
+            _tokenBurnSum[address(token)] += amount;
+            _registerHolder(address(token), target);
+
+            // TEMPO-TIP23: Balance should decrease
+            assertEq(
+                token.balanceOf(target),
+                targetBalance - amount,
+                "TEMPO-TIP23: Target balance not decreased"
+            );
+
+            // TEMPO-TIP23: Total supply should decrease
+            assertEq(
+                token.totalSupply(),
+                totalSupplyBefore - amount,
+                "TEMPO-TIP23: Total supply not decreased"
+            );
+
+            _log(
+                string.concat(
+                    "BURN_BLOCKED: ",
+                    vm.toString(amount),
+                    " ",
+                    token.symbol(),
+                    " from ",
+                    _getActorIndex(target)
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for attempting burnBlocked on protected addresses
+    /// @dev Tests TEMPO-TIP24 (protected addresses cannot be burned from)
+    function burnBlockedProtectedAddress(uint256 tokenSeed, uint256 amount) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        amount = bound(amount, 1, 1_000_000);
+
+        address feeManager = 0xfeEC000000000000000000000000000000000000;
+        address dex = 0xDEc0000000000000000000000000000000000000;
+
+        vm.startPrank(admin);
+        token.grantRole(_BURN_BLOCKED_ROLE, admin);
+
+        // Try to burn from FeeManager - should revert with ProtectedAddress
+        try token.burnBlocked(feeManager, amount) {
+            vm.stopPrank();
+            revert("TEMPO-TIP24: Should revert for FeeManager");
+        } catch (bytes memory reason) {
+            assertEq(
+                bytes4(reason),
+                ITIP20.ProtectedAddress.selector,
+                "TEMPO-TIP24: Should revert with ProtectedAddress for FeeManager"
+            );
+        }
+
+        // Try to burn from DEX - should revert with ProtectedAddress
+        try token.burnBlocked(dex, amount) {
+            vm.stopPrank();
+            revert("TEMPO-TIP24: Should revert for DEX");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            assertEq(
+                bytes4(reason),
+                ITIP20.ProtectedAddress.selector,
+                "TEMPO-TIP24: Should revert with ProtectedAddress for DEX"
+            );
+        }
+    }
+
+    /// @notice Handler for unauthorized mint attempts
+    /// @dev Tests TEMPO-TIP26 (only ISSUER_ROLE can mint)
+    function mintUnauthorized(uint256 actorSeed, uint256 tokenSeed, uint256 amount) external {
+        address attacker = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Ensure attacker doesn't have ISSUER_ROLE
+        vm.assume(!token.hasRole(attacker, _ISSUER_ROLE));
+
+        amount = bound(amount, 1, 1_000_000);
+
+        vm.startPrank(attacker);
+        try token.mint(attacker, amount) {
+            vm.stopPrank();
+            revert("TEMPO-TIP26: Non-issuer should not be able to mint");
+        } catch {
+            vm.stopPrank();
+            // Expected to revert - access control enforced
+        }
+    }
+
+    /// @notice Handler for unauthorized pause attempts
+    /// @dev Tests TEMPO-TIP27 (only PAUSE_ROLE can pause)
+    function pauseUnauthorized(uint256 actorSeed, uint256 tokenSeed) external {
+        address attacker = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Ensure attacker doesn't have PAUSE_ROLE
+        vm.assume(!token.hasRole(attacker, _PAUSE_ROLE));
+        vm.assume(!token.paused());
+
+        vm.startPrank(attacker);
+        try token.pause() {
+            vm.stopPrank();
+            revert("TEMPO-TIP27: Non-pause-role should not be able to pause");
+        } catch {
+            vm.stopPrank();
+            // Expected to revert - access control enforced
+        }
+    }
+
+    /// @notice Handler for unauthorized unpause attempts
+    /// @dev Tests TEMPO-TIP28 (only UNPAUSE_ROLE can unpause)
+    function unpauseUnauthorized(uint256 actorSeed, uint256 tokenSeed) external {
+        address attacker = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Ensure attacker doesn't have UNPAUSE_ROLE
+        vm.assume(!token.hasRole(attacker, _UNPAUSE_ROLE));
+        vm.assume(token.paused());
+
+        vm.startPrank(attacker);
+        try token.unpause() {
+            vm.stopPrank();
+            revert("TEMPO-TIP28: Non-unpause-role should not be able to unpause");
+        } catch {
+            vm.stopPrank();
+            // Expected to revert - access control enforced
+        }
+    }
+
+    /// @notice Handler for unauthorized burnBlocked attempts
+    /// @dev Tests TEMPO-TIP29 (only BURN_BLOCKED_ROLE can call burnBlocked)
+    function burnBlockedUnauthorized(
+        uint256 actorSeed,
+        uint256 tokenSeed,
+        uint256 targetSeed,
+        uint256 amount
+    ) external {
+        address attacker = _selectActor(actorSeed);
+        address target = _selectActor(targetSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Ensure attacker doesn't have BURN_BLOCKED_ROLE
+        vm.assume(!token.hasRole(attacker, _BURN_BLOCKED_ROLE));
+
+        uint256 targetBalance = token.balanceOf(target);
+        vm.assume(targetBalance > 0);
+        amount = bound(amount, 1, targetBalance);
+
+        vm.startPrank(attacker);
+        try token.burnBlocked(target, amount) {
+            vm.stopPrank();
+            revert("TEMPO-TIP29: Non-burn-blocked-role should not be able to call burnBlocked");
+        } catch {
+            vm.stopPrank();
+            // Expected to revert - access control enforced
+        }
+    }
+
+    /// @notice Handler for changing transfer policy ID
+    /// @dev Tests that only admin can change policy, and policy must exist
+    function changeTransferPolicyId(uint256 tokenSeed, uint256 policySeed) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Select from special policies (0, 1) or created policies
+        uint64 newPolicyId;
+        if (policySeed % 3 == 0) {
+            newPolicyId = 0; // always-reject
+        } else if (policySeed % 3 == 1) {
+            newPolicyId = 1; // always-allow
+        } else {
+            // Use the token's current policy or a nearby valid one
+            newPolicyId = uint64(policySeed % 10) + 2;
+        }
+
+        uint64 currentPolicyId = token.transferPolicyId();
+
+        vm.startPrank(admin);
+        try token.changeTransferPolicyId(newPolicyId) {
+            vm.stopPrank();
+
+            assertEq(token.transferPolicyId(), newPolicyId, "Transfer policy ID not updated");
+
+            _log(
+                string.concat(
+                    "CHANGE_POLICY: ",
+                    token.symbol(),
+                    " policy ",
+                    vm.toString(currentPolicyId),
+                    " -> ",
+                    vm.toString(newPolicyId)
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            // Expected if policy doesn't exist
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for unauthorized policy change attempts
+    /// @dev Tests that non-admin cannot change transfer policy
+    function changeTransferPolicyIdUnauthorized(uint256 actorSeed, uint256 tokenSeed) external {
+        address attacker = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Ensure attacker is not admin
+        vm.assume(!token.hasRole(attacker, bytes32(0))); // DEFAULT_ADMIN_ROLE
+
+        vm.startPrank(attacker);
+        try token.changeTransferPolicyId(1) {
+            vm.stopPrank();
+            revert("Non-admin should not change policy");
+        } catch {
+            vm.stopPrank();
+            // Expected - access control enforced
+        }
+    }
+
+    /// @notice Handler for quote token updates
+    /// @dev Tests setNextQuoteToken and completeQuoteTokenUpdate
+    function updateQuoteToken(uint256 tokenSeed, uint256 quoteTokenSeed) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Skip pathUSD - it cannot change quote token
+        vm.assume(address(token) != address(pathUSD));
+
+        // Select a different token as potential new quote
+        TIP20 newQuoteToken = _selectBaseToken(quoteTokenSeed);
+        vm.assume(address(newQuoteToken) != address(token));
+
+        // For USD tokens, quote must also be USD
+        bool isUsdToken = keccak256(bytes(token.currency())) == keccak256(bytes("USD"));
+        if (isUsdToken) {
+            bool isUsdQuote = keccak256(bytes(newQuoteToken.currency())) == keccak256(bytes("USD"));
+            vm.assume(isUsdQuote);
+        }
+
+        vm.startPrank(admin);
+        try token.setNextQuoteToken(ITIP20(address(newQuoteToken))) {
+            // Next quote token should be set
+            assertEq(
+                address(token.nextQuoteToken()), address(newQuoteToken), "Next quote token not set"
+            );
+
+            // Try to complete the update
+            try token.completeQuoteTokenUpdate() {
+                vm.stopPrank();
+
+                // Quote token should be updated
+                assertEq(
+                    address(token.quoteToken()), address(newQuoteToken), "Quote token not updated"
+                );
+
+                _log(string.concat("UPDATE_QUOTE_TOKEN: ", token.symbol(), " quote changed"));
+            } catch (bytes memory reason) {
+                vm.stopPrank();
+                // Cycle detection may reject
+                bytes4 selector = bytes4(reason);
+                assertTrue(
+                    selector == ITIP20.InvalidQuoteToken.selector,
+                    "Unexpected error on completeQuoteTokenUpdate"
+                );
+            }
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for unauthorized quote token update attempts
+    /// @dev Tests that non-admin cannot change quote token
+    function updateQuoteTokenUnauthorized(uint256 actorSeed, uint256 tokenSeed) external {
+        address attacker = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.assume(address(token) != address(pathUSD));
+        vm.assume(!token.hasRole(attacker, bytes32(0))); // DEFAULT_ADMIN_ROLE
+
+        vm.startPrank(attacker);
+        try token.setNextQuoteToken(ITIP20(address(pathUSD))) {
+            vm.stopPrank();
+            revert("Non-admin should not set quote token");
+        } catch {
+            vm.stopPrank();
+            // Expected - access control enforced
+        }
+    }
+
+    /// @notice Handler for toggling blacklist
+    /// @dev Tests TEMPO-TIP16 (blacklist enforcement)
+    function toggleBlacklist(uint256 actorSeed, uint256 tokenSeed, bool blacklist) external {
+        address actor = _selectActor(actorSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Only toggle for actors 0-4
+        vm.assume(actorSeed % _actors.length < 5);
+
+        bool currentlyAuthorized = _isAuthorized(address(token), actor);
+
+        if (blacklist && !currentlyAuthorized) return;
+        if (!blacklist && currentlyAuthorized) return;
+
+        _setBlacklist(address(token), actor, blacklist);
+
+        // TEMPO-TIP16: Authorization status should be updated
+        bool afterAuthorized = _isAuthorized(address(token), actor);
+        assertEq(afterAuthorized, !blacklist, "TEMPO-TIP16: Blacklist status not updated correctly");
+
+        _log(
+            string.concat(
+                "TOGGLE_BLACKLIST: ",
+                _getActorIndex(actor),
+                " ",
+                blacklist ? "BLACKLISTED" : "UNBLACKLISTED",
+                " on ",
+                token.symbol()
+            )
+        );
+    }
+
+    /// @notice Handler for pause/unpause
+    /// @dev Tests TEMPO-TIP17 (pause enforcement)
+    function togglePause(uint256 tokenSeed, bool pause) external {
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        vm.startPrank(admin);
+        token.grantRole(_PAUSE_ROLE, admin);
+        token.grantRole(_UNPAUSE_ROLE, admin);
+
+        if (pause && !token.paused()) {
+            token.pause();
+            assertTrue(token.paused(), "TEMPO-TIP17: Token should be paused");
+        } else if (!pause && token.paused()) {
+            token.unpause();
+            assertFalse(token.paused(), "TEMPO-TIP17: Token should be unpaused");
+        }
+        vm.stopPrank();
+
+        _log(string.concat("TOGGLE_PAUSE: ", token.symbol(), " ", pause ? "PAUSED" : "UNPAUSED"));
+    }
+
+    /// @notice Handler that verifies paused tokens reject transfers
+    /// @dev Tests that pause actually blocks operations
+    function tryTransferWhilePaused(uint256 actorSeed, uint256 tokenSeed, uint256 recipientSeed)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+        address recipient = _selectActor(recipientSeed);
+        TIP20 token = _selectBaseToken(tokenSeed);
+
+        // Only test when token is paused
+        vm.assume(token.paused());
+        vm.assume(actor != recipient);
+
+        uint256 actorBalance = token.balanceOf(actor);
+        vm.assume(actorBalance > 0);
+
+        vm.startPrank(actor);
+        try token.transfer(recipient, 1) {
+            vm.stopPrank();
+            revert("Transfer should fail when paused");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+
+        _log(
+            string.concat(
+                "TRY_TRANSFER_PAUSED: ",
+                _getActorIndex(actor),
+                " blocked on paused ",
+                token.symbol()
+            )
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         GLOBAL INVARIANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Run all invariant checks
+    function invariant_globalInvariants() public view {
+        _invariantOptedInSupplyBounded();
+        _invariantDecimalsConstant();
+        _invariantSupplyCapEnforced();
+        _invariantRewardsConservation();
+        _invariantQuoteTokenAcyclic();
+        _invariantPauseBlocksTransfers();
+        _invariantSupplyConservation();
+        _invariantBalanceSumEqualsSupply();
+    }
+
+    /// @notice TEMPO-TIP19: Opted-in supply <= total supply
+    function _invariantOptedInSupplyBounded() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+            assertLe(
+                token.optedInSupply(),
+                token.totalSupply(),
+                "TEMPO-TIP19: Opted-in supply exceeds total supply"
+            );
+        }
+    }
+
+    /// @notice TEMPO-TIP21: Decimals is always 6
+    function _invariantDecimalsConstant() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            assertEq(_tokens[i].decimals(), 6, "TEMPO-TIP21: Decimals should always be 6");
+        }
+    }
+
+    /// @notice TEMPO-TIP22: Supply cap is enforced
+    function _invariantSupplyCapEnforced() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+            assertLe(
+                token.totalSupply(),
+                token.supplyCap(),
+                "TEMPO-TIP22: Total supply exceeds supply cap"
+            );
+        }
+    }
+
+    /// @notice Rewards conservation: claimed <= distributed, dust bounded by O(holders * distributions)
+    function _invariantRewardsConservation() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+            address tokenAddr = address(token);
+            uint256 distributed = _tokenRewardsDistributed[tokenAddr];
+            uint256 claimed = _tokenRewardsClaimed[tokenAddr];
+
+            assertLe(claimed, distributed, "Rewards claimed exceeds distributed");
+            if (distributed == 0) continue;
+
+            uint256 contractBalance = token.balanceOf(address(token));
+            uint256 expectedUnclaimed = distributed - claimed;
+
+            // Max dust = distributions * holders (1 unit per holder per distribution due to floor)
+            uint256 maxDust = _tokenDistributionCount[tokenAddr]
+                * (_tokenOptedInHolderCount[tokenAddr] > 0
+                        ? _tokenOptedInHolderCount[tokenAddr]
+                        : 1);
+
+            if (expectedUnclaimed > maxDust) {
+                assertGe(
+                    contractBalance,
+                    expectedUnclaimed - maxDust,
+                    "Reward dust exceeds theoretical bound"
+                );
+            }
+        }
+    }
+
+    /// @notice Quote token graph must be acyclic
+    function _invariantQuoteTokenAcyclic() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+
+            // Walk the quote token chain, should terminate without cycle
+            ITIP20 current = token.quoteToken();
+            uint256 maxDepth = 20;
+            uint256 depth = 0;
+
+            while (address(current) != address(0) && depth < maxDepth) {
+                // Should never point back to itself
+                assertTrue(address(current) != address(token), "Quote token cycle detected");
+                current = current.quoteToken();
+                depth++;
+            }
+
+            // Should not hit max depth (indicates infinite loop)
+            assertLt(depth, maxDepth, "Quote token chain too deep (possible cycle)");
+        }
+    }
+
+    /// @notice When paused, token state should reflect pause
+    function _invariantPauseBlocksTransfers() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+
+            // If paused, verify pause state is consistent
+            if (token.paused()) {
+                // Pause state should be true
+                assertTrue(token.paused(), "Paused token reports unpaused");
+            }
+        }
+    }
+
+    /// @notice TEMPO-TIP18: Supply conservation - totalSupply = mints - burns per token
+    function _invariantSupplyConservation() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+            address tokenAddr = address(token);
+
+            // _tokenMintSum includes the initial supply from _buildActors (set in setUp)
+            uint256 expectedSupply = _tokenMintSum[tokenAddr] - _tokenBurnSum[tokenAddr];
+
+            assertEq(
+                token.totalSupply(), expectedSupply, "TEMPO-TIP18: Supply conservation violated"
+            );
+        }
+    }
+
+    /// @notice TEMPO-TIP20: Balance sum equals supply - sum of all holder balances equals totalSupply
+    /// @dev Iterates over all dynamically tracked token holders to ensure no balances are missed.
+    function _invariantBalanceSumEqualsSupply() internal view {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            TIP20 token = _tokens[i];
+            address tokenAddr = address(token);
+            uint256 balanceSum = 0;
+
+            address[] storage holders = _tokenHolders[tokenAddr];
+            for (uint256 j = 0; j < holders.length; j++) {
+                balanceSum += token.balanceOf(holders[j]);
+            }
+
+            assertEq(
+                balanceSum,
+                token.totalSupply(),
+                "TEMPO-TIP20: Balance sum does not equal totalSupply"
+            );
+        }
+    }
+
+    /// @notice Verify operation counters are consistent
+    /// @dev Counters should reflect operations that were successfully executed
+    function _invariantOperationCountersPositive() internal view {
+        // At minimum, we should have some operations from setup
+        // This just validates the counters are being maintained
+        assertTrue(
+            _totalTransfers + _totalMints + _totalBurns + _totalApprovals >= 0,
+            "Operation counters should be non-negative"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Checks if an error is known/expected
+    function _assertKnownError(bytes memory reason) internal pure {
+        assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
+    }
+
+}

--- a/docs/specs/test/invariants/TIP20Factory.t.sol
+++ b/docs/specs/test/invariants/TIP20Factory.t.sol
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { TIP20 } from "../../src/TIP20.sol";
+import { TIP20Factory } from "../../src/TIP20Factory.sol";
+import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+import { ITIP20Factory } from "../../src/interfaces/ITIP20Factory.sol";
+import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
+
+/// @title TIP20Factory Invariant Tests
+/// @notice Fuzz-based invariant tests for the TIP20Factory implementation
+/// @dev Tests invariants TEMPO-FAC1 through TEMPO-FAC10 as documented in README.md
+contract TIP20FactoryInvariantTest is InvariantBaseTest {
+
+    /// @dev Log file path for recording actions
+    string private constant LOG_FILE = "tip20_factory.log";
+
+    /// @dev Ghost variables for tracking operations
+    uint256 private _totalTokensCreated;
+    uint256 private _totalReservedAttempts;
+    uint256 private _totalDuplicateAttempts;
+    uint256 private _totalInvalidQuoteAttempts;
+
+    /// @dev Track created tokens and their properties
+    address[] private _createdTokens;
+    mapping(address => bool) private _isCreatedToken;
+    mapping(bytes32 => address) private _saltToToken;
+    mapping(address => bytes32) private _tokenToSalt;
+
+    /// @dev Track salts used by each sender
+    mapping(address => bytes32[]) private _senderSalts;
+
+    /// @notice Sets up the test environment
+    function setUp() public override {
+        super.setUp();
+
+        targetContract(address(this));
+
+        _setupInvariantBase();
+        _actors = _buildActors(10);
+
+        _initLogFile(LOG_FILE, "TIP20Factory Invariant Test Log");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            FUZZ HANDLERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Handler for creating tokens
+    /// @dev Tests TEMPO-FAC1 (deterministic addresses), TEMPO-FAC2 (address uniqueness)
+    function createToken(uint256 actorSeed, bytes32 salt, uint256 nameIdx, uint256 symbolIdx)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+
+        // Generate varied names and symbols
+        string memory name = _generateName(nameIdx);
+        string memory symbol = _generateSymbol(symbolIdx);
+
+        // Predict the address before creation
+        address predictedAddr;
+        try factory.getTokenAddress(actor, salt) returns (address addr) {
+            predictedAddr = addr;
+        } catch (bytes memory reason) {
+            // TEMPO-FAC5: Reserved address range is enforced
+            if (bytes4(reason) == ITIP20Factory.AddressReserved.selector) {
+                _totalReservedAttempts++;
+                _log(
+                    string.concat(
+                        "CREATE_TOKEN_RESERVED: ",
+                        _getActorIndex(actor),
+                        " salt=",
+                        vm.toString(salt)
+                    )
+                );
+                return;
+            }
+            revert("Unknown error in getTokenAddress");
+        }
+
+        // Check if token already exists at this address
+        if (predictedAddr.code.length != 0) {
+            vm.startPrank(actor);
+            try factory.createToken(name, symbol, "USD", pathUSD, admin, salt) {
+                vm.stopPrank();
+                revert("TEMPO-FAC3: Should revert for existing token");
+            } catch (bytes memory reason) {
+                vm.stopPrank();
+                if (bytes4(reason) == ITIP20Factory.TokenAlreadyExists.selector) {
+                    _totalDuplicateAttempts++;
+                    _log(
+                        string.concat(
+                            "CREATE_TOKEN_EXISTS: ",
+                            _getActorIndex(actor),
+                            " at ",
+                            vm.toString(predictedAddr)
+                        )
+                    );
+                    return;
+                }
+            }
+            return;
+        }
+
+        vm.startPrank(actor);
+        try factory.createToken(name, symbol, "USD", pathUSD, admin, salt) returns (
+            address tokenAddr
+        ) {
+            vm.stopPrank();
+
+            _totalTokensCreated++;
+            _createdTokens.push(tokenAddr);
+            _isCreatedToken[tokenAddr] = true;
+
+            bytes32 uniqueKey = keccak256(abi.encode(actor, salt));
+            _saltToToken[uniqueKey] = tokenAddr;
+            _tokenToSalt[tokenAddr] = salt;
+            _senderSalts[actor].push(salt);
+
+            // TEMPO-FAC1: Created address matches predicted address
+            assertEq(
+                tokenAddr,
+                predictedAddr,
+                "TEMPO-FAC1: Created address does not match predicted address"
+            );
+
+            // TEMPO-FAC2: Token is recognized as TIP20
+            assertTrue(
+                factory.isTIP20(tokenAddr), "TEMPO-FAC2: Created token not recognized as TIP20"
+            );
+
+            // TEMPO-FAC6: Token has correct properties
+            TIP20 newToken = TIP20(tokenAddr);
+            assertEq(
+                keccak256(bytes(newToken.name())),
+                keccak256(bytes(name)),
+                "TEMPO-FAC6: Token name mismatch"
+            );
+            assertEq(
+                keccak256(bytes(newToken.symbol())),
+                keccak256(bytes(symbol)),
+                "TEMPO-FAC6: Token symbol mismatch"
+            );
+            assertEq(
+                keccak256(bytes(newToken.currency())),
+                keccak256(bytes("USD")),
+                "TEMPO-FAC6: Token currency mismatch"
+            );
+
+            _log(
+                string.concat(
+                    "CREATE_TOKEN: ",
+                    _getActorIndex(actor),
+                    " created ",
+                    symbol,
+                    " at ",
+                    vm.toString(tokenAddr)
+                )
+            );
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for creating tokens with invalid quote token
+    /// @dev Tests TEMPO-FAC4 (quote token validation)
+    function createTokenInvalidQuote(uint256 actorSeed, bytes32 salt) external {
+        address actor = _selectActor(actorSeed);
+
+        // Use a non-TIP20 address as quote token
+        address invalidQuote = makeAddr("InvalidQuote");
+
+        vm.startPrank(actor);
+        try factory.createToken("Test", "TST", "USD", ITIP20(invalidQuote), admin, salt) {
+            vm.stopPrank();
+            revert("TEMPO-FAC4: Should revert for invalid quote token");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            if (bytes4(reason) == ITIP20Factory.InvalidQuoteToken.selector) {
+                _totalInvalidQuoteAttempts++;
+                _log(
+                    string.concat(
+                        "CREATE_TOKEN_INVALID_QUOTE: ", _getActorIndex(actor), " with invalid quote"
+                    )
+                );
+            } else {
+                _assertKnownError(reason);
+            }
+        }
+    }
+
+    /// @notice Handler for creating tokens with mismatched currency
+    /// @dev Tests TEMPO-FAC7 (currency/quote token consistency)
+    function createTokenMismatchedCurrency(uint256 actorSeed, bytes32 salt, uint256 currencyIdx)
+        external
+    {
+        address actor = _selectActor(actorSeed);
+
+        // Use a non-USD currency with a USD quote token
+        string memory currency = _generateNonUsdCurrency(currencyIdx);
+
+        // This should succeed - non-USD tokens can have USD quote tokens
+        // But USD tokens must have USD quote tokens
+        vm.startPrank(actor);
+        try factory.createToken("Test", "TST", currency, pathUSD, admin, salt) returns (
+            address tokenAddr
+        ) {
+            vm.stopPrank();
+
+            if (tokenAddr != address(0)) {
+                _createdTokens.push(tokenAddr);
+                _isCreatedToken[tokenAddr] = true;
+
+                TIP20 newToken = TIP20(tokenAddr);
+                assertEq(
+                    keccak256(bytes(newToken.currency())),
+                    keccak256(bytes(currency)),
+                    "TEMPO-FAC7: Currency mismatch"
+                );
+
+                _log(
+                    string.concat(
+                        "CREATE_TOKEN_NON_USD: ", _getActorIndex(actor), " currency=", currency
+                    )
+                );
+            }
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+        }
+    }
+
+    /// @notice Handler for attempting to create USD token with non-USD quote
+    /// @dev Tests TEMPO-FAC12 (USD tokens must have USD quote tokens)
+    function createUsdTokenWithNonUsdQuote(uint256 actorSeed, bytes32 salt) external {
+        address actor = _selectActor(actorSeed);
+
+        // First create a non-USD token to use as quote
+        bytes32 eurSalt = keccak256(abi.encode(salt, "EUR"));
+        address eurToken;
+
+        vm.startPrank(actor);
+        try factory.createToken("EUR Token", "EUR", "EUR", pathUSD, admin, eurSalt) returns (
+            address addr
+        ) {
+            eurToken = addr;
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            _assertKnownError(reason);
+            return; // Can't proceed if EUR token creation failed
+        }
+        vm.stopPrank();
+
+        // Now try to create a USD token with EUR quote - should fail
+        bytes32 usdSalt = keccak256(abi.encode(salt, "USD_WITH_EUR"));
+
+        vm.startPrank(actor);
+        try factory.createToken("Bad USD", "BUSD", "USD", ITIP20(eurToken), admin, usdSalt) {
+            vm.stopPrank();
+            revert("TEMPO-FAC12: USD token with non-USD quote should fail");
+        } catch (bytes memory reason) {
+            vm.stopPrank();
+            // Expected - USD tokens must have USD quote tokens
+            assertEq(
+                bytes4(reason),
+                ITIP20Factory.InvalidQuoteToken.selector,
+                "TEMPO-FAC12: Should revert with InvalidQuoteToken"
+            );
+            _log(
+                string.concat(
+                    "CREATE_USD_WITH_NON_USD_QUOTE: ", _getActorIndex(actor), " correctly rejected"
+                )
+            );
+        }
+    }
+
+    /// @notice Handler for verifying isTIP20 on random addresses
+    /// @dev Tests TEMPO-FAC8 (isTIP20 consistency)
+    function checkIsTIP20(uint256 addrSeed) external view {
+        address checkAddr;
+
+        if (addrSeed % 3 == 0 && _createdTokens.length > 0) {
+            // Check a created token
+            checkAddr = _createdTokens[addrSeed % _createdTokens.length];
+            assertTrue(factory.isTIP20(checkAddr), "TEMPO-FAC8: Created token should be TIP20");
+        } else if (addrSeed % 3 == 1) {
+            // Check pathUSD (known TIP20)
+            assertTrue(factory.isTIP20(address(pathUSD)), "TEMPO-FAC8: pathUSD should be TIP20");
+        } else {
+            // Check a random non-TIP20 address
+            checkAddr = address(uint160(addrSeed));
+            // Skip addresses in TIP20 range
+            if ((uint160(checkAddr) >> 64) != 0x20C000000000000000000000) {
+                assertFalse(
+                    factory.isTIP20(checkAddr), "TEMPO-FAC8: Random address should not be TIP20"
+                );
+            }
+        }
+    }
+
+    /// @notice Handler for verifying getTokenAddress determinism
+    /// @dev Tests TEMPO-FAC9 (address prediction is deterministic)
+    function verifyAddressDeterminism(uint256 actorSeed, bytes32 salt) external view {
+        address actor = _selectActor(actorSeed);
+
+        try factory.getTokenAddress(actor, salt) returns (address addr1) {
+            address addr2 = factory.getTokenAddress(actor, salt);
+
+            // TEMPO-FAC9: Same inputs always produce same output
+            assertEq(addr1, addr2, "TEMPO-FAC9: getTokenAddress not deterministic");
+
+            // TEMPO-FAC10: Different senders produce different addresses
+            address otherActor = _selectActor(actorSeed + 1);
+            if (actor != otherActor) {
+                try factory.getTokenAddress(otherActor, salt) returns (address otherAddr) {
+                    assertTrue(
+                        addr1 != otherAddr,
+                        "TEMPO-FAC10: Different senders should produce different addresses"
+                    );
+                } catch (bytes memory reason) {
+                    _assertKnownError(reason);
+                }
+            }
+        } catch (bytes memory reason) {
+            _assertKnownError(reason);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         GLOBAL INVARIANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Run all invariant checks
+    function invariant_globalInvariants() public view {
+        _invariantAllCreatedTokensAreTIP20();
+        _invariantAddressUniqueness();
+        _invariantAddressFormat();
+        _invariantUsdTokensHaveUsdQuote();
+        _invariantSaltToTokenConsistency();
+    }
+
+    /// @notice TEMPO-FAC2: All created tokens are recognized as TIP20
+    function _invariantAllCreatedTokensAreTIP20() internal view {
+        for (uint256 i = 0; i < _createdTokens.length; i++) {
+            assertTrue(
+                factory.isTIP20(_createdTokens[i]),
+                "TEMPO-FAC2: Created token not recognized as TIP20"
+            );
+        }
+    }
+
+    /// @notice TEMPO-FAC3: All created token addresses are unique
+    function _invariantAddressUniqueness() internal view {
+        for (uint256 i = 0; i < _createdTokens.length; i++) {
+            for (uint256 j = i + 1; j < _createdTokens.length; j++) {
+                assertTrue(
+                    _createdTokens[i] != _createdTokens[j],
+                    "TEMPO-FAC3: Duplicate token addresses found"
+                );
+            }
+        }
+    }
+
+    /// @notice TEMPO-FAC11: All created tokens have correct address format
+    function _invariantAddressFormat() internal view {
+        for (uint256 i = 0; i < _createdTokens.length; i++) {
+            address token = _createdTokens[i];
+            uint160 addrValue = uint160(token);
+            uint96 prefix = uint96(addrValue >> 64);
+
+            assertEq(
+                prefix,
+                0x20C000000000000000000000,
+                "TEMPO-FAC11: Token address has incorrect prefix"
+            );
+        }
+    }
+
+    /// @notice TEMPO-FAC12: USD tokens must have USD quote tokens
+    function _invariantUsdTokensHaveUsdQuote() internal view {
+        for (uint256 i = 0; i < _createdTokens.length; i++) {
+            TIP20 token = TIP20(_createdTokens[i]);
+
+            // Check if this is a USD token
+            if (keccak256(bytes(token.currency())) == keccak256(bytes("USD"))) {
+                // Its quote token must also be USD
+                ITIP20 quote = token.quoteToken();
+                if (address(quote) != address(0)) {
+                    assertEq(
+                        keccak256(bytes(TIP20(address(quote)).currency())),
+                        keccak256(bytes("USD")),
+                        "TEMPO-FAC12: USD token has non-USD quote token"
+                    );
+                }
+            }
+        }
+    }
+
+    /// @notice TEMPO-FAC1: Salt-to-token mapping is consistent with factory
+    function _invariantSaltToTokenConsistency() internal view {
+        for (uint256 i = 0; i < _actors.length; i++) {
+            address actor = _actors[i];
+            bytes32[] memory salts = _senderSalts[actor];
+
+            for (uint256 j = 0; j < salts.length; j++) {
+                bytes32 salt = salts[j];
+                bytes32 uniqueKey = keccak256(abi.encode(actor, salt));
+                address storedToken = _saltToToken[uniqueKey];
+
+                if (storedToken != address(0)) {
+                    // Verify factory returns same address
+                    address factoryAddr = factory.getTokenAddress(actor, salt);
+                    assertEq(
+                        storedToken,
+                        factoryAddr,
+                        "TEMPO-FAC1: Salt-to-token mapping inconsistent with factory"
+                    );
+
+                    // Verify reverse mapping
+                    assertEq(
+                        _tokenToSalt[storedToken],
+                        salt,
+                        "TEMPO-FAC1: Token-to-salt reverse mapping inconsistent"
+                    );
+                }
+            }
+        }
+    }
+
+    /// @notice Verify rejection counters are being tracked
+    /// @dev Ensures edge cases (reserved, duplicate, invalid quote) are being exercised
+    function _invariantRejectionCountersTracked() internal view {
+        // These counters validate that edge cases are being tested
+        // No specific assertion needed - just confirm they exist and are accessible
+        uint256 total =
+            _totalReservedAttempts + _totalDuplicateAttempts + _totalInvalidQuoteAttempts;
+        assertTrue(total >= 0, "Rejection counters should be non-negative");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Generates a token name based on index
+    function _generateName(uint256 idx) internal pure returns (string memory) {
+        string[5] memory names =
+            ["Token Alpha", "Token Beta", "Token Gamma", "Token Delta", "Token Epsilon"];
+        return names[idx % names.length];
+    }
+
+    /// @dev Generates a token symbol based on index
+    function _generateSymbol(uint256 idx) internal pure returns (string memory) {
+        string[5] memory symbols = ["TALP", "TBET", "TGAM", "TDEL", "TEPS"];
+        return symbols[idx % symbols.length];
+    }
+
+    /// @dev Generates a non-USD currency based on index
+    function _generateNonUsdCurrency(uint256 idx) internal pure returns (string memory) {
+        string[4] memory currencies = ["EUR", "GBP", "JPY", "CHF"];
+        return currencies[idx % currencies.length];
+    }
+
+    /// @dev Checks if an error is known/expected
+    function _assertKnownError(bytes memory reason) internal pure {
+        bytes4 selector = bytes4(reason);
+        bool isKnown = selector == ITIP20Factory.AddressReserved.selector
+            || selector == ITIP20Factory.InvalidQuoteToken.selector
+            || selector == ITIP20Factory.TokenAlreadyExists.selector;
+        assertTrue(isKnown, "Unknown error encountered");
+    }
+
+}


### PR DESCRIPTION
## Summary

Add invariant tests for TIP20 token standard and TIP20Factory.

## Changes

- **TIP20.t.sol**: Invariant tests for the TIP20 token implementation
  - Transfer invariants (TEMPO-TIP1-4, TIP9)
  - Approval invariants (TEMPO-TIP5)
  - Mint/Burn invariants (TEMPO-TIP6-8, TIP23)
  - Reward distribution invariants (TEMPO-TIP10-15, TIP25)
  - Policy invariants (TEMPO-TIP16-17)
  - Global invariants (TEMPO-TIP18-22)
  - Protected address invariants (TEMPO-TIP24)
  - Access control invariants (TEMPO-TIP26-29)

- **TIP20Factory.t.sol**: Invariant tests for the TIP20Factory
  - Token creation invariants (TEMPO-FAC1-7)
  - Address prediction invariants (TEMPO-FAC8-10)
  - Global invariants (TEMPO-FAC11-12)

- **BaseTest.t.sol**: Add `_BURN_BLOCKED_ROLE` constant

- **README.md**: Add TIP20 and TIP20Factory invariant documentation

## Dependencies

This PR is based on #2086 (InvariantBaseTest + FeeAMM + StablecoinDEX)

## Testing

```bash
cd docs/specs && forge test --match-contract TIP20InvariantTest
cd docs/specs && forge test --match-contract TIP20FactoryInvariantTest
```