### PR TITLE
fix(docs): use dynamic baseUrl for Vercel preview deployments

### DIFF
--- a/docs/pages/network-upgrades.mdx
+++ b/docs/pages/network-upgrades.mdx
@@ -50,6 +50,14 @@ If continuing to run an Andantino node during the transition:
 - Add the `--chain testnet` flag
 - Do not update to `v1.0.0-rc.1`
 
+### Legacy Andantino Explorer
+
+If you need to view contracts or transactions from the old Andantino network, use the legacy explorer:
+
+**[https://explore.andantino.tempo.xyz/](https://explore.andantino.tempo.xyz/)**
+
+The current explorer at [explore.tempo.xyz](https://explore.tempo.xyz) only shows data from the Moderato network.
+
 ## Need Help?
 
 If you need assistance with migration, redeployment, or infrastructure coordination (RPCs, indexers, explorers), please reach out, we're here to help.

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -56,8 +56,12 @@ function getTipsData() {
     .filter((t) => t.id && t.title)
 }
 
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : 'https://docs.tempo.xyz'
+
 export default defineConfig({
-  baseUrl: 'https://docs.tempo.xyz',
+  baseUrl,
   head: () => (
     <>
       <meta
@@ -128,12 +132,12 @@ export default defineConfig({
     </>
   ),
   ogImageUrl: {
-    '/': 'https://docs.tempo.xyz/og-docs.png',
-    '/learn': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
-    '/quickstart': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
-    '/guide': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
-    '/protocol': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
-    '/sdk': 'https://docs.tempo.xyz/api/og?title=%title&description=%description',
+    '/': `${baseUrl}/og-docs.png`,
+    '/learn': `${baseUrl}/api/og?title=%title&description=%description`,
+    '/quickstart': `${baseUrl}/api/og?title=%title&description=%description`,
+    '/guide': `${baseUrl}/api/og?title=%title&description=%description`,
+    '/protocol': `${baseUrl}/api/og?title=%title&description=%description`,
+    '/sdk': `${baseUrl}/api/og?title=%title&description=%description`,
   },
   title: 'Tempo',
   titleTemplate: '%s | Tempo Docs',


### PR DESCRIPTION
## Summary

Fixes Vercel preview URLs pointing to production (docs.tempo.xyz) instead of the preview domain.

## Problem

Commit 07dfcd2d added a hardcoded `baseUrl: 'https://docs.tempo.xyz'` which caused all URLs in Vercel preview deployments to redirect to production.

## Solution

Uses `VERCEL_URL` environment variable when available to dynamically set `baseUrl` and `ogImageUrl`.

- Preview deployments → use preview URL
- Production → use docs.tempo.xyz