### PR TITLE
feat: configure default pruning values for `--minimal` mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11650,6 +11650,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-node-builder",
+ "reth-prune-types",
  "reth-rpc-server-types",
  "tempo-chainspec",
  "tempo-commonware-node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6", default-features = false }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6", default-features = false }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e178f6ac6" }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -33,7 +33,6 @@ reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }
 reth-ethereum-cli.workspace = true
 reth-node-builder.workspace = true
-reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 clap.workspace = true
 eyre.workspace = true

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -33,6 +33,7 @@ reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }
 reth-ethereum-cli.workspace = true
 reth-node-builder.workspace = true
+reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 clap.workspace = true
 eyre.workspace = true

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -1,11 +1,11 @@
 use reth_cli_commands::download::DownloadDefaults;
-use reth_ethereum::node::core::args::{
-    DefaultPayloadBuilderValues, DefaultPruningValues, DefaultTxPoolValues,
-};
-use reth_prune_types::{PruneMode, PruneModes};
+use reth_ethereum::node::core::args::{DefaultPayloadBuilderValues, DefaultTxPoolValues};
 use std::{borrow::Cow, time::Duration};
 
-const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
+// TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
+// use reth_ethereum::node::core::args::DefaultPruningValues;
+// use reth_prune_types::{PruneMode, PruneModes};
+// const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42431";
 
@@ -33,20 +33,21 @@ fn init_payload_builder_defaults() {
         .expect("failed to initialize payload builder defaults");
 }
 
