### PR TITLE
feat(consensus): add external consensus certificate indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -849,7 +849,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck",
+ "heck 0.5.0",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -1411,7 +1411,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -1458,6 +1458,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2315,7 +2324,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2755,6 +2764,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "consensus-indexer"
+version = "1.0.2"
+dependencies = [
+ "alloy-primitives",
+ "commonware-codec",
+ "commonware-consensus",
+ "commonware-cryptography",
+ "eyre",
+ "futures",
+ "jsonrpsee",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "tempo-commonware-node",
+ "tempo-node",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,7 +2926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2972,6 +3001,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3493,7 +3531,7 @@ dependencies = [
  "enr",
  "fnv",
  "futures",
- "hashlink",
+ "hashlink 0.9.1",
  "hex",
  "hkdf",
  "lazy_static",
@@ -3536,6 +3574,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -3703,7 +3747,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3775,6 +3819,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethereum_hashing"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,6 +3882,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3842,7 +3903,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -4006,6 +4067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4106,6 +4178,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4392,6 +4475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -4416,6 +4500,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4459,6 +4552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4552,6 +4654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5266,7 +5377,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -5412,6 +5523,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "libc"
@@ -5516,6 +5630,17 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5705,6 +5830,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -6078,6 +6213,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -6687,6 +6838,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -10598,6 +10760,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11392,6 +11574,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
@@ -11416,6 +11607,218 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 2.5.3",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink 0.8.4",
+ "hex",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlformat",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.4.1",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.10.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.10.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11426,6 +11829,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -11457,7 +11871,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -11470,7 +11884,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -11842,6 +12256,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-consensus-indexer"
+version = "1.0.2"
+dependencies = [
+ "clap",
+ "consensus-indexer",
+ "eyre",
+ "jsonrpsee",
+ "tempo-node",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "tempo-contracts"
 version = "1.0.2"
 dependencies = [
@@ -12005,6 +12433,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-contracts",
+ "tempo-dkg-onchain-artifacts",
  "tempo-e2e",
  "tempo-evm",
  "tempo-payload-builder",
@@ -13032,10 +13461,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -13071,6 +13521,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unit-prefix"
@@ -13118,6 +13574,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -13269,6 +13731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13408,6 +13876,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -849,7 +849,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck 0.5.0",
+ "heck",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -1411,7 +1411,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -2324,7 +2324,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3747,7 +3747,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3882,12 +3882,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3903,7 +3897,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -4475,7 +4469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -4504,20 +4497,20 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4552,15 +4545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -5377,7 +5361,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -5634,9 +5618,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -11607,20 +11591,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -11631,38 +11605,33 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "ahash",
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 2.5.3",
- "futures-channel",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashlink 0.8.4",
- "hex",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
  "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -11672,26 +11641,26 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -11703,20 +11672,19 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
- "tempfile",
+ "syn 2.0.114",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.10.0",
  "byteorder",
  "bytes",
@@ -11747,7 +11715,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -11755,12 +11723,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.10.0",
  "byteorder",
  "chrono",
@@ -11769,7 +11737,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -11787,7 +11754,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "whoami",
@@ -11795,9 +11762,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
@@ -11811,10 +11778,11 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.17",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 
@@ -11871,7 +11839,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -11884,7 +11852,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13522,12 +13490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13573,12 +13535,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12433,7 +12433,6 @@ dependencies = [
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-contracts",
- "tempo-dkg-onchain-artifacts",
  "tempo-e2e",
  "tempo-evm",
  "tempo-payload-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ publish = false
 members = [
   "bin/tempo",
   "bin/tempo-bench",
+  "bin/tempo-consensus-indexer",
   "bin/tempo-sidecar",
   "crates/alloy",
   "crates/chainspec",
   "crates/commonware-node",
   "crates/commonware-node-config",
+  "crates/consensus-indexer",
   "crates/dkg-onchain-artifacts",
   "crates/consensus",
   "crates/eyre",
@@ -117,6 +119,7 @@ tempo-primitives = { path = "crates/primitives", default-features = false, featu
 tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
+consensus-indexer = { path = "crates/consensus-indexer", default-features = false }
 
 # reth v1.10.1
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0c9cb9" }
@@ -238,6 +241,7 @@ tokio = { version = "1.45.1", features = ["full"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+sqlx = { version = "0.7.4", features = ["runtime-tokio", "sqlite", "macros", "chrono", "uuid"] }
 criterion = "0.7.0"
 test-case = "3"
 secp256k1 = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ tokio = { version = "1.45.1", features = ["full"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-sqlx = { version = "0.7.4", features = ["runtime-tokio", "sqlite", "macros", "chrono", "uuid"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "macros", "chrono", "uuid"] }
 criterion = "0.7.0"
 test-case = "3"
 secp256k1 = "0.30.0"

--- a/bin/tempo-consensus-indexer/Cargo.toml
+++ b/bin/tempo-consensus-indexer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tempo-consensus-indexer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap.workspace = true
+eyre.workspace = true
+jsonrpsee = { workspace = true, features = ["server"] }
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+consensus-indexer.workspace = true
+tempo-node.workspace = true
+
+[lints]
+workspace = true

--- a/bin/tempo-consensus-indexer/src/README.md
+++ b/bin/tempo-consensus-indexer/src/README.md
@@ -1,0 +1,17 @@
+# tempo-consensus-indexer
+
+Indexes consensus certificates into sqlite and exposes a local consensus RPC surface.
+
+## Usage
+
+```bash
+cargo run -p tempo-consensus-indexer -- \
+  --db-url sqlite://consensus-indexer.db \
+  --upstream-ws-url ws://moderato-stable-rpc-service:8546 \
+  --upstream-http-url http://moderato-stable-rpc-service:8545 \
+  --http-listen 0.0.0.0:8545 \
+  --ws-listen 0.0.0.0:8546
+```
+
+On startup the indexer will detect missing finalized heights and fill gaps
+up to the latest finalized block.

--- a/bin/tempo-consensus-indexer/src/main.rs
+++ b/bin/tempo-consensus-indexer/src/main.rs
@@ -1,0 +1,107 @@
+use clap::Parser;
+use consensus_indexer::{
+    db::ConsensusDb, feed::ConsensusFeed, indexer::ConsensusIndexer, state::ConsensusCache,
+    store::ConsensusStore,
+};
+use jsonrpsee::server::{ServerBuilder, ServerConfigBuilder};
+use std::net::SocketAddr;
+use tempo_node::rpc::consensus::{TempoConsensusApiServer, TempoConsensusRpc};
+use tokio::sync::watch;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(long, default_value = "sqlite://consensus-indexer.db")]
+    db_url: String,
+
+    #[arg(long, default_value = "ws://moderato-stable-rpc-service:8546")]
+    upstream_ws_url: String,
+
+    #[arg(long, default_value = "http://moderato-stable-rpc-service:8545")]
+    upstream_http_url: String,
+
+    #[arg(long, default_value = "0.0.0.0:8545")]
+    http_listen: SocketAddr,
+
+    #[arg(long, default_value = "0.0.0.0:8546")]
+    ws_listen: SocketAddr,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info,consensus_indexer=debug,tempo_consensus_indexer=debug")
+    });
+    tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(env_filter)
+        .init();
+
+    let args = Args::parse();
+    tracing::info!(
+        db_url = %args.db_url,
+        upstream_ws_url = %args.upstream_ws_url,
+        upstream_http_url = %args.upstream_http_url,
+        http_listen = %args.http_listen,
+        ws_listen = %args.ws_listen,
+        "starting consensus indexer"
+    );
+
+    let db = ConsensusDb::connect(&args.db_url).await?;
+
+    let feed = ConsensusFeed::new();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let feed_task = {
+        let feed = feed.clone();
+        let shutdown_rx = shutdown_rx.clone();
+        let ws_url = args.upstream_ws_url.clone();
+        tokio::spawn(async move { feed.run(ws_url, shutdown_rx).await })
+    };
+
+    let cache = ConsensusCache::new();
+    let indexer = ConsensusIndexer::new(db.clone(), args.upstream_http_url.clone(), cache.clone());
+    indexer.seed_cache().await?;
+    indexer.fill_gaps().await?;
+    let indexer_task = {
+        let events = feed.subscribe();
+        let shutdown_rx = shutdown_rx.clone();
+        tokio::spawn(async move { indexer.run(events, shutdown_rx).await })
+    };
+
+    let http_server = ServerBuilder::new()
+        .set_config(ServerConfigBuilder::default().http_only().build())
+        .build(args.http_listen)
+        .await?;
+    let ws_server = ServerBuilder::new()
+        .set_config(ServerConfigBuilder::default().ws_only().build())
+        .build(args.ws_listen)
+        .await?;
+
+    let store = ConsensusStore::new(db.clone(), feed.events_tx(), cache);
+    let http_rpc = TempoConsensusRpc::new(store.clone());
+    let ws_rpc = TempoConsensusRpc::new(store.clone());
+    let http_handle = http_server.start(http_rpc.into_rpc());
+    let ws_handle = ws_server.start(ws_rpc.into_rpc());
+    tracing::info!("consensus RPC servers started");
+    let http_handle_wait = http_handle.clone();
+    let ws_handle_wait = ws_handle.clone();
+
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+
+    tokio::select! {
+        _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down"),
+        _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down"),
+        _ = http_handle_wait.stopped() => tracing::info!("HTTP RPC server stopped"),
+        _ = ws_handle_wait.stopped() => tracing::info!("WS RPC server stopped"),
+    }
+
+    let _ = shutdown_tx.send(true);
+    http_handle.stop().ok();
+    ws_handle.stop().ok();
+    feed_task.abort();
+    indexer_task.abort();
+
+    Ok(())
+}

--- a/bin/tempo-consensus-indexer/src/main.rs
+++ b/bin/tempo-consensus-indexer/src/main.rs
@@ -1,3 +1,5 @@
+//! Consensus indexer binary entrypoint.
+
 use clap::Parser;
 use consensus_indexer::{
     db::ConsensusDb, feed::ConsensusFeed, indexer::ConsensusIndexer, state::ConsensusCache,

--- a/crates/consensus-indexer/Cargo.toml
+++ b/crates/consensus-indexer/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "consensus-indexer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+eyre.workspace = true
+jsonrpsee = { workspace = true, features = ["server", "client"] }
+serde_json.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+alloy-primitives.workspace = true
+tempo-node.workspace = true
+commonware-codec.workspace = true
+commonware-consensus.workspace = true
+commonware-cryptography.workspace = true
+tempo-commonware-node.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio.workspace = true
+tempo-node.workspace = true
+
+[lints]
+workspace = true

--- a/crates/consensus-indexer/src/db.rs
+++ b/crates/consensus-indexer/src/db.rs
@@ -1,0 +1,384 @@
+use eyre::WrapErr;
+use std::str::FromStr;
+
+use sqlx::{
+    SqlitePool,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+};
+use tempo_node::rpc::consensus::{
+    CertifiedBlock, ConsensusState, IdentityTransition, IdentityTransitionResponse, Query,
+    TransitionProofData,
+};
+
+#[derive(Clone, Debug)]
+pub struct ConsensusDb {
+    pool: SqlitePool,
+}
+
+impl ConsensusDb {
+    pub async fn connect(database_url: &str) -> eyre::Result<Self> {
+        let options = SqliteConnectOptions::from_str(database_url)
+            .wrap_err("parse sqlite url")?
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(8)
+            .connect_with(options)
+            .await
+            .wrap_err("connect sqlite")?;
+        let db = Self { pool };
+        db.migrate().await?;
+        Ok(db)
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    pub async fn migrate(&self) -> eyre::Result<()> {
+        sqlx::query(
+            r#"
+            PRAGMA journal_mode = WAL;
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .wrap_err("set journal_mode")?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS certified_blocks (
+                kind TEXT NOT NULL,
+                epoch INTEGER NOT NULL,
+                view INTEGER NOT NULL,
+                height INTEGER,
+                digest BLOB NOT NULL,
+                certificate TEXT NOT NULL,
+                seen INTEGER NOT NULL,
+                PRIMARY KEY (kind, epoch, view, digest)
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .wrap_err("create certified_blocks")?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS certified_blocks_height_idx
+                ON certified_blocks(kind, height);
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .wrap_err("create certified_blocks_height_idx")?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS nullifications (
+                epoch INTEGER NOT NULL,
+                view INTEGER NOT NULL,
+                seen INTEGER NOT NULL,
+                PRIMARY KEY (epoch, view)
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .wrap_err("create nullifications")?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS identity_transitions (
+                transition_epoch INTEGER NOT NULL PRIMARY KEY,
+                old_identity TEXT NOT NULL,
+                new_identity TEXT NOT NULL,
+                header_json TEXT,
+                finalization_certificate TEXT
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await
+        .wrap_err("create identity_transitions")?;
+
+        Ok(())
+    }
+
+    pub async fn upsert_finalized_block(
+        &self,
+        block: &CertifiedBlock,
+        seen: u64,
+    ) -> eyre::Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO certified_blocks (kind, epoch, view, height, digest, certificate, seen)
+            VALUES ('finalized', ?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(kind, epoch, view, digest) DO UPDATE SET
+                height = excluded.height,
+                certificate = excluded.certificate,
+                seen = MAX(certified_blocks.seen, excluded.seen);
+            "#,
+        )
+        .bind(block.epoch as i64)
+        .bind(block.view as i64)
+        .bind(block.height.map(|h| h as i64))
+        .bind(block.digest.as_slice())
+        .bind(&block.certificate)
+        .bind(seen as i64)
+        .execute(&self.pool)
+        .await
+        .wrap_err("upsert certified block")?;
+        Ok(())
+    }
+
+    pub async fn insert_nullification(&self, epoch: u64, view: u64, seen: u64) -> eyre::Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO nullifications (epoch, view, seen)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(epoch, view) DO UPDATE SET seen = MAX(seen, excluded.seen);
+            "#,
+        )
+        .bind(epoch as i64)
+        .bind(view as i64)
+        .bind(seen as i64)
+        .execute(&self.pool)
+        .await
+        .wrap_err("insert nullification")?;
+        Ok(())
+    }
+
+    pub async fn upsert_identity_transition(
+        &self,
+        transition: &IdentityTransition,
+    ) -> eyre::Result<()> {
+        let (header_json, finalization_certificate) = if let Some(proof) = transition.proof.as_ref()
+        {
+            (
+                Some(serde_json::to_string(&proof.header)?),
+                Some(proof.finalization_certificate.clone()),
+            )
+        } else {
+            (None, None)
+        };
+
+        sqlx::query(
+            r#"
+            INSERT INTO identity_transitions (
+                transition_epoch,
+                old_identity,
+                new_identity,
+                header_json,
+                finalization_certificate
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(transition_epoch) DO UPDATE SET
+                old_identity = excluded.old_identity,
+                new_identity = excluded.new_identity,
+                header_json = excluded.header_json,
+                finalization_certificate = excluded.finalization_certificate;
+            "#,
+        )
+        .bind(transition.transition_epoch as i64)
+        .bind(&transition.old_identity)
+        .bind(&transition.new_identity)
+        .bind(header_json)
+        .bind(finalization_certificate)
+        .execute(&self.pool)
+        .await
+        .wrap_err("upsert identity transition")?;
+        Ok(())
+    }
+
+    pub async fn latest_finalized(&self) -> eyre::Result<Option<CertifiedBlock>> {
+        let row = sqlx::query_as::<_, CertifiedBlockRow>(
+            r#"
+            SELECT epoch, view, height, digest, certificate
+            FROM certified_blocks
+            WHERE kind = 'finalized'
+            ORDER BY COALESCE(height, 0) DESC, view DESC
+            LIMIT 1;
+            "#,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .wrap_err("fetch latest certified block")?;
+        Ok(row.map(|r| r.into()))
+    }
+
+    pub async fn latest_finalized_height(&self) -> eyre::Result<Option<u64>> {
+        let row = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT height
+            FROM certified_blocks
+            WHERE kind = 'finalized' AND height IS NOT NULL
+            ORDER BY height DESC
+            LIMIT 1;
+            "#,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .wrap_err("fetch latest finalized height")?;
+        Ok(row.flatten().map(|h| h as u64))
+    }
+
+    pub async fn get_finalization(&self, query: Query) -> eyre::Result<Option<CertifiedBlock>> {
+        match query {
+            Query::Latest => self.latest_finalized().await,
+            Query::Height(height) => {
+                let row = sqlx::query_as::<_, CertifiedBlockRow>(
+                    r#"
+                    SELECT epoch, view, height, digest, certificate
+                    FROM certified_blocks
+                    WHERE kind = 'finalized' AND height = ?1
+                    LIMIT 1;
+                    "#,
+                )
+                .bind(height as i64)
+                .fetch_optional(&self.pool)
+                .await
+                .wrap_err("fetch finalization by height")?;
+                Ok(row.map(|r| r.into()))
+            }
+        }
+    }
+
+    pub async fn get_latest(&self) -> eyre::Result<ConsensusState> {
+        let finalized = self.latest_finalized().await?;
+        Ok(ConsensusState {
+            finalized,
+            notarized: None,
+        })
+    }
+
+    pub async fn get_identity_transition_proof(
+        &self,
+        from_epoch: Option<u64>,
+        full: bool,
+    ) -> eyre::Result<IdentityTransitionResponse> {
+        let latest_epoch = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(transition_epoch) FROM identity_transitions;
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .wrap_err("fetch latest transition epoch")?
+        .unwrap_or(0);
+
+        let latest_finalized_epoch = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT epoch
+            FROM certified_blocks
+            WHERE kind = 'finalized'
+            ORDER BY COALESCE(height, 0) DESC, view DESC
+            LIMIT 1;
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .wrap_err("fetch latest finalized epoch")?
+        .map(|epoch| epoch as u64);
+
+        let start_epoch = from_epoch
+            .or(latest_finalized_epoch)
+            .unwrap_or(latest_epoch as u64);
+        let rows = if full {
+            sqlx::query_as::<_, TransitionRow>(
+                r#"
+                SELECT transition_epoch, old_identity, new_identity, header_json, finalization_certificate
+                FROM identity_transitions
+                WHERE transition_epoch <= ?1
+                ORDER BY transition_epoch DESC;
+                "#,
+            )
+            .bind(start_epoch as i64)
+            .fetch_all(&self.pool)
+            .await
+        } else {
+            sqlx::query_as::<_, TransitionRow>(
+                r#"
+                SELECT transition_epoch, old_identity, new_identity, header_json, finalization_certificate
+                FROM identity_transitions
+                WHERE transition_epoch <= ?1
+                ORDER BY transition_epoch DESC
+                LIMIT 1;
+                "#,
+            )
+            .bind(start_epoch as i64)
+            .fetch_all(&self.pool)
+            .await
+        }
+        .wrap_err("fetch identity transitions")?;
+
+        let mut transitions: Vec<IdentityTransition> = rows
+            .into_iter()
+            .map(IdentityTransition::try_from)
+            .collect::<eyre::Result<_>>()?;
+
+        let identity = crate::identity::derive_identity(start_epoch, &transitions);
+
+        if !full && transitions.len() > 1 {
+            transitions.truncate(1);
+        }
+
+        Ok(IdentityTransitionResponse {
+            identity,
+            transitions,
+        })
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct CertifiedBlockRow {
+    epoch: i64,
+    view: i64,
+    height: Option<i64>,
+    digest: Vec<u8>,
+    certificate: String,
+}
+
+impl From<CertifiedBlockRow> for CertifiedBlock {
+    fn from(row: CertifiedBlockRow) -> Self {
+        let digest = alloy_primitives::B256::from_slice(&row.digest);
+        Self {
+            epoch: row.epoch as u64,
+            view: row.view as u64,
+            height: row.height.map(|h| h as u64),
+            digest,
+            certificate: row.certificate,
+        }
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct TransitionRow {
+    transition_epoch: i64,
+    old_identity: String,
+    new_identity: String,
+    header_json: Option<String>,
+    finalization_certificate: Option<String>,
+}
+
+impl TryFrom<TransitionRow> for IdentityTransition {
+    type Error = eyre::Error;
+
+    fn try_from(row: TransitionRow) -> Result<Self, Self::Error> {
+        let proof = match (row.header_json, row.finalization_certificate) {
+            (Some(header_json), Some(finalization_certificate)) => {
+                let header = serde_json::from_str(&header_json)?;
+                Some(TransitionProofData {
+                    header,
+                    finalization_certificate,
+                })
+            }
+            _ => None,
+        };
+        Ok(Self {
+            transition_epoch: row.transition_epoch as u64,
+            old_identity: row.old_identity,
+            new_identity: row.new_identity,
+            proof,
+        })
+    }
+}

--- a/crates/consensus-indexer/src/feed.rs
+++ b/crates/consensus-indexer/src/feed.rs
@@ -1,0 +1,90 @@
+use eyre::WrapErr;
+use jsonrpsee::ws_client::WsClientBuilder;
+use std::time::Duration;
+use tempo_node::rpc::consensus::{Event, TempoConsensusApiClient};
+use tokio::sync::{broadcast, watch};
+use tracing::{info, warn};
+
+#[derive(Clone, Debug)]
+pub struct ConsensusFeed {
+    events_tx: broadcast::Sender<Event>,
+}
+
+impl ConsensusFeed {
+    pub fn new() -> Self {
+        let (events_tx, _) = broadcast::channel(1024);
+        Self { events_tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Event> {
+        self.events_tx.subscribe()
+    }
+
+    pub fn events_tx(&self) -> broadcast::Sender<Event> {
+        self.events_tx.clone()
+    }
+
+    pub async fn run(self, ws_url: String, shutdown: watch::Receiver<bool>) -> eyre::Result<()> {
+        let mut shutdown = shutdown;
+        loop {
+            if *shutdown.borrow() {
+                return Ok(());
+            }
+
+            match self.connect_and_stream(&ws_url, &mut shutdown).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    warn!(?err, "consensus websocket stream failed; reconnecting");
+                    tokio::select! {
+                        _ = shutdown.changed() => {
+                            if *shutdown.borrow() {
+                                return Ok(());
+                            }
+                        }
+                        _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    async fn connect_and_stream(
+        &self,
+        ws_url: &str,
+        shutdown: &mut watch::Receiver<bool>,
+    ) -> eyre::Result<()> {
+        let client = WsClientBuilder::default()
+            .build(ws_url)
+            .await
+            .wrap_err("connect consensus ws")?;
+        info!(%ws_url, "connected consensus ws");
+
+        let mut subscription = client
+            .subscribe_events()
+            .await
+            .wrap_err("subscribe events")?;
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        return Ok(());
+                    }
+                }
+                maybe_event = subscription.next() => {
+                    let event = match maybe_event {
+                        Some(Ok(event)) => event,
+                        Some(Err(err)) => return Err(err.into()),
+                        None => return Err(eyre::eyre!("subscription ended")),
+                    };
+                    let _ = self.events_tx.send(event);
+                }
+            }
+        }
+    }
+}
+
+impl Default for ConsensusFeed {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/consensus-indexer/src/identity.rs
+++ b/crates/consensus-indexer/src/identity.rs
@@ -1,0 +1,110 @@
+use alloy_primitives::{B256, hex};
+use commonware_codec::{Encode as _, ReadExt as _};
+use commonware_consensus::simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization};
+use commonware_cryptography::{
+    bls12381::primitives::{
+        ops::verify_message,
+        variant::{MinSig, Variant},
+    },
+    ed25519::PublicKey,
+};
+use eyre::WrapErr;
+use jsonrpsee::http_client::HttpClient;
+use std::{error::Error as StdError, fmt};
+use tempo_commonware_node::consensus::Digest;
+use tempo_node::rpc::consensus::{CertifiedBlock, IdentityTransition, TempoConsensusApiClient};
+
+use crate::db::ConsensusDb;
+
+pub async fn refresh_identity_transitions(
+    db: &ConsensusDb,
+    client: &HttpClient,
+) -> eyre::Result<()> {
+    let response = client
+        .get_identity_transition_proof(None, Some(true))
+        .await?;
+    for transition in &response.transitions {
+        db.upsert_identity_transition(transition).await?;
+    }
+    Ok(())
+}
+
+pub fn derive_identity(start_epoch: u64, transitions: &[IdentityTransition]) -> String {
+    if start_epoch == 0 {
+        transitions
+            .last()
+            .map(|t| t.old_identity.clone())
+            .unwrap_or_default()
+    } else {
+        transitions
+            .first()
+            .map(|t| t.new_identity.clone())
+            .unwrap_or_default()
+    }
+}
+
+pub fn verify_finalization(
+    block: &CertifiedBlock,
+    identity_hex: &str,
+) -> Result<(), VerificationError> {
+    let identity_bytes =
+        hex::decode(identity_hex).map_err(|err| VerificationError::new(block, err))?;
+    let pubkey = <MinSig as Variant>::Public::read(&mut identity_bytes.as_slice())
+        .map_err(|err| VerificationError::new(block, err))?;
+    let finalization = decode_finalization(&block.certificate)
+        .map_err(|err| VerificationError::new(block, err))?;
+    let message = finalization.proposal.encode();
+    verify_message::<MinSig>(
+        &pubkey,
+        b"TEMPO_FINALIZE",
+        &message,
+        &finalization.certificate.vote_signature,
+    )
+    .map_err(|err| VerificationError::new(block, err))?;
+    Ok(())
+}
+
+fn decode_finalization(
+    certificate_hex: &str,
+) -> eyre::Result<Finalization<Scheme<PublicKey, MinSig>, Digest>> {
+    let certificate_bytes = hex::decode(certificate_hex)?;
+    let finalization =
+        Finalization::<Scheme<PublicKey, MinSig>, Digest>::read(&mut certificate_bytes.as_slice())
+            .wrap_err("decode finalization")?;
+    Ok(finalization)
+}
+
+#[derive(Debug)]
+pub struct VerificationError {
+    epoch: u64,
+    digest: B256,
+    source: String,
+}
+
+impl VerificationError {
+    pub fn new(block: &CertifiedBlock, source: impl fmt::Display) -> Self {
+        Self {
+            epoch: block.epoch,
+            digest: block.digest,
+            source: source.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for VerificationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "failed to verify finalization (epoch {}, digest {}): {}",
+            self.epoch,
+            hex::encode(self.digest.as_slice()),
+            self.source
+        )
+    }
+}
+
+impl StdError for VerificationError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
+}

--- a/crates/consensus-indexer/src/indexer.rs
+++ b/crates/consensus-indexer/src/indexer.rs
@@ -1,0 +1,238 @@
+use eyre::WrapErr;
+use futures::future::try_join_all;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder};
+use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
+use tokio::sync::{broadcast, watch};
+use tracing::{debug, warn};
+
+use crate::{db::ConsensusDb, identity, state::ConsensusCache};
+
+#[derive(Clone, Debug)]
+pub struct ConsensusIndexer {
+    db: ConsensusDb,
+    http_url: String,
+    cache: ConsensusCache,
+}
+
+impl ConsensusIndexer {
+    pub fn new(db: ConsensusDb, http_url: String, cache: ConsensusCache) -> Self {
+        Self {
+            db,
+            http_url,
+            cache,
+        }
+    }
+
+    pub async fn seed_cache(&self) -> eyre::Result<()> {
+        let client = self.http_client()?;
+        let latest = client.get_latest().await.wrap_err("fetch latest")?;
+        if let Some(finalized) = latest.finalized.clone() {
+            self.verify_finalization(&client, &finalized).await?;
+            self.cache.update_finalized(finalized).await;
+        }
+        if let Some(notarized) = latest.notarized.clone() {
+            self.cache.update_notarized(notarized).await;
+        }
+        Ok(())
+    }
+
+    pub async fn fill_gaps(&self) -> eyre::Result<()> {
+        let client = self.http_client()?;
+        let latest = client.get_latest().await.wrap_err("fetch latest")?;
+        let Some(finalized) = latest.finalized else {
+            tracing::info!("no finalized block available; skipping gap fill");
+            return Ok(());
+        };
+        let Some(latest_height) = finalized.height else {
+            tracing::info!("latest finalized block missing height; skipping gap fill");
+            return Ok(());
+        };
+        let start_height = self
+            .db
+            .latest_finalized_height()
+            .await?
+            .map(|height| height + 1)
+            .unwrap_or(1);
+
+        if start_height > latest_height {
+            return Ok(());
+        }
+
+        tracing::info!(start_height, latest_height, "filling finalized height gaps");
+        let mut processed = 0u64;
+        let mut height = start_height;
+        while height <= latest_height {
+            let end = (height + 499).min(latest_height);
+            debug!(height, end, "gap fill batch start");
+            let mut batch = jsonrpsee::core::params::BatchRequestBuilder::new();
+            for h in height..=end {
+                batch
+                    .insert(
+                        "consensus_getFinalization",
+                        jsonrpsee::rpc_params![Query::Height(h)],
+                    )
+                    .wrap_err("build batch request")?;
+            }
+            let responses = client
+                .batch_request::<Option<CertifiedBlock>>(batch)
+                .await
+                .wrap_err("fetch finalization batch")?;
+            debug!(
+                height,
+                end,
+                response_count = responses.len(),
+                "gap fill batch fetched"
+            );
+            let blocks: Vec<CertifiedBlock> = responses
+                .into_iter()
+                .filter_map(|response| response.ok().flatten())
+                .collect();
+            if !blocks.is_empty() {
+                try_join_all(
+                    blocks
+                        .iter()
+                        .map(|block| self.verify_finalization(&client, block)),
+                )
+                .await?;
+                for block in blocks {
+                    self.db.upsert_finalized_block(&block, now_millis()).await?;
+                    self.cache.update_finalized(block).await;
+                }
+            }
+            processed += (end - height + 1) as u64;
+            debug!(processed, latest_height, "gap fill batch stored");
+            if processed.is_multiple_of(10_000) {
+                tracing::info!(processed, latest_height, "gap fill progress");
+            }
+            height = end + 1;
+        }
+        tracing::info!(processed, "gap fill complete");
+        Ok(())
+    }
+
+    pub async fn run(
+        &self,
+        mut events: broadcast::Receiver<Event>,
+        shutdown: watch::Receiver<bool>,
+    ) -> eyre::Result<()> {
+        let mut shutdown = shutdown;
+        let client = self.http_client()?;
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        return Ok(());
+                    }
+                }
+                event = events.recv() => {
+                    match event {
+                        Ok(event) => {
+                            if let Err(err) = self.handle_event(&client, &event).await {
+                                warn!(?err, "failed to handle consensus event");
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_event(
+        &self,
+        client: &jsonrpsee::http_client::HttpClient,
+        event: &Event,
+    ) -> eyre::Result<()> {
+        tracing::debug!(?event, "consensus event");
+        match event {
+            Event::Notarized { block, .. } => {
+                self.cache.update_notarized(block.clone()).await;
+            }
+            Event::Finalized { block, seen } => {
+                let mut updated_block = block.clone();
+                if updated_block.height.is_none() {
+                    let fetched = client.get_finalization(Query::Latest).await?;
+                    if let Some(fetched) = fetched
+                        && fetched.digest == block.digest
+                    {
+                        updated_block.height = fetched.height;
+                    }
+                }
+                self.verify_finalization(client, &updated_block).await?;
+                self.db
+                    .upsert_finalized_block(&updated_block, *seen)
+                    .await?;
+                self.cache.update_finalized(updated_block.clone()).await;
+                if let Err(err) = self.fill_gaps().await {
+                    debug!(?err, "failed to fill gaps");
+                }
+
+                if let Some(height) = updated_block.height {
+                    let _ = sqlx::query(
+                        r#"
+                        UPDATE certified_blocks
+                        SET height = ?1
+                        WHERE digest = ?2;
+                        "#,
+                    )
+                    .bind(height as i64)
+                    .bind(updated_block.digest.as_slice())
+                    .execute(self.db.pool())
+                    .await;
+                }
+
+                if let Err(err) = identity::refresh_identity_transitions(&self.db, client).await {
+                    debug!(?err, "failed to refresh identity transitions");
+                }
+            }
+            Event::Nullified { epoch, view, seen } => {
+                self.db.insert_nullification(*epoch, *view, *seen).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn verify_finalization(
+        &self,
+        client: &jsonrpsee::http_client::HttpClient,
+        block: &CertifiedBlock,
+    ) -> eyre::Result<()> {
+        let response = client
+            .get_identity_transition_proof(Some(block.epoch), Some(true))
+            .await
+            .wrap_err("fetch identity transitions for verification")?;
+        match identity::verify_finalization(block, &response.identity) {
+            Ok(()) => Ok(()),
+            Err(primary) => {
+                let fallback_identity = response
+                    .transitions
+                    .first()
+                    .map(|transition| transition.old_identity.as_str());
+                if let Some(fallback_identity) = fallback_identity {
+                    identity::verify_finalization(block, fallback_identity).map_err(
+                        |fallback| {
+                            eyre::eyre!("{primary}; fallback verification failed with {fallback}")
+                        },
+                    )?;
+                    Ok(())
+                } else {
+                    Err(primary.into())
+                }
+            }
+        }
+    }
+
+    fn http_client(&self) -> eyre::Result<jsonrpsee::http_client::HttpClient> {
+        HttpClientBuilder::default()
+            .build(&self.http_url)
+            .wrap_err("build consensus http client")
+    }
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/consensus-indexer/src/indexer.rs
+++ b/crates/consensus-indexer/src/indexer.rs
@@ -99,7 +99,7 @@ impl ConsensusIndexer {
                     self.cache.update_finalized(block).await;
                 }
             }
-            processed += (end - height + 1) as u64;
+            processed += end - height + 1;
             debug!(processed, latest_height, "gap fill batch stored");
             if processed.is_multiple_of(10_000) {
                 tracing::info!(processed, latest_height, "gap fill progress");

--- a/crates/consensus-indexer/src/lib.rs
+++ b/crates/consensus-indexer/src/lib.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+pub mod db;
+pub mod feed;
+pub mod identity;
+pub mod indexer;
+pub mod state;
+pub mod store;
+
+#[cfg(test)]
+mod tests;

--- a/crates/consensus-indexer/src/lib.rs
+++ b/crates/consensus-indexer/src/lib.rs
@@ -1,3 +1,5 @@
+//! Consensus indexer library.
+
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod db;

--- a/crates/consensus-indexer/src/state.rs
+++ b/crates/consensus-indexer/src/state.rs
@@ -1,0 +1,51 @@
+use tempo_node::rpc::consensus::{CertifiedBlock, ConsensusState};
+use tokio::sync::RwLock;
+
+#[derive(Clone, Debug, Default)]
+pub struct ConsensusCache {
+    state: std::sync::Arc<RwLock<ConsensusState>>,
+}
+
+impl ConsensusCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn snapshot(&self) -> ConsensusState {
+        self.state.read().await.clone()
+    }
+
+    pub async fn update_notarized(&self, block: CertifiedBlock) {
+        let mut state = self.state.write().await;
+        let finalized_height = state.finalized.as_ref().and_then(|b| b.height);
+        let should_update_finalized = finalized_height
+            .zip(block.height)
+            .map(|(finalized, candidate)| finalized < candidate)
+            .unwrap_or(finalized_height.is_none());
+
+        let should_update_view = state.notarized.as_ref().is_none_or(|n| n.view < block.view);
+
+        if should_update_finalized && should_update_view {
+            state.notarized = Some(block);
+        }
+    }
+
+    pub async fn update_finalized(&self, block: CertifiedBlock) {
+        let mut state = self.state.write().await;
+        let should_update = state
+            .finalized
+            .as_ref()
+            .is_none_or(|f| f.height < block.height);
+
+        if should_update {
+            if state
+                .notarized
+                .as_ref()
+                .is_some_and(|n| n.view <= block.view)
+            {
+                state.notarized = None;
+            }
+            state.finalized = Some(block);
+        }
+    }
+}

--- a/crates/consensus-indexer/src/store.rs
+++ b/crates/consensus-indexer/src/store.rs
@@ -1,0 +1,77 @@
+use tempo_node::rpc::consensus::{
+    ConsensusFeed, ConsensusState, DkgOutcomeError, DkgOutcomeQuery, DkgOutcomeResponse, Event,
+    IdentityProofError, IdentityTransitionResponse, Query,
+};
+use tokio::sync::broadcast;
+
+use crate::{db::ConsensusDb, state::ConsensusCache};
+
+#[derive(Clone, Debug)]
+pub struct ConsensusStore {
+    db: ConsensusDb,
+    events_tx: broadcast::Sender<Event>,
+    cache: ConsensusCache,
+}
+
+impl ConsensusStore {
+    pub fn new(
+        db: ConsensusDb,
+        events_tx: broadcast::Sender<Event>,
+        cache: ConsensusCache,
+    ) -> Self {
+        Self {
+            db,
+            events_tx,
+            cache,
+        }
+    }
+
+    pub fn events_tx(&self) -> broadcast::Sender<Event> {
+        self.events_tx.clone()
+    }
+
+    pub fn cache(&self) -> &ConsensusCache {
+        &self.cache
+    }
+}
+
+impl ConsensusFeed for ConsensusStore {
+    async fn get_finalization(
+        &self,
+        query: Query,
+    ) -> Option<tempo_node::rpc::consensus::CertifiedBlock> {
+        self.db.get_finalization(query).await.ok().flatten()
+    }
+
+    async fn get_latest(&self) -> ConsensusState {
+        let mut snapshot = self.cache.snapshot().await;
+        if snapshot.finalized.is_none()
+            && let Ok(finalized) = self.db.latest_finalized().await
+        {
+            snapshot.finalized = finalized;
+        }
+        snapshot
+    }
+
+    async fn subscribe(&self) -> Option<broadcast::Receiver<Event>> {
+        Some(self.events_tx.subscribe())
+    }
+
+    async fn get_identity_transition_proof(
+        &self,
+        from_epoch: Option<u64>,
+        full: bool,
+    ) -> Result<IdentityTransitionResponse, IdentityProofError> {
+        self.db
+            .get_identity_transition_proof(from_epoch, full)
+            .await
+            .map_err(|_| IdentityProofError::NotReady)
+    }
+
+    async fn get_dkg_outcome(
+        &self,
+        _query: DkgOutcomeQuery,
+    ) -> Result<DkgOutcomeResponse, DkgOutcomeError> {
+        Err(DkgOutcomeError::NotReady)
+    }
+}

--- a/crates/consensus-indexer/src/store.rs
+++ b/crates/consensus-indexer/src/store.rs
@@ -1,6 +1,5 @@
 use tempo_node::rpc::consensus::{
-    ConsensusFeed, ConsensusState, DkgOutcomeError, DkgOutcomeQuery, DkgOutcomeResponse, Event,
-    IdentityProofError, IdentityTransitionResponse, Query,
+    ConsensusFeed, ConsensusState, Event, IdentityProofError, IdentityTransitionResponse, Query,
 };
 use tokio::sync::broadcast;
 
@@ -66,12 +65,5 @@ impl ConsensusFeed for ConsensusStore {
             .get_identity_transition_proof(from_epoch, full)
             .await
             .map_err(|_| IdentityProofError::NotReady)
-    }
-
-    async fn get_dkg_outcome(
-        &self,
-        _query: DkgOutcomeQuery,
-    ) -> Result<DkgOutcomeResponse, DkgOutcomeError> {
-        Err(DkgOutcomeError::NotReady)
     }
 }

--- a/crates/consensus-indexer/src/tests.rs
+++ b/crates/consensus-indexer/src/tests.rs
@@ -1,0 +1,34 @@
+use tempfile::NamedTempFile;
+use tempo_node::rpc::consensus::{CertifiedBlock, Query};
+
+use crate::db::ConsensusDb;
+
+fn sample_block(height: Option<u64>, view: u64) -> CertifiedBlock {
+    CertifiedBlock {
+        epoch: 1,
+        view,
+        height,
+        digest: alloy_primitives::B256::ZERO,
+        certificate: "cert".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn db_roundtrip_finalization_latest() {
+    let file = NamedTempFile::new().unwrap();
+    let url = format!("sqlite://{}", file.path().display());
+    let db = ConsensusDb::connect(&url).await.unwrap();
+
+    let block = sample_block(Some(5), 7);
+    db.upsert_finalized_block(&block, 123).await.unwrap();
+
+    let latest = db.get_finalization(Query::Latest).await.unwrap().unwrap();
+    assert_eq!(latest, block);
+
+    let by_height = db
+        .get_finalization(Query::Height(5))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(by_height, block);
+}


### PR DESCRIPTION
This will be used to guard our validator nodes against traffic, and eventually will be used for RPC nodes to follow.

The indexer stores finalizations (no notarizations for now) in SQLite, which is fine, given that resyncing an indexer takes around 15 minutes and we do not expect to lose the data.

The indexer also verifies the finalizations against the network identity (and supports identity transitions).