### PR TITLE
chore(deny): ignore RUSTSEC-2026-0003 cmov timing advisory (ARM32 not targeted)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ ignore = [
   "RUSTSEC-2026-0002",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0003 cmov timing on ARM32 - we don't target ARM32
+  "RUSTSEC-2026-0003",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Ignores RUSTSEC-2026-0003 which reports a timing side-channel in the `cmov` crate on ARM32. We don't target ARM32, so this advisory doesn't affect us.

https://rustsec.org/advisories/RUSTSEC-2026-0003