### PR TITLE
feat: avoid extra copy in Block::read RLP decoding

### DIFF
--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -80,19 +80,30 @@ impl Read for Block {
             commonware_codec::Error::Wrapped("reading RLP header", rlp_err.into())
         })?;
 
-        if header.length_with_payload() > buf.remaining() {
+        let payload_len = header.length_with_payload();
+        if payload_len > buf.remaining() {
             // TODO: it would be nice to report more information here, but commonware_codex::Error does not
             // have the fidelity for it (outside abusing Error::Wrapped).
             return Err(commonware_codec::Error::EndOfBuffer);
         }
-        let bytes = buf.copy_to_bytes(header.length_with_payload());
-
-        // TODO: decode straight to a reth SealedBlock once released:
-        // https://github.com/paradigmxyz/reth/pull/18003
-        // For now relies on `Decodable for alloy_consensus::Block`.
-        let inner = alloy_rlp::Decodable::decode(&mut bytes.as_ref()).map_err(|rlp_err| {
-            commonware_codec::Error::Wrapped("reading RLP encoded block", rlp_err.into())
-        })?;
+        let decode_block = |input: &mut &[u8]| {
+            tempo_primitives::Block::decode_sealed(input).map(Into::into).map_err(|rlp_err| {
+                commonware_codec::Error::Wrapped("reading RLP encoded block", rlp_err.into())
+            })
+        };
+        let inner = if buf.chunk().len() >= payload_len {
+            let inner = {
+                let chunk = buf.chunk();
+                let mut slice = &chunk[..payload_len];
+                decode_block(&mut slice)?
+            };
+            buf.advance(payload_len);
+            inner
+        } else {
+            let bytes = buf.copy_to_bytes(payload_len);
+            let mut bytes_ref = bytes.as_ref();
+            decode_block(&mut bytes_ref)?
+        };
 
         Ok(Self::from_execution_block(inner))
     }


### PR DESCRIPTION
Optimize Block::read_cfg RLP decoding by using decode_sealed for zero-copy fast path when the payload is fully contained in the current buffer chunk.

This uses the new tempo_primitives::Block::decode_sealed method which computes the header hash directly from the raw RLP bytes, avoiding re-encoding after decoding.

Closes #1696

---

This is a finalized version of #1740 by @0xKarl98, rebased on main and squashed.