### PR TITLE
fix(feed): use sort_by_key instead of sort_by

### DIFF
--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -432,7 +432,7 @@ impl ConsensusFeed for FeedStateHandle {
                                 merged.push(t.clone());
                             }
                         }
-                        merged.sort_by(|a, b| b.transition_epoch.cmp(&a.transition_epoch));
+                        merged.sort_by_key(|t| std::cmp::Reverse(t.transition_epoch));
                         Arc::new(merged)
                     } else {
                         Arc::new(transitions.clone())


### PR DESCRIPTION
Fixes this warning with latest clippy:
```
warning: consider using `sort_by_key`
   --> crates/commonware-node/src/feed/state.rs:435:25
    |
435 |                         merged.sort_by(|a, b| b.transition_epoch.cmp(&a.transition_epoch));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
    = note: `#[warn(clippy::unnecessary_sort_by)]` on by default
help: try
    |
435 -                         merged.sort_by(|a, b| b.transition_epoch.cmp(&a.transition_epoch));
435 +                         merged.sort_by_key(|b| std::cmp::Reverse(b.transition_epoch));
    |
```