### PR TITLE
feat(rpc): add consensus_epochNumber RPC method

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -305,6 +305,7 @@ where
             epoch_strategy: epoch_strategy.clone(),
         });
 
+        let feed_state = self.feed_state.clone();
         let (feed, feed_mailbox) = crate::feed::init(
             context.with_label("feed"),
             marshal_mailbox.clone(),
@@ -359,6 +360,8 @@ where
                 views_until_leader_skip: ViewDelta::new(self.views_until_leader_skip),
             },
         );
+
+        feed_state.set_epoch_manager(epoch_manager_mailbox.clone());
 
         let (dkg_manager, dkg_manager_mailbox) = dkg::manager::init(
             context.with_label("dkg_manager"),

--- a/crates/commonware-node/src/epoch/manager/actor.rs
+++ b/crates/commonware-node/src/epoch/manager/actor.rs
@@ -71,7 +71,7 @@ use tracing::{Level, Span, debug, error, error_span, info, instrument, warn, war
 
 use crate::{
     consensus::Digest,
-    epoch::manager::ingress::{EpochTransition, Exit},
+    epoch::manager::ingress::{EpochTransition, Exit, GetCurrentEpoch},
 };
 
 use super::ingress::{Content, Message};
@@ -259,6 +259,10 @@ where
                                     ack.acknowledge();
                                 }
                             }
+                        }
+                        Content::GetCurrentEpoch(GetCurrentEpoch { response }) => {
+                            let epoch = self.active_epochs.last_key_value().map(|(e, _)| e.get());
+                            let _ = response.send(epoch);
                         }
                     }
                 },

--- a/crates/commonware-node/src/epoch/manager/ingress.rs
+++ b/crates/commonware-node/src/epoch/manager/ingress.rs
@@ -43,12 +43,12 @@ impl Mailbox {
             .wrap_err("epoch manager no longer running")
     }
 
-    pub async fn get_current_epoch(&mut self) -> Option<u64> {
+    pub async fn get_current_epoch(&mut self) -> eyre::Result<Option<u64>> {
         let (tx, rx) = oneshot::channel();
         self.inner
             .unbounded_send(Message::in_current_span(GetCurrentEpoch { response: tx }))
-            .ok()?;
-        rx.await.ok().flatten()
+            .wrap_err("epoch manager no longer running")?;
+        rx.await.wrap_err("epoch manager dropped the response channel")
     }
 }
 

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -459,8 +459,12 @@ impl ConsensusFeed for FeedStateHandle {
         })
     }
 
-    async fn epoch_number(&self) -> Option<u64> {
-        let mut mailbox = self.epoch_manager.read().clone()?;
+    async fn epoch_number(&self) -> eyre::Result<Option<u64>> {
+        let mut mailbox = self
+            .epoch_manager
+            .read()
+            .clone()
+            .ok_or_else(|| eyre::eyre!("epoch manager not yet initialized"))?;
         mailbox.get_current_epoch().await
     }
 }

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -451,6 +451,13 @@ impl ConsensusFeed for FeedStateHandle {
             transitions,
         })
     }
+
+    async fn epoch_number(&self) -> Option<u64> {
+        let epocher = self.epocher()?;
+        let state = self.state.read();
+        let height = state.latest_finalized.as_ref()?.height?;
+        epocher.containing(height).map(|info| info.epoch().get())
+    }
 }
 
 /// Fetch last block of epoch and decode DKG outcome.

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -456,7 +456,9 @@ impl ConsensusFeed for FeedStateHandle {
         let epocher = self.epocher()?;
         let state = self.state.read();
         let height = state.latest_finalized.as_ref()?.height?;
-        epocher.containing(height).map(|info| info.epoch().get())
+        epocher
+            .containing(Height::new(height))
+            .map(|info| info.epoch().get())
     }
 }
 

--- a/crates/node/src/rpc/consensus/mod.rs
+++ b/crates/node/src/rpc/consensus/mod.rs
@@ -128,6 +128,9 @@ impl<I: ConsensusFeed> TempoConsensusApiServer for TempoConsensusRpc<I> {
     }
 
     async fn epoch_number(&self) -> RpcResult<Option<u64>> {
-        Ok(self.consensus_feed.epoch_number().await)
+        self.consensus_feed
+            .epoch_number()
+            .await
+            .map_err(|e| ErrorObject::owned(INTERNAL_ERROR_CODE, e.to_string(), None::<()>))
     }
 }

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -150,5 +150,8 @@ pub trait ConsensusFeed: Send + Sync + 'static {
     ) -> impl Future<Output = Result<IdentityTransitionResponse, IdentityProofError>> + Send;
 
     /// Get the current consensus epoch number based on the latest finalized block height.
-    fn epoch_number(&self) -> impl Future<Output = Option<u64>> + Send;
+    ///
+    /// Returns `Ok(None)` if no epoch is currently active.
+    /// Returns `Err` if the epoch manager is not available or communication fails.
+    fn epoch_number(&self) -> impl Future<Output = eyre::Result<Option<u64>>> + Send;
 }

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -148,4 +148,7 @@ pub trait ConsensusFeed: Send + Sync + 'static {
         from_epoch: Option<u64>,
         full: bool,
     ) -> impl Future<Output = Result<IdentityTransitionResponse, IdentityProofError>> + Send;
+
+    /// Get the current consensus epoch number based on the latest finalized block height.
+    fn epoch_number(&self) -> impl Future<Output = Option<u64>> + Send;
 }

--- a/scripts/get-epoch.sh
+++ b/scripts/get-epoch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Fetch the current epoch from the consensus metrics endpoint
+
+METRICS_URL="${1:-http://127.0.0.1:8001/metrics}"
+
+curl -s "$METRICS_URL" | grep -E "epoch_manager_latest_epoch" | grep -v "^#"


### PR DESCRIPTION
## Summary
Add a new RPC method `consensus_epochNumber` that returns the current consensus epoch number based on the latest finalized block height.

## Changes
- Add `consensus_epochNumber` to `TempoConsensusApi` trait
- Add `epoch_number()` to `ConsensusFeed` trait
- Implement in `FeedStateHandle` using the epocher's `containing(height)` method

## Usage
```bash
curl -X POST -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","method":"consensus_epochNumber","params":[],"id":1}' \
  http://localhost:8545
```

Returns the epoch number (block_height / epoch_length) or null if consensus is not ready.