### PR TITLE
feat: make `t1Time` optional in genesis generator

### DIFF
--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -21,7 +21,6 @@
     "terminalTotalDifficultyPassed": true,
     "epochLength": 302400,
     "t0Time": 0,
-    "t1Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -151,9 +151,8 @@ pub(crate) struct GenesisArgs {
     #[arg(long, default_value = "0")]
     t0_time: u64,
 
-    /// Timestamp for T1 hardfork activation (0 = genesis).
-    #[arg(long, default_value = "0")]
-    t1_time: u64,
+    /// Timestamp for T1 hardfork activation
+    t1_time: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -489,9 +488,12 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("t0Time".to_string(), self.t0_time)?;
-        chain_config
-            .extra_fields
-            .insert_value("t1Time".to_string(), self.t1_time)?;
+
+        if let Some(t1_time) = self.t1_time {
+            chain_config
+                .extra_fields
+                .insert_value("t1Time".to_string(), t1_time)?;
+        }
         let mut extra_data = Bytes::from_static(b"tempo-genesis");
 
         if let Some(consensus_config) = &consensus_config {


### PR DESCRIPTION
This PR makes `t1Time` optional in the genesis generator and updates test genesis file accordingly.