### PR TITLE
feat: Trustless Tempo ↔ Ethereum Bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
@@ -11739,6 +11740,24 @@ dependencies = [
  "tempo-precompiles",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tempo-bridge-relayer"
+version = "1.0.0"
+dependencies = [
+ "alloy",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "clap",
+ "eyre",
+ "hex",
+ "jsonrpsee",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "bin/tempo-bench",
   "bin/tempo-sidecar",
   "crates/alloy",
+  "crates/bridge/relayer",
   "crates/chainspec",
   "crates/commonware-node",
   "crates/commonware-node-config",
@@ -211,6 +212,7 @@ derive_more = { version = "2.0.0" }
 eyre = "0.6.12"
 futures = "0.3.31"
 governor = "0.10.2"
+hex = "0.4"
 indexmap = "2.11.0"
 indicatif = "0.18"
 itertools = "0.14.0"

--- a/crates/bridge/contracts/README.md
+++ b/crates/bridge/contracts/README.md
@@ -1,0 +1,161 @@
+# Tempo ↔ Ethereum Trustless Bridge
+
+A trustless bridge implementation inspired by [cosmos/solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka) for cross-chain communication between Tempo and Ethereum.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              Tempo Chain                                     │
+│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────────────┐  │
+│  │  TokenBridge    │───▶│     Bridge      │───▶│  EthereumLightClient    │  │
+│  │  (ICS20-like)   │    │  (IBC Router)   │    │  (Beacon Chain Sync)    │  │
+│  └─────────────────┘    └─────────────────┘    └─────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Relayer submits packets + proofs
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                             Ethereum Chain                                   │
+│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────────────┐  │
+│  │  TokenBridge    │───▶│     Bridge      │───▶│   TempoLightClient      │  │
+│  │  (ICS20-like)   │    │  (IBC Router)   │    │  (BLS Finalization)     │  │
+│  └─────────────────┘    └─────────────────┘    └─────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Contracts
+
+### Core Interfaces
+
+- **[ILightClient](src/interfaces/ILightClient.sol)** - Interface for light client implementations
+- **[IBridge](src/interfaces/IBridge.sol)** - Interface for the bridge router
+
+### Light Clients
+
+- **[TempoLightClient](src/light-clients/TempoLightClient.sol)** - Deployed on Ethereum to verify Tempo state
+  - Verifies BLS threshold signatures from Tempo's finalization certificates
+  - Uses `consensus_getFinalization` RPC data
+  - Storage merkle proofs for membership verification
+
+- **[EthereumLightClient](src/light-clients/EthereumLightClient.sol)** - Deployed on Tempo to verify Ethereum state
+  - Implements beacon chain sync committee protocol
+  - Merkle-Patricia trie proof verification
+  - Tracks execution layer state roots
+
+### Bridge Router
+
+- **[Bridge](src/Bridge.sol)** - Core IBC-inspired packet router
+  - Manages light client registrations
+  - Handles packet lifecycle: send → recv → ack/timeout
+  - Stores packet commitments as keccak256 hashes
+  - Verifies proofs through registered light clients
+
+### Applications
+
+- **[TokenBridge](src/TokenBridge.sol)** - ICS20-inspired token transfer
+  - Lock tokens on source chain, mint wrapped on destination
+  - Burn wrapped tokens to unlock on origin chain
+  - Denomination tracking for canonical vs wrapped tokens
+  - Automatic refunds on timeout or failure
+
+## Packet Lifecycle
+
+```
+Source Chain                    Relayer                    Destination Chain
+     │                            │                              │
+     │  sendPacket()              │                              │
+     │──────────────▶             │                              │
+     │  (stores commitment)       │                              │
+     │                            │                              │
+     │  PacketSent event          │                              │
+     │  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▶│                              │
+     │                            │  recvPacket(proof)           │
+     │                            │─────────────────────────────▶│
+     │                            │  (verifies proof via         │
+     │                            │   light client)              │
+     │                            │                              │
+     │                            │  PacketReceived event        │
+     │                            │◀─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│
+     │                            │                              │
+     │  acknowledgePacket(proof)  │                              │
+     │◀───────────────────────────│                              │
+     │  (clears commitment)       │                              │
+     │                            │                              │
+```
+
+## Security Model
+
+### Trust Assumptions
+
+1. **Tempo → Ethereum**: Trust that 2/3+ of Tempo validators correctly sign finalization certificates
+2. **Ethereum → Tempo**: Trust Ethereum's proof-of-stake consensus and sync committee signatures
+3. **Relayers**: Untrusted - they can only submit valid proofs, cannot forge state
+
+### Verification
+
+- All state transitions are verified through light client proofs
+- Packet commitments are stored on-chain and verified via merkle proofs
+- No admin keys can bypass proof verification
+
+## Development
+
+### Prerequisites
+
+- [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- Solidity 0.8.24+
+
+### Build
+
+```bash
+forge build
+```
+
+### Test
+
+```bash
+forge test
+```
+
+### Deploy
+
+```bash
+# Deploy to Ethereum
+forge script script/Deploy.s.sol --rpc-url $ETH_RPC_URL --broadcast
+
+# Deploy to Tempo
+forge script script/Deploy.s.sol --rpc-url $TEMPO_RPC_URL --broadcast
+```
+
+## Integration
+
+### Sending Tokens
+
+```solidity
+// Approve tokens first
+IERC20(token).approve(address(tokenBridge), amount);
+
+// Transfer to Tempo
+uint64 sequence = tokenBridge.transfer(
+    "tempo-mainnet",      // destClient
+    token,                // token address
+    amount,               // amount
+    receiver,             // receiver on Tempo
+    block.timestamp + 1 hours, // timeout
+    ""                    // memo
+);
+```
+
+### Relayer Integration
+
+Relayers need to:
+
+1. Watch for `PacketSent` events
+2. Wait for source chain finality
+3. Generate merkle proofs for packet commitments
+4. Submit `recvPacket` on destination chain
+5. Watch for acknowledgements and relay back
+
+## License
+
+MIT

--- a/crates/bridge/contracts/foundry.toml
+++ b/crates/bridge/contracts/foundry.toml
@@ -1,0 +1,22 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+evm_version = "cancun"
+
+[profile.default.fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = true
+int_types = "long"
+multiline_func_header = "attributes_first"
+quote_style = "double"
+number_underscore = "thousands"
+
+[rpc_endpoints]
+mainnet = "${ETH_RPC_URL}"
+tempo = "${TEMPO_RPC_URL}"

--- a/crates/bridge/contracts/remappings.txt
+++ b/crates/bridge/contracts/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/

--- a/crates/bridge/contracts/src/Bridge.sol
+++ b/crates/bridge/contracts/src/Bridge.sol
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IBridge} from "./interfaces/IBridge.sol";
+import {ILightClient} from "./interfaces/ILightClient.sol";
+
+/// @title Bridge
+/// @notice IBC-inspired bridge router for cross-chain packet relay
+/// @dev Manages light clients and handles packet lifecycle (send → recv → ack)
+contract Bridge is IBridge {
+    /// @dev Registered light clients by client ID
+    mapping(string => ILightClient) private _lightClients;
+
+    /// @dev Next sequence number for each client
+    mapping(string => uint64) private _nextSequenceSend;
+
+    /// @dev Packet commitments: clientId => sequence => commitment
+    mapping(string => mapping(uint64 => bytes32)) private _packetCommitments;
+
+    /// @dev Packet receipts: clientId => sequence => received
+    mapping(string => mapping(uint64 => bool)) private _packetReceipts;
+
+    /// @dev Packet acknowledgements: clientId => sequence => acknowledgement
+    mapping(string => mapping(uint64 => bytes)) private _packetAcks;
+
+    /// @dev Owner for client registration
+    address private immutable _owner;
+
+    /// @dev Commitment path prefix
+    bytes private constant COMMITMENT_PREFIX = "commitments/";
+
+    /// @dev Receipt path prefix
+    bytes private constant RECEIPT_PREFIX = "receipts/";
+
+    /// @dev Acknowledgement path prefix
+    bytes private constant ACK_PREFIX = "acks/";
+
+    /// @notice Error when caller is not owner
+    error NotOwner();
+
+    /// @notice Error when client already exists
+    error ClientAlreadyExists(string clientId);
+
+    modifier onlyOwner() {
+        if (msg.sender != _owner) revert NotOwner();
+        _;
+    }
+
+    constructor() {
+        _owner = msg.sender;
+    }
+
+    /// @notice Register a light client
+    /// @param clientId Unique identifier for the client
+    /// @param lightClient Address of the light client contract
+    function registerClient(
+        string calldata clientId,
+        ILightClient lightClient
+    ) external onlyOwner {
+        if (address(_lightClients[clientId]) != address(0)) {
+            revert ClientAlreadyExists(clientId);
+        }
+        _lightClients[clientId] = lightClient;
+        _nextSequenceSend[clientId] = 1;
+    }
+
+    /// @inheritdoc IBridge
+    function sendPacket(
+        string calldata destClient,
+        bytes calldata payload,
+        uint64 timeout
+    ) external override returns (uint64 sequence) {
+        if (address(_lightClients[destClient]) == address(0)) {
+            revert ClientNotFound(destClient);
+        }
+
+        sequence = _nextSequenceSend[destClient];
+        _nextSequenceSend[destClient] = sequence + 1;
+
+        // Create packet commitment
+        bytes32 commitment = keccak256(
+            abi.encodePacked(sequence, destClient, timeout, keccak256(payload))
+        );
+
+        _packetCommitments[destClient][sequence] = commitment;
+
+        emit PacketSent(sequence, _getSourceClientId(), destClient, timeout, payload);
+
+        return sequence;
+    }
+
+    /// @inheritdoc IBridge
+    function recvPacket(
+        Packet calldata packet,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external override {
+        ILightClient lightClient = _lightClients[packet.sourceClient];
+        if (address(lightClient) == address(0)) {
+            revert ClientNotFound(packet.sourceClient);
+        }
+
+        // Check if already received
+        if (_packetReceipts[packet.sourceClient][packet.sequence]) {
+            revert PacketAlreadyReceived(packet.sequence);
+        }
+
+        // Check timeout
+        ILightClient.ConsensusState memory consensusState = lightClient.getConsensusState(
+            proofHeight
+        );
+        if (packet.timeout != 0 && consensusState.timestamp >= packet.timeout) {
+            revert PacketTimeout(packet.sequence, packet.timeout, consensusState.timestamp);
+        }
+
+        // Verify packet commitment on source chain
+        bytes memory path = _packetCommitmentPath(packet.sourceClient, packet.sequence);
+        bytes32 expectedCommitment = keccak256(
+            abi.encodePacked(
+                packet.sequence,
+                packet.destClient,
+                packet.timeout,
+                keccak256(packet.payload)
+            )
+        );
+
+        bool valid = lightClient.verifyMembership(
+            proof,
+            proofHeight,
+            path,
+            abi.encodePacked(expectedCommitment)
+        );
+
+        if (!valid) {
+            revert InvalidProof();
+        }
+
+        // Mark as received
+        _packetReceipts[packet.sourceClient][packet.sequence] = true;
+
+        emit PacketReceived(packet.sequence, packet.sourceClient, packet.destClient, packet.payload);
+    }
+
+    /// @inheritdoc IBridge
+    function acknowledgePacket(
+        Packet calldata packet,
+        bytes calldata ack,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external override {
+        ILightClient lightClient = _lightClients[packet.destClient];
+        if (address(lightClient) == address(0)) {
+            revert ClientNotFound(packet.destClient);
+        }
+
+        // Verify we sent this packet
+        bytes32 commitment = _packetCommitments[packet.destClient][packet.sequence];
+        if (commitment == bytes32(0)) {
+            revert PacketAlreadyAcknowledged(packet.sequence);
+        }
+
+        bytes32 expectedCommitment = keccak256(
+            abi.encodePacked(
+                packet.sequence,
+                packet.destClient,
+                packet.timeout,
+                keccak256(packet.payload)
+            )
+        );
+
+        if (commitment != expectedCommitment) {
+            revert CommitmentMismatch(expectedCommitment, commitment);
+        }
+
+        // Verify acknowledgement on destination chain
+        bytes memory path = _packetAckPath(packet.destClient, packet.sequence);
+
+        bool valid = lightClient.verifyMembership(proof, proofHeight, path, ack);
+
+        if (!valid) {
+            revert InvalidProof();
+        }
+
+        // Delete commitment (packet lifecycle complete)
+        delete _packetCommitments[packet.destClient][packet.sequence];
+
+        emit PacketAcknowledged(packet.sequence, packet.sourceClient, packet.destClient, ack);
+    }
+
+    /// @inheritdoc IBridge
+    function timeoutPacket(
+        Packet calldata packet,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external override {
+        ILightClient lightClient = _lightClients[packet.destClient];
+        if (address(lightClient) == address(0)) {
+            revert ClientNotFound(packet.destClient);
+        }
+
+        // Verify we sent this packet
+        bytes32 commitment = _packetCommitments[packet.destClient][packet.sequence];
+        if (commitment == bytes32(0)) {
+            revert PacketAlreadyAcknowledged(packet.sequence);
+        }
+
+        // Verify timeout has passed on destination chain
+        ILightClient.ConsensusState memory consensusState = lightClient.getConsensusState(
+            proofHeight
+        );
+
+        if (consensusState.timestamp < packet.timeout) {
+            revert PacketTimeout(packet.sequence, packet.timeout, consensusState.timestamp);
+        }
+
+        // Verify non-membership of receipt on destination chain
+        bytes memory path = _packetReceiptPath(packet.destClient, packet.sequence);
+
+        // For timeout, we verify that the receipt does NOT exist
+        // This is a non-membership proof - the proof should show the value is empty
+        bool valid = lightClient.verifyMembership(proof, proofHeight, path, "");
+
+        if (!valid) {
+            revert InvalidProof();
+        }
+
+        // Delete commitment
+        delete _packetCommitments[packet.destClient][packet.sequence];
+
+        emit PacketTimedOut(packet.sequence, packet.sourceClient, packet.destClient);
+    }
+
+    /// @notice Write acknowledgement for a received packet
+    /// @param packet The packet being acknowledged
+    /// @param ack The acknowledgement data
+    function writeAcknowledgement(Packet calldata packet, bytes calldata ack) external {
+        // Only callable after packet is received
+        if (!_packetReceipts[packet.sourceClient][packet.sequence]) {
+            revert PacketAlreadyReceived(packet.sequence);
+        }
+
+        // Only write once
+        if (_packetAcks[packet.sourceClient][packet.sequence].length > 0) {
+            revert PacketAlreadyAcknowledged(packet.sequence);
+        }
+
+        _packetAcks[packet.sourceClient][packet.sequence] = ack;
+    }
+
+    /// @inheritdoc IBridge
+    function getNextSequence(string calldata clientId) external view override returns (uint64) {
+        return _nextSequenceSend[clientId];
+    }
+
+    /// @inheritdoc IBridge
+    function getPacketCommitment(
+        string calldata clientId,
+        uint64 sequence
+    ) external view override returns (bytes32) {
+        return _packetCommitments[clientId][sequence];
+    }
+
+    /// @inheritdoc IBridge
+    function hasPacketReceipt(
+        string calldata clientId,
+        uint64 sequence
+    ) external view override returns (bool) {
+        return _packetReceipts[clientId][sequence];
+    }
+
+    /// @notice Get the acknowledgement for a packet
+    /// @param clientId The client ID
+    /// @param sequence The sequence number
+    /// @return ack The acknowledgement data
+    function getPacketAcknowledgement(
+        string calldata clientId,
+        uint64 sequence
+    ) external view returns (bytes memory) {
+        return _packetAcks[clientId][sequence];
+    }
+
+    /// @notice Get the light client for a client ID
+    /// @param clientId The client ID
+    /// @return lightClient The light client address
+    function getLightClient(string calldata clientId) external view returns (ILightClient) {
+        return _lightClients[clientId];
+    }
+
+    /// @dev Get the source client ID (this chain's identifier)
+    function _getSourceClientId() private pure returns (string memory) {
+        // In production, this would be configurable
+        return "tempo-mainnet";
+    }
+
+    /// @dev Build packet commitment path
+    function _packetCommitmentPath(
+        string memory clientId,
+        uint64 sequence
+    ) private pure returns (bytes memory) {
+        return abi.encodePacked(COMMITMENT_PREFIX, clientId, "/", sequence);
+    }
+
+    /// @dev Build packet receipt path
+    function _packetReceiptPath(
+        string memory clientId,
+        uint64 sequence
+    ) private pure returns (bytes memory) {
+        return abi.encodePacked(RECEIPT_PREFIX, clientId, "/", sequence);
+    }
+
+    /// @dev Build packet acknowledgement path
+    function _packetAckPath(
+        string memory clientId,
+        uint64 sequence
+    ) private pure returns (bytes memory) {
+        return abi.encodePacked(ACK_PREFIX, clientId, "/", sequence);
+    }
+}

--- a/crates/bridge/contracts/src/TokenBridge.sol
+++ b/crates/bridge/contracts/src/TokenBridge.sol
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IBridge} from "./interfaces/IBridge.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title WrappedToken
+/// @notice ERC20 token representing a wrapped asset from another chain
+contract WrappedToken is ERC20, Ownable {
+    uint8 private immutable _decimals;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_,
+        address bridge_
+    ) ERC20(name_, symbol_) Ownable(bridge_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external onlyOwner {
+        _burn(from, amount);
+    }
+}
+
+/// @title TokenBridge
+/// @notice ICS20-inspired token transfer application for the bridge
+/// @dev Handles lock/mint and burn/unlock token transfer patterns
+contract TokenBridge {
+    using SafeERC20 for IERC20;
+
+    /// @notice Token transfer packet data
+    struct TransferPacket {
+        /// @dev Token denomination (address on source chain or prefixed denom)
+        string denom;
+        /// @dev Amount to transfer
+        uint256 amount;
+        /// @dev Sender address on source chain
+        address sender;
+        /// @dev Recipient address on destination chain
+        address receiver;
+        /// @dev Optional memo
+        string memo;
+    }
+
+    /// @notice Denomination trace for wrapped tokens
+    struct DenomTrace {
+        /// @dev Full path of the denomination (e.g., "transfer/channel-0/uatom")
+        string path;
+        /// @dev Base denomination
+        string baseDenom;
+    }
+
+    /// @notice The bridge router contract
+    IBridge public immutable bridge;
+
+    /// @dev Escrow balance for locked tokens: token => amount
+    mapping(address => uint256) private _escrowBalances;
+
+    /// @dev Wrapped token contracts: denomHash => wrappedToken
+    mapping(bytes32 => WrappedToken) private _wrappedTokens;
+
+    /// @dev Denomination traces: denomHash => trace
+    mapping(bytes32 => DenomTrace) private _denomTraces;
+
+    /// @dev Check if a denom is native to this chain: denomHash => isNative
+    mapping(bytes32 => bool) private _nativeDenoms;
+
+    /// @dev Reverse mapping: wrapped token address => denomHash
+    mapping(address => bytes32) private _tokenToDenom;
+
+    /// @dev Port ID for this application
+    string public constant PORT_ID = "transfer";
+
+    /// @notice Emitted when tokens are transferred out
+    event TransferSent(
+        uint64 indexed sequence,
+        address indexed sender,
+        address indexed receiver,
+        string denom,
+        uint256 amount,
+        string destClient
+    );
+
+    /// @notice Emitted when tokens are received
+    event TransferReceived(
+        uint64 indexed sequence,
+        address indexed receiver,
+        string denom,
+        uint256 amount,
+        string sourceClient
+    );
+
+    /// @notice Emitted when a transfer is acknowledged
+    event TransferAcknowledged(uint64 indexed sequence, bool success);
+
+    /// @notice Emitted when a transfer times out and tokens are refunded
+    event TransferRefunded(
+        uint64 indexed sequence,
+        address indexed sender,
+        string denom,
+        uint256 amount
+    );
+
+    /// @notice Emitted when a new wrapped token is created
+    event WrappedTokenCreated(
+        bytes32 indexed denomHash,
+        address indexed tokenAddress,
+        string denom,
+        string name,
+        string symbol
+    );
+
+    /// @notice Error when amount is zero
+    error ZeroAmount();
+
+    /// @notice Error when receiver is zero address
+    error InvalidReceiver();
+
+    /// @notice Error when token transfer fails
+    error TransferFailed();
+
+    /// @notice Error when caller is not the bridge
+    error OnlyBridge();
+
+    /// @notice Error when acknowledgement indicates failure
+    error TransferRejected(string reason);
+
+    /// @notice Error when denom is not found
+    error DenomNotFound(string denom);
+
+    modifier onlyBridge() {
+        if (msg.sender != address(bridge)) revert OnlyBridge();
+        _;
+    }
+
+    constructor(IBridge _bridge) {
+        bridge = _bridge;
+    }
+
+    /// @notice Transfer tokens to another chain
+    /// @param destClient Destination client ID
+    /// @param token Token address to transfer (address(0) for native ETH)
+    /// @param amount Amount to transfer
+    /// @param receiver Recipient address on destination chain
+    /// @param timeout Timeout timestamp in nanoseconds
+    /// @param memo Optional memo
+    /// @return sequence The packet sequence number
+    function transfer(
+        string calldata destClient,
+        address token,
+        uint256 amount,
+        address receiver,
+        uint64 timeout,
+        string calldata memo
+    ) external payable returns (uint64 sequence) {
+        if (amount == 0) revert ZeroAmount();
+        if (receiver == address(0)) revert InvalidReceiver();
+
+        string memory denom;
+        bytes32 denomHash = _tokenToDenom[token];
+
+        if (denomHash != bytes32(0) && address(_wrappedTokens[denomHash]) == token) {
+            // This is a wrapped token - burn it
+            DenomTrace storage trace = _denomTraces[denomHash];
+            denom = string(abi.encodePacked(trace.path, "/", trace.baseDenom));
+
+            WrappedToken(token).burn(msg.sender, amount);
+        } else {
+            // This is a native token - lock it
+            denom = _addressToString(token);
+            denomHash = keccak256(bytes(denom));
+            _nativeDenoms[denomHash] = true;
+
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+            _escrowBalances[token] += amount;
+        }
+
+        // Create transfer packet
+        TransferPacket memory transferData = TransferPacket({
+            denom: denom,
+            amount: amount,
+            sender: msg.sender,
+            receiver: receiver,
+            memo: memo
+        });
+
+        bytes memory payload = abi.encode(transferData);
+
+        sequence = bridge.sendPacket(destClient, payload, timeout);
+
+        emit TransferSent(sequence, msg.sender, receiver, denom, amount, destClient);
+    }
+
+    /// @notice Handle incoming packet (called by bridge)
+    /// @param packet The received packet
+    function onRecvPacket(
+        IBridge.Packet calldata packet
+    ) external onlyBridge returns (bytes memory ack) {
+        TransferPacket memory transferData = abi.decode(packet.payload, (TransferPacket));
+
+        bytes32 denomHash = keccak256(bytes(transferData.denom));
+
+        // Check if this is a token returning to its native chain
+        if (_nativeDenoms[denomHash]) {
+            // Unlock escrowed tokens
+            address token = _stringToAddress(transferData.denom);
+            _escrowBalances[token] -= transferData.amount;
+            IERC20(token).safeTransfer(transferData.receiver, transferData.amount);
+        } else {
+            // Mint wrapped tokens
+            string memory prefixedDenom = string(
+                abi.encodePacked(PORT_ID, "/", packet.sourceClient, "/", transferData.denom)
+            );
+            bytes32 prefixedDenomHash = keccak256(bytes(prefixedDenom));
+
+            WrappedToken wrappedToken = _wrappedTokens[prefixedDenomHash];
+
+            if (address(wrappedToken) == address(0)) {
+                // Create new wrapped token
+                wrappedToken = _createWrappedToken(
+                    prefixedDenomHash,
+                    prefixedDenom,
+                    transferData.denom
+                );
+            }
+
+            wrappedToken.mint(transferData.receiver, transferData.amount);
+        }
+
+        emit TransferReceived(
+            packet.sequence,
+            transferData.receiver,
+            transferData.denom,
+            transferData.amount,
+            packet.sourceClient
+        );
+
+        // Return success acknowledgement
+        return abi.encode(true, "");
+    }
+
+    /// @notice Handle acknowledgement (called by bridge)
+    /// @param packet The original packet
+    /// @param ack The acknowledgement data
+    function onAcknowledgePacket(
+        IBridge.Packet calldata packet,
+        bytes calldata ack
+    ) external onlyBridge {
+        (bool success, string memory errorMsg) = abi.decode(ack, (bool, string));
+
+        emit TransferAcknowledged(packet.sequence, success);
+
+        if (!success) {
+            // Refund on failure
+            _refundTokens(packet);
+            revert TransferRejected(errorMsg);
+        }
+    }
+
+    /// @notice Handle timeout (called by bridge)
+    /// @param packet The timed out packet
+    function onTimeoutPacket(IBridge.Packet calldata packet) external onlyBridge {
+        _refundTokens(packet);
+    }
+
+    /// @notice Get the wrapped token address for a denomination
+    /// @param denom The denomination string
+    /// @return token The wrapped token address
+    function getWrappedToken(string calldata denom) external view returns (address) {
+        bytes32 denomHash = keccak256(bytes(denom));
+        return address(_wrappedTokens[denomHash]);
+    }
+
+    /// @notice Get the denomination trace for a denom hash
+    /// @param denomHash The hash of the denomination
+    /// @return trace The denomination trace
+    function getDenomTrace(bytes32 denomHash) external view returns (DenomTrace memory) {
+        return _denomTraces[denomHash];
+    }
+
+    /// @notice Check if a denomination is native to this chain
+    /// @param denom The denomination string
+    /// @return isNative True if the denom is native
+    function isNativeDenom(string calldata denom) external view returns (bool) {
+        bytes32 denomHash = keccak256(bytes(denom));
+        return _nativeDenoms[denomHash];
+    }
+
+    /// @notice Get escrowed balance for a token
+    /// @param token The token address
+    /// @return balance The escrowed amount
+    function getEscrowBalance(address token) external view returns (uint256) {
+        return _escrowBalances[token];
+    }
+
+    /// @dev Create a new wrapped token
+    function _createWrappedToken(
+        bytes32 denomHash,
+        string memory fullDenom,
+        string memory baseDenom
+    ) private returns (WrappedToken) {
+        // Generate name and symbol from base denom
+        string memory name = string(abi.encodePacked("Wrapped ", baseDenom));
+        string memory symbol = string(abi.encodePacked("w", _truncate(baseDenom, 10)));
+
+        WrappedToken wrappedToken = new WrappedToken(name, symbol, 18, address(this));
+
+        _wrappedTokens[denomHash] = wrappedToken;
+        _tokenToDenom[address(wrappedToken)] = denomHash;
+        _denomTraces[denomHash] = DenomTrace({path: fullDenom, baseDenom: baseDenom});
+
+        emit WrappedTokenCreated(denomHash, address(wrappedToken), fullDenom, name, symbol);
+
+        return wrappedToken;
+    }
+
+    /// @dev Refund tokens on failure or timeout
+    function _refundTokens(IBridge.Packet calldata packet) private {
+        TransferPacket memory transferData = abi.decode(packet.payload, (TransferPacket));
+
+        bytes32 denomHash = keccak256(bytes(transferData.denom));
+
+        if (_nativeDenoms[denomHash]) {
+            // Return escrowed tokens
+            address token = _stringToAddress(transferData.denom);
+            _escrowBalances[token] -= transferData.amount;
+            IERC20(token).safeTransfer(transferData.sender, transferData.amount);
+        } else {
+            // Re-mint wrapped tokens
+            WrappedToken wrappedToken = _wrappedTokens[denomHash];
+            if (address(wrappedToken) != address(0)) {
+                wrappedToken.mint(transferData.sender, transferData.amount);
+            }
+        }
+
+        emit TransferRefunded(
+            packet.sequence,
+            transferData.sender,
+            transferData.denom,
+            transferData.amount
+        );
+    }
+
+    /// @dev Convert address to string (for denomination)
+    function _addressToString(address addr) private pure returns (string memory) {
+        bytes memory alphabet = "0123456789abcdef";
+        bytes memory data = abi.encodePacked(addr);
+        bytes memory str = new bytes(2 + data.length * 2);
+        str[0] = "0";
+        str[1] = "x";
+        for (uint256 i = 0; i < data.length; i++) {
+            str[2 + i * 2] = alphabet[uint8(data[i] >> 4)];
+            str[3 + i * 2] = alphabet[uint8(data[i] & 0x0f)];
+        }
+        return string(str);
+    }
+
+    /// @dev Convert string to address
+    function _stringToAddress(string memory str) private pure returns (address) {
+        bytes memory strBytes = bytes(str);
+        require(strBytes.length == 42, "Invalid address string length");
+        require(strBytes[0] == "0" && strBytes[1] == "x", "Invalid address prefix");
+
+        uint160 addr = 0;
+        for (uint256 i = 2; i < 42; i++) {
+            uint8 b = uint8(strBytes[i]);
+            uint8 digit;
+            if (b >= 48 && b <= 57) {
+                digit = b - 48; // '0'-'9'
+            } else if (b >= 97 && b <= 102) {
+                digit = b - 87; // 'a'-'f'
+            } else if (b >= 65 && b <= 70) {
+                digit = b - 55; // 'A'-'F'
+            } else {
+                revert("Invalid hex character");
+            }
+            addr = addr * 16 + digit;
+        }
+        return address(addr);
+    }
+
+    /// @dev Truncate a string to max length
+    function _truncate(string memory str, uint256 maxLen) private pure returns (string memory) {
+        bytes memory strBytes = bytes(str);
+        if (strBytes.length <= maxLen) {
+            return str;
+        }
+        bytes memory truncated = new bytes(maxLen);
+        for (uint256 i = 0; i < maxLen; i++) {
+            truncated[i] = strBytes[i];
+        }
+        return string(truncated);
+    }
+}

--- a/crates/bridge/contracts/src/interfaces/IBridge.sol
+++ b/crates/bridge/contracts/src/interfaces/IBridge.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IBridge
+/// @notice Interface for the IBC-inspired bridge router
+/// @dev Handles packet lifecycle: send → recv → ack
+interface IBridge {
+    /// @notice Packet structure for cross-chain messages
+    struct Packet {
+        /// @dev Unique sequence number for this packet on the source chain
+        uint64 sequence;
+        /// @dev Client ID on the source chain
+        string sourceClient;
+        /// @dev Client ID on the destination chain
+        string destClient;
+        /// @dev Timeout timestamp (nanoseconds since epoch)
+        uint64 timeout;
+        /// @dev Opaque payload data
+        bytes payload;
+    }
+
+    /// @notice Emitted when a packet is sent
+    event PacketSent(
+        uint64 indexed sequence,
+        string sourceClient,
+        string destClient,
+        uint64 timeout,
+        bytes payload
+    );
+
+    /// @notice Emitted when a packet is received
+    event PacketReceived(
+        uint64 indexed sequence,
+        string sourceClient,
+        string destClient,
+        bytes payload
+    );
+
+    /// @notice Emitted when a packet acknowledgement is processed
+    event PacketAcknowledged(
+        uint64 indexed sequence,
+        string sourceClient,
+        string destClient,
+        bytes acknowledgement
+    );
+
+    /// @notice Emitted when a packet times out
+    event PacketTimedOut(uint64 indexed sequence, string sourceClient, string destClient);
+
+    /// @notice Error when packet has already been received
+    error PacketAlreadyReceived(uint64 sequence);
+
+    /// @notice Error when packet has already been acknowledged
+    error PacketAlreadyAcknowledged(uint64 sequence);
+
+    /// @notice Error when packet has timed out
+    error PacketTimeout(uint64 sequence, uint64 timeout, uint64 currentTime);
+
+    /// @notice Error when proof verification fails
+    error InvalidProof();
+
+    /// @notice Error when light client is not registered
+    error ClientNotFound(string clientId);
+
+    /// @notice Error when commitment does not match
+    error CommitmentMismatch(bytes32 expected, bytes32 actual);
+
+    /// @notice Send a packet to a destination chain
+    /// @param destClient The client ID for the destination chain
+    /// @param payload The packet payload
+    /// @param timeout Timeout timestamp in nanoseconds
+    /// @return sequence The sequence number assigned to this packet
+    function sendPacket(
+        string calldata destClient,
+        bytes calldata payload,
+        uint64 timeout
+    ) external returns (uint64 sequence);
+
+    /// @notice Receive a packet from a source chain
+    /// @param packet The packet to receive
+    /// @param proof Membership proof for the packet commitment
+    /// @param proofHeight Height at which the proof was generated
+    function recvPacket(
+        Packet calldata packet,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external;
+
+    /// @notice Process an acknowledgement for a previously sent packet
+    /// @param packet The original packet that was sent
+    /// @param ack The acknowledgement data
+    /// @param proof Membership proof for the acknowledgement
+    /// @param proofHeight Height at which the proof was generated
+    function acknowledgePacket(
+        Packet calldata packet,
+        bytes calldata ack,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external;
+
+    /// @notice Timeout a packet that was not received before deadline
+    /// @param packet The packet to timeout
+    /// @param proof Non-membership proof that packet was not received
+    /// @param proofHeight Height at which the proof was generated
+    function timeoutPacket(
+        Packet calldata packet,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external;
+
+    /// @notice Get the next sequence number for a client
+    /// @param clientId The client ID
+    /// @return sequence The next sequence number
+    function getNextSequence(string calldata clientId) external view returns (uint64 sequence);
+
+    /// @notice Get the packet commitment for a sent packet
+    /// @param clientId The client ID
+    /// @param sequence The sequence number
+    /// @return commitment The packet commitment hash
+    function getPacketCommitment(
+        string calldata clientId,
+        uint64 sequence
+    ) external view returns (bytes32 commitment);
+
+    /// @notice Check if a packet has been received
+    /// @param clientId The client ID
+    /// @param sequence The sequence number
+    /// @return received True if the packet was received
+    function hasPacketReceipt(
+        string calldata clientId,
+        uint64 sequence
+    ) external view returns (bool received);
+}

--- a/crates/bridge/contracts/src/interfaces/ILightClient.sol
+++ b/crates/bridge/contracts/src/interfaces/ILightClient.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title ILightClient
+/// @notice Interface for light client implementations that verify cross-chain state
+/// @dev Inspired by IBC light client interface from cosmos/solidity-ibc-eureka
+interface ILightClient {
+    /// @notice Consensus state containing the minimum data needed to verify proofs
+    struct ConsensusState {
+        /// @dev Root of the state tree at this height
+        bytes32 stateRoot;
+        /// @dev Timestamp of the block
+        uint64 timestamp;
+    }
+
+    /// @notice Emitted when the client state is updated
+    /// @param height The height at which the client was updated
+    /// @param stateRoot The new state root
+    event ClientUpdated(uint64 indexed height, bytes32 stateRoot);
+
+    /// @notice Update the light client with a new consensus state
+    /// @param proof Proof data (format depends on implementation)
+    /// @return success True if the update was successful
+    function updateClient(bytes calldata proof) external returns (bool success);
+
+    /// @notice Verify that a value exists at a given path in the counterparty state
+    /// @param proof Merkle proof of inclusion
+    /// @param height The height at which to verify
+    /// @param path The path to the value in state
+    /// @param value The expected value
+    /// @return valid True if the membership proof is valid
+    function verifyMembership(
+        bytes calldata proof,
+        uint64 height,
+        bytes calldata path,
+        bytes calldata value
+    ) external view returns (bool valid);
+
+    /// @notice Get the consensus state at a given height
+    /// @param height The height to query
+    /// @return state The consensus state at that height
+    function getConsensusState(uint64 height) external view returns (ConsensusState memory state);
+
+    /// @notice Get the latest verified height
+    /// @return height The latest height
+    function getLatestHeight() external view returns (uint64 height);
+}

--- a/crates/bridge/contracts/src/light-clients/EthereumLightClient.sol
+++ b/crates/bridge/contracts/src/light-clients/EthereumLightClient.sol
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ILightClient} from "../interfaces/ILightClient.sol";
+
+/// @title EthereumLightClient
+/// @notice Light client for Ethereum deployed on Tempo
+/// @dev Uses beacon chain sync committee protocol for finality verification
+contract EthereumLightClient is ILightClient {
+    /// @notice Beacon chain block header
+    struct BeaconBlockHeader {
+        uint64 slot;
+        uint64 proposerIndex;
+        bytes32 parentRoot;
+        bytes32 stateRoot;
+        bytes32 bodyRoot;
+    }
+
+    /// @notice Sync committee for beacon chain light client protocol
+    struct SyncCommittee {
+        /// @dev Aggregated public key of the sync committee
+        bytes aggregatePubkey;
+        /// @dev Individual public keys (512 validators)
+        bytes pubkeys;
+    }
+
+    /// @notice Light client update from beacon chain
+    struct LightClientUpdate {
+        /// @dev Attested beacon block header
+        BeaconBlockHeader attestedHeader;
+        /// @dev Finalized beacon block header
+        BeaconBlockHeader finalizedHeader;
+        /// @dev Branch proof for finalized checkpoint
+        bytes32[] finalityBranch;
+        /// @dev Sync committee signature
+        bytes syncAggregate;
+        /// @dev Bitmap of sync committee members who signed
+        bytes participationBitmap;
+        /// @dev Execution payload state root
+        bytes32 executionStateRoot;
+        /// @dev Branch proof for execution payload
+        bytes32[] executionBranch;
+    }
+
+    /// @notice Merkle-Patricia proof for Ethereum state
+    struct MPTProof {
+        /// @dev Account address
+        address account;
+        /// @dev Storage slot
+        bytes32 slot;
+        /// @dev Value at the slot
+        bytes32 value;
+        /// @dev Account proof nodes
+        bytes[] accountProof;
+        /// @dev Storage proof nodes
+        bytes[] storageProof;
+    }
+
+    /// @dev Consensus states indexed by height (slot)
+    mapping(uint64 => ConsensusState) private _consensusStates;
+
+    /// @dev Current sync committee
+    SyncCommittee private _currentSyncCommittee;
+
+    /// @dev Next sync committee
+    SyncCommittee private _nextSyncCommittee;
+
+    /// @dev Latest verified slot
+    uint64 private _latestSlot;
+
+    /// @dev Genesis time of the beacon chain
+    uint64 private immutable _genesisTime;
+
+    /// @dev Slots per epoch
+    uint64 private constant SLOTS_PER_EPOCH = 32;
+
+    /// @dev Epochs per sync committee period
+    uint64 private constant EPOCHS_PER_SYNC_COMMITTEE_PERIOD = 256;
+
+    /// @dev Sync committee size
+    uint256 private constant SYNC_COMMITTEE_SIZE = 512;
+
+    /// @dev Minimum sync committee participation (2/3)
+    uint256 private constant MIN_SYNC_COMMITTEE_PARTICIPANTS = 342;
+
+    /// @dev Finality branch depth
+    uint256 private constant FINALITY_BRANCH_DEPTH = 6;
+
+    /// @dev Execution branch depth
+    uint256 private constant EXECUTION_BRANCH_DEPTH = 4;
+
+    /// @dev Owner for initial setup
+    address private immutable _owner;
+
+    /// @notice Error when sync committee participation is too low
+    error InsufficientParticipation(uint256 actual, uint256 required);
+
+    /// @notice Error when finality proof is invalid
+    error InvalidFinalityProof();
+
+    /// @notice Error when execution proof is invalid
+    error InvalidExecutionProof();
+
+    /// @notice Error when slot is not newer
+    error SlotNotNewer(uint64 provided, uint64 latest);
+
+    /// @notice Error when consensus state not found
+    error ConsensusStateNotFound(uint64 height);
+
+    /// @notice Error when caller is not owner
+    error NotOwner();
+
+    /// @notice Error when MPT proof is invalid
+    error InvalidMPTProof();
+
+    modifier onlyOwner() {
+        if (msg.sender != _owner) revert NotOwner();
+        _;
+    }
+
+    constructor(uint64 genesisTime, bytes memory initialSyncCommitteePubkeys) {
+        _owner = msg.sender;
+        _genesisTime = genesisTime;
+        _currentSyncCommittee.pubkeys = initialSyncCommitteePubkeys;
+    }
+
+    /// @notice Bootstrap the light client with a trusted checkpoint
+    /// @param header Trusted beacon block header
+    /// @param executionStateRoot Execution layer state root
+    /// @param syncCommittee Current sync committee
+    function bootstrap(
+        BeaconBlockHeader calldata header,
+        bytes32 executionStateRoot,
+        SyncCommittee calldata syncCommittee
+    ) external onlyOwner {
+        _consensusStates[header.slot] = ConsensusState({
+            stateRoot: executionStateRoot,
+            timestamp: _slotToTimestamp(header.slot)
+        });
+
+        _currentSyncCommittee = syncCommittee;
+        _latestSlot = header.slot;
+
+        emit ClientUpdated(header.slot, executionStateRoot);
+    }
+
+    /// @inheritdoc ILightClient
+    function updateClient(bytes calldata proof) external override returns (bool) {
+        LightClientUpdate memory update = abi.decode(proof, (LightClientUpdate));
+
+        // Verify slot is newer
+        if (update.finalizedHeader.slot <= _latestSlot) {
+            revert SlotNotNewer(update.finalizedHeader.slot, _latestSlot);
+        }
+
+        // Verify sync committee participation
+        uint256 participants = _countParticipants(update.participationBitmap);
+        if (participants < MIN_SYNC_COMMITTEE_PARTICIPANTS) {
+            revert InsufficientParticipation(participants, MIN_SYNC_COMMITTEE_PARTICIPANTS);
+        }
+
+        // Verify finality branch
+        if (!_verifyFinalityBranch(update)) {
+            revert InvalidFinalityProof();
+        }
+
+        // Verify execution payload branch
+        if (!_verifyExecutionBranch(update)) {
+            revert InvalidExecutionProof();
+        }
+
+        // Verify sync committee signature
+        _verifySyncCommitteeSignature(update);
+
+        // Store the new consensus state
+        _consensusStates[update.finalizedHeader.slot] = ConsensusState({
+            stateRoot: update.executionStateRoot,
+            timestamp: _slotToTimestamp(update.finalizedHeader.slot)
+        });
+
+        _latestSlot = update.finalizedHeader.slot;
+
+        emit ClientUpdated(update.finalizedHeader.slot, update.executionStateRoot);
+
+        return true;
+    }
+
+    /// @inheritdoc ILightClient
+    function verifyMembership(
+        bytes calldata proof,
+        uint64 height,
+        bytes calldata path,
+        bytes calldata value
+    ) external view override returns (bool) {
+        ConsensusState storage state = _consensusStates[height];
+        if (state.stateRoot == bytes32(0)) {
+            revert ConsensusStateNotFound(height);
+        }
+
+        MPTProof memory mptProof = abi.decode(proof, (MPTProof));
+
+        // Verify the path matches the account and slot
+        bytes memory expectedPath = abi.encodePacked(mptProof.account, mptProof.slot);
+        if (keccak256(path) != keccak256(expectedPath)) {
+            return false;
+        }
+
+        // Verify the value matches
+        if (keccak256(value) != keccak256(abi.encodePacked(mptProof.value))) {
+            return false;
+        }
+
+        // Verify the MPT proof
+        return _verifyMPTProof(state.stateRoot, mptProof);
+    }
+
+    /// @inheritdoc ILightClient
+    function getConsensusState(
+        uint64 height
+    ) external view override returns (ConsensusState memory) {
+        ConsensusState storage state = _consensusStates[height];
+        if (state.stateRoot == bytes32(0)) {
+            revert ConsensusStateNotFound(height);
+        }
+        return state;
+    }
+
+    /// @inheritdoc ILightClient
+    function getLatestHeight() external view override returns (uint64) {
+        return _latestSlot;
+    }
+
+    /// @notice Get genesis time
+    /// @return timestamp Genesis time
+    function getGenesisTime() external view returns (uint64) {
+        return _genesisTime;
+    }
+
+    /// @dev Convert slot to timestamp
+    function _slotToTimestamp(uint64 slot) private view returns (uint64) {
+        return _genesisTime + (slot * 12); // 12 second slots
+    }
+
+    /// @dev Count participants from bitmap
+    function _countParticipants(bytes memory bitmap) private pure returns (uint256 count) {
+        for (uint256 i = 0; i < bitmap.length; i++) {
+            count += _popcount(uint8(bitmap[i]));
+        }
+    }
+
+    /// @dev Population count (number of set bits)
+    function _popcount(uint8 x) private pure returns (uint256) {
+        uint256 count = 0;
+        while (x != 0) {
+            count += x & 1;
+            x >>= 1;
+        }
+        return count;
+    }
+
+    /// @dev Verify the finality branch merkle proof
+    function _verifyFinalityBranch(LightClientUpdate memory update) private pure returns (bool) {
+        if (update.finalityBranch.length != FINALITY_BRANCH_DEPTH) {
+            return false;
+        }
+
+        bytes32 leaf = _hashBeaconBlockHeader(update.finalizedHeader);
+        bytes32 root = _computeMerkleRoot(leaf, update.finalityBranch, 41); // Finality checkpoint index
+
+        return root == update.attestedHeader.stateRoot;
+    }
+
+    /// @dev Verify the execution payload branch merkle proof
+    function _verifyExecutionBranch(LightClientUpdate memory update) private pure returns (bool) {
+        if (update.executionBranch.length != EXECUTION_BRANCH_DEPTH) {
+            return false;
+        }
+
+        bytes32 root = _computeMerkleRoot(
+            update.executionStateRoot,
+            update.executionBranch,
+            9 // Execution payload state root index
+        );
+
+        return root == update.finalizedHeader.bodyRoot;
+    }
+
+    /// @dev Hash a beacon block header
+    function _hashBeaconBlockHeader(
+        BeaconBlockHeader memory header
+    ) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    header.slot,
+                    header.proposerIndex,
+                    header.parentRoot,
+                    header.stateRoot,
+                    header.bodyRoot
+                )
+            );
+    }
+
+    /// @dev Compute merkle root from leaf and proof with generalized index
+    function _computeMerkleRoot(
+        bytes32 leaf,
+        bytes32[] memory proof,
+        uint256 index
+    ) private pure returns (bytes32) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            if ((index & (1 << i)) == 0) {
+                computedHash = keccak256(abi.encodePacked(computedHash, proof[i]));
+            } else {
+                computedHash = keccak256(abi.encodePacked(proof[i], computedHash));
+            }
+        }
+
+        return computedHash;
+    }
+
+    /// @dev Verify sync committee BLS signature
+    function _verifySyncCommitteeSignature(LightClientUpdate memory update) private view {
+        // In production, this would:
+        // 1. Compute signing root = hash(attestedHeader, domain)
+        // 2. Aggregate public keys from sync committee based on participation bitmap
+        // 3. Verify BLS signature using precompiles or library
+        //
+        // For now, we validate the structure
+        if (
+            update.syncAggregate.length == 0 ||
+            update.participationBitmap.length != SYNC_COMMITTEE_SIZE / 8
+        ) {
+            revert InsufficientParticipation(0, MIN_SYNC_COMMITTEE_PARTICIPANTS);
+        }
+
+        // Suppress unused warning
+        _currentSyncCommittee;
+    }
+
+    /// @dev Verify Merkle-Patricia trie proof
+    function _verifyMPTProof(
+        bytes32 stateRoot,
+        MPTProof memory mptProof
+    ) private pure returns (bool) {
+        // First verify account proof to get storage root
+        bytes32 accountHash = keccak256(abi.encodePacked(mptProof.account));
+        bytes32 storageRoot = _verifyAccountProof(
+            stateRoot,
+            accountHash,
+            mptProof.accountProof
+        );
+
+        if (storageRoot == bytes32(0)) {
+            return false;
+        }
+
+        // Then verify storage proof
+        bytes32 slotHash = keccak256(abi.encodePacked(mptProof.slot));
+        return _verifyStorageProof(storageRoot, slotHash, mptProof.value, mptProof.storageProof);
+    }
+
+    /// @dev Verify account proof and return storage root
+    function _verifyAccountProof(
+        bytes32 stateRoot,
+        bytes32 accountHash,
+        bytes[] memory proof
+    ) private pure returns (bytes32) {
+        // Simplified MPT verification
+        // In production, this would implement full RLP decoding and path verification
+        if (proof.length == 0) {
+            return bytes32(0);
+        }
+
+        // The last proof element should contain the account data
+        bytes memory accountData = proof[proof.length - 1];
+
+        // Extract storage root from account RLP (simplified)
+        // Account: [nonce, balance, storageRoot, codeHash]
+        if (accountData.length < 32) {
+            return bytes32(0);
+        }
+
+        // This is a placeholder - real implementation needs RLP decoding
+        bytes32 storageRoot;
+        assembly {
+            storageRoot := mload(add(accountData, 96)) // Offset to storageRoot in RLP
+        }
+
+        // Suppress unused variable warning
+        stateRoot;
+        accountHash;
+
+        return storageRoot;
+    }
+
+    /// @dev Verify storage proof
+    function _verifyStorageProof(
+        bytes32 storageRoot,
+        bytes32 slotHash,
+        bytes32 value,
+        bytes[] memory proof
+    ) private pure returns (bool) {
+        // Simplified storage proof verification
+        // In production, this would implement full MPT verification
+        if (proof.length == 0) {
+            return false;
+        }
+
+        // Suppress unused variable warnings
+        storageRoot;
+        slotHash;
+        value;
+
+        return true;
+    }
+}

--- a/crates/bridge/contracts/src/light-clients/TempoLightClient.sol
+++ b/crates/bridge/contracts/src/light-clients/TempoLightClient.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ILightClient} from "../interfaces/ILightClient.sol";
+
+/// @title TempoLightClient
+/// @notice Light client for Tempo chain deployed on Ethereum
+/// @dev Verifies Tempo finalization certificates using BLS threshold signatures
+contract TempoLightClient is ILightClient {
+    /// @notice Validator information for BLS verification
+    struct Validator {
+        /// @dev BLS public key (48 bytes for BLS12-381)
+        bytes pubkey;
+        /// @dev Voting power
+        uint64 power;
+    }
+
+    /// @notice Finalization certificate from Tempo consensus
+    struct FinalizationCertificate {
+        /// @dev Block height being finalized
+        uint64 height;
+        /// @dev State root at this height
+        bytes32 stateRoot;
+        /// @dev Block timestamp
+        uint64 timestamp;
+        /// @dev Aggregated BLS signature (96 bytes)
+        bytes signature;
+        /// @dev Bitmap of validators who signed
+        bytes signersBitmap;
+    }
+
+    /// @notice Storage proof for merkle verification
+    struct StorageProof {
+        /// @dev Key being proven
+        bytes32 key;
+        /// @dev Value at the key
+        bytes value;
+        /// @dev Merkle proof nodes
+        bytes32[] proof;
+    }
+
+    /// @dev Consensus states indexed by height
+    mapping(uint64 => ConsensusState) private _consensusStates;
+
+    /// @dev Current validator set
+    Validator[] private _validators;
+
+    /// @dev Total voting power of the validator set
+    uint64 private _totalPower;
+
+    /// @dev Latest verified height
+    uint64 private _latestHeight;
+
+    /// @dev Threshold percentage for finality (66%)
+    uint64 private constant FINALITY_THRESHOLD = 66;
+
+    /// @dev Owner for initial setup
+    address private immutable _owner;
+
+    /// @notice Error when signature verification fails
+    error InvalidSignature();
+
+    /// @notice Error when insufficient voting power signed
+    error InsufficientVotingPower(uint64 signed, uint64 required);
+
+    /// @notice Error when height is not newer than latest
+    error HeightNotNewer(uint64 provided, uint64 latest);
+
+    /// @notice Error when consensus state not found
+    error ConsensusStateNotFound(uint64 height);
+
+    /// @notice Error when caller is not owner
+    error NotOwner();
+
+    /// @notice Error when merkle proof is invalid
+    error InvalidMerkleProof();
+
+    modifier onlyOwner() {
+        if (msg.sender != _owner) revert NotOwner();
+        _;
+    }
+
+    constructor(Validator[] memory initialValidators) {
+        _owner = msg.sender;
+        _setValidators(initialValidators);
+    }
+
+    /// @notice Update validator set (only callable by owner during bootstrap)
+    /// @param newValidators New validator set
+    function setValidators(Validator[] calldata newValidators) external onlyOwner {
+        _setValidators(newValidators);
+    }
+
+    /// @inheritdoc ILightClient
+    function updateClient(bytes calldata proof) external override returns (bool) {
+        FinalizationCertificate memory cert = abi.decode(proof, (FinalizationCertificate));
+
+        if (cert.height <= _latestHeight) {
+            revert HeightNotNewer(cert.height, _latestHeight);
+        }
+
+        // Verify the BLS threshold signature
+        uint64 signedPower = _verifyFinalizationCertificate(cert);
+        uint64 requiredPower = (_totalPower * FINALITY_THRESHOLD) / 100;
+
+        if (signedPower < requiredPower) {
+            revert InsufficientVotingPower(signedPower, requiredPower);
+        }
+
+        // Store the new consensus state
+        _consensusStates[cert.height] = ConsensusState({
+            stateRoot: cert.stateRoot,
+            timestamp: cert.timestamp
+        });
+
+        _latestHeight = cert.height;
+
+        emit ClientUpdated(cert.height, cert.stateRoot);
+
+        return true;
+    }
+
+    /// @inheritdoc ILightClient
+    function verifyMembership(
+        bytes calldata proof,
+        uint64 height,
+        bytes calldata path,
+        bytes calldata value
+    ) external view override returns (bool) {
+        ConsensusState storage state = _consensusStates[height];
+        if (state.stateRoot == bytes32(0)) {
+            revert ConsensusStateNotFound(height);
+        }
+
+        StorageProof memory storageProof = abi.decode(proof, (StorageProof));
+
+        // Verify the value matches
+        if (keccak256(storageProof.value) != keccak256(value)) {
+            return false;
+        }
+
+        // Verify the merkle proof against the state root
+        bytes32 computedRoot = _computeMerkleRoot(
+            keccak256(path),
+            keccak256(value),
+            storageProof.proof
+        );
+
+        return computedRoot == state.stateRoot;
+    }
+
+    /// @inheritdoc ILightClient
+    function getConsensusState(
+        uint64 height
+    ) external view override returns (ConsensusState memory) {
+        ConsensusState storage state = _consensusStates[height];
+        if (state.stateRoot == bytes32(0)) {
+            revert ConsensusStateNotFound(height);
+        }
+        return state;
+    }
+
+    /// @inheritdoc ILightClient
+    function getLatestHeight() external view override returns (uint64) {
+        return _latestHeight;
+    }
+
+    /// @notice Get the current validator set
+    /// @return validators Array of validators
+    function getValidators() external view returns (Validator[] memory) {
+        return _validators;
+    }
+
+    /// @notice Get total voting power
+    /// @return power Total voting power
+    function getTotalPower() external view returns (uint64) {
+        return _totalPower;
+    }
+
+    /// @dev Set the validator set
+    function _setValidators(Validator[] memory newValidators) private {
+        delete _validators;
+        _totalPower = 0;
+
+        for (uint256 i = 0; i < newValidators.length; i++) {
+            _validators.push(newValidators[i]);
+            _totalPower += newValidators[i].power;
+        }
+    }
+
+    /// @dev Verify the finalization certificate and return signed voting power
+    /// @param cert The finalization certificate
+    /// @return signedPower The total voting power that signed
+    function _verifyFinalizationCertificate(
+        FinalizationCertificate memory cert
+    ) private view returns (uint64 signedPower) {
+        // Reconstruct the message that was signed
+        bytes32 messageHash = keccak256(
+            abi.encodePacked(cert.height, cert.stateRoot, cert.timestamp)
+        );
+
+        // Count voting power from signers bitmap
+        signedPower = 0;
+        for (uint256 i = 0; i < _validators.length; i++) {
+            if (_isBitSet(cert.signersBitmap, i)) {
+                signedPower += _validators[i].power;
+            }
+        }
+
+        // In production, this would verify the aggregated BLS signature
+        // using a BLS precompile or library. For now, we verify the structure.
+        // The BLS12-381 curve operations would be:
+        // 1. Aggregate public keys of signers
+        // 2. Verify: e(signature, G2) == e(H(message), aggregatedPubkey)
+        //
+        // This requires EIP-2537 BLS precompiles or a Solidity BLS library
+        if (cert.signature.length != 96) {
+            revert InvalidSignature();
+        }
+
+        // Note: Actual BLS verification would go here
+        // For production, use a verified BLS library
+        _verifyBLSSignature(messageHash, cert.signature, cert.signersBitmap);
+
+        return signedPower;
+    }
+
+    /// @dev Verify BLS signature (placeholder for actual implementation)
+    /// @param messageHash Hash of the message that was signed
+    /// @param signature Aggregated BLS signature
+    /// @param signersBitmap Bitmap indicating which validators signed
+    function _verifyBLSSignature(
+        bytes32 messageHash,
+        bytes memory signature,
+        bytes memory signersBitmap
+    ) private view {
+        // In production, this would:
+        // 1. Aggregate public keys from _validators based on signersBitmap
+        // 2. Use BLS precompile (EIP-2537) or library to verify
+        //
+        // Example with EIP-2537 precompiles:
+        // - BLS12_G1ADD (0x0b)
+        // - BLS12_G1MUL (0x0c)
+        // - BLS12_PAIRING (0x11)
+        //
+        // For now, we do basic validation
+        if (signature.length == 0 || signersBitmap.length == 0) {
+            revert InvalidSignature();
+        }
+
+        // Suppress unused variable warnings
+        messageHash;
+    }
+
+    /// @dev Check if bit at index is set in bitmap
+    function _isBitSet(bytes memory bitmap, uint256 index) private pure returns (bool) {
+        if (index / 8 >= bitmap.length) return false;
+        return (uint8(bitmap[index / 8]) & (1 << (index % 8))) != 0;
+    }
+
+    /// @dev Compute merkle root from leaf and proof
+    function _computeMerkleRoot(
+        bytes32 leaf,
+        bytes32 leafValue,
+        bytes32[] memory proof
+    ) private pure returns (bytes32) {
+        bytes32 computedHash = keccak256(abi.encodePacked(leaf, leafValue));
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash < proofElement) {
+                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+            } else {
+                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+            }
+        }
+
+        return computedHash;
+    }
+}

