### PR TITLE
docs: add TIP-1011 Mainnet Gas Parameters

### DIFF
--- a/docs/pages/protocol/tips/tip-1010.mdx
+++ b/docs/pages/protocol/tips/tip-1010.mdx
@@ -1,8 +1,8 @@
-# TIP-1011: Mainnet Gas Parameters
+# TIP-1010: Mainnet Gas Parameters
 
 This document defines the initial gas parameters for Tempo mainnet launch.
 
-- **TIP ID**: TIP-1011
+- **TIP ID**: TIP-1010
 - **Authors/Owners**: Dankrad Feist @dankrad
 - **Status**: Draft
 - **Related Specs/TIPs**: [TIP-1000](/protocol/tips/tip-1000), [Payment Lane Specification](/protocol/blockspace/payment-lane-specification)


### PR DESCRIPTION
## Summary

Adds TIP-1011 which specifies the initial gas parameters for Tempo mainnet launch.

## Parameters Defined

| Parameter | Value | Purpose |
|-----------|-------|---------|
| Base fee | `2 × 10^10` wei (20 gwei) | Target 0.1 cent per TIP-20 transfer |
| Payment lane gas limit | 500,000,000 gas/block | Support ~20,000 TPS for payments |
| General gas limit | 30,000,000 gas/block | General contract interactions |
| Transaction gas cap | 30,000,000 gas | Allow max-size contract deployment |

## Context

These parameters were previously bundled with TIP-1000 in PR #1917 but have been separated into their own TIP for clarity. TIP-1000 focuses on state creation costs while TIP-1008 focuses on mainnet capacity/pricing parameters.

## Related

- Extracted from: #1917
- Related: TIP-1000 (state creation costs)