### PR TITLE
feat(bin): require --force to override signing key

### DIFF
--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -37,8 +37,11 @@ impl SigningKey {
         Ok(Self { inner })
     }
 
-    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), SigningKeyError> {
-        std::fs::write(path, self.to_string()).map_err(SigningKeyErrorKind::Write)?;
+    /// Writes the signing key to `writer`.
+    pub fn to_writer<W: std::io::Write>(&self, mut writer: W) -> Result<(), SigningKeyError> {
+        writer
+            .write_all(self.to_string().as_bytes())
+            .map_err(SigningKeyErrorKind::Write)?;
         Ok(())
     }
 

--- a/xtask/src/generate_genesis.rs
+++ b/xtask/src/generate_genesis.rs
@@ -52,9 +52,14 @@ impl GenerateGenesis {
                     )
                 })?;
                 let signing_key_dst = validator.dst_signing_key(&output);
-                validator
-                    .signing_key
-                    .write_to_file(&signing_key_dst)
+                std::fs::File::create(&signing_key_dst)
+                    .map_err(eyre::Report::new)
+                    .and_then(|f| {
+                        validator
+                            .signing_key
+                            .to_writer(f)
+                            .map_err(eyre::Report::new)
+                    })
                     .wrap_err_with(|| {
                         format!(
                             "failed writing ed25519 signing key to `{}`",


### PR DESCRIPTION
Adds `--force` to `tempo consensus generate-signing-key` to ensure that the target is not overwritten accidentally.

Replaces `SigningKey::write_to_file` by `SigningKey::to_writer` to remove a potentially dangerous pattern (now its the caller's responsibility to provide a `File` with `OpenOptions` set appropriately).

Replaces https://github.com/tempoxyz/tempo/pull/2196