### PR TITLE
feat!: add currency limits

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -29,8 +29,8 @@ crate::sol! {
 
         /// Currency spending limit structure
         struct CurrencyLimit {
-            string currency;
             uint256 amount;
+            string currency;
         }
 
         /// Key information structure

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -25,9 +25,17 @@ impl Precompile for AccountKeychain {
                         self.update_spending_limit(sender, c)
                     })
                 }
+                IAccountKeychainCalls::updateCurrencyLimit(call) => {
+                    mutate_void(call, msg_sender, |sender, c| {
+                        self.update_currency_limit(sender, c)
+                    })
+                }
                 IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
                 IAccountKeychainCalls::getRemainingLimit(call) => {
                     view(call, |c| self.get_remaining_limit(c))
+                }
+                IAccountKeychainCalls::getRemainingCurrencyLimit(call) => {
+                    view(call, |c| self.get_remaining_currency_limit(c))
                 }
                 IAccountKeychainCalls::getTransactionKey(call) => {
                     view(call, |c| self.get_transaction_key(c, msg_sender))

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1268,12 +1268,12 @@ mod tests {
                 tokenLimits: vec![],
                 currencyLimits: vec![
                     CurrencyLimit {
+                        limit: U256::from(1000),
                         currency: "USD".to_string(),
-                        amount: U256::from(1000),
                     },
                     CurrencyLimit {
+                        limit: U256::from(500),
                         currency: "EUR".to_string(),
-                        amount: U256::from(500),
                     },
                 ],
             };
@@ -1371,8 +1371,8 @@ mod tests {
                 enforceLimits: true,
                 tokenLimits: vec![],
                 currencyLimits: vec![CurrencyLimit {
+                    limit: U256::from(1000),
                     currency: "USD".to_string(),
-                    amount: U256::from(1000),
                 }],
             };
             keychain.authorize_key(eoa, auth_call)?;
@@ -1480,8 +1480,8 @@ mod tests {
                 enforceLimits: true,
                 tokenLimits: vec![],
                 currencyLimits: vec![CurrencyLimit {
+                    limit: U256::from(500),
                     currency: "USD".to_string(),
-                    amount: U256::from(500),
                 }],
             };
             keychain.authorize_key(eoa, auth_call)?;
@@ -1612,8 +1612,8 @@ mod tests {
                     amount: U256::from(100),
                 }],
                 currencyLimits: vec![CurrencyLimit {
+                    limit: U256::from(1000),
                     currency: "USD".to_string(),
-                    amount: U256::from(1000),
                 }],
             };
             keychain.authorize_key(eoa, auth_call)?;
@@ -1671,8 +1671,8 @@ mod tests {
                 enforceLimits: true,
                 tokenLimits: vec![],
                 currencyLimits: vec![CurrencyLimit {
+                    limit: U256::from(1000),
                     currency: "USD".to_string(),
-                    amount: U256::from(1000),
                 }],
             };
             keychain.authorize_key(eoa, auth_call)?;

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -35,11 +35,11 @@ pub struct TokenLimit {
 #[cfg_attr(feature = "reth-codec", derive(reth_codecs::Compact))]
 #[cfg_attr(test, reth_codecs::add_arbitrary_tests(compact, rlp))]
 pub struct CurrencyLimit {
-    /// Currency code (e.g., "USD", "EUR", "GBP")
-    pub currency: String,
-
     /// Maximum spending amount in this currency (enforced over the key's lifetime)
     pub limit: U256,
+
+    /// Currency code (e.g., "USD", "EUR", "GBP")
+    pub currency: String,
 }
 
 /// Key authorization for provisioning access keys

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -848,7 +848,8 @@ where
                     signatureType: signature_type,
                     expiry,
                     enforceLimits: enforce_limits,
-                    limits: precompile_limits,
+                    tokenLimits: precompile_limits,
+                    currencyLimits: vec![],
                 };
 
                 // Call precompile to authorize the key (same phase as nonce increment)

