### PR TITLE
ci: revert to upstream nextest now that on-timeout panic is fixed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - name: cargo nextest
-        run: cargo install cargo-nextest --git https://github.com/gakonst/nextest --branch fix/write-final-status-timeout-pass --locked
+      - uses: taiki-e/install-action@3512d461db8b87f0a5fd5600df9006c8156dcf67 # v2.67.1
+        with:
+          tool: nextest
       - name: Build and compile tests
         run: cargo nextest run --no-run -j num-cpus
       - name: Run tests


### PR DESCRIPTION
Closes #2138

Reverts to upstream `cargo-nextest` via `taiki-e/install-action` now that the `on-timeout = "pass"` panic fix has been released in nextest 0.9.123-b.1.

Upstream fix: https://github.com/nextest-rs/nextest/pull/2940
