### PR TITLE
feat(tempo-bench): add Tempo vs Reth TPS comparison script

### DIFF
--- a/bin/tempo-bench/Cargo.toml
+++ b/bin/tempo-bench/Cargo.toml
@@ -20,6 +20,7 @@ alloy = { workspace = true, features = [
     "network",
     "rand",
     "reqwest",
+    "rpc-types",
     "secp256k1",
     "signer-local",
     "signer-mnemonic",

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -125,6 +125,15 @@ Options:
       --disable-2d-nonces
           Disable 2D nonces
 
+      --reth-mode
+          Run in Reth-compatible mode (vanilla Ethereum).
+          
+          This mode:
+          - Disables 2D nonces (uses standard Ethereum nonces)
+          - Forces ERC-20 only transactions (no TIP-20, DEX)
+          - Skips Tempo-specific setup (fee manager, DEX)
+          - Requires accounts to be pre-funded (--faucet won't work)
+
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -188,3 +188,19 @@ Use the following commands to run the node with [sampling](https://github.com/ms
 ```bash
 	samply record --output tempo.samply -- just localnet 50000
 ```
+
+## Tempo vs Reth Comparison
+
+Compare TPS performance between Tempo and Reth nodes:
+
+```bash
+TEMPO_RPC=http://tempo:8545 RETH_RPC=http://reth:8545 ./scripts/tempo-vs-reth-bench.sh
+```
+
+This runs `tempo-bench` against both nodes and generates a markdown report comparing:
+- Actual TPS achieved
+- Transaction success/failure rates
+- Gas throughput
+- Speedup factor
+
+See `scripts/tempo-vs-reth-bench.sh -h` for configuration options.

--- a/bin/tempo-bench/scripts/BENCHMARK_COMPARISON.md
+++ b/bin/tempo-bench/scripts/BENCHMARK_COMPARISON.md
@@ -1,0 +1,108 @@
+# Tempo vs Reth TPS Benchmark Guide
+
+This guide explains how to run a fair TPS comparison between Tempo and Reth nodes.
+
+## Prerequisites
+
+1. Access to a reth dev box (request in #reth-infra if needed)
+2. `tempo-bench` built with `--profile maxperf`
+3. Both Tempo and Reth running in dev mode on the same machine
+
+## Setup
+
+### 1. Build tempo-bench
+
+```bash
+cd /path/to/tempo
+cargo install --path bin/tempo-bench --profile maxperf
+```
+
+### 2. Start Reth in Dev Mode
+
+```bash
+# Start Reth with dev mode (pre-funded accounts, instant sealing)
+reth node --dev --dev.block-time 100ms --http --http.port 8546
+
+# Note the mnemonic used by Reth dev mode:
+# "test test test test test test test test test test test junk"
+```
+
+### 3. Start Tempo in Dev Mode
+
+```bash
+# Generate genesis with pre-funded accounts
+cargo x generate-genesis --accounts 50000 --output genesis.json
+
+# Start Tempo localnet
+just localnet 50000
+```
+
+## Running the Benchmark
+
+### Option A: Use the Comparison Script
+
+```bash
+# Set environment variables
+export TEMPO_RPC="http://localhost:8545"
+export RETH_RPC="http://localhost:8546"
+export DURATION=60
+export TARGET_TPS=10000
+export ACCOUNTS=200
+
+# Run comparison
+./bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
+```
+
+### Option B: Manual Benchmark
+
+**Benchmark Tempo:**
+```bash
+tempo-bench run-max-tps \
+  --target-urls http://localhost:8545 \
+  --tps 10000 \
+  --duration 60 \
+  --accounts 200 \
+  --faucet \
+  --erc20-weight 1 \
+  --tip20-weight 0 \
+  > tempo_results.json
+```
+
+**Benchmark Reth:**
+```bash
+# First, fund accounts using Reth dev mode mnemonic
+tempo-bench run-max-tps \
+  --target-urls http://localhost:8546 \
+  --tps 10000 \
+  --duration 60 \
+  --accounts 200 \
+  --reth-mode \
+  --mnemonic "test test test test test test test test test test test junk" \
+  > reth_results.json
+```
+
+## Fair Comparison Notes
+
+1. **Same transaction type**: Both use ERC-20 transfers only (no Tempo-specific TIP-20/DEX)
+2. **Same hardware**: Run both on the same machine
+3. **Same parameters**: Use identical TPS, duration, and account count
+4. **Pre-funded accounts**: Reth dev mode comes with funded accounts; use the dev mnemonic
+
+## Interpreting Results
+
+The JSON output contains:
+- `metadata.target_tps`: Requested TPS
+- `blocks[].tx_count`: Transactions per block
+- `blocks[].ok_count`: Successful transactions
+- Actual TPS = sum(tx_count) / duration
+
+Key metrics to compare:
+- **Actual TPS achieved**: Higher is better
+- **Success rate**: ok_count / tx_count
+- **Block latency**: Time between blocks
+
+## Known Limitations
+
+- Reth dev mode uses instant sealing, while Tempo uses consensus
+- For production comparison, both should run with realistic block times
+- Network conditions vary; run multiple trials and average results

--- a/bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
+++ b/bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+set -euo pipefail
+
+# Tempo vs Reth TPS Comparison Script
+# Runs tempo-bench against both nodes and generates a comparison report
+
+TEMPO_RPC="${TEMPO_RPC:-http://localhost:8545}"
+RETH_RPC="${RETH_RPC:-http://localhost:8546}"
+DURATION="${DURATION:-30}"
+TARGET_TPS="${TARGET_TPS:-10000}"
+ACCOUNTS="${ACCOUNTS:-200}"
+RESULTS_DIR="${RESULTS_DIR:-./benchmark-results}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Benchmark Tempo and Reth nodes and compare TPS performance.
+
+Environment Variables:
+  TEMPO_RPC      Tempo node RPC URL (default: http://localhost:8545)
+  RETH_RPC       Reth node RPC URL (default: http://localhost:8546)
+  DURATION       Test duration in seconds (default: 30)
+  TARGET_TPS     Target TPS to attempt (default: 10000)
+  ACCOUNTS       Number of accounts to use (default: 200)
+  RESULTS_DIR    Output directory (default: ./benchmark-results)
+
+Example:
+  TEMPO_RPC=http://tempo:8545 RETH_RPC=http://reth:8545 $0
+EOF
+    exit 1
+}
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && usage
+
+mkdir -p "$RESULTS_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+TEMPO_OUT="$RESULTS_DIR/tempo_${TIMESTAMP}.json"
+RETH_OUT="$RESULTS_DIR/reth_${TIMESTAMP}.json"
+REPORT="$RESULTS_DIR/comparison_${TIMESTAMP}.md"
+
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║           Tempo vs Reth TPS Benchmark                        ║"
+echo "╠══════════════════════════════════════════════════════════════╣"
+echo "║ Tempo RPC:  $TEMPO_RPC"
+echo "║ Reth RPC:   $RETH_RPC"
+echo "║ Duration:   ${DURATION}s"
+echo "║ Target TPS: $TARGET_TPS"
+echo "║ Accounts:   $ACCOUNTS"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo
+
+run_bench() {
+    local name="$1"
+    local rpc="$2"
+    local output="$3"
+    local extra_args="${4:-}"
+    
+    echo "▶ Benchmarking $name at $rpc..."
+    
+    if ! tempo-bench run-max-tps \
+        --duration "$DURATION" \
+        --tps "$TARGET_TPS" \
+        --target-urls "$rpc" \
+        --accounts "$ACCOUNTS" \
+        --benchmark-mode "max_tps" \
+        $extra_args \
+        > "$output" 2>&1; then
+        echo "  ✗ $name benchmark failed"
+        cat "$output"
+        return 1
+    fi
+    
+    echo "  ✓ $name benchmark complete → $output"
+}
+
+extract_metrics() {
+    local file="$1"
+    local name="$2"
+    
+    if [[ ! -f "$file" ]]; then
+        echo "0 0 0 0 0"
+        return
+    fi
+    
+    jq -r '
+        .blocks as $blocks |
+        ($blocks | map(.tx_count) | add // 0) as $total_tx |
+        ($blocks | map(.ok_count) | add // 0) as $ok_tx |
+        ($blocks | map(.err_count) | add // 0) as $err_tx |
+        ($blocks | map(.gas_used) | add // 0) as $total_gas |
+        .metadata.run_duration_secs as $duration |
+        ($total_tx / ($duration // 1)) as $actual_tps |
+        "\($total_tx) \($ok_tx) \($err_tx) \($total_gas) \($actual_tps | floor)"
+    ' "$file" 2>/dev/null || echo "0 0 0 0 0"
+}
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "Phase 1: Benchmark Tempo"
+echo "═══════════════════════════════════════════════════════════════"
+run_bench "Tempo" "$TEMPO_RPC" "$TEMPO_OUT" "--faucet"
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "Phase 2: Benchmark Reth"
+echo "═══════════════════════════════════════════════════════════════"
+# Reth doesn't have Tempo's faucet, so skip --faucet flag
+# Also disable 2D nonces since Reth uses standard nonces
+run_bench "Reth" "$RETH_RPC" "$RETH_OUT" "--disable-2d-nonces"
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "Phase 3: Generate Comparison Report"
+echo "═══════════════════════════════════════════════════════════════"
+
+read -r tempo_tx tempo_ok tempo_err tempo_gas tempo_tps <<< "$(extract_metrics "$TEMPO_OUT" "Tempo")"
+read -r reth_tx reth_ok reth_err reth_gas reth_tps <<< "$(extract_metrics "$RETH_OUT" "Reth")"
+
+if [[ "$reth_tps" -gt 0 ]]; then
+    speedup=$(echo "scale=2; $tempo_tps / $reth_tps" | bc)
+    diff_pct=$(echo "scale=1; (($tempo_tps - $reth_tps) / $reth_tps) * 100" | bc)
+else
+    speedup="N/A"
+    diff_pct="N/A"
+fi
+
+cat > "$REPORT" <<EOF
+# Tempo vs Reth TPS Benchmark Report
+
+**Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+## Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Tempo RPC | \`$TEMPO_RPC\` |
+| Reth RPC | \`$RETH_RPC\` |
+| Duration | ${DURATION}s |
+| Target TPS | $TARGET_TPS |
+| Accounts | $ACCOUNTS |
+
+## Results
+
+| Metric | Tempo | Reth | Difference |
+|--------|-------|------|------------|
+| **Actual TPS** | $tempo_tps | $reth_tps | ${diff_pct}% |
+| Total Transactions | $tempo_tx | $reth_tx | - |
+| Successful Txs | $tempo_ok | $reth_ok | - |
+| Failed Txs | $tempo_err | $reth_err | - |
+| Total Gas Used | $tempo_gas | $reth_gas | - |
+
+## Summary
+
+- **Tempo TPS:** $tempo_tps tx/s
+- **Reth TPS:** $reth_tps tx/s
+- **Speedup:** ${speedup}x
+
+## Raw Data
+
+- Tempo results: \`$TEMPO_OUT\`
+- Reth results: \`$RETH_OUT\`
+EOF
+
+echo
+cat "$REPORT"
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo "Report saved to: $REPORT"
+echo "═══════════════════════════════════════════════════════════════"

--- a/bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
+++ b/bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
@@ -99,15 +99,18 @@ echo
 echo "═══════════════════════════════════════════════════════════════"
 echo "Phase 1: Benchmark Tempo"
 echo "═══════════════════════════════════════════════════════════════"
-run_bench "Tempo" "$TEMPO_RPC" "$TEMPO_OUT" "--faucet"
+# Use ERC-20 only for fair comparison with Reth (no TIP-20/DEX advantage)
+run_bench "Tempo" "$TEMPO_RPC" "$TEMPO_OUT" "--faucet --erc20-weight 1 --tip20-weight 0"
 
 echo
 echo "═══════════════════════════════════════════════════════════════"
 echo "Phase 2: Benchmark Reth"
 echo "═══════════════════════════════════════════════════════════════"
-# Reth doesn't have Tempo's faucet, so skip --faucet flag
-# Also disable 2D nonces since Reth uses standard nonces
-run_bench "Reth" "$RETH_RPC" "$RETH_OUT" "--disable-2d-nonces"
+# Use --reth-mode which auto-configures for vanilla Ethereum:
+# - Disables 2D nonces
+# - Forces ERC-20 only transactions
+# - Skips Tempo-specific setup
+run_bench "Reth" "$RETH_RPC" "$RETH_OUT" "--reth-mode"
 
 echo
 echo "═══════════════════════════════════════════════════════════════"

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -200,7 +200,9 @@ impl MaxTpsArgs {
                 self.erc20_weight = 1.0;
             }
             if self.faucet {
-                eyre::bail!("--faucet is not supported in --reth-mode. Pre-fund accounts using genesis or dev mode.");
+                eyre::bail!(
+                    "--faucet is not supported in --reth-mode. Pre-fund accounts using genesis or dev mode."
+                );
             }
         }
 

--- a/bin/tempo-bench/src/cmd/mod.rs
+++ b/bin/tempo-bench/src/cmd/mod.rs
@@ -1,2 +1,3 @@
 pub mod max_tps;
+pub mod reth_bench;
 mod signer_providers;

--- a/bin/tempo-bench/src/cmd/reth_bench.rs
+++ b/bin/tempo-bench/src/cmd/reth_bench.rs
@@ -1,0 +1,308 @@
+//! Reth-compatible benchmarking mode using standard Ethereum network.
+//!
+//! This module provides a separate code path for benchmarking vanilla Ethereum nodes
+//! like Reth, which don't have Tempo-specific RPC extensions.
+
+use alloy::{
+    consensus::TxEnvelope,
+    eips::Encodable2718,
+    network::{Ethereum, EthereumWallet, TxSignerSync},
+    primitives::{Address, U256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::{MnemonicBuilder, Secp256k1Signer},
+    sol,
+    transports::http::reqwest::Url,
+};
+use eyre::Context;
+use futures::{StreamExt, stream};
+use governor::{Quota, RateLimiter, state::StreamRateLimitExt};
+use indicatif::{ParallelProgressIterator, ProgressBar, ProgressIterator};
+use rand::seq::IndexedRandom;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use reth_tracing::tracing::info;
+use serde::Serialize;
+use std::{
+    num::NonZeroU32,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+sol! {
+    #[sol(rpc)]
+    #[allow(clippy::too_many_arguments)]
+    MockERC20,
+    "artifacts/MockERC20.json"
+}
+
+/// Run the benchmark in Reth-compatible mode
+pub async fn run_reth_benchmark(
+    target_urls: Vec<Url>,
+    tps: u64,
+    duration: u64,
+    accounts: u64,
+    mnemonic: String,
+    from_mnemonic_index: u32,
+    max_concurrent_requests: usize,
+) -> eyre::Result<RethBenchmarkReport> {
+    info!("Running Reth-compatible benchmark");
+
+    // Create signers
+    info!(accounts, "Creating signers");
+    let signers: Vec<Secp256k1Signer> = (from_mnemonic_index..)
+        .take(accounts as usize)
+        .progress_count(accounts)
+        .map(|i| MnemonicBuilder::from_phrase_nth(&mnemonic, i).into_secp256k1())
+        .collect();
+
+    // Create base provider with explicit Ethereum network
+    let provider = ProviderBuilder::new()
+        .network::<Ethereum>()
+        .connect_http(target_urls[0].clone());
+
+    // Get start block and chain info
+    let start_block = provider.get_block_number().await?;
+    let chain_id = provider.get_chain_id().await?;
+
+    // Get gas price for transactions
+    let gas_price = provider.get_gas_price().await?;
+    info!(chain_id, gas_price, "Connected to chain");
+
+    // Deploy ERC-20 token using first signer
+    info!("Deploying ERC-20 token");
+    let deployer_provider = ProviderBuilder::new()
+        .network::<Ethereum>()
+        .wallet(EthereumWallet::from(signers[0].clone()))
+        .connect_http(target_urls[0].clone());
+
+    let token = MockERC20::deploy(
+        &deployer_provider,
+        "BenchToken".to_string(),
+        "BENCH".to_string(),
+        18,
+    )
+    .await
+    .context("Failed to deploy ERC-20 token")?;
+    let token_address = *token.address();
+    info!(%token_address, "ERC-20 token deployed");
+
+    // Mint tokens to all signers
+    let mint_amount = U256::MAX / U256::from(signers.len());
+    info!(%mint_amount, "Minting ERC-20 tokens to all accounts");
+
+    for signer in signers.iter().progress() {
+        let to = signer.address();
+        token
+            .mint(to, mint_amount)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+    }
+
+    // Get initial nonces for all signers
+    info!("Fetching initial nonces");
+    let mut nonces: std::collections::HashMap<Address, u64> = std::collections::HashMap::new();
+    for signer in &signers {
+        let nonce = provider.get_transaction_count(signer.address()).await?;
+        nonces.insert(signer.address(), nonce);
+    }
+
+    // Generate transaction data
+    let total_txs = tps * duration;
+    info!(total_txs, "Generating transaction data");
+
+    let progress = ProgressBar::new(total_txs);
+    let mut tx_data: Vec<(Secp256k1Signer, u64, Vec<u8>)> = Vec::with_capacity(total_txs as usize);
+
+    for _ in (0..total_txs).progress_with(progress) {
+        let signer = signers.choose(&mut rand::rng()).unwrap().clone();
+        let from = signer.address();
+
+        // Get and increment nonce
+        let nonce = nonces.get(&from).copied().unwrap_or(0);
+        nonces.insert(from, nonce + 1);
+
+        // Create transfer calldata with random recipient
+        let call = MockERC20::transferCall {
+            to: Address::random(),
+            amount: U256::from(1),
+        };
+        let calldata = alloy::sol_types::SolCall::abi_encode(&call);
+
+        tx_data.push((signer, nonce, calldata));
+    }
+
+    // Sign transactions in parallel
+    info!(transactions = tx_data.len(), "Signing transactions");
+
+    let transactions: Vec<Vec<u8>> = tx_data
+        .into_par_iter()
+        .progress()
+        .map(|(signer, nonce, calldata)| -> eyre::Result<Vec<u8>> {
+            use alloy::consensus::{SignableTransaction, TxEip1559};
+
+            let mut tx = TxEip1559 {
+                chain_id,
+                nonce,
+                gas_limit: 100_000,
+                max_fee_per_gas: gas_price + 1_000_000_000, // gas price + 1 gwei
+                max_priority_fee_per_gas: 1_000_000_000,    // 1 gwei
+                to: alloy::primitives::TxKind::Call(token_address),
+                value: U256::ZERO,
+                access_list: Default::default(),
+                input: calldata.into(),
+            };
+
+            let sig = signer.sign_transaction_sync(&mut tx)?;
+            let envelope = TxEnvelope::Eip1559(tx.into_signed(sig));
+            Ok(envelope.encoded_2718())
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+
+    // Send transactions
+    info!(
+        transactions = transactions.len(),
+        tps, "Sending transactions"
+    );
+    let rate_limiter = RateLimiter::direct(Quota::per_second(NonZeroU32::new(tps as u32).unwrap()));
+
+    let deadline = tokio::time::sleep(Duration::from_secs(duration));
+    tokio::pin!(deadline);
+
+    let sent_count = Arc::new(AtomicUsize::new(0));
+    let failed_count = Arc::new(AtomicUsize::new(0));
+
+    stream::iter(transactions)
+        .ratelimit_stream(&rate_limiter)
+        .map(|bytes: Vec<u8>| {
+            let provider = provider.clone();
+            let sent = sent_count.clone();
+            let failed = failed_count.clone();
+            async move {
+                match tokio::time::timeout(
+                    Duration::from_secs(5),
+                    provider.send_raw_transaction(&bytes),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {
+                        sent.fetch_add(1, Ordering::Relaxed);
+                    }
+                    _ => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        })
+        .buffer_unordered(max_concurrent_requests)
+        .take_until(&mut deadline)
+        .collect::<Vec<_>>()
+        .await;
+
+    let sent = sent_count.load(Ordering::Relaxed);
+    let failed = failed_count.load(Ordering::Relaxed);
+    info!(sent, failed, "Finished sending transactions");
+
+    // Wait for transactions to be mined
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Get end block and generate report
+    let end_block = provider.get_block_number().await?;
+    info!(start_block, end_block, "Generating report");
+
+    let mut blocks = Vec::new();
+    let mut last_timestamp: Option<u64> = None;
+
+    for number in start_block..=end_block {
+        let block: Option<alloy::rpc::types::Block> = provider.get_block(number.into()).await?;
+        if let Some(block) = block {
+            let receipts: Vec<alloy::rpc::types::TransactionReceipt> = provider
+                .get_block_receipts(number.into())
+                .await?
+                .unwrap_or_default();
+
+            let timestamp = block.header.timestamp;
+            let latency_ms = last_timestamp.map(|last| (timestamp - last) * 1000);
+
+            // Count successful and failed transactions
+            let tx_count = receipts.len();
+            let ok_count = receipts.iter().filter(|r| r.status()).count();
+            let err_count = tx_count - ok_count;
+
+            blocks.push(RethBenchmarkedBlock {
+                number,
+                tx_count,
+                ok_count,
+                err_count,
+                gas_used: block.header.gas_used,
+                timestamp,
+                latency_ms,
+            });
+
+            last_timestamp = Some(timestamp);
+        }
+    }
+
+    let total_tx: usize = blocks.iter().map(|b| b.tx_count).sum();
+    let total_ok: usize = blocks.iter().map(|b| b.ok_count).sum();
+    let actual_tps = total_tx as f64 / duration as f64;
+
+    info!(total_tx, total_ok, actual_tps, "Benchmark complete");
+
+    Ok(RethBenchmarkReport {
+        metadata: RethBenchmarkMetadata {
+            target_tps: tps,
+            run_duration_secs: duration,
+            accounts,
+            chain_id,
+            start_block,
+            end_block,
+            mode: "reth".to_string(),
+        },
+        blocks,
+        summary: RethBenchmarkSummary {
+            total_tx,
+            total_ok,
+            actual_tps,
+        },
+    })
+}
+
+#[derive(Serialize)]
+pub struct RethBenchmarkReport {
+    pub metadata: RethBenchmarkMetadata,
+    pub blocks: Vec<RethBenchmarkedBlock>,
+    pub summary: RethBenchmarkSummary,
+}
+
+#[derive(Serialize)]
+pub struct RethBenchmarkMetadata {
+    pub target_tps: u64,
+    pub run_duration_secs: u64,
+    pub accounts: u64,
+    pub chain_id: u64,
+    pub start_block: u64,
+    pub end_block: u64,
+    pub mode: String,
+}
+
+#[derive(Serialize)]
+pub struct RethBenchmarkedBlock {
+    pub number: u64,
+    pub tx_count: usize,
+    pub ok_count: usize,
+    pub err_count: usize,
+    pub gas_used: u64,
+    pub timestamp: u64,
+    pub latency_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub struct RethBenchmarkSummary {
+    pub total_tx: usize,
+    pub total_ok: usize,
+    pub actual_tps: f64,
+}


### PR DESCRIPTION
## Summary

Adds a shell script to benchmark both Tempo and Reth nodes using `tempo-bench` and generate a markdown comparison report.

## Usage

```bash
TEMPO_RPC=http://tempo:8545 RETH_RPC=http://reth:8545 ./bin/tempo-bench/scripts/tempo-vs-reth-bench.sh
```

## Output

Generates a markdown report comparing:
- Actual TPS achieved
- Transaction success/failure rates  
- Gas throughput
- Speedup factor (Tempo TPS / Reth TPS)

## Known Limitations

For Reth compatibility, the script uses:
- `--disable-2d-nonces` (Reth uses standard Ethereum nonces)
- `--erc20-weight 1` with all Tempo-specific weights at 0 (no TIP-20/DEX on vanilla Reth)

**Note:** This PR is a stepping stone. Follow-up work needed:
- [ ] Add `--reth-mode` flag to tempo-bench that auto-configures for vanilla Ethereum nodes
- [ ] Alternative account funding for Reth (genesis pre-fund or dev account unlock)

Requested by @tanishk in https://tempoxyz.slack.com/archives/C0A87C21805/p1769438316564369