### PR TITLE
feat(rpc): add block header and threshold public key to consensus RPC

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -308,6 +308,7 @@ where
             context.with_label("feed"),
             marshal_mailbox.clone(),
             self.feed_state,
+            scheme_provider.clone(),
         );
 
         let (executor, executor_mailbox) = crate::executor::init(

--- a/crates/commonware-node/src/feed/mod.rs
+++ b/crates/commonware-node/src/feed/mod.rs
@@ -14,7 +14,7 @@ mod state;
 use commonware_runtime::Spawner;
 use futures::channel::mpsc;
 
-use crate::alias::marshal;
+use crate::{alias::marshal, epoch::SchemeProvider};
 pub(crate) use actor::Actor;
 pub(crate) use ingress::Mailbox;
 pub use state::FeedStateHandle;
@@ -24,9 +24,10 @@ pub(crate) fn init<TContext: Spawner>(
     context: TContext,
     marshal: marshal::Mailbox,
     state: FeedStateHandle,
+    scheme_provider: SchemeProvider,
 ) -> (Actor<TContext>, Mailbox) {
     let (tx, rx) = mpsc::unbounded();
     let mailbox = Mailbox::new(tx);
-    let actor = Actor::new(context, marshal, rx, state);
+    let actor = Actor::new(context, marshal, rx, state, scheme_provider);
     (actor, mailbox)
 }

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -1,12 +1,16 @@
 //! Shared state for the feed module.
 
-use crate::{alias::marshal, consensus::Digest};
+use crate::{alias::marshal, consensus::Digest, epoch::SchemeProvider};
+use alloy_consensus::BlockHeader as _;
 use alloy_primitives::hex;
 use commonware_codec::Encode;
 use commonware_consensus::{Heightable as _, types::Height};
+use commonware_cryptography::certificate::Provider;
 use parking_lot::RwLock;
 use std::sync::{Arc, OnceLock};
-use tempo_node::rpc::consensus::{CertifiedBlock, ConsensusFeed, ConsensusState, Event, Query};
+use tempo_node::rpc::consensus::{
+    BlockHeaderData, CertifiedBlock, ConsensusFeed, ConsensusState, Event, Query,
+};
 use tokio::sync::broadcast;
 
 const BROADCAST_CHANNEL_SIZE: usize = 1024;
@@ -28,6 +32,7 @@ pub(super) struct FeedState {
 pub struct FeedStateHandle {
     state: Arc<RwLock<FeedState>>,
     marshal: Arc<OnceLock<marshal::Mailbox>>,
+    scheme_provider: Arc<OnceLock<SchemeProvider>>,
     events_tx: broadcast::Sender<Event>,
 }
 
@@ -44,6 +49,7 @@ impl FeedStateHandle {
                 latest_finalized: None,
             })),
             marshal: Arc::new(OnceLock::new()),
+            scheme_provider: Arc::new(OnceLock::new()),
             events_tx,
         }
     }
