### PR TITLE
docs: add legacy Andantino explorer link to network upgrades page

### DIFF
--- a/docs/pages/network-upgrades.mdx
+++ b/docs/pages/network-upgrades.mdx
@@ -50,6 +50,14 @@ If continuing to run an Andantino node during the transition:
 - Add the `--chain testnet` flag
 - Do not update to `v1.0.0-rc.1`
 
+### Legacy Andantino Explorer
+
+If you need to view contracts or transactions from the old Andantino network, use the legacy explorer:
+
+**[https://explore.andantino.tempo.xyz/](https://explore.andantino.tempo.xyz/)**
+
+The current explorer at [explore.tempo.xyz](https://explore.tempo.xyz) only shows data from the Moderato network.
+
 ## Need Help?
 
 If you need assistance with migration, redeployment, or infrastructure coordination (RPCs, indexers, explorers), please reach out, we're here to help.


### PR DESCRIPTION
Adds a link to https://explore.andantino.tempo.xyz/ in the network upgrades page so users can view contracts from the old Andantino testnet.

Requested by @liam