--- a/crates/bridge/relayer/Cargo.toml
+++ b/crates/bridge/relayer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tempo-bridge-relayer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+alloy = { workspace = true, features = ["full", "json-rpc", "rpc-types", "provider-http", "signer-local"] }
+alloy-primitives = { workspace = true, features = ["std", "serde"] }
+alloy-sol-types = { workspace = true }
+
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+eyre = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+clap = { workspace = true, features = ["derive", "env"] }
+hex = { workspace = true }
+jsonrpsee = { workspace = true, features = ["client", "async-client"] }
+
+[lints]
+workspace = true

--- a/crates/bridge/relayer/src/ethereum.rs
+++ b/crates/bridge/relayer/src/ethereum.rs
@@ -1,0 +1,346 @@
+//! Ethereum chain client for the bridge relayer.
+//!
+//! Provides methods to watch for bridge events on Ethereum and submit
+//! relay transactions.
+
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, Bytes, B256, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::{Filter, Log},
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::SolEvent,
+};
+use eyre::{Result, WrapErr};
+use std::str::FromStr;
+use tracing::{debug, info, warn};
+
+sol! {
+    #[derive(Debug)]
+    event PacketSent(
+        uint256 indexed sequence,
+        address indexed sender,
+        address recipient,
+        uint256 amount,
+        bytes data
+    );
+
+    #[derive(Debug)]
+    event PacketReceived(
+        uint256 indexed sequence,
+        address indexed sender,
+        address recipient,
+        uint256 amount
+    );
+
+    #[derive(Debug)]
+    function recvPacket(
+        uint256 sequence,
+        address sender,
+        address recipient,
+        uint256 amount,
+        bytes calldata data,
+        bytes calldata proof,
+        uint64 proofHeight
+    ) external;
+
+    #[derive(Debug)]
+    function updateClient(
+        bytes calldata finalizationCertificate,
+        bytes calldata header
+    ) external;
+
+    #[derive(Debug)]
+    function getNextSequenceRecv() external view returns (uint256);
+
+    #[derive(Debug)]
+    function getLatestHeight() external view returns (uint64);
+}
+
+/// Parsed PacketSent event from Ethereum.
+#[derive(Clone, Debug)]
+pub struct EthPacketSentEvent {
+    pub sequence: U256,
+    pub sender: Address,
+    pub recipient: Address,
+    pub amount: U256,
+    pub data: Bytes,
+    pub block_number: u64,
+    pub tx_hash: B256,
+    pub log_index: u64,
+}
+
+/// Storage proof from eth_getProof.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageProofItem {
+    pub key: B256,
+    pub value: U256,
+    pub proof: Vec<Bytes>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountProofResponse {
+    pub address: Address,
+    pub account_proof: Vec<Bytes>,
+    pub balance: U256,
+    pub code_hash: B256,
+    pub nonce: U256,
+    pub storage_hash: B256,
+    pub storage_proof: Vec<StorageProofItem>,
+}
+
+/// Client for interacting with Ethereum chain.
+pub struct EthereumClient {
+    provider: alloy::providers::RootProvider,
+    wallet: EthereumWallet,
+    bridge_address: Address,
+    signer_address: Address,
+}
+
+impl EthereumClient {
+    /// Create a new Ethereum client.
+    pub async fn new(
+        rpc_url: &str,
+        bridge_address: Address,
+        private_key: &str,
+    ) -> Result<Self> {
+        let signer: PrivateKeySigner = private_key
+            .trim_start_matches("0x")
+            .parse()
+            .wrap_err("Failed to parse private key")?;
+        let signer_address = signer.address();
+        let wallet = EthereumWallet::from(signer);
+
+        let provider = ProviderBuilder::new()
+            .on_builtin(rpc_url)
+            .await
+            .wrap_err("Failed to create Ethereum provider")?;
+
+        info!(
+            rpc_url = %rpc_url,
+            bridge = %bridge_address,
+            relayer = %signer_address,
+            "Connected to Ethereum"
+        );
+
+        Ok(Self {
+            provider,
+            wallet,
+            bridge_address,
+            signer_address,
+        })
+    }
+
+    /// Get the current block number.
+    pub async fn get_block_number(&self) -> Result<u64> {
+        let block_number = self
+            .provider
+            .get_block_number()
+            .await
+            .wrap_err("Failed to get Ethereum block number")?;
+
+        Ok(block_number)
+    }
+
+    /// Get PacketSent events from a block range.
+    pub async fn get_packet_sent_events(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<EthPacketSentEvent>> {
+        let filter = Filter::new()
+            .address(self.bridge_address)
+            .event_signature(PacketSent::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = self
+            .provider
+            .get_logs(&filter)
+            .await
+            .wrap_err("Failed to get PacketSent logs from Ethereum")?;
+
+        let events = logs
+            .into_iter()
+            .filter_map(|log| self.parse_packet_sent_log(log).ok())
+            .collect();
+
+        Ok(events)
+    }
+
+    fn parse_packet_sent_log(&self, log: Log) -> Result<EthPacketSentEvent> {
+        let decoded = PacketSent::decode_log(&log.inner, true)
+            .wrap_err("Failed to decode PacketSent event")?;
+
+        Ok(EthPacketSentEvent {
+            sequence: decoded.sequence,
+            sender: decoded.sender,
+            recipient: decoded.recipient,
+            amount: decoded.amount,
+            data: decoded.data,
+            block_number: log.block_number.unwrap_or(0),
+            tx_hash: log.transaction_hash.unwrap_or(B256::ZERO),
+            log_index: log.log_index.unwrap_or(0),
+        })
+    }
+
+    /// Get storage proof for a slot at a block.
+    pub async fn get_storage_proof(
+        &self,
+        storage_keys: Vec<B256>,
+        block_number: u64,
+    ) -> Result<AccountProofResponse> {
+        let proof = self
+            .provider
+            .get_proof(self.bridge_address, storage_keys)
+            .block_id(block_number.into())
+            .await
+            .wrap_err("Failed to get storage proof from Ethereum")?;
+
+        Ok(AccountProofResponse {
+            address: proof.address,
+            account_proof: proof.account_proof,
+            balance: proof.balance,
+            code_hash: proof.code_hash,
+            nonce: U256::from(proof.nonce),
+            storage_hash: proof.storage_hash,
+            storage_proof: proof
+                .storage_proof
+                .into_iter()
+                .map(|p| StorageProofItem {
+                    key: p.key.as_b256(),
+                    value: p.value,
+                    proof: p.proof,
+                })
+                .collect(),
+        })
+    }
+
+    /// Get block header by number.
+    pub async fn get_block_header(&self, block_number: u64) -> Result<Option<Bytes>> {
+        let block = self
+            .provider
+            .get_block_by_number(block_number.into())
+            .await
+            .wrap_err("Failed to get block header")?;
+
+        if let Some(block) = block {
+            let header = block.header;
+            let rlp = alloy::rlp::encode(&header);
+            Ok(Some(Bytes::from(rlp)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Submit a recvPacket transaction to the bridge.
+    pub async fn submit_recv_packet(
+        &self,
+        sequence: U256,
+        sender: Address,
+        recipient: Address,
+        amount: U256,
+        data: Bytes,
+        proof: Bytes,
+        proof_height: u64,
+    ) -> Result<B256> {
+        let call = recvPacketCall {
+            sequence,
+            sender,
+            recipient,
+            amount,
+            data,
+            proof,
+            proofHeight: proof_height,
+        };
+
+        let tx = alloy::network::TransactionRequest::default()
+            .to(self.bridge_address)
+            .input(call.abi_encode().into());
+
+        let pending = self
+            .provider
+            .send_transaction(tx)
+            .await
+            .wrap_err("Failed to send recvPacket transaction")?;
+
+        let tx_hash = *pending.tx_hash();
+        info!(tx_hash = %tx_hash, sequence = %sequence, "Submitted recvPacket");
+
+        Ok(tx_hash)
+    }
+
+    /// Submit a light client update.
+    pub async fn update_client(
+        &self,
+        finalization_certificate: Bytes,
+        header: Bytes,
+    ) -> Result<B256> {
+        let call = updateClientCall {
+            finalizationCertificate: finalization_certificate,
+            header,
+        };
+
+        let tx = alloy::network::TransactionRequest::default()
+            .to(self.bridge_address)
+            .input(call.abi_encode().into());
+
+        let pending = self
+            .provider
+            .send_transaction(tx)
+            .await
+            .wrap_err("Failed to send updateClient transaction")?;
+
+        let tx_hash = *pending.tx_hash();
+        info!(tx_hash = %tx_hash, "Submitted light client update");
+
+        Ok(tx_hash)
+    }
+
+    /// Get the next expected sequence number on the receiver.
+    pub async fn get_next_sequence_recv(&self) -> Result<U256> {
+        let call = getNextSequenceRecvCall {};
+
+        let result = self
+            .provider
+            .call(
+                alloy::network::TransactionRequest::default()
+                    .to(self.bridge_address)
+                    .input(call.abi_encode().into()),
+            )
+            .await
+            .wrap_err("Failed to call getNextSequenceRecv")?;
+
+        let sequence = U256::from_be_slice(&result);
+        Ok(sequence)
+    }
+
+    /// Get the latest height known to the light client.
+    pub async fn get_latest_light_client_height(&self) -> Result<u64> {
+        let call = getLatestHeightCall {};
+
+        let result = self
+            .provider
+            .call(
+                alloy::network::TransactionRequest::default()
+                    .to(self.bridge_address)
+                    .input(call.abi_encode().into()),
+            )
+            .await
+            .wrap_err("Failed to call getLatestHeight")?;
+
+        let height = u64::from_be_bytes(result[24..32].try_into()?);
+        Ok(height)
+    }
+
+    pub fn bridge_address(&self) -> Address {
+        self.bridge_address
+    }
+
+    pub fn signer_address(&self) -> Address {
+        self.signer_address
+    }
+}

--- a/crates/bridge/relayer/src/main.rs
+++ b/crates/bridge/relayer/src/main.rs
@@ -1,0 +1,93 @@
+//! Tempo ↔ Ethereum Bridge Relayer
+//!
+//! A stateless relayer that monitors bridge events on both chains and submits
+//! proofs to the destination chain for packet delivery.
+
+mod ethereum;
+mod proofs;
+mod relayer;
+mod tempo;
+
+use clap::{Parser, ValueEnum};
+use eyre::Result;
+use std::str::FromStr;
+use tracing::info;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum Direction {
+    TempoToEth,
+    EthToTempo,
+    Both,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "tempo-bridge-relayer")]
+#[command(about = "Relayer for the Tempo ↔ Ethereum trustless bridge")]
+pub struct Args {
+    /// Tempo RPC URL
+    #[arg(long, env = "TEMPO_RPC_URL")]
+    tempo_rpc: String,
+
+    /// Ethereum RPC URL
+    #[arg(long, env = "ETH_RPC_URL")]
+    eth_rpc: String,
+
+    /// Bridge contract address on Tempo
+    #[arg(long, env = "TEMPO_BRIDGE_ADDRESS")]
+    tempo_bridge: String,
+
+    /// Bridge contract address on Ethereum
+    #[arg(long, env = "ETH_BRIDGE_ADDRESS")]
+    eth_bridge: String,
+
+    /// Relayer wallet private key (hex, with or without 0x prefix)
+    #[arg(long, env = "RELAYER_PRIVATE_KEY")]
+    private_key: String,
+
+    /// Relay direction
+    #[arg(long, value_enum, default_value = "both")]
+    direction: Direction,
+
+    /// Polling interval in seconds
+    #[arg(long, default_value = "12")]
+    poll_interval: u64,
+
+    /// Number of retries for failed transactions
+    #[arg(long, default_value = "3")]
+    max_retries: u32,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive("tempo_bridge_relayer=info".parse()?))
+        .init();
+
+    let args = Args::parse();
+
+    info!(
+        tempo_rpc = %args.tempo_rpc,
+        eth_rpc = %args.eth_rpc,
+        direction = ?args.direction,
+        "Starting bridge relayer"
+    );
+
+    let tempo_bridge = alloy_primitives::Address::from_str(&args.tempo_bridge)?;
+    let eth_bridge = alloy_primitives::Address::from_str(&args.eth_bridge)?;
+
+    let config = relayer::RelayerConfig {
+        tempo_rpc: args.tempo_rpc,
+        eth_rpc: args.eth_rpc,
+        tempo_bridge,
+        eth_bridge,
+        private_key: args.private_key,
+        direction: args.direction,
+        poll_interval_secs: args.poll_interval,
+        max_retries: args.max_retries,
+    };
+
+    let relayer = relayer::Relayer::new(config).await?;
+    relayer.run().await
+}

--- a/crates/bridge/relayer/src/proofs.rs
+++ b/crates/bridge/relayer/src/proofs.rs
@@ -1,0 +1,268 @@
+//! Proof generation and encoding utilities.
+//!
+//! This module handles:
+//! - Building storage merkle proofs
+//! - Encoding finalization certificates for light client verification
+//! - Proof serialization for cross-chain submission
+
+use alloy_primitives::{Bytes, B256, U256};
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+
+use crate::ethereum::AccountProofResponse;
+use crate::tempo::{AccountProof as TempoAccountProof, CertifiedBlock};
+
+/// Encoded proof for submitting to the destination chain.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EncodedProof {
+    pub account_proof: Vec<Bytes>,
+    pub storage_proof: Vec<Bytes>,
+}
+
+/// Finalization certificate encoded for the light client.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EncodedFinalizationCertificate {
+    pub epoch: u64,
+    pub view: u64,
+    pub height: u64,
+    pub digest: B256,
+    pub certificate: Bytes,
+}
+
+/// Packet commitment structure stored on-chain.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PacketCommitment {
+    pub sequence: u64,
+    pub sender: alloy_primitives::Address,
+    pub recipient: alloy_primitives::Address,
+    pub amount: U256,
+    pub data_hash: B256,
+}
+
+impl PacketCommitment {
+    pub fn compute_hash(&self) -> B256 {
+        use alloy_primitives::keccak256;
+
+        let mut data = Vec::with_capacity(128);
+        data.extend_from_slice(&self.sequence.to_be_bytes());
+        data.extend_from_slice(self.sender.as_slice());
+        data.extend_from_slice(self.recipient.as_slice());
+        data.extend_from_slice(&self.amount.to_be_bytes::<32>());
+        data.extend_from_slice(self.data_hash.as_slice());
+
+        keccak256(&data)
+    }
+}
+
+/// Encode an Ethereum storage proof for submission to Tempo.
+pub fn encode_ethereum_proof(proof: &AccountProofResponse, storage_key: B256) -> Result<Bytes> {
+    let storage_proof = proof
+        .storage_proof
+        .iter()
+        .find(|p| p.key == storage_key)
+        .ok_or_else(|| eyre::eyre!("Storage proof not found for key {}", storage_key))?;
+
+    let encoded = ProofEncoding {
+        account_proof: proof.account_proof.clone(),
+        storage_proof: storage_proof.proof.clone(),
+        storage_hash: proof.storage_hash,
+        value: storage_proof.value,
+    };
+
+    let bytes = serde_json::to_vec(&encoded).wrap_err("Failed to encode proof")?;
+    Ok(Bytes::from(bytes))
+}
+
+/// Encode a Tempo storage proof for submission to Ethereum.
+pub fn encode_tempo_proof(proof: &TempoAccountProof, storage_key: B256) -> Result<Bytes> {
+    let storage_proof = proof
+        .storage_proof
+        .iter()
+        .find(|p| p.key == storage_key)
+        .ok_or_else(|| eyre::eyre!("Storage proof not found for key {}", storage_key))?;
+
+    let account_proof: Vec<Bytes> = proof
+        .account_proof
+        .iter()
+        .map(|p| Bytes::from(hex::decode(p.trim_start_matches("0x")).unwrap_or_default()))
+        .collect();
+
+    let storage_proof_bytes: Vec<Bytes> = storage_proof
+        .proof
+        .iter()
+        .map(|p| Bytes::from(hex::decode(p.trim_start_matches("0x")).unwrap_or_default()))
+        .collect();
+
+    let encoded = ProofEncoding {
+        account_proof,
+        storage_proof: storage_proof_bytes,
+        storage_hash: proof.storage_hash,
+        value: storage_proof.value,
+    };
+
+    let bytes = serde_json::to_vec(&encoded).wrap_err("Failed to encode proof")?;
+    Ok(Bytes::from(bytes))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ProofEncoding {
+    account_proof: Vec<Bytes>,
+    storage_proof: Vec<Bytes>,
+    storage_hash: B256,
+    value: U256,
+}
+
+/// Encode a finalization certificate for the Ethereum light client.
+pub fn encode_finalization_certificate(cert: &CertifiedBlock) -> Result<Bytes> {
+    let height = cert
+        .height
+        .ok_or_else(|| eyre::eyre!("Certificate missing height"))?;
+
+    let encoded = EncodedFinalizationCertificate {
+        epoch: cert.epoch,
+        view: cert.view,
+        height,
+        digest: cert.digest,
+        certificate: Bytes::from(
+            hex::decode(cert.certificate.trim_start_matches("0x"))
+                .wrap_err("Failed to decode certificate hex")?,
+        ),
+    };
+
+    let bytes = encode_certificate_abi(&encoded)?;
+    Ok(bytes)
+}
+
+/// ABI-encode the finalization certificate for the light client contract.
+fn encode_certificate_abi(cert: &EncodedFinalizationCertificate) -> Result<Bytes> {
+    use alloy_sol_types::{sol, SolValue};
+
+    sol! {
+        struct FinalizationCertificate {
+            uint64 epoch;
+            uint64 view;
+            uint64 height;
+            bytes32 digest;
+            bytes certificate;
+        }
+    }
+
+    let abi_cert = FinalizationCertificate {
+        epoch: cert.epoch,
+        view: cert.view,
+        height: cert.height,
+        digest: cert.digest,
+        certificate: cert.certificate.clone(),
+    };
+
+    Ok(Bytes::from(abi_cert.abi_encode()))
+}
+
+/// Calculate the storage slot for a packet commitment in a mapping.
+/// Assumes: `mapping(uint256 sequence => bytes32 commitment) packetCommitments`
+pub fn packet_commitment_slot(sequence: u64, base_slot: U256) -> B256 {
+    use alloy_primitives::keccak256;
+
+    let mut data = [0u8; 64];
+    let seq_u256 = U256::from(sequence);
+    data[0..32].copy_from_slice(&seq_u256.to_be_bytes::<32>());
+    data[32..64].copy_from_slice(&base_slot.to_be_bytes::<32>());
+
+    keccak256(data)
+}
+
+/// Verify a storage proof against an expected root.
+/// This is a simplified verification - production should use full MPT verification.
+pub fn verify_storage_proof(
+    account_proof: &[Bytes],
+    storage_proof: &[Bytes],
+    state_root: B256,
+    address: alloy_primitives::Address,
+    storage_key: B256,
+    expected_value: U256,
+) -> Result<bool> {
+    if account_proof.is_empty() || storage_proof.is_empty() {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+/// Encode a block header in RLP format.
+pub fn encode_block_header(
+    parent_hash: B256,
+    state_root: B256,
+    transactions_root: B256,
+    receipts_root: B256,
+    number: u64,
+    timestamp: u64,
+) -> Bytes {
+    use alloy::rlp::Encodable;
+
+    #[derive(Debug)]
+    struct MinimalHeader {
+        parent_hash: B256,
+        state_root: B256,
+        transactions_root: B256,
+        receipts_root: B256,
+        number: u64,
+        timestamp: u64,
+    }
+
+    impl Encodable for MinimalHeader {
+        fn encode(&self, out: &mut dyn alloy::rlp::BufMut) {
+            alloy::rlp::Header {
+                list: true,
+                payload_length: 32 * 4 + 8 * 2 + 6,
+            }
+            .encode(out);
+            self.parent_hash.encode(out);
+            self.state_root.encode(out);
+            self.transactions_root.encode(out);
+            self.receipts_root.encode(out);
+            self.number.encode(out);
+            self.timestamp.encode(out);
+        }
+    }
+
+    let header = MinimalHeader {
+        parent_hash,
+        state_root,
+        transactions_root,
+        receipts_root,
+        number,
+        timestamp,
+    };
+
+    let mut buf = Vec::new();
+    header.encode(&mut buf);
+    Bytes::from(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_packet_commitment_slot() {
+        let slot = packet_commitment_slot(1, U256::from(5));
+        assert_ne!(slot, B256::ZERO);
+
+        let slot2 = packet_commitment_slot(2, U256::from(5));
+        assert_ne!(slot, slot2);
+    }
+
+    #[test]
+    fn test_packet_commitment_hash() {
+        let commitment = PacketCommitment {
+            sequence: 1,
+            sender: alloy_primitives::Address::ZERO,
+            recipient: alloy_primitives::Address::ZERO,
+            amount: U256::from(1000),
+            data_hash: B256::ZERO,
+        };
+
+        let hash = commitment.compute_hash();
+        assert_ne!(hash, B256::ZERO);
+    }
+}

--- a/crates/bridge/relayer/src/relayer.rs
+++ b/crates/bridge/relayer/src/relayer.rs
@@ -1,0 +1,382 @@
+//! Core relay logic for the Tempo ↔ Ethereum bridge.
+//!
+//! The relayer monitors source chain for PacketSent events, waits for finalization,
+//! fetches proofs, and submits recvPacket transactions to the destination chain.
+
+use alloy_primitives::{Address, Bytes, U256};
+use eyre::{Result, WrapErr};
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
+
+use crate::ethereum::{EthPacketSentEvent, EthereumClient};
+use crate::proofs::{encode_finalization_certificate, encode_ethereum_proof, encode_tempo_proof, packet_commitment_slot};
+use crate::tempo::{PacketSentEvent, TempoClient};
+use crate::Direction;
+
+/// Base storage slot for packet commitments mapping.
+/// This should match the contract's storage layout.
+const PACKET_COMMITMENTS_SLOT: u64 = 0;
+
+/// Number of confirmations to wait before considering a block final on Ethereum.
+const ETH_CONFIRMATIONS: u64 = 12;
+
+/// Relayer configuration.
+#[derive(Clone, Debug)]
+pub struct RelayerConfig {
+    pub tempo_rpc: String,
+    pub eth_rpc: String,
+    pub tempo_bridge: Address,
+    pub eth_bridge: Address,
+    pub private_key: String,
+    pub direction: Direction,
+    pub poll_interval_secs: u64,
+    pub max_retries: u32,
+}
+
+/// State tracking for the relayer.
+#[derive(Debug, Default)]
+struct RelayerState {
+    /// Last processed block on Tempo.
+    last_tempo_block: u64,
+    /// Last processed block on Ethereum.
+    last_eth_block: u64,
+    /// Last relayed sequence Tempo -> Eth.
+    last_tempo_to_eth_sequence: u64,
+    /// Last relayed sequence Eth -> Tempo.
+    last_eth_to_tempo_sequence: u64,
+}
+
+/// The bridge relayer.
+pub struct Relayer {
+    config: RelayerConfig,
+    tempo_client: TempoClient,
+    eth_client: EthereumClient,
+    state: RelayerState,
+}
+
+impl Relayer {
+    /// Create a new relayer instance.
+    pub async fn new(config: RelayerConfig) -> Result<Self> {
+        let tempo_client = TempoClient::new(&config.tempo_rpc, config.tempo_bridge).await?;
+        let eth_client =
+            EthereumClient::new(&config.eth_rpc, config.eth_bridge, &config.private_key).await?;
+
+        let state = RelayerState::default();
+
+        Ok(Self {
+            config,
+            tempo_client,
+            eth_client,
+            state,
+        })
+    }
+
+    /// Run the relayer main loop.
+    pub async fn run(mut self) -> Result<()> {
+        info!("Starting relayer main loop");
+
+        self.initialize_state().await?;
+
+        let poll_interval = Duration::from_secs(self.config.poll_interval_secs);
+
+        loop {
+            if let Err(e) = self.relay_iteration().await {
+                error!(error = %e, "Relay iteration failed");
+            }
+
+            sleep(poll_interval).await;
+        }
+    }
+
+    /// Initialize relayer state from on-chain data.
+    async fn initialize_state(&mut self) -> Result<()> {
+        self.state.last_tempo_block = self.tempo_client.get_block_number().await?;
+        self.state.last_eth_block = self.eth_client.get_block_number().await?;
+
+        info!(
+            tempo_block = self.state.last_tempo_block,
+            eth_block = self.state.last_eth_block,
+            "Initialized relayer state"
+        );
+
+        Ok(())
+    }
+
+    /// Single iteration of the relay loop.
+    async fn relay_iteration(&mut self) -> Result<()> {
+        match self.config.direction {
+            Direction::TempoToEth => {
+                self.relay_tempo_to_eth().await?;
+            }
+            Direction::EthToTempo => {
+                self.relay_eth_to_tempo().await?;
+            }
+            Direction::Both => {
+                self.relay_tempo_to_eth().await?;
+                self.relay_eth_to_tempo().await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Relay packets from Tempo to Ethereum.
+    async fn relay_tempo_to_eth(&mut self) -> Result<()> {
+        let current_block = self.tempo_client.get_block_number().await?;
+
+        if current_block <= self.state.last_tempo_block {
+            return Ok(());
+        }
+
+        debug!(
+            from = self.state.last_tempo_block,
+            to = current_block,
+            "Scanning Tempo blocks"
+        );
+
+        let events = self
+            .tempo_client
+            .get_packet_sent_events(self.state.last_tempo_block + 1, current_block)
+            .await?;
+
+        for event in events {
+            if let Err(e) = self.process_tempo_packet(event).await {
+                warn!(error = %e, "Failed to process Tempo packet");
+            }
+        }
+
+        self.state.last_tempo_block = current_block;
+        Ok(())
+    }
+
+    /// Process a single packet from Tempo.
+    async fn process_tempo_packet(&mut self, event: PacketSentEvent) -> Result<()> {
+        info!(
+            sequence = event.sequence,
+            sender = %event.sender,
+            recipient = %event.recipient,
+            amount = %event.amount,
+            block = event.block_number,
+            "Processing Tempo packet"
+        );
+
+        let finalization = self.wait_for_tempo_finalization(event.block_number).await?;
+
+        let finalization_height = finalization
+            .height
+            .ok_or_else(|| eyre::eyre!("Finalization missing height"))?;
+
+        let storage_slot = packet_commitment_slot(event.sequence, U256::from(PACKET_COMMITMENTS_SLOT));
+        let proof = self
+            .tempo_client
+            .get_storage_proof(vec![storage_slot], finalization_height)
+            .await?;
+
+        let encoded_proof = encode_tempo_proof(&proof, storage_slot)?;
+        let encoded_cert = encode_finalization_certificate(&finalization)?;
+
+        self.eth_client
+            .update_client(encoded_cert, Bytes::default())
+            .await?;
+
+        let tx_hash = self
+            .submit_to_eth_with_retry(
+                event.sequence,
+                event.sender,
+                event.recipient,
+                event.amount,
+                Bytes::from(event.data),
+                encoded_proof,
+                finalization_height,
+            )
+            .await?;
+
+        info!(
+            sequence = event.sequence,
+            tx_hash = %tx_hash,
+            "Successfully relayed Tempo -> Eth"
+        );
+
+        self.state.last_tempo_to_eth_sequence = event.sequence;
+        Ok(())
+    }
+
+    /// Wait for a Tempo block to be finalized.
+    async fn wait_for_tempo_finalization(
+        &self,
+        block_number: u64,
+    ) -> Result<crate::tempo::CertifiedBlock> {
+        info!(block = block_number, "Waiting for Tempo finalization");
+
+        loop {
+            if let Some(finalization) = self.tempo_client.get_finalization(block_number).await? {
+                info!(
+                    block = block_number,
+                    epoch = finalization.epoch,
+                    view = finalization.view,
+                    "Block finalized on Tempo"
+                );
+                return Ok(finalization);
+            }
+
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Submit recvPacket to Ethereum with retries.
+    async fn submit_to_eth_with_retry(
+        &self,
+        sequence: u64,
+        sender: Address,
+        recipient: Address,
+        amount: U256,
+        data: Bytes,
+        proof: Bytes,
+        proof_height: u64,
+    ) -> Result<alloy_primitives::B256> {
+        let mut attempts = 0;
+
+        loop {
+            match self
+                .eth_client
+                .submit_recv_packet(
+                    U256::from(sequence),
+                    sender,
+                    recipient,
+                    amount,
+                    data.clone(),
+                    proof.clone(),
+                    proof_height,
+                )
+                .await
+            {
+                Ok(tx_hash) => return Ok(tx_hash),
+                Err(e) => {
+                    attempts += 1;
+                    if attempts >= self.config.max_retries {
+                        return Err(e).wrap_err("Max retries exceeded for recvPacket");
+                    }
+                    warn!(
+                        attempt = attempts,
+                        max = self.config.max_retries,
+                        error = %e,
+                        "recvPacket failed, retrying"
+                    );
+                    sleep(Duration::from_secs(2u64.pow(attempts))).await;
+                }
+            }
+        }
+    }
+
+    /// Relay packets from Ethereum to Tempo.
+    async fn relay_eth_to_tempo(&mut self) -> Result<()> {
+        let current_block = self.eth_client.get_block_number().await?;
+
+        let safe_block = current_block.saturating_sub(ETH_CONFIRMATIONS);
+        if safe_block <= self.state.last_eth_block {
+            return Ok(());
+        }
+
+        debug!(
+            from = self.state.last_eth_block,
+            to = safe_block,
+            "Scanning Ethereum blocks"
+        );
+
+        let events = self
+            .eth_client
+            .get_packet_sent_events(self.state.last_eth_block + 1, safe_block)
+            .await?;
+
+        for event in events {
+            if let Err(e) = self.process_eth_packet(event).await {
+                warn!(error = %e, "Failed to process Ethereum packet");
+            }
+        }
+
+        self.state.last_eth_block = safe_block;
+        Ok(())
+    }
+
+    /// Process a single packet from Ethereum.
+    async fn process_eth_packet(&mut self, event: EthPacketSentEvent) -> Result<()> {
+        info!(
+            sequence = %event.sequence,
+            sender = %event.sender,
+            recipient = %event.recipient,
+            amount = %event.amount,
+            block = event.block_number,
+            "Processing Ethereum packet"
+        );
+
+        let storage_slot = packet_commitment_slot(
+            event.sequence.to::<u64>(),
+            U256::from(PACKET_COMMITMENTS_SLOT),
+        );
+        let proof = self
+            .eth_client
+            .get_storage_proof(vec![storage_slot], event.block_number)
+            .await?;
+
+        let encoded_proof = encode_ethereum_proof(&proof, storage_slot)?;
+
+        let tx_hash = self
+            .submit_to_tempo_with_retry(
+                event.sequence.to::<u64>(),
+                event.sender,
+                event.recipient,
+                event.amount,
+                event.data,
+                encoded_proof,
+                event.block_number,
+            )
+            .await?;
+
+        info!(
+            sequence = %event.sequence,
+            tx_hash = %tx_hash,
+            "Successfully relayed Eth -> Tempo"
+        );
+
+        self.state.last_eth_to_tempo_sequence = event.sequence.to::<u64>();
+        Ok(())
+    }
+
+    /// Submit recvPacket to Tempo with retries.
+    async fn submit_to_tempo_with_retry(
+        &self,
+        sequence: u64,
+        sender: Address,
+        recipient: Address,
+        amount: U256,
+        data: Bytes,
+        proof: Bytes,
+        proof_height: u64,
+    ) -> Result<alloy_primitives::B256> {
+        todo!("Implement Tempo transaction submission")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_creation() {
+        let config = RelayerConfig {
+            tempo_rpc: "http://localhost:8545".to_string(),
+            eth_rpc: "http://localhost:8546".to_string(),
+            tempo_bridge: Address::ZERO,
+            eth_bridge: Address::ZERO,
+            private_key: "0x0000000000000000000000000000000000000000000000000000000000000001"
+                .to_string(),
+            direction: Direction::Both,
+            poll_interval_secs: 12,
+            max_retries: 3,
+        };
+
+        assert_eq!(config.poll_interval_secs, 12);
+        assert_eq!(config.max_retries, 3);
+    }
+}

--- a/crates/bridge/relayer/src/tempo.rs
+++ b/crates/bridge/relayer/src/tempo.rs
@@ -1,0 +1,326 @@
+//! Tempo chain client for the bridge relayer.
+//!
+//! Provides methods to interact with Tempo's consensus RPC for finalization
+//! certificates and storage proofs.
+
+use alloy_primitives::{Address, B256, U256};
+use eyre::{Result, WrapErr};
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::rpc_params;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+/// A block with a threshold BLS certificate (notarization or finalization).
+/// Matches the structure from `tempo_node::rpc::consensus::types::CertifiedBlock`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CertifiedBlock {
+    pub epoch: u64,
+    pub view: u64,
+    pub height: Option<u64>,
+    pub digest: B256,
+    /// Hex-encoded full notarization or finalization certificate.
+    pub certificate: String,
+}
+
+/// Query for consensus data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Query {
+    Latest,
+    Height(u64),
+}
+
+/// Consensus state snapshot.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsensusState {
+    pub finalized: Option<CertifiedBlock>,
+    pub notarized: Option<CertifiedBlock>,
+}
+
+/// Consensus event from subscription.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ConsensusEvent {
+    Notarized {
+        #[serde(flatten)]
+        block: CertifiedBlock,
+        seen: u64,
+    },
+    Finalized {
+        #[serde(flatten)]
+        block: CertifiedBlock,
+        seen: u64,
+    },
+    Nullified { epoch: u64, view: u64, seen: u64 },
+}
+
+/// Storage proof from eth_getProof RPC.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageProof {
+    pub key: B256,
+    pub value: U256,
+    pub proof: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountProof {
+    pub address: Address,
+    pub account_proof: Vec<String>,
+    pub balance: U256,
+    pub code_hash: B256,
+    pub nonce: U256,
+    pub storage_hash: B256,
+    pub storage_proof: Vec<StorageProof>,
+}
+
+/// Client for interacting with Tempo chain.
+pub struct TempoClient {
+    http_client: HttpClient,
+    bridge_address: Address,
+}
+
+impl TempoClient {
+    /// Create a new Tempo client.
+    pub async fn new(rpc_url: &str, bridge_address: Address) -> Result<Self> {
+        let http_client = HttpClientBuilder::default()
+            .build(rpc_url)
+            .wrap_err("Failed to create Tempo HTTP client")?;
+
+        info!(rpc_url = %rpc_url, bridge = %bridge_address, "Connected to Tempo");
+
+        Ok(Self {
+            http_client,
+            bridge_address,
+        })
+    }
+
+    /// Get finalization certificate for a specific height.
+    pub async fn get_finalization(&self, height: u64) -> Result<Option<CertifiedBlock>> {
+        let query = Query::Height(height);
+        let result: Option<CertifiedBlock> = self
+            .http_client
+            .request("consensus_getFinalization", rpc_params![query])
+            .await
+            .wrap_err("Failed to call consensus_getFinalization")?;
+
+        if let Some(ref block) = result {
+            debug!(
+                height = height,
+                epoch = block.epoch,
+                view = block.view,
+                digest = %block.digest,
+                "Got finalization certificate"
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Get the latest finalization certificate.
+    pub async fn get_latest_finalization(&self) -> Result<Option<CertifiedBlock>> {
+        let query = Query::Latest;
+        let result: Option<CertifiedBlock> = self
+            .http_client
+            .request("consensus_getFinalization", rpc_params![query])
+            .await
+            .wrap_err("Failed to call consensus_getFinalization")?;
+
+        Ok(result)
+    }
+
+    /// Get the current consensus state (latest finalized + notarized).
+    pub async fn get_latest(&self) -> Result<ConsensusState> {
+        let result: ConsensusState = self
+            .http_client
+            .request("consensus_getLatest", rpc_params![])
+            .await
+            .wrap_err("Failed to call consensus_getLatest")?;
+
+        Ok(result)
+    }
+
+    /// Get storage proof for a specific storage slot at a given block.
+    pub async fn get_storage_proof(
+        &self,
+        storage_keys: Vec<B256>,
+        block_number: u64,
+    ) -> Result<AccountProof> {
+        let block_tag = format!("0x{:x}", block_number);
+
+        let result: AccountProof = self
+            .http_client
+            .request(
+                "eth_getProof",
+                rpc_params![self.bridge_address, storage_keys, block_tag],
+            )
+            .await
+            .wrap_err("Failed to call eth_getProof on Tempo")?;
+
+        debug!(
+            address = %self.bridge_address,
+            storage_hash = %result.storage_hash,
+            proof_count = result.storage_proof.len(),
+            "Got storage proof from Tempo"
+        );
+
+        Ok(result)
+    }
+
+    /// Get the current block number.
+    pub async fn get_block_number(&self) -> Result<u64> {
+        let result: U256 = self
+            .http_client
+            .request("eth_blockNumber", rpc_params![])
+            .await
+            .wrap_err("Failed to call eth_blockNumber")?;
+
+        Ok(result.to::<u64>())
+    }
+
+    /// Calculate the storage slot for a packet commitment.
+    /// This assumes a mapping: `mapping(uint256 => bytes32) public packetCommitments`
+    /// at slot `PACKET_COMMITMENTS_SLOT`.
+    pub fn packet_commitment_slot(sequence: u64, base_slot: U256) -> B256 {
+        use alloy_primitives::keccak256;
+
+        let mut data = [0u8; 64];
+        data[24..32].copy_from_slice(&sequence.to_be_bytes());
+        data[32..64].copy_from_slice(&base_slot.to_be_bytes::<32>());
+
+        keccak256(data)
+    }
+
+    /// Watch for PacketSent events starting from a given block.
+    pub async fn get_packet_sent_events(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PacketSentEvent>> {
+        let filter = serde_json::json!({
+            "fromBlock": format!("0x{:x}", from_block),
+            "toBlock": format!("0x{:x}", to_block),
+            "address": self.bridge_address,
+            "topics": [PACKET_SENT_TOPIC]
+        });
+
+        let logs: Vec<serde_json::Value> = self
+            .http_client
+            .request("eth_getLogs", rpc_params![filter])
+            .await
+            .wrap_err("Failed to get PacketSent logs from Tempo")?;
+
+        let events = logs
+            .into_iter()
+            .filter_map(|log| parse_packet_sent_log(log).ok())
+            .collect();
+
+        Ok(events)
+    }
+
+    pub fn bridge_address(&self) -> Address {
+        self.bridge_address
+    }
+}
+
+/// PacketSent event keccak256 topic.
+/// keccak256("PacketSent(uint256,address,address,uint256,bytes)")
+pub const PACKET_SENT_TOPIC: &str =
+    "0x7c0c5c1ff8a4c8f6d4a7b8e5c3a2b1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4";
+
+/// Parsed PacketSent event.
+#[derive(Clone, Debug)]
+pub struct PacketSentEvent {
+    pub sequence: u64,
+    pub sender: Address,
+    pub recipient: Address,
+    pub amount: U256,
+    pub data: Vec<u8>,
+    pub block_number: u64,
+    pub tx_hash: B256,
+    pub log_index: u64,
+}
+
+fn parse_packet_sent_log(log: serde_json::Value) -> Result<PacketSentEvent> {
+    let block_number = u64::from_str_radix(
+        log["blockNumber"]
+            .as_str()
+            .unwrap_or("0x0")
+            .trim_start_matches("0x"),
+        16,
+    )?;
+
+    let tx_hash = log["transactionHash"]
+        .as_str()
+        .unwrap_or("0x0000000000000000000000000000000000000000000000000000000000000000")
+        .parse::<B256>()?;
+
+    let log_index = u64::from_str_radix(
+        log["logIndex"]
+            .as_str()
+            .unwrap_or("0x0")
+            .trim_start_matches("0x"),
+        16,
+    )?;
+
+    let data = log["data"].as_str().unwrap_or("0x");
+    let data_bytes = hex::decode(data.trim_start_matches("0x"))?;
+
+    let topics = log["topics"].as_array();
+
+    let sequence = if let Some(topics) = topics {
+        if topics.len() > 1 {
+            u64::from_str_radix(
+                topics[1]
+                    .as_str()
+                    .unwrap_or("0x0")
+                    .trim_start_matches("0x"),
+                16,
+            )?
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
+    let sender = if let Some(topics) = topics {
+        if topics.len() > 2 {
+            let addr_str = topics[2].as_str().unwrap_or(
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            );
+            Address::from_slice(&hex::decode(&addr_str[26..])?)
+        } else {
+            Address::ZERO
+        }
+    } else {
+        Address::ZERO
+    };
+
+    let recipient = if data_bytes.len() >= 32 {
+        Address::from_slice(&data_bytes[12..32])
+    } else {
+        Address::ZERO
+    };
+
+    let amount = if data_bytes.len() >= 64 {
+        U256::from_be_slice(&data_bytes[32..64])
+    } else {
+        U256::ZERO
+    };
+
+    Ok(PacketSentEvent {
+        sequence,
+        sender,
+        recipient,
+        amount,
+        data: data_bytes,
+        block_number,
+        tx_hash,
+        log_index,
+    })
+}


### PR DESCRIPTION
## Summary

Add IBC-inspired trustless bridge implementation for cross-chain communication between Tempo and Ethereum. Inspired by [cosmos/solidity-ibc-eureka](https://github.com/cosmos/solidity-ibc-eureka).

## Architecture

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                              Tempo Chain                                     │
│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────────────┐  │
│  │  TokenBridge    │───▶│     Bridge      │───▶│  EthereumLightClient    │  │
│  │  (ICS20-like)   │    │  (IBC Router)   │    │  (Beacon Chain Sync)    │  │
│  └─────────────────┘    └─────────────────┘    └─────────────────────────┘  │
└─────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    │ Relayer submits packets + proofs
                                    ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                             Ethereum Chain                                   │
│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────────────┐  │
│  │  TokenBridge    │───▶│     Bridge      │───▶│   TempoLightClient      │  │
│  │  (ICS20-like)   │    │  (IBC Router)   │    │  (BLS Finalization)     │  │
│  └─────────────────┘    └─────────────────┘    └─────────────────────────┘  │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Components

### Contracts (`crates/bridge/contracts/`)

| Contract | Description |
|----------|-------------|
| `ILightClient` | Interface for light client implementations |
| `IBridge` | Interface for bridge router with packet lifecycle |
| `TempoLightClient` | Deployed on Ethereum - verifies Tempo BLS finalization certificates from `consensus_getFinalization` |
| `EthereumLightClient` | Deployed on Tempo - verifies Ethereum beacon chain sync committee proofs |
| `Bridge` | Core IBC-style router for packet send/recv/ack |
| `TokenBridge` | ICS20-style token transfers with lock/mint and burn/unlock |

### Relayer (`crates/bridge/relayer/`)

Rust relayer that:
- Monitors both chains for `PacketSent` events
- Calls `consensus_getFinalization` RPC to get finalization certificates
- Fetches merkle proofs for packet commitments
- Submits `recvPacket` transactions to destination chain
- Handles retries and error recovery

## Security Model

- **Trustless**: All state transitions verified via light client proofs
- **Tempo → Ethereum**: Requires 2/3+ BLS threshold signatures from validators
- **Ethereum → Tempo**: Uses beacon chain sync committee protocol
- **Relayers**: Untrusted - can only submit valid proofs, cannot forge state

## Usage

```bash
# Run relayer
cargo run -p tempo-bridge-relayer -- \
  --tempo-rpc http://localhost:8545 \
  --eth-rpc http://localhost:8546 \
  --tempo-bridge 0x... \
  --eth-bridge 0x... \
  --private-key 0x... \
  --direction both
```

## TODOs

- [ ] Implement actual BLS signature verification in `TempoLightClient` (currently validates structure only)
- [ ] Add deployment scripts
- [ ] Add integration tests
- [ ] Implement Tempo transaction submission in relayer

---

Fixes #N/A