### PR TITLE
fix(evm): correct incentive gas calculation when fewer subblocks than validators

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1089,7 +1089,10 @@ mod tests {
         );
     }
 
-    fn create_subblock_tx_with_gas(proposer: &PartialValidatorKey, gas_limit: u64) -> TempoTxEnvelope {
+    fn create_subblock_tx_with_gas(
+        proposer: &PartialValidatorKey,
+        gas_limit: u64,
+    ) -> TempoTxEnvelope {
         let mut nonce_bytes = [0u8; 32];
         nonce_bytes[0] = TEMPO_SUBBLOCK_NONCE_KEY_PREFIX;
         nonce_bytes[1..16].copy_from_slice(proposer.as_slice());


### PR DESCRIPTION
## Problem

The devnet was stuck at block 25696 with all proposed blocks failing validation with `incentive gas limit exceeded`. The root cause was that the incentive gas calculation in `validate_shared_gas()` incorrectly reduced the available gas pool when fewer validators submitted subblocks than the total validator set.

## Root Cause

The old calculation:
```rust
let gas_per_subblock = shared_gas_limit / validator_set.len();
for metadata in metadata {
    incentive_gas += gas_per_subblock - reserved_gas;
}
```

With 4 validators but only 3 subblocks submitted:
- `gas_per_subblock = 50M / 4 = 12.5M`
- `incentive_gas = 3 * 12.5M = 37.5M` ❌ (should be 50M)

This meant transactions using >37.5M of incentive gas would fail validation, even though the full 50M `shared_gas_limit` should be available.

## Fix

The incentive gas pool is now calculated as:
```rust
let incentive_gas = shared_gas_limit.saturating_sub(total_reserved_gas);
```

This correctly makes the full `shared_gas_limit` available for incentive transactions, minus only the gas actually reserved by subblock transactions.

## Hardfork Analysis

This change is **backward-compatible**:
- Makes validation more permissive (allows higher incentive gas usage)
- Blocks valid under old rules remain valid under new rules
- Can be deployed as a hotfix without a hardfork

## Testing

Added comprehensive tests covering:
- `test_validate_shared_gas_fewer_subblocks_than_validators` - the bug case
- `test_validate_shared_gas_with_reserved_gas_in_subblocks` - reserved gas reduces pool
- `test_validate_shared_gas_exceeds_with_reserved_gas` - exceeding limits fails correctly
- `test_validate_shared_gas_no_subblocks` - edge case with zero subblocks

## Related

- Discovered via devnet halt at block 25696
- Related to TIP-1010 implementation (#2194)

/cc @daniel @kamil @kuyziss