### PR TITLE
chore: point reth deps at resumable downloads branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+checksum = "6adac476434bf024279164dcdca299309f0c7d1e3557024eb7a83f8d9d01c6b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
@@ -344,8 +345,29 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "op-alloy",
- "op-revm",
- "revm",
+ "op-revm 14.1.0",
+ "revm 33.1.0",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "op-alloy",
+ "op-revm 15.0.0",
+ "revm 34.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -2100,13 +2122,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2114,12 +2146,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -6359,7 +6391,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
 dependencies = [
  "auto_impl",
- "revm",
+ "revm 33.1.0",
+ "serde",
+]
+
+[[package]]
+name = "op-revm"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+dependencies = [
+ "auto_impl",
+ "revm 34.0.0",
  "serde",
 ]
 
@@ -7609,7 +7652,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7631,9 +7674,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-chain"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "metrics",
+ "parking_lot",
+ "reth-ethereum-primitives",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-trie",
+ "reth-trie-common",
+ "serde",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7645,6 +7709,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
+ "reth-chain",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7653,8 +7718,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0",
+ "revm-state 9.0.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7664,12 +7729,12 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7684,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7698,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7776,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7786,7 +7851,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7804,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7824,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7850,7 +7915,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7863,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7875,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7901,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7927,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7955,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7985,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8000,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8025,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8049,7 +8114,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8073,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8108,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8154,7 +8219,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
- "revm",
+ "revm 34.0.0",
  "serde_json",
  "tempfile",
  "tokio",
@@ -8166,7 +8231,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8194,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8217,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8242,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "futures",
  "pin-project",
@@ -8259,17 +8324,18 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
+ "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8306,11 +8372,13 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
- "revm",
- "revm-primitives",
+ "revm 34.0.0",
+ "revm-primitives 22.0.0",
  "schnellru",
  "smallvec",
  "thiserror 2.0.17",
@@ -8321,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8349,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8364,7 +8432,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8380,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8402,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8413,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8441,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8462,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8503,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "clap",
  "eyre",
@@ -8525,7 +8593,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8541,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8559,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8572,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8594,14 +8662,14 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm",
+ "revm 34.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8621,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8631,11 +8699,11 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8649,17 +8717,17 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -8671,15 +8739,15 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-storage-errors",
- "revm",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -8690,17 +8758,16 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm",
+ "revm 34.0.0",
  "serde",
  "serde_with",
 ]
@@ -8708,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8737,6 +8804,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "rmp-serde",
+ "serde_with",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
@@ -8746,12 +8814,12 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "reth-chain",
  "reth-chain-state",
- "reth-execution-types",
  "reth-primitives-traits",
  "serde",
  "serde_with",
@@ -8760,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "serde",
  "serde_json",
@@ -8770,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8788,9 +8856,9 @@ dependencies = [
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
- "revm",
- "revm-bytecode",
- "revm-database",
+ "revm 34.0.0",
+ "revm-bytecode 8.0.0",
+ "revm-database 10.0.0",
  "serde",
  "serde_json",
 ]
@@ -8798,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "bytes",
  "futures",
@@ -8818,7 +8886,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8834,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8843,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "futures",
  "metrics",
