### PR TITLE
txpool: reduce LAST_SEEN_TOKENS_WINDOW from 100 to 10

### DIFF
--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -22,7 +22,7 @@ use tempo_primitives::TempoReceipt;
 use tempo_revm::IntoAddress;
 
 /// Number of recent validator tokens to track.
-const LAST_SEEN_TOKENS_WINDOW: usize = 100;
+const LAST_SEEN_TOKENS_WINDOW: usize = 10;
 
 #[derive(Debug, Clone)]
 pub struct AmmLiquidityCache {


### PR DESCRIPTION
Closes CHAIN-442
Closes CHAIN-491

## Summary

Reduces the window of validator fee tokens tracked by the AMM liquidity cache from 100 blocks to 10 blocks.

## Context

Per discussion in https://tempoxyz.slack.com/archives/C09PGSBNXFG/p1768507723481939 - this mitigates potential issues with illiquid fee tokens while validators are expected to choose liquid tokens.

This is an interim measure until a fully decentralized validator set requires revisiting token tracking for malicious validators.

## Changes

- `LAST_SEEN_TOKENS_WINDOW`: 100 → 10 in `crates/transaction-pool/src/amm.rs`