-fn init_pruning_defaults() {
-    DefaultPruningValues::default()
-        .with_minimal_prune_modes(PruneModes {
-            sender_recovery: Some(PruneMode::Full),
-            transaction_lookup: Some(PruneMode::Full),
-            receipts: Some(PruneMode::Full),
-            account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            receipts_log_filter: Default::default(),
-        })
-        .try_init()
-        .expect("failed to initialize pruning defaults");
-}
+// TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
+// fn init_pruning_defaults() {
+//     DefaultPruningValues::default()
+//         .with_minimal_prune_modes(PruneModes {
+//             sender_recovery: Some(PruneMode::Full),
+//             transaction_lookup: Some(PruneMode::Full),
+//             receipts: Some(PruneMode::Full),
+//             account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             receipts_log_filter: Default::default(),
+//         })
+//         .try_init()
+//         .expect("failed to initialize pruning defaults");
+// }
 
 fn init_txpool_defaults() {
     DefaultTxPoolValues::default()
@@ -74,6 +75,7 @@ fn init_txpool_defaults() {
 pub(crate) fn init_defaults() {
     init_download_urls();
     init_payload_builder_defaults();
-    init_pruning_defaults();
+    // TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
+    // init_pruning_defaults();
     init_txpool_defaults();
 }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -1,6 +1,11 @@
 use reth_cli_commands::download::DownloadDefaults;
-use reth_ethereum::node::core::args::{DefaultPayloadBuilderValues, DefaultTxPoolValues};
+use reth_ethereum::node::core::args::{
+    DefaultPayloadBuilderValues, DefaultPruningValues, DefaultTxPoolValues,
+};
+use reth_prune_types::{PruneMode, PruneModes};
 use std::{borrow::Cow, time::Duration};
+
+const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42431";
 
@@ -26,6 +31,21 @@ fn init_payload_builder_defaults() {
         .with_deadline(4)
         .try_init()
         .expect("failed to initialize payload builder defaults");
+}
+
+fn init_pruning_defaults() {
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(PruneModes {
+            sender_recovery: Some(PruneMode::Full),
+            transaction_lookup: Some(PruneMode::Full),
+            receipts: Some(PruneMode::Full),
+            account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            receipts_log_filter: Default::default(),
+        })
+        .try_init()
+        .expect("failed to initialize pruning defaults");
 }
 
 fn init_txpool_defaults() {
@@ -54,5 +74,6 @@ fn init_txpool_defaults() {
 pub(crate) fn init_defaults() {
     init_download_urls();
     init_payload_builder_defaults();
+    init_pruning_defaults();
     init_txpool_defaults();
 }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -1,11 +1,11 @@
 use reth_cli_commands::download::DownloadDefaults;
-use reth_ethereum::node::core::args::{DefaultPayloadBuilderValues, DefaultTxPoolValues};
+use reth_ethereum::node::core::args::{
+    DefaultPayloadBuilderValues, DefaultPruningValues, DefaultTxPoolValues,
+};
+use reth_prune_types::{PruneMode, PruneModes};
 use std::{borrow::Cow, time::Duration};
 
-// TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
-// use reth_ethereum::node::core::args::DefaultPruningValues;
-// use reth_prune_types::{PruneMode, PruneModes};
-// const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
+const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42431";
 
@@ -33,21 +33,20 @@ fn init_payload_builder_defaults() {
         .expect("failed to initialize payload builder defaults");
 }
 
-// TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
-// fn init_pruning_defaults() {
-//     DefaultPruningValues::default()
-//         .with_minimal_prune_modes(PruneModes {
-//             sender_recovery: Some(PruneMode::Full),
-//             transaction_lookup: Some(PruneMode::Full),
-//             receipts: Some(PruneMode::Full),
-//             account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-//             storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-//             bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-//             receipts_log_filter: Default::default(),
-//         })
-//         .try_init()
-//         .expect("failed to initialize pruning defaults");
-// }
+fn init_pruning_defaults() {
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(PruneModes {
+            sender_recovery: Some(PruneMode::Full),
+            transaction_lookup: Some(PruneMode::Full),
+            receipts: Some(PruneMode::Full),
+            account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+            receipts_log_filter: Default::default(),
+        })
+        .try_init()
+        .expect("failed to initialize pruning defaults");
+}
 
 fn init_txpool_defaults() {
     DefaultTxPoolValues::default()
@@ -75,7 +74,6 @@ fn init_txpool_defaults() {
 pub(crate) fn init_defaults() {
     init_download_urls();
     init_payload_builder_defaults();
-    // TODO: Uncomment when reth is bumped to include paradigmxyz/reth#21207
-    // init_pruning_defaults();
+    init_pruning_defaults();
     init_txpool_defaults();
 }

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -1,11 +1,6 @@
 use reth_cli_commands::download::DownloadDefaults;
-use reth_ethereum::node::core::args::{
-    DefaultPayloadBuilderValues, DefaultPruningValues, DefaultTxPoolValues,
-};
-use reth_prune_types::{PruneMode, PruneModes};
+use reth_ethereum::node::core::args::{DefaultPayloadBuilderValues, DefaultTxPoolValues};
 use std::{borrow::Cow, time::Duration};
-
-const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42431";
 
@@ -33,20 +28,24 @@ fn init_payload_builder_defaults() {
         .expect("failed to initialize payload builder defaults");
 }
 
-fn init_pruning_defaults() {
-    DefaultPruningValues::default()
-        .with_minimal_prune_modes(PruneModes {
-            sender_recovery: Some(PruneMode::Full),
-            transaction_lookup: Some(PruneMode::Full),
-            receipts: Some(PruneMode::Full),
-            account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
-            receipts_log_filter: Default::default(),
-        })
-        .try_init()
-        .expect("failed to initialize pruning defaults");
-}
+// TODO: Enable after bumping reth to include paradigmxyz/reth#21207
+// const PRUNING_HISTORY_DISTANCE: u64 = 50_000;
+// fn init_pruning_defaults() {
+//     use reth_ethereum::node::core::args::DefaultPruningValues;
+//     use reth_prune_types::{PruneMode, PruneModes};
+//     DefaultPruningValues::default()
+//         .with_minimal_prune_modes(PruneModes {
+//             sender_recovery: Some(PruneMode::Full),
+//             transaction_lookup: Some(PruneMode::Full),
+//             receipts: Some(PruneMode::Full),
+//             account_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             storage_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             bodies_history: Some(PruneMode::Distance(PRUNING_HISTORY_DISTANCE)),
+//             receipts_log_filter: Default::default(),
+//         })
+//         .try_init()
+//         .expect("failed to initialize pruning defaults");
+// }
 
 fn init_txpool_defaults() {
     DefaultTxPoolValues::default()
@@ -74,6 +73,7 @@ fn init_txpool_defaults() {
 pub(crate) fn init_defaults() {
     init_download_urls();
     init_payload_builder_defaults();
-    init_pruning_defaults();
+    // TODO: Enable after bumping reth to include paradigmxyz/reth#21207
+    // init_pruning_defaults();
     init_txpool_defaults();
 }


### PR DESCRIPTION
## Summary

Sets `account_history`, `storage_history`, and `bodies_history` to 50k blocks for the `--minimal` pruning mode using reth's new `DefaultPruningValues` API.

## Motivation

The default pruning distance of 10064 blocks is insufficient for validator contract state across epochs (~43201 blocks). This change increases the history retention to 50k blocks.

## Dependencies

This PR depends on https://github.com/paradigmxyz/reth/pull/21207 being merged. Once merged, the reth rev in Cargo.toml will need to be bumped to include the `DefaultPruningValues` export.

## Changes

- Added `init_pruning_defaults()` in `bin/tempo/src/defaults.rs`
- Added `reth-prune-types` workspace dependency