@@ -8855,7 +8923,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8864,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8878,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8934,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8982,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8997,7 +9065,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9011,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9028,7 +9096,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9052,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,6 +9178,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9120,7 +9189,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9170,13 +9239,13 @@ dependencies = [
  "tracing",
  "url",
  "vergen",
- "vergen-git2",
+ "vergen-git2 9.1.0",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9207,14 +9276,14 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
+ "revm 34.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9262,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "bytes",
  "eyre",
@@ -9291,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9303,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9318,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9339,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9351,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9384,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9397,7 +9466,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9418,9 +9487,9 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -9430,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9443,6 +9512,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
+ "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-codecs",
@@ -9463,8 +9533,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0",
+ "revm-state 9.0.0",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9473,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,26 +9586,26 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm",
+ "revm 34.0.0",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9594,9 +9664,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
+ "revm 34.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9611,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9635,14 +9705,13 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
- "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,10 +9752,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9704,7 +9773,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9734,12 +9803,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9769,7 +9838,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
+ "revm 34.0.0",
  "revm-inspectors",
  "tokio",
  "tracing",
@@ -9778,11 +9847,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.26.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -9797,12 +9866,12 @@ dependencies = [
  "metrics",
  "rand 0.9.2",
  "reqwest",
+ "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-execution-types",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
@@ -9812,7 +9881,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 34.0.0",
  "revm-inspectors",
  "schnellru",
  "serde",
@@ -9826,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9840,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9856,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9868,6 +9937,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest",
+ "reth-chain",
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
@@ -9880,7 +9950,6 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-etl",
  "reth-evm",
- "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
@@ -9905,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9932,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9946,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9966,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9979,13 +10048,14 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
+ "reth-chain",
  "reth-chainspec",
  "reth-db-api",
  "reth-db-models",
@@ -9996,14 +10066,14 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database",
+ "revm-database 10.0.0",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10012,14 +10082,15 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 9.0.0",
+ "revm-state 9.0.0",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10037,7 +10108,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10063,7 +10134,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "clap",
  "eyre",
@@ -10080,7 +10151,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "clap",
  "eyre",
@@ -10097,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10112,6 +10183,7 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.9.2",
+ "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -10122,8 +10194,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "revm-interpreter",
- "revm-primitives",
+ "revm-interpreter 32.0.0",
+ "revm-primitives 22.0.0",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -10138,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10156,7 +10228,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
+ "revm-database 10.0.0",
  "tracing",
  "triehash",
 ]
@@ -10164,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10183,7 +10255,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
+ "revm-database 10.0.0",
  "serde",
  "serde_with",
 ]
@@ -10191,22 +10263,27 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
+ "metrics",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10231,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10250,7 +10327,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10268,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
 dependencies = [
  "zstd",
 ]
@@ -10279,17 +10356,36 @@ version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database 9.0.6",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-inspector 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+dependencies = [
+ "revm-bytecode 8.0.0",
+ "revm-context 13.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database 10.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-handler 15.0.0",
+ "revm-inspector 15.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-precompile 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
 ]
 
 [[package]]
@@ -10300,7 +10396,19 @@ checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
  "phf",
