### PR TITLE
fix(tips): add frontmatter to TIP-1009 and TIP-1010

### DIFF
--- a/tips/tip-1009.md
+++ b/tips/tip-1009.md
@@ -1,21 +1,14 @@
 ---
-title: "TIP-1009: Expiring Nonces"
+id: TIP-1009
+title: Expiring Nonces
 description: Time-bounded replay protection using transaction hashes instead of sequential nonce management.
+authors: Tempo Team
+status: Approved
+related: TIP-20, Transactions
+protocolVersion: T1
 ---
 
 # TIP-1009: Expiring Nonces
-
-This document specifies expiring nonces for Tempo transactions, providing time-bounded replay protection without requiring sequential nonce management.
-
-- **TIP ID**: TIP-1009
-- **Authors/Owners**: Tempo Team
-- **Status**: Approved
-- **Related Specs/TIPs**: [TIP-20](/protocol/tip20/spec), [Transactions](/protocol/transactions/spec)
-- **Protocol Version**: T1
-
----
-
-# Overview
 
 ## Abstract
 

--- a/tips/tip-1010.md
+++ b/tips/tip-1010.md
@@ -1,16 +1,14 @@
-# TIP-1010: Mainnet Gas Parameters
-
-This document defines the initial gas parameters for Tempo mainnet launch.
-
-- **TIP ID**: TIP-1010
-- **Authors/Owners**: Dankrad Feist @dankrad
-- **Status**: Approved
-- **Related Specs/TIPs**: [TIP-1000](/protocol/tips/tip-1000), [Payment Lane Specification](/protocol/blockspace/payment-lane-specification)
-- **Protocol Version**: T1
-
+---
+id: TIP-1010
+title: Mainnet Gas Parameters
+description: Initial gas parameters for Tempo mainnet launch including base fee pricing, payment lane capacity, and transaction gas limits.
+authors: Dankrad Feist @dankrad
+status: Approved
+related: TIP-1000, Payment Lane Specification
+protocolVersion: T1
 ---
 
-# Overview
+# TIP-1010: Mainnet Gas Parameters
 
 ## Abstract
 


### PR DESCRIPTION
Ensures TIP files follow the template format:

- Added proper frontmatter to TIP-1009 and TIP-1010 (id, title, description, authors, status, related, protocolVersion)
- Renamed .mdx to .md for consistency with other TIP files
- Removed duplicate inline metadata from body