### PR TITLE
fix: upgrade to revm 34.0.0 for gas_params support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+checksum = "6adac476434bf024279164dcdca299309f0c7d1e3557024eb7a83f8d9d01c6b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
@@ -330,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ccc4c702c840148af1ce784cc5c6ed9274a020ef32417c5b1dbeab8c317673"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1566,12 +1567,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
@@ -4299,16 +4294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
 dependencies = [
  "auto_impl",
  "revm",
@@ -7609,7 +7594,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7633,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7664,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7684,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7698,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7776,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7786,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7804,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7824,7 +7809,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7850,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7863,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7875,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7901,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7927,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7955,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7985,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8000,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8025,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8049,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8073,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8108,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8166,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8194,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8217,7 +8202,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8242,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "futures",
  "pin-project",
@@ -8259,12 +8244,13 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
+ "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8306,6 +8292,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
@@ -8321,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8349,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8364,7 +8351,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8380,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8402,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8413,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8441,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8462,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8503,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "clap",
  "eyre",
@@ -8525,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8541,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8559,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8572,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8601,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8621,7 +8608,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8631,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8677,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8690,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8708,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8746,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8760,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8770,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8798,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "bytes",
  "futures",
@@ -8818,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8834,7 +8821,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8843,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "futures",
  "metrics",
@@ -8855,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8864,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8878,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8934,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8982,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8997,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9011,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9028,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9052,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,6 +9097,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9120,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9176,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9214,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9262,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "bytes",
  "eyre",
@@ -9291,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9303,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9318,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9339,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9351,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9384,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9397,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9430,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9473,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9529,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9611,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9635,14 +9623,13 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
- "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9704,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9734,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9778,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9826,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9840,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9856,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9905,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9932,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9946,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9966,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9979,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10003,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10013,13 +10000,14 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
+ "revm-state",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10037,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10063,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "clap",
  "eyre",
@@ -10080,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "clap",
  "eyre",
@@ -10097,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10138,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10164,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,22 +10179,27 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
+ "metrics",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10231,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10250,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10268,16 +10261,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "33.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10294,9 +10287,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "7.1.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
 dependencies = [
  "bitvec",
  "phf",
@@ -10306,9 +10299,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10323,9 +10316,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "13.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10339,9 +10332,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "9.0.6"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10353,22 +10346,23 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "8.0.5"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10385,9 +10379,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
 dependencies = [
  "auto_impl",
  "either",
@@ -10403,9 +10397,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
+checksum = "4a1ce3f52a052d78cc251714d57bf05dc8bc75e269677de11805d3153300a2cd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10423,9 +10417,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "31.1.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10436,9 +10430,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10454,16 +10448,15 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "21.0.2"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10473,10 +10466,11 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "8.1.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
+ "alloy-eip7928",
  "bitflags 2.10.0",
  "revm-bytecode",
  "revm-primitives",
@@ -10599,18 +10593,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rug"
-version = "1.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
-]
 
 [[package]]
 name = "ruint"
@@ -12126,6 +12108,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-rpc-convert",
+ "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,7 +4708,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7594,7 +7594,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7618,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7761,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7771,7 +7771,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7809,7 +7809,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7819,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8093,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8179,7 +8179,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8202,7 +8202,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8227,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "futures",
  "pin-project",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8308,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8336,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8351,7 +8351,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8449,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "clap",
  "eyre",
@@ -8512,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8528,7 +8528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8546,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8608,7 +8608,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8733,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8747,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "serde",
  "serde_json",
@@ -8757,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8785,7 +8785,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "bytes",
  "futures",
@@ -8805,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8821,7 +8821,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "futures",
  "metrics",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8865,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8984,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9039,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "bytes",
  "eyre",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9291,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9362,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9418,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9670,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9691,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10041,7 +10041,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10051,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "clap",
  "eyre",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "clap",
  "eyre",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10126,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10152,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10199,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10224,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10243,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=86c414081a74587f508e3eab36fafdf80cb1b0a7#86c414081a74587f508e3eab36fafdf80cb1b0a7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e178f6ac67f178bcd47a9203ad975c1b3319017#5e178f6ac67f178bcd47a9203ad975c1b3319017"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,64 +118,64 @@ tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
-# reth v1.10.0 (b25f32a)
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
+# reth post-v1.10.0 (86c4140) - includes revm 34.0.0 with gas_params
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "33.1.0", features = ["optional_fee_charge"] }
+revm = { version = "34.0.0", features = ["optional_fee_charge"] }
 
 alloy = { version = "1.4.3", default-features = false }
 alloy-consensus = { version = "1.4.3", default-features = false }
 alloy-contract = { version = "1.4.3", default-features = false }
 alloy-eips = { version = "1.4.3", default-features = false }
-alloy-evm = "0.25.2"
+alloy-evm = "0.26.3"
 alloy-genesis = "1.4.3"
-alloy-hardforks = "0.4.5"
+alloy-hardforks = "0.4.7"
 alloy-network = { version = "1.4.3", default-features = false }
 alloy-primitives = { version = "1.5.0", default-features = false }
 alloy-provider = { version = "1.4.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,52 +118,52 @@ tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
-# reth post-v1.10.0 (86c4140) - includes revm 34.0.0 with gas_params
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7" }
+# reth post-v1.10.0 (5e178f6) - includes revm 34.0.0 with gas_params
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "86c414081a74587f508e3eab36fafdf80cb1b0a7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac67f178bcd47a9203ad975c1b3319017", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -648,7 +648,7 @@ where
                 .ok_or(TempoInvalidTransaction::ExpiringNonceMissingValidBefore)?;
             let now: u64 = block.timestamp().saturating_to();
 
-            StorageCtx::enter_evm(journal, block, cfg, || {
+            StorageCtx::enter_evm(journal, block, cfg, tx, || {
                 let mut nonce_manager = NonceManager::new();
 
                 nonce_manager
@@ -667,7 +667,7 @@ where
             })?;
         } else if !nonce_key.is_zero() {
             // 2D nonce transaction
-            StorageCtx::enter_evm(journal, block, cfg, || {
+            StorageCtx::enter_evm(journal, block, cfg, tx, || {
                 let mut nonce_manager = NonceManager::new();
 
                 if !cfg.is_nonce_check_disabled() {


### PR DESCRIPTION
## Summary

TIP-1000 (PR #2128) uses `cfg.gas_params` which requires revm 34.0.0. The devnet/nonce-expiry-gas-repricing branch was using revm 33.1.0 which doesn't have this field, causing the Docker build to fail.

## Changes

- Bump reth from `b25f32a` to `86c4140` (includes revm 34.0.0)
- Bump revm from 33.1.0 to 34.0.0
- Bump alloy-evm from 0.25.2 to 0.26.3
- Bump alloy-hardforks from 0.4.5 to 0.4.7
- Fix `StorageCtx::enter_evm` calls to include missing `tx` argument

## Testing

- `cargo check --package tempo-precompiles` ✓
- `cargo check --package tempo-revm` ✓

Fixes: https://github.com/tempoxyz/tempo/actions/runs/21094962595