### PR TITLE
ci: add explicit permissions to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
           - "maxperf"
           - "profiling"
 
+permissions: {}
+
 concurrency:
   group: build-${{ github.head_ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -25,6 +27,8 @@ jobs:
   build:
     name: Build
     runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
     strategy:
       matrix:
         binary: [tempo, tempo-bench, tempo-sidecar]

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -8,6 +8,8 @@ on:
         type: string
         default: "profiling"
 
+permissions: {}
+
 env:
   REGISTRY: ghcr.io/tempoxyz
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,8 @@ on:
     - cron: "5 9 * * *"
     - cron: "30 20 * * *"
 
+permissions: {}
+
 env:
   REGISTRY: ghcr.io/tempoxyz
 

--- a/.github/workflows/docs-specs.yml
+++ b/.github/workflows/docs-specs.yml
@@ -15,6 +15,8 @@ on:
       - "crates/precompiles/**"
       - ".github/workflows/docs-specs.yml"
 
+permissions: {}
+
 env:
   FOUNDRY_PROFILE: ci
   CARGO_TERM_COLOR: always
@@ -24,6 +26,8 @@ jobs:
   build:
     name: Forge Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -42,6 +46,8 @@ jobs:
   lint:
     name: Forge Fmt
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -57,6 +63,8 @@ jobs:
   test:
     name: Forge Test (Solidity)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -72,6 +80,8 @@ jobs:
   tempo-foundry-test:
     name: Forge Test (Rust Precompiles)
     runs-on: depot-ubuntu-latest-8
+    permissions:
+      contents: read
     timeout-minutes: 60
     steps:
       - name: Checkout tempo

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened]
 
+permissions: {}
+
 jobs:
   label_prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   merge_group:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -19,6 +21,8 @@ jobs:
   clippy:
     name: clippy
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -35,6 +39,8 @@ jobs:
   fmt:
     name: fmt
     runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,6 +51,8 @@ jobs:
 
   crate-checks:
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
     timeout-minutes: 60
     if: github.event_name == 'push'
     strategy:
@@ -64,6 +72,10 @@ jobs:
   docs:
     name: docs
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -103,6 +115,8 @@ jobs:
 
   typos:
     runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -114,6 +128,8 @@ jobs:
   zepter:
     name: zepter
     runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ on:
         default: false
         type: boolean
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
@@ -48,6 +50,8 @@ jobs:
   check-version:
     name: check version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: get-version
     if: ${{ github.event.inputs.dry_run != 'true' }}
     steps:
@@ -66,6 +70,8 @@ jobs:
     name: Build Release Binaries
     needs: get-version
     runs-on: ${{ matrix.platform.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -193,6 +199,8 @@ jobs:
     needs: [get-version, build-release]
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   merge_group:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -19,6 +21,8 @@ jobs:
   genesis:
     name: Genesis generation
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,6 +50,8 @@ jobs:
   test:
     name: test
     runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -67,6 +73,8 @@ jobs:
   msrv:
     name: MSRV
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -83,6 +91,8 @@ jobs:
   snapshot-re-execute:
     name: Snapshot re-execution
     runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

Adds explicit permission declarations to all GitHub Actions workflows following the principle of least privilege.

:warning: Note that the selected permissions are at a best attempt, it may be possible that some workflow failure throws a hard failure if it requires more permissions (previously explicit).

## Changes

### Global permissions
Added `permissions: {}` at workflow level to disable all default permissions:
- build.yml
- docker.yml
- docker-profiling.yml
- docs.yml
- docs-specs.yml
- label-pr.yml
- lint.yml
- release.yml
- test.yml

### Job-level permissions
Added `permissions: { contents: read }` to all jobs that use `actions/checkout`:

| Workflow | Jobs |
|----------|------|
| **test.yml** | genesis, test, msrv, snapshot-re-execute |
| **lint.yml** | clippy, fmt, crate-checks, typos, zepter |
| **lint.yml** | docs (also needs `pages: write`, `id-token: write` for page upload) |
| **docs-specs.yml** | build, lint, test, tempo-foundry-test |
| **build.yml** | build |
| **release.yml** | check-version, build-release, upload-cloudflare |

### Preserved existing permissions
- **lint.yml deploy-docs**: `pages: write`, `id-token: write`
- **docker*.yml build-and-push**: `contents: read`, `packages: write`, `id-token: write`
- **release.yml create-release**: `contents: write`
- **label-pr.yml label_prs**: `contents: read`, `issues: write`, `pull-requests: write`

### Jobs without explicit permissions (inherit empty `{}`)
These jobs don't checkout or access repo contents:
- test-success, lint-success, docs-specs-success (just run alls-green)
- get-version in release.yml (just sets output)

## Security benefit
This change ensures workflows only have the minimum permissions required, reducing the attack surface if a workflow is compromised.