### PR TITLE
test(chainspec): add sanity test for from_genesis hardfork activation

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -416,4 +416,32 @@ mod tests {
         assert_eq!(dev_chainspec.tempo_hardfork_at(0), TempoHardfork::T1);
         assert_eq!(dev_chainspec.tempo_hardfork_at(1000), TempoHardfork::T1);
     }
+
+    #[test]
+    fn test_from_genesis_with_hardforks_at_zero() {
+        use alloy_genesis::Genesis;
+
+        let genesis: Genesis = serde_json::from_str(
+            r#"{
+                "config": {
+                    "chainId": 1234,
+                    "t0Time": 0,
+                    "t1Time": 0
+                },
+                "alloc": {}
+            }"#,
+        )
+        .unwrap();
+
+        let chainspec = super::TempoChainSpec::from_genesis(genesis);
+
+        assert!(chainspec.is_t0_active_at_timestamp(0));
+        assert!(chainspec.is_t0_active_at_timestamp(1000));
+        assert!(chainspec.is_t1_active_at_timestamp(0));
+        assert!(chainspec.is_t1_active_at_timestamp(1000));
+
+        assert_eq!(chainspec.tempo_hardfork_at(0), TempoHardfork::T1);
+        assert_eq!(chainspec.tempo_hardfork_at(1000), TempoHardfork::T1);
+        assert_eq!(chainspec.tempo_hardfork_at(u64::MAX), TempoHardfork::T1);
+    }
 }


### PR DESCRIPTION
Adds a test for `TempoChainSpec::from_genesis` that verifies T0 and T1 hardfork activation works correctly when both are set to timestamp 0.

**What this tests:**
- `is_t0_active_at_timestamp()` returns true for various timestamps
- `is_t1_active_at_timestamp()` returns true for various timestamps  
- `tempo_hardfork_at()` returns `T1` (the latest active hardfork)