### PR TITLE
chore(consensus): bump commonware to 374285d, use metric attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "paste",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "futures",
  "proc-macro-crate",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "cfg-if",
  "rayon",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "async-lock",
  "axum",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=cf349ae38b862f0336e9b33b3559ec846a499e0c#cf349ae38b862f0336e9b33b3559ec846a499e0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=374285d20a3333acf06ffd954e6eb7eb2826568e#374285d20a3333acf06ffd954e6eb7eb2826568e"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,15 +246,15 @@ rayon = "1.10"
 vergen = "9"
 vergen-git2 = "1"
 [patch.crates-io]
-# Commonware right after after PR #2841 was merged
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "cf349ae38b862f0336e9b33b3559ec846a499e0c"}
+# Commonware right after after PR #2863 was merged
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "374285d20a3333acf06ffd954e6eb7eb2826568e"}

--- a/crates/commonware-node/src/alias.rs
+++ b/crates/commonware-node/src/alias.rs
@@ -3,7 +3,7 @@
 pub(crate) mod marshal {
     use commonware_consensus::{
         marshal,
-        simplex::{scheme::bls12381_threshold::Scheme, types::Finalization},
+        simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
         types::FixedEpocher,
     };
     use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -10,7 +10,7 @@ use std::{
 use commonware_broadcast::buffered;
 use commonware_consensus::{
     Reporters, marshal,
-    simplex::scheme::bls12381_threshold::Scheme,
+    simplex::scheme::bls12381_threshold::vrf::Scheme,
     types::{FixedEpocher, ViewDelta},
 };
 use commonware_cryptography::{

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -6,7 +6,7 @@ use commonware_codec::{Encode as _, EncodeSize, Read, ReadExt as _, Write};
 use commonware_consensus::{
     Heightable as _,
     marshal::{self, Update},
-    simplex::scheme::bls12381_threshold::Scheme,
+    simplex::scheme::bls12381_threshold::vrf::Scheme,
     types::{Epoch, EpochPhase, Epocher as _, FixedEpocher, Height},
 };
 use commonware_cryptography::{

--- a/crates/commonware-node/src/epoch/manager/mod.rs
+++ b/crates/commonware-node/src/epoch/manager/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use ingress::Mailbox;
 
 use commonware_consensus::{
     marshal,
-    simplex::scheme::bls12381_threshold::Scheme,
+    simplex::scheme::bls12381_threshold::vrf::Scheme,
     types::{FixedEpocher, ViewDelta},
 };
 use commonware_p2p::Blocker;

--- a/crates/commonware-node/src/epoch/scheme_provider.rs
+++ b/crates/commonware-node/src/epoch/scheme_provider.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use commonware_consensus::{simplex::scheme::bls12381_threshold::Scheme, types::Epoch};
+use commonware_consensus::{simplex::scheme::bls12381_threshold::vrf::Scheme, types::Epoch};
 use commonware_cryptography::{
     bls12381::primitives::variant::MinSig, certificate::Provider, ed25519::PublicKey,
 };

--- a/crates/commonware-node/src/feed/actor.rs
+++ b/crates/commonware-node/src/feed/actor.rs
@@ -9,7 +9,7 @@ use alloy_primitives::hex;
 use commonware_codec::Encode;
 use commonware_consensus::{
     Heightable as _,
-    simplex::{scheme::bls12381_threshold::Scheme, types::Activity},
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
 };
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_macros::select;

--- a/crates/commonware-node/src/feed/ingress.rs
+++ b/crates/commonware-node/src/feed/ingress.rs
@@ -2,7 +2,7 @@
 
 use commonware_consensus::{
     Reporter,
-    simplex::{scheme::bls12381_threshold::Scheme, types::Activity},
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
 };
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use futures::channel::mpsc;


### PR DESCRIPTION
Bumps all commonware dependencies to https://github.com/commonwarexyz/monorepo/tree/374285d20a3333acf06ffd954e6eb7eb2826568e, which gives access to their fix for duplicate metrics: https://github.com/commonwarexyz/monorepo/pull/2864

Changes the simplex engine context to have an `epoch` attributes. This will emit all metrics for a given epoch belonging to the simplex engines with an `epoch` label. This means that metrics like formerly `consensus_engine_epoch_manager_simplex_epoch_<epoch>_notarization_latency` will now be changed to `consensus_engine_epoch_manager_simplex_notarization_latency{epoch="<epoch>"}`.