--- a/docs/specs/src/interfaces/IAccountKeychain.sol
+++ b/docs/specs/src/interfaces/IAccountKeychain.sol
@@ -39,8 +39,8 @@ interface IAccountKeychain {
 
     /// @notice Currency spending limit structure
     struct CurrencyLimit {
-        string currency; // Currency code (e.g., "USD", "EUR", "GBP")
         uint256 amount; // Spending limit amount
+        string currency; // Currency code (e.g., "USD", "EUR", "GBP")
     }
 
     /// @notice Key information structure

--- a/docs/specs/test/AccountKeychain.t.sol
+++ b/docs/specs/test/AccountKeychain.t.sol
@@ -43,7 +43,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true, // Enforce spending limits
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         IAccountKeychain.KeyInfo memory info = keychain.getKey(alice, aliceAccessKey);
@@ -77,7 +78,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             true, // Enforce spending limits
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         IAccountKeychain.KeyInfo memory info = keychain.getKey(alice, aliceAccessKey);
@@ -105,7 +107,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.WebAuthn,
             uint64(block.timestamp + 1 days),
             false, // No spending limits enforced
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         IAccountKeychain.KeyInfo memory info = keychain.getKey(alice, aliceAccessKey);
@@ -125,7 +128,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify key exists
@@ -157,7 +161,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify initial limit
@@ -182,7 +187,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false, // No limits initially
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify key has no limits
@@ -236,7 +242,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.revokeKey(aliceAccessKey);
 
@@ -261,7 +268,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
@@ -282,7 +290,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Try to authorize same key again
@@ -291,7 +300,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 2 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
@@ -312,7 +322,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.revokeKey(aliceAccessKey);
 
@@ -322,7 +333,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
@@ -369,7 +381,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.revokeKey(aliceAccessKey);
 
@@ -390,7 +403,12 @@ contract AccountKeychainTest is BaseTest {
 
         uint64 expiry = uint64(block.timestamp + 1 hours);
         keychain.authorizeKey(
-            aliceAccessKey, IAccountKeychain.SignatureType.P256, expiry, false, limits
+            aliceAccessKey,
+            IAccountKeychain.SignatureType.P256,
+            expiry,
+            false,
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Warp time past expiry
@@ -418,7 +436,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify USDT limit is 0 initially
@@ -448,7 +467,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false, // enforceLimits = false
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify limits were NOT stored (should be 0)
@@ -473,7 +493,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             0, // Zero expiry
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Key should appear non-existent because expiry=0 is the "not exists" sentinel
@@ -495,7 +516,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.revokeKey(aliceAccessKey);
 
@@ -505,7 +527,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify new key is authorized
@@ -541,7 +564,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         assertEq(
             uint8(keychain.getKey(alice, aliceAccessKey).signatureType),
@@ -555,7 +579,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         assertEq(
             uint8(keychain.getKey(bob, bobAccessKey).signatureType),
@@ -569,7 +594,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.WebAuthn,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         assertEq(
             uint8(keychain.getKey(charlie, charlieAccessKey).signatureType),
@@ -592,11 +618,23 @@ contract AccountKeychainTest is BaseTest {
         address sharedKeyId = address(0x9999);
 
         vm.prank(alice);
-        keychain.authorizeKey(sharedKeyId, IAccountKeychain.SignatureType.P256, 100, true, limits1);
+        keychain.authorizeKey(
+            sharedKeyId,
+            IAccountKeychain.SignatureType.P256,
+            100,
+            true,
+            limits1,
+            new IAccountKeychain.CurrencyLimit[](0)
+        );
 
         vm.prank(bob);
         keychain.authorizeKey(
-            sharedKeyId, IAccountKeychain.SignatureType.Secp256k1, 200, true, limits2
+            sharedKeyId,
+            IAccountKeychain.SignatureType.Secp256k1,
+            200,
+            true,
+            limits2,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify keys are isolated per account
@@ -623,21 +661,24 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.authorizeKey(
             bobAccessKey,
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
         keychain.authorizeKey(
             charlieAccessKey,
             IAccountKeychain.SignatureType.WebAuthn,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify all keys exist with correct types
@@ -676,7 +717,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         vm.stopPrank();
@@ -692,7 +734,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             false,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         if (!isTempo) {
@@ -716,7 +759,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         if (!isTempo) {
@@ -748,7 +792,12 @@ contract AccountKeychainTest is BaseTest {
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](0);
 
         keychain.authorizeKey(
-            keyId, IAccountKeychain.SignatureType(sigType), expiry, enforceLimits, limits
+            keyId,
+            IAccountKeychain.SignatureType(sigType),
+            expiry,
+            enforceLimits,
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         IAccountKeychain.KeyInfo memory info = keychain.getKey(alice, keyId);
@@ -782,7 +831,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.P256,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Verify limits are stored
@@ -811,7 +861,8 @@ contract AccountKeychainTest is BaseTest {
             IAccountKeychain.SignatureType.Secp256k1,
             uint64(block.timestamp + 1 days),
             true,
-            limits
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
         );
 
         // Update the spending limit
@@ -831,7 +882,14 @@ contract AccountKeychainTest is BaseTest {
 
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](0);
 
-        keychain.authorizeKey(keyId, IAccountKeychain.SignatureType.P256, expiry, false, limits);
+        keychain.authorizeKey(
+            keyId,
+            IAccountKeychain.SignatureType.P256,
+            expiry,
+            false,
+            limits,
+            new IAccountKeychain.CurrencyLimit[](0)
+        );
 
         // Verify key exists
         IAccountKeychain.KeyInfo memory infoBefore = keychain.getKey(alice, keyId);
@@ -886,10 +944,24 @@ contract AccountKeychainTest is BaseTest {
 
         // Authorize same keyId for two different accounts
         vm.prank(account1);
-        keychain.authorizeKey(keyId, IAccountKeychain.SignatureType.P256, 100, true, limits1);
+        keychain.authorizeKey(
+            keyId,
+            IAccountKeychain.SignatureType.P256,
+            100,
+            true,
+            limits1,
+            new IAccountKeychain.CurrencyLimit[](0)
+        );
 
         vm.prank(account2);
-        keychain.authorizeKey(keyId, IAccountKeychain.SignatureType.Secp256k1, 200, true, limits2);
+        keychain.authorizeKey(
+            keyId,
+            IAccountKeychain.SignatureType.Secp256k1,
+            200,
+            true,
+            limits2,
+            new IAccountKeychain.CurrencyLimit[](0)
+        );
 
         // Verify keys are isolated per account
         IAccountKeychain.KeyInfo memory info1 = keychain.getKey(account1, keyId);


### PR DESCRIPTION
In a landscape of multiple stablecoins, wallets might hold a basket of different stablecoins, abstracted via a user interface to show something like "total USD". Access key spending limits on Tempo, as well as implementations of this on other chains require a limit to be set per token. This will not be the most efficient abstraction in this world

This PR introduces currency limits. Access keys can be granted a currency limit alongside a spending limit and allows that key to spend up to that amount of currency

Notes:
1. Token specific spending limits are consumed before currency limits. If spend limits are insufficient then it will consume the currency limit, if any
2. We pack 2 additional flags in the key slot, `hasSpendLimit` and `hasCurrencyLimit` so we only load limits that are set for the account to skip unnecessary SLOADs