### PR TITLE
fix(validator): make public keys immutable to prevent DKG chain halt

### DIFF
--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -432,7 +432,7 @@ impl ConsensusFeed for FeedStateHandle {
                                 merged.push(t.clone());
                             }
                         }
-                        merged.sort_by(|a, b| b.transition_epoch.cmp(&a.transition_epoch));
+                        merged.sort_by_key(|t| std::cmp::Reverse(t.transition_epoch));
                         Arc::new(merged)
                     } else {
                         Arc::new(transitions.clone())

--- a/crates/contracts/src/precompiles/validator_config.rs
+++ b/crates/contracts/src/precompiles/validator_config.rs
@@ -93,6 +93,7 @@ crate::sol! {
 
         error NotHostPort(string field, string input, string backtrace);
         error NotIpPort(string field, string input, string backtrace);
+        error PublicKeyImmutable();
     }
 }
 
@@ -131,5 +132,9 @@ impl ValidatorConfigError {
             input,
             backtrace,
         })
+    }
+
+    pub const fn public_key_immutable() -> Self {
+        Self::PublicKeyImmutable(IValidatorConfig::PublicKeyImmutable {})
     }
 }

--- a/tips/ref-impls/foundry.lock
+++ b/tips/ref-impls/foundry.lock
@@ -1,4 +1,7 @@
 {
+  "lib/forge-std": {
+    "rev": "f61e4dd133379a4536a54ee57a808c9c00019b60"
+  },
   "lib/tempo-std": {
     "branch": {
       "name": "master",

--- a/tips/ref-impls/src/ValidatorConfig.sol
+++ b/tips/ref-impls/src/ValidatorConfig.sol
@@ -109,6 +109,11 @@ contract ValidatorConfig is IValidatorConfig {
         // Load old validator info
         Validator memory oldValidator = validators[msg.sender];
 
+        // Public key is immutable - changing it mid-epoch would cause DKG failures
+        if (publicKey != oldValidator.publicKey) {
+            revert PublicKeyImmutable();
+        }
+
         // Check if rotating to a new address
         if (newValidatorAddress != msg.sender) {
             // Check if new address already exists

--- a/tips/ref-impls/src/interfaces/IValidatorConfig.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfig.sol
@@ -32,6 +32,11 @@ interface IValidatorConfig {
     /// @param backtrace Additional error context
     error NotIpPort(string field, string input, string backtrace);
 
+    /// @notice Thrown when trying to change the public key in updateValidator
+    /// @dev Public keys are immutable after creation. Key rotation must be done via
+    ///      owner-managed process (add new validator, deactivate old one).
+    error PublicKeyImmutable();
+
     /// @notice Validator information
     /// @param publicKey The validator's communication public key
     /// @param active Whether the validator is active in consensus
@@ -68,9 +73,11 @@ interface IValidatorConfig {
 
     /// @notice Update validator information (only validator)
     /// @param newValidatorAddress The new address for this validator
-    /// @param publicKey The validator's new communication public key
+    /// @param publicKey The validator's communication public key (must match existing key - immutable)
     /// @param inboundAddress The validator's inbound address `<hostname|ip>:<port>` for incoming connections
     /// @param outboundAddress The validator's outbound IP address `<ip>:<port>` for firewall whitelisting (IP only, no hostnames)
+    /// @dev The public key is immutable after creation. Passing a different public key will revert
+    ///      with PublicKeyImmutable(). Key rotation must be done via owner-managed process.
     function updateValidator(
         address newValidatorAddress,
         bytes32 publicKey,


### PR DESCRIPTION
Closes CHAIN-458 

Fixes a chain halt vulnerability where validators could change their Ed25519 public key mid-epoch, causing DKG to panic at the next epoch boundary when the frozen key no longer existed in the registry.

- Make validator public keys immutable in `updateValidator()` - validators can still update addresses but key rotation now requires owner intervention (add new validator, deactivate old)
- Add `PublicKeyImmutable` error to reject key change attempts

Note: these changes effectively disallow validators to change their Ed25519 public key, making owners responsible for that (and consequently changing validator operations). Alternatively we could introduce the concept of pending public keys that can be sent by validators mid-epoch and only activated at epoch boundary, before DKG runs.