### PR TITLE
feat(cli): add safety check to prevent overwriting existing private keys

### DIFF
--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::{fmt::Display, path::Path};
+use std::{fmt::Display, io::Write, path::Path};
 
 use commonware_codec::{DecodeExt as _, Encode as _};
 use commonware_cryptography::{
@@ -35,6 +35,11 @@ impl SigningKey {
         let bytes = const_hex::decode(hex).map_err(SigningKeyErrorKind::Hex)?;
         let inner = PrivateKey::decode(&bytes[..]).map_err(SigningKeyErrorKind::Parse)?;
         Ok(Self { inner })
+    }
+
+    pub fn to_writer<W: Write>(&self, mut writer: W) -> Result<(), SigningKeyError> {
+        writer.write_all(self.to_string().as_bytes()).map_err(SigningKeyErrorKind::Write)?;
+        Ok(())
     }
 
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), SigningKeyError> {


### PR DESCRIPTION
## Description
This PR improves the safety of the `generate-private-key` command.

Currently, if a user accidentally runs the generation command pointing to an existing key file, the CLI silently overwrites it. 

This creates a risk of **permanent loss of the validator identity and associated funds**.

This change adds a safeguard to ensure the output file does not exist before writing. It also introduces a `--force` flag for users who intentionally want to overwrite the file.

## Changes
- Modified `GeneratePrivateKey` struct to include a `force` flag.
- Added a safety check: `if output.exists() && !force` returns an error.
- Updated user feedback to explicitly suggest `--force` if a conflict is detected.

## Usage
**Default Behavior (Safe):**
```bash
$ tempo consensus generate-private-key --output ./secret.key
Error: File `./secret.key` already exists. Use --force to overwrite it.
```
**Force Overwrite:**
```bash
$ tempo consensus generate-private-key --output ./secret.key --force
wrote private key to: ./secret.key
...
```

## Checklist
- [x] I have performed a self-review of my code.
- [x] The code compiles successfully.
- [x] I have verified the protection logic locally.