### PR TITLE
feat(consensus): periodically send heartbeat FCU to EL

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -130,6 +130,13 @@ pub struct Args {
     #[arg(long = "consensus.subblock-broadcast-interval", default_value = "50ms")]
     pub subblock_broadcast_interval: jiff::SignedDuration,
 
+    /// The interval at which to send a forkchoice update heartbeat to the
+    /// execution layer. This is sent periodically even when there are no new
+    /// blocks to ensure the execution layer stays in sync with the consensus
+    /// layer's view of the chain head.
+    #[arg(long = "consensus.fcu-heartbeat-interval", default_value = "5m")]
+    pub fcu_heartbeat_interval: jiff::SignedDuration,
+
     /// Cache for the signing key loaded from CLI-provided file.
     #[clap(skip)]
     loaded_signing_key: OnceLock<Option<SigningKey>>,

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -90,6 +90,7 @@ pub struct Builder<TBlocker, TPeerManager> {
     pub new_payload_wait_time: Duration,
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,
+    pub fcu_heartbeat_interval: Duration,
 
     pub feed_state: crate::feed::FeedStateHandle,
 }
@@ -316,6 +317,7 @@ where
                 execution_node: execution_node.clone(),
                 last_finalized_height,
                 marshal: marshal_mailbox.clone(),
+                fcu_heartbeat_interval: self.fcu_heartbeat_interval,
             },
         )
         .wrap_err("failed initialization executor actor")?;

--- a/crates/commonware-node/src/executor/mod.rs
+++ b/crates/commonware-node/src/executor/mod.rs
@@ -1,6 +1,6 @@
 //! The executor is sending fork-choice-updates to the execution layer.
 use commonware_consensus::types::Height;
-use commonware_runtime::{Metrics, Pacer, Spawner};
+use commonware_runtime::{Clock, Metrics, Pacer, Spawner};
 
 mod actor;
 mod ingress;
@@ -16,7 +16,7 @@ pub(crate) fn init<TContext>(
     config: Config,
 ) -> eyre::Result<(Actor<TContext>, Mailbox)>
 where
-    TContext: Metrics + Pacer + Spawner,
+    TContext: Clock + Metrics + Pacer + Spawner,
 {
     let (tx, rx) = mpsc::unbounded();
     let mailbox = Mailbox { inner: tx };
@@ -37,4 +37,8 @@ pub(crate) struct Config {
 
     /// The mailbox of the marshal actor. Used to backfill blocks.
     pub(crate) marshal: crate::alias::marshal::Mailbox,
+
+    /// The interval at which to send a forkchoice update heartbeat to the
+    /// execution layer.
+    pub(crate) fcu_heartbeat_interval: std::time::Duration,
 }

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -132,6 +132,10 @@ pub async fn run_consensus_stack(
             "failed converting argument subblock-broadcast-interval to regular \
             duration; was it negative or chosen too large",
         )?,
+        fcu_heartbeat_interval: config.fcu_heartbeat_interval.try_into().wrap_err(
+            "failed converting argument fcu-heartbeat-interval to regular \
+            duration; was it negative or chosen too large",
+        )?,
 
         feed_state,
     }

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -255,6 +255,7 @@ pub async fn setup_validators(
             new_payload_wait_time: Duration::from_millis(200),
             time_to_build_subblock: Duration::from_millis(100),
             subblock_broadcast_interval: Duration::from_millis(50),
+            fcu_heartbeat_interval: Duration::from_secs(300),
             feed_state,
         };
 


### PR DESCRIPTION
Periodically sends forkchoice-updates to the execution layer using the last forwarded forkchoice-update.

In sync-scenarios, the consensus layer rapid-fires Forkchoice-Updates to the execution layer. But if the first one triggers a pipeline-sync, the following messages are dropped. This was fixed upstream in https://github.com/paradigmxyz/reth/pull/21150, but it's good practice to sporadically send a heartbeat.

This is configurable with `--consensus.fcu-heartbeat-interval`. Default is set to 5min.