@@ -51,6 +57,11 @@ impl FeedStateHandle {
     /// Set the marshal mailbox for historical finalization lookups. Should only be called once.
     pub(crate) fn set_marshal(&self, marshal: marshal::Mailbox) {
         let _ = self.marshal.set(marshal);
+    }
+
+    /// Set the scheme provider for threshold public key lookups. Should only be called once.
+    pub(crate) fn set_scheme_provider(&self, provider: SchemeProvider) {
+        let _ = self.scheme_provider.set(provider);
     }
 
     /// Get the broadcast sender for events.
@@ -72,15 +83,33 @@ impl FeedStateHandle {
         marshal
     }
 
-    /// Fill in the height for a block if it's missing by querying the marshal.
-    async fn maybe_fill_height(&self, block: &mut CertifiedBlock) {
-        if block.height.is_none()
-            && let Some(mut marshal) = self.marshal()
-        {
-            block.height = marshal
-                .get_block(&Digest(block.digest))
-                .await
-                .map(|b| b.height().get());
+    /// Get the threshold public key for an epoch.
+    fn threshold_public_key(&self, epoch: u64) -> Option<String> {
+        use commonware_codec::Encode as _;
+        self.scheme_provider.get().and_then(|provider| {
+            provider
+                .scoped(commonware_consensus::types::Epoch::new(epoch))
+                .map(|scheme| hex::encode(scheme.identity().encode()))
+        })
+    }
+
+    /// Fill in missing block data by querying the marshal.
+    async fn maybe_fill_block_data(&self, block: &mut CertifiedBlock) {
+        if block.height.is_none() || block.header.is_none() {
+            if let Some(mut marshal) = self.marshal() {
+                if let Some(b) = marshal.get_block(&Digest(block.digest)).await {
+                    block.height = Some(b.height().get());
+                    block.header = Some(BlockHeaderData {
+                        parent_hash: b.parent_hash(),
+                        state_root: b.state_root(),
+                        receipts_root: b.receipts_root(),
+                        timestamp: b.timestamp(),
+                    });
+                }
+            }
+        }
+        if block.threshold_public_key.is_none() {
+            block.threshold_public_key = self.threshold_public_key(block.epoch);
         }
     }
 }
@@ -108,26 +137,32 @@ impl ConsensusFeed for FeedStateHandle {
         match query {
             Query::Latest => {
                 let mut block = self.state.read().latest_finalized.clone()?;
-                self.maybe_fill_height(&mut block).await;
+                self.maybe_fill_block_data(&mut block).await;
                 Some(block)
             }
             Query::Height(height) => {
                 let mut marshal = self.marshal()?;
                 let finalization = marshal.get_finalization(Height::new(height)).await?;
 
-                Some(CertifiedBlock {
-                    epoch: finalization.proposal.round.epoch().get(),
+                let epoch = finalization.proposal.round.epoch().get();
+                let mut block = CertifiedBlock {
+                    epoch,
                     view: finalization.proposal.round.view().get(),
                     height: Some(height),
                     digest: finalization.proposal.payload.0,
                     certificate: hex::encode(finalization.encode()),
-                })
+                    header: None,
+                    threshold_public_key: None,
+                };
+
+                self.maybe_fill_block_data(&mut block).await;
+                Some(block)
             }
         }
     }
 
     async fn get_latest(&self) -> ConsensusState {
-        let (mut finalized, notarized) = {
+        let (mut finalized, mut notarized) = {
             let state = self.state.read();
             (
                 state.latest_finalized.clone(),
@@ -136,7 +171,10 @@ impl ConsensusFeed for FeedStateHandle {
         };
 
         if let Some(ref mut block) = finalized {
-            self.maybe_fill_height(block).await;
+            self.maybe_fill_block_data(block).await;
+        }
+        if let Some(ref mut block) = notarized {
+            self.maybe_fill_block_data(block).await;
         }
 
         ConsensusState {

--- a/crates/node/src/rpc/consensus/mod.rs
+++ b/crates/node/src/rpc/consensus/mod.rs
@@ -13,7 +13,7 @@ use jsonrpsee::{
     types::{ErrorObject, error::INTERNAL_ERROR_CODE},
 };
 
-pub use types::{CertifiedBlock, ConsensusFeed, ConsensusState, Event, Query};
+pub use types::{BlockHeaderData, CertifiedBlock, ConsensusFeed, ConsensusState, Event, Query};
 
 /// Consensus namespace RPC trait.
 #[rpc(server, client, namespace = "consensus")]


### PR DESCRIPTION
## Summary

Extends `CertifiedBlock` in the consensus RPC with all data needed for clients to verify certificates independently:

### New fields in `CertifiedBlock`:
- **`parentHash`**, **`stateRoot`**, **`receiptsRoot`**, **`timestamp`**: Block header data for commitment reconstruction
- **`thresholdPublicKey`**: Hex-encoded BLS G2 point (96 bytes) for verifying the threshold signature

### Benefits:
- Clients can verify finalization/notarization certificates without additional RPC calls
- No need to fetch block data or look up the validator public key for the epoch separately
- Enables trustless light clients that verify consensus certificates

### Example response:
```json
{
  "epoch": 1,
  "view": 42,
  "height": 1000,
  "digest": "0x...",
  "certificate": "0x...",
  "parentHash": "0x...",
  "stateRoot": "0x...",
  "receiptsRoot": "0x...",
  "timestamp": 1737086400,
  "thresholdPublicKey": "0x..."
}
```

### Testing:
- [x] `cargo test -p tempo-e2e consensus_rpc` passes
