### PR TITLE
feat(tempo-bench): add state bloat benchmark with SSTORE to new slots

### DIFF
--- a/bin/tempo-bench/artifacts/StorageBloat.json
+++ b/bin/tempo-bench/artifacts/StorageBloat.json
@@ -1,0 +1,64 @@
+{
+  "abi": [
+    {
+      "type": "function",
+      "name": "load",
+      "inputs": [
+        {
+          "name": "key",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "store",
+      "inputs": [
+        {
+          "name": "key",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "storeBatch",
+      "inputs": [
+        {
+          "name": "startKey",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "count",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    }
+  ],
+  "bytecode": {
+    "object": "0x6080604052348015600e575f5ffd5b506101db8061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80633ae20806146100435780636ed28ed01461005f57806399d548aa1461007b575b5f5ffd5b61005d60048036038101906100589190610114565b6100ab565b005b61007960048036038101906100749190610114565b6100cc565b005b61009560048036038101906100909190610152565b6100d3565b6040516100a2919061018c565b60405180910390f35b335f5b828110156100c65781818501556001810190506100ae565b50505050565b8082555050565b5f81549050919050565b5f5ffd5b5f819050919050565b6100f3816100e1565b81146100fd575f5ffd5b50565b5f8135905061010e816100ea565b92915050565b5f5f6040838503121561012a576101296100dd565b5b5f61013785828601610100565b925050602061014885828601610100565b9150509250929050565b5f60208284031215610167576101666100dd565b5b5f61017484828501610100565b91505092915050565b610186816100e1565b82525050565b5f60208201905061019f5f83018461017d565b9291505056fea2646970667358221220da38e8ddac4aa8aa629c950bfd6046d90f7dbd566d745c06920c76ef731a244864736f6c63430008210033",
+    "sourceMap": "139:1044:0:-:0;;;;;;;;;;;;;;;;;;;",
+    "linkReferences": {}
+  }
+}

--- a/bin/tempo-bench/src/cmd/max_tps/storage_bloat.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/storage_bloat.rs
@@ -1,0 +1,27 @@
+use super::*;
+use alloy::sol;
+
+sol! {
+    #[sol(rpc)]
+    StorageBloat,
+    "artifacts/StorageBloat.json"
+}
+
+/// Setup storage bloat contract for benchmarking state bloat:
+/// - Deploy a single StorageBloat contract
+pub(super) async fn setup(
+    signer_providers: &[(Secp256k1Signer, DynProvider<TempoNetwork>)],
+) -> eyre::Result<Address> {
+    let (_signer, provider) = signer_providers
+        .first()
+        .ok_or_eyre("No signer providers found")?;
+
+    info!("Deploying StorageBloat contract");
+
+    let contract = StorageBloat::deploy(provider.clone()).await?;
+    let address = *contract.address();
+
+    info!(%address, "Deployed StorageBloat contract");
+
+    Ok(address)
+}


### PR DESCRIPTION
## Summary

Adds a new transaction type for benchmarking state bloat costs to measure the effectiveness of 2D expiring nonces and increased SSTORE gas pricing.

## Changes

- **StorageBloat contract**: Simple contract that does `SSTORE` to arbitrary storage slots
- **`--sstore_weight` CLI arg**: Controls the proportion of SSTORE transactions in the benchmark
- Each transaction writes to a unique slot key (incrementing counter) to maximize state bloat

## Usage

```bash
# Benchmark WITH 2D expiring nonces (default)
tempo-bench run-max-tps --tps 1000 --duration 60 --sstore_weight 1.0 --tip20_weight 0 --faucet

# Benchmark WITHOUT 2D nonces (for comparison)
tempo-bench run-max-tps --tps 1000 --duration 60 --sstore_weight 1.0 --tip20_weight 0 --faucet --disable-2d-nonces
```

## Success Criteria

Compare between devnets with and without the changes:
1. Devnet with 2D nonces + new SSTORE pricing should cost more to bloat
2. Database should be smaller because 2D nonce keys aren't persisted

Closes: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1768646412596649