### PR TITLE
docs: add redirects for docs section root paths

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -59,6 +59,51 @@
       "source": "/stablecoin-exchange/:path*",
       "destination": "/stablecoin-dex/:path*",
       "permanent": true
+    },
+    {
+      "source": "/guide",
+      "destination": "/quickstart/integrate-tempo",
+      "permanent": false
+    },
+    {
+      "source": "/quickstart",
+      "destination": "/quickstart/integrate-tempo",
+      "permanent": false
+    },
+    {
+      "source": "/protocol/blockspace",
+      "destination": "/protocol/blockspace/overview",
+      "permanent": false
+    },
+    {
+      "source": "/protocol/tip20",
+      "destination": "/protocol/tip20/overview",
+      "permanent": false
+    },
+    {
+      "source": "/protocol/tip20-rewards",
+      "destination": "/protocol/tip20-rewards/overview",
+      "permanent": false
+    },
+    {
+      "source": "/protocol/tip403",
+      "destination": "/protocol/tip403/overview",
+      "permanent": false
+    },
+    {
+      "source": "/learn/use-cases",
+      "destination": "/learn/use-cases/remittances",
+      "permanent": false
+    },
+    {
+      "source": "/sdk/typescript/server",
+      "destination": "/sdk/typescript/server/handlers",
+      "permanent": false
+    },
+    {
+      "source": "/sdk/typescript/prool",
+      "destination": "/sdk/typescript/prool/setup",
+      "permanent": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds redirects so that visiting the root path of a docs section (e.g., `/protocol/tip20`) redirects to the overview/index page instead of returning a 404

**Redirects added:**
| Source | Destination |
|--------|-------------|
| `/guide` | `/quickstart/integrate-tempo` |
| `/quickstart` | `/quickstart/integrate-tempo` |
| `/protocol/blockspace` | `/protocol/blockspace/overview` |
| `/protocol/tip20` | `/protocol/tip20/overview` |
| `/protocol/tip20-rewards` | `/protocol/tip20-rewards/overview` |
| `/protocol/tip403` | `/protocol/tip403/overview` |
| `/learn/use-cases` | `/learn/use-cases/remittances` |
| `/sdk/typescript/server` | `/sdk/typescript/server/handlers` |
| `/sdk/typescript/prool` | `/sdk/typescript/prool/setup` |

## Test plan

- [ ] Deploy preview and verify each redirect works
- [ ] Confirm previously 404ing paths now redirect correctly