- "revm-primitives",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -10313,11 +10421,28 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10331,9 +10456,25 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10344,10 +10485,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "alloy-eips",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+dependencies = [
+ "alloy-eips",
+ "revm-bytecode 8.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10359,9 +10514,23 @@ checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
  "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
+ "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -10372,14 +10541,33 @@ checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 8.0.0",
+ "revm-context 13.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-precompile 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10391,21 +10579,39 @@ checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 12.1.0",
+ "revm-database-interface 8.0.5",
+ "revm-handler 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 13.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-handler 15.0.0",
+ "revm-interpreter 32.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
+checksum = "4a1ce3f52a052d78cc251714d57bf05dc8bc75e269677de11805d3153300a2cd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10415,7 +10621,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 34.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -10427,10 +10633,23 @@ version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 7.1.1",
+ "revm-context-interface 13.1.0",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+dependencies = [
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10452,9 +10671,33 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 21.0.2",
  "ripemd",
  "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-primitives 22.0.0",
+ "ripemd",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
@@ -10472,14 +10715,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "revm-state"
 version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags 2.10.0",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.10.0",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -11746,7 +12014,7 @@ name = "tempo-chainspec"
 version = "1.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -11828,7 +12096,7 @@ name = "tempo-consensus"
 version = "1.0.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -11869,7 +12137,7 @@ name = "tempo-e2e"
 version = "1.0.0"
 dependencies = [
  "alloy",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -11912,7 +12180,7 @@ name = "tempo-evm"
 version = "1.0.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -11927,7 +12195,7 @@ dependencies = [
  "reth-revm",
  "reth-rpc-eth-api",
  "reth-storage-api",
- "revm",
+ "revm 33.1.0",
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-payload-types",
@@ -12014,7 +12282,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "vergen",
- "vergen-git2",
+ "vergen-git2 1.0.5",
 ]
 
 [[package]]
@@ -12069,7 +12337,7 @@ name = "tempo-precompiles"
 version = "1.0.0"
 dependencies = [
  "alloy",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -12078,7 +12346,7 @@ dependencies = [
  "eyre",
  "proptest",
  "rand 0.8.5",
- "revm",
+ "revm 33.1.0",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -12138,7 +12406,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -12150,7 +12418,7 @@ dependencies = [
  "reth-evm",
  "reth-rpc-eth-types",
  "reth-storage-api",
- "revm",
+ "revm 33.1.0",
  "sha2 0.10.9",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12199,7 +12467,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.25.2",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -12216,7 +12484,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
+ "revm 33.1.0",
  "tempo-chainspec",
  "tempo-precompiles",
  "tempo-primitives",
@@ -13163,17 +13431,17 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.4"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
  "time",
- "vergen-lib",
+ "vergen-lib 9.1.0",
 ]
 
 [[package]]
@@ -13188,7 +13456,22 @@ dependencies = [
  "rustversion",
  "time",
  "vergen",
- "vergen-lib",
+ "vergen-lib 0.1.6",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib 9.1.0",
 ]
 
 [[package]]
@@ -13196,6 +13479,17 @@ name = "vergen-lib"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ dependencies = [
  "crc",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -288,18 +288,17 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adac476434bf024279164dcdca299309f0c7d1e3557024eb7a83f8d9d01c6b5"
+checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "borsh",
  "serde",
 ]
 
@@ -326,7 +325,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -345,30 +344,9 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "op-alloy",
- "op-revm 14.1.0",
- "revm 33.1.0",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-evm"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "op-alloy",
- "op-revm 15.0.0",
- "revm 34.0.0",
- "thiserror 2.0.17",
+ "op-revm",
+ "revm",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -423,7 +401,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -450,7 +428,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -536,7 +514,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -680,7 +658,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -736,7 +714,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -765,7 +743,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -804,7 +782,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -823,7 +801,7 @@ dependencies = [
  "k256",
  "rand 0.8.5",
  "secp256k1 0.30.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "yubihsm",
  "zeroize",
 ]
@@ -916,7 +894,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1892,7 +1870,7 @@ dependencies = [
  "tag_ptr",
  "tap",
  "thin-vec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "xsum",
 ]
@@ -2122,23 +2100,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "cargo_metadata"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform 0.1.9",
+ "cargo-platform",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2146,16 +2114,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.23.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform 0.3.2",
+ "cargo-platform",
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2472,7 +2440,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "prometheus-client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2485,7 +2453,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2512,7 +2480,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr 0.4.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2542,7 +2510,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2596,7 +2564,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr 0.4.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2625,7 +2593,7 @@ dependencies = [
  "futures",
  "prometheus-client",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2658,7 +2626,7 @@ dependencies = [
  "rayon",
  "sha2 0.10.9",
  "sysinfo 0.37.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -2683,7 +2651,7 @@ dependencies = [
  "futures-util",
  "prometheus-client",
  "rayon",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -2703,7 +2671,7 @@ dependencies = [
  "futures",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2725,7 +2693,7 @@ dependencies = [
  "num-traits",
  "pin-project",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -4544,7 +4512,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4568,7 +4536,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5238,7 +5206,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -5266,7 +5234,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -5291,7 +5259,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "url",
@@ -5329,7 +5297,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5346,7 +5314,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5528,7 +5496,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -5800,7 +5768,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5814,7 +5782,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6309,7 +6277,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6359,7 +6327,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6381,7 +6349,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6391,18 +6359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
 dependencies = [
  "auto_impl",
- "revm 33.1.0",
- "serde",
-]
-
-[[package]]
-name = "op-revm"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
-dependencies = [
- "auto_impl",
- "revm 34.0.0",
+ "revm",
  "serde",
 ]
 
@@ -6428,7 +6385,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6458,7 +6415,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
@@ -6495,7 +6452,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -6815,7 +6772,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "sync_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6904,7 +6861,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7273,7 +7230,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -7294,7 +7251,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7538,7 +7495,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7652,7 +7609,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7674,30 +7631,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-chain"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "metrics",
- "parking_lot",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-trie",
- "reth-trie-common",
- "serde",
- "serde_with",
- "tracing",
-]
-
-[[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7709,7 +7645,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "reth-chain",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7718,8 +7653,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
- "revm-database 10.0.0",
- "revm-state 9.0.0",
+ "revm-database",
+ "revm-state",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7729,12 +7664,12 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7749,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7763,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7841,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7851,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7862,14 +7797,14 @@ dependencies = [
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
 ]
 
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7889,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7899,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7915,20 +7850,20 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7940,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7966,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7986,13 +7921,13 @@ dependencies = [
  "strum 0.27.2",
  "sysinfo 0.33.1",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8020,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8043,14 +7978,14 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8065,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8081,7 +8016,7 @@ dependencies = [
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8090,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8106,7 +8041,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "secp256k1 0.30.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8114,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8129,7 +8064,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8138,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8163,7 +8098,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8173,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8219,7 +8154,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
- "revm 34.0.0",
+ "revm",
  "serde_json",
  "tempfile",
  "tokio",
@@ -8231,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8249,7 +8184,7 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8259,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8282,7 +8217,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8300,14 +8235,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "futures",
  "pin-project",
@@ -8324,18 +8259,17 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8372,16 +8306,14 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
- "revm 34.0.0",
- "revm-primitives 22.0.0",
+ "revm",
+ "revm-primitives",
  "schnellru",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8389,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8417,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8426,13 +8358,13 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8448,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8470,18 +8402,18 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8499,7 +8431,7 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8509,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8524,13 +8456,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8571,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "clap",
  "eyre",
@@ -8593,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8609,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8621,13 +8553,13 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8640,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8662,14 +8594,14 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm 34.0.0",
+ "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8689,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8699,11 +8631,11 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8717,17 +8649,17 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 34.0.0",
+ "revm",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -8739,35 +8671,36 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits",
  "reth-storage-errors",
- "revm 34.0.0",
+ "revm",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-primitives",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm 34.0.0",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -8775,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8804,8 +8737,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "rmp-serde",
- "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8814,12 +8746,12 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-chain",
  "reth-chain-state",
+ "reth-execution-types",
  "reth-primitives-traits",
  "serde",
  "serde_with",
@@ -8828,17 +8760,17 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8856,9 +8788,9 @@ dependencies = [
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
- "revm 34.0.0",
- "revm-bytecode 8.0.0",
- "revm-database 10.0.0",
+ "revm",
+ "revm-bytecode",
+ "revm-database",
  "serde",
  "serde_json",
 ]
@@ -8866,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "bytes",
  "futures",
@@ -8875,7 +8807,7 @@ dependencies = [
  "jsonrpsee",
  "pin-project",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8886,7 +8818,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8895,14 +8827,14 @@ dependencies = [
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8911,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "futures",
  "metrics",
@@ -8923,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8932,13 +8864,13 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "futures-util",
  "if-addrs",
  "reqwest",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8946,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8992,7 +8924,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9002,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9019,7 +8951,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -9027,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9050,14 +8982,14 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "enr",
  "secp256k1 0.30.0",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -9065,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9079,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9088,7 +9020,7 @@ dependencies = [
  "memmap2",
  "reth-fs-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -9096,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9120,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9178,7 +9110,6 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9189,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9234,18 +9165,18 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
  "url",
  "vergen",
- "vergen-git2 9.1.0",
+ "vergen-git2",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9276,14 +9207,14 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 34.0.0",
+ "revm",
  "tokio",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9296,7 +9227,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -9307,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9331,7 +9262,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "bytes",
  "eyre",
@@ -9360,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9372,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9387,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9408,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9420,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9436,14 +9367,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9453,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9466,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,19 +9418,19 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode 8.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9512,7 +9443,6 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
- "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-codecs",
@@ -9533,8 +9463,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm-database 10.0.0",
- "revm-state 9.0.0",
+ "revm-database",
+ "revm-state",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9543,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9563,7 +9493,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-tokio-util",
  "rustc-hash",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9571,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9580,32 +9510,32 @@ dependencies = [
  "reth-codecs",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm 34.0.0",
+ "revm",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9664,13 +9594,13 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 34.0.0",
+ "revm",
  "revm-inspectors",
- "revm-primitives 22.0.0",
+ "revm-primitives",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -9681,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9705,13 +9635,14 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9741,7 +9672,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower",
@@ -9752,10 +9683,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9767,13 +9698,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9795,7 +9726,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9803,12 +9734,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9838,7 +9769,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 34.0.0",
+ "revm",
  "revm-inspectors",
  "tokio",
  "tracing",
@@ -9847,11 +9778,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.26.3",
+ "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -9866,12 +9797,12 @@ dependencies = [
  "metrics",
  "rand 0.9.2",
  "reqwest",
- "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
@@ -9881,11 +9812,11 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 34.0.0",
+ "revm",
  "revm-inspectors",
  "schnellru",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9895,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9909,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9925,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9868,6 @@ dependencies = [
  "num-traits",
  "rayon",
  "reqwest",
- "reth-chain",
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
@@ -9950,6 +9880,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-etl",
  "reth-evm",
+ "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
  "reth-network-p2p",
@@ -9966,7 +9897,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9974,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9993,7 +9924,7 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-tokio-util",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10001,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10015,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10035,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10048,14 +9979,13 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chain",
  "reth-chainspec",
  "reth-db-api",
  "reth-db-models",
@@ -10066,14 +9996,14 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database 10.0.0",
+ "revm-database",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10082,15 +10012,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface 9.0.0",
- "revm-state 9.0.0",
- "thiserror 2.0.17",
+ "revm-database-interface",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10099,7 +10028,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -10108,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10124,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10134,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "clap",
  "eyre",
@@ -10151,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "clap",
  "eyre",
@@ -10168,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10183,7 +10112,6 @@ dependencies = [
  "paste",
  "pin-project",
  "rand 0.9.2",
- "reth-chain",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -10194,14 +10122,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "revm-interpreter 32.0.0",
- "revm-primitives 22.0.0",
+ "revm-interpreter",
+ "revm-primitives",
  "rustc-hash",
  "schnellru",
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10210,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10228,7 +10156,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database 10.0.0",
+ "revm-database",
  "tracing",
  "triehash",
 ]
@@ -10236,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10255,7 +10183,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database 10.0.0",
+ "revm-database",
  "serde",
  "serde_with",
 ]
@@ -10263,27 +10191,22 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
- "metrics",
- "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
- "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10300,7 +10223,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-sparse",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10308,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10327,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10345,7 +10268,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#33067b8f2f75d9600f0a788f576874e80023e283"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-with-retry#bce5704bf61993791eab89f95463aa46fbe47b3a"
 dependencies = [
  "zstd",
 ]
@@ -10356,36 +10279,17 @@ version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
- "revm-bytecode 7.1.1",
- "revm-context 12.1.0",
- "revm-context-interface 13.1.0",
- "revm-database 9.0.6",
- "revm-database-interface 8.0.5",
- "revm-handler 14.1.0",
- "revm-inspector 14.1.0",
- "revm-interpreter 31.1.0",
- "revm-precompile 31.0.0",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
-]
-
-[[package]]
-name = "revm"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
-dependencies = [
- "revm-bytecode 8.0.0",
- "revm-context 13.0.0",
- "revm-context-interface 14.0.0",
- "revm-database 10.0.0",
- "revm-database-interface 9.0.0",
- "revm-handler 15.0.0",
- "revm-inspector 15.0.0",
- "revm-interpreter 32.0.0",
- "revm-precompile 32.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
 ]
 
 [[package]]
@@ -10396,19 +10300,7 @@ checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
  "phf",
- "revm-primitives 21.0.2",
- "serde",
-]
-
-[[package]]
-name = "revm-bytecode"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
-dependencies = [
- "bitvec",
- "phf",
- "revm-primitives 22.0.0",
+ "revm-primitives",
  "serde",
 ]
 
@@ -10421,28 +10313,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 7.1.1",
- "revm-context-interface 13.1.0",
- "revm-database-interface 8.0.5",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
-]
-
-[[package]]
-name = "revm-context"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode 8.0.0",
- "revm-context-interface 14.0.0",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10456,25 +10331,9 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 8.0.5",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10485,24 +10344,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "alloy-eips",
- "revm-bytecode 7.1.1",
- "revm-database-interface 8.0.5",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
-]
-
-[[package]]
-name = "revm-database"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
-dependencies = [
- "alloy-eips",
- "revm-bytecode 8.0.0",
- "revm-database-interface 9.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10514,23 +10359,9 @@ checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
+ "revm-primitives",
+ "revm-state",
  "serde",
-]
-
-[[package]]
-name = "revm-database-interface"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
-dependencies = [
- "auto_impl",
- "either",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
- "serde",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -10541,33 +10372,14 @@ checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 7.1.1",
- "revm-context 12.1.0",
- "revm-context-interface 13.1.0",
- "revm-database-interface 8.0.5",
- "revm-interpreter 31.1.0",
- "revm-precompile 31.0.0",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
-]
-
-[[package]]
-name = "revm-handler"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode 8.0.0",
- "revm-context 13.0.0",
- "revm-context-interface 14.0.0",
- "revm-database-interface 9.0.0",
- "revm-interpreter 32.0.0",
- "revm-precompile 32.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10579,39 +10391,21 @@ checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 12.1.0",
- "revm-database-interface 8.0.5",
- "revm-handler 14.1.0",
- "revm-interpreter 31.1.0",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context 13.0.0",
- "revm-database-interface 9.0.0",
- "revm-handler 15.0.0",
- "revm-interpreter 32.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce3f52a052d78cc251714d57bf05dc8bc75e269677de11805d3153300a2cd"
+checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10621,10 +10415,10 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 34.0.0",
+ "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10633,23 +10427,10 @@ version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
- "revm-bytecode 7.1.1",
- "revm-context-interface 13.1.0",
- "revm-primitives 21.0.2",
- "revm-state 8.1.1",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
-dependencies = [
- "revm-bytecode 8.0.0",
- "revm-context-interface 14.0.0",
- "revm-primitives 22.0.0",
- "revm-state 9.0.0",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10671,33 +10452,9 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives 21.0.2",
+ "revm-primitives",
  "ripemd",
  "rug",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "blst",
- "c-kzg",
- "cfg-if",
- "k256",
- "p256",
- "revm-primitives 22.0.0",
- "ripemd",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
@@ -10715,39 +10472,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-primitives"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "revm-state"
 version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags 2.10.0",
- "revm-bytecode 7.1.1",
- "revm-primitives 21.0.2",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
-dependencies = [
- "alloy-eip7928",
- "bitflags 2.10.0",
- "revm-bytecode 8.0.0",
- "revm-primitives 22.0.0",
+ "revm-bytecode",
+ "revm-primitives",
  "serde",
 ]
 
@@ -11575,7 +11307,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -12014,7 +11746,7 @@ name = "tempo-chainspec"
 version = "1.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -12088,7 +11820,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12096,7 +11828,7 @@ name = "tempo-consensus"
 version = "1.0.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -12137,7 +11869,7 @@ name = "tempo-e2e"
 version = "1.0.0"
 dependencies = [
  "alloy",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -12180,7 +11912,7 @@ name = "tempo-evm"
 version = "1.0.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -12195,13 +11927,13 @@ dependencies = [
  "reth-revm",
  "reth-rpc-eth-api",
  "reth-storage-api",
- "revm 33.1.0",
+ "revm",
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-payload-types",
  "tempo-primitives",
  "tempo-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -12279,10 +12011,10 @@ dependencies = [
  "tempo-primitives",
  "tempo-transaction-pool",
  "test-case",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "vergen",
- "vergen-git2 1.0.5",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -12337,7 +12069,7 @@ name = "tempo-precompiles"
 version = "1.0.0"
 dependencies = [
  "alloy",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -12346,7 +12078,7 @@ dependencies = [
  "eyre",
  "proptest",
  "rand 0.8.5",
- "revm 33.1.0",
+ "revm",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -12354,7 +12086,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -12406,7 +12138,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -12418,14 +12150,14 @@ dependencies = [
  "reth-evm",
  "reth-rpc-eth-types",
  "reth-storage-api",
- "revm 33.1.0",
+ "revm",
  "sha2 0.10.9",
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-primitives",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -12467,7 +12199,7 @@ version = "1.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.25.2",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -12484,13 +12216,13 @@ dependencies = [
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 33.1.0",
+ "revm",
  "tempo-chainspec",
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
  "test-case",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -12578,11 +12310,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12598,9 +12330,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13028,7 +12760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
 ]
@@ -13232,7 +12964,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -13431,17 +13163,17 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
+version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.23.1",
+ "cargo_metadata 0.19.2",
  "derive_builder",
  "regex",
  "rustversion",
  "time",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -13456,22 +13188,7 @@ dependencies = [
  "rustversion",
  "time",
  "vergen",
- "vergen-lib 0.1.6",
-]
-
-[[package]]
-name = "vergen-git2"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
-dependencies = [
- "anyhow",
- "derive_builder",
- "git2",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -13479,17 +13196,6 @@ name = "vergen-lib"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -14340,7 +14046,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -14540,9 +14246,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.4.5"
+version = "0.5.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1339d398d44e506d9b72c1af2f6f51a41c9c64f9a0738eb9aedede47ed1f683"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
 name = "coins-bip32"
@@ -3056,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
 dependencies = [
  "cmov",
 ]
@@ -3925,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "findshlibs"
@@ -7609,7 +7609,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7664,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7850,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7875,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7955,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8000,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8025,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8073,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8217,7 +8217,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8242,7 +8242,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "futures",
  "pin-project",
@@ -8264,7 +8264,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8321,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8364,7 +8364,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8441,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "clap",
  "eyre",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8572,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8631,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8746,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8760,7 +8760,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "serde",
  "serde_json",
@@ -8770,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "bytes",
  "futures",
@@ -8818,7 +8818,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "futures",
  "metrics",
@@ -8855,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8878,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9262,7 +9262,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "bytes",
  "eyre",
@@ -9291,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9318,7 +9318,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9351,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9397,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9473,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9778,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9826,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9932,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10003,7 +10003,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "clap",
  "eyre",
@@ -10080,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "clap",
  "eyre",
@@ -10097,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10138,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10164,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10206,7 +10206,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10250,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10268,7 +10268,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fresumable-downloads-tempo#592115e5c0bae137b05e8f10c7ca5ae089bd7796"
 dependencies = [
  "zstd",
 ]
@@ -10760,9 +10760,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -10797,9 +10797,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -13163,9 +13163,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -13178,9 +13178,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.7"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,7 @@ pyroscope_pprofrs = "0.2.10"
 rayon = "1.10"
 
 # build deps
-vergen = "=9.1.0"
+vergen = "=9.0.4"
 vergen-git2 = "=1.0.5"
 [patch.crates-io]
 # Commonware right after after PR #2841 was merged

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,51 +117,51 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 # reth v1.10.0 (b25f32a)
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-with-retry", features = [
   "std",
   "optional-checks",
 ] }
@@ -243,7 +243,7 @@ pyroscope_pprofrs = "0.2.10"
 rayon = "1.10"
 
 # build deps
-vergen = "=9.0.4"
+vergen = "=9.1.0"
 vergen-git2 = "=1.0.5"
 [patch.crates-io]
 # Commonware right after after PR #2841 was merged

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,51 +117,51 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 # reth v1.10.0 (b25f32a)
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b25f32a977b489f9b84254c7811a2a5a25a81369", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/resumable-downloads-tempo", features = [
   "std",
   "optional-checks",
 ] }
@@ -243,8 +243,8 @@ pyroscope_pprofrs = "0.2.10"
 rayon = "1.10"
 
 # build deps
-vergen = "9"
-vergen-git2 = "1"
+vergen = "=9.0.4"
+vergen-git2 = "=1.0.5"
 [patch.crates-io]
 # Commonware right after after PR #2841 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}


### PR DESCRIPTION
points reth dependencies at [paradigmxyz/reth#21161](https://github.com/paradigmxyz/reth/pull/21161) to pick up resumable snapshot downloads with auto-retry.

## what this gets us

- snapshot downloads resume from where they left off on interruption
- auto-retry up to 10x with 5s backoff
- no more restarting 100GB downloads from scratch

once the reth PR is merged, we switch back to a rev pin.

closes #2147