### PR TITLE
feat(consensus/rpc): add `consensus_getDkgOutcome` RPC query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12005,6 +12005,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-contracts",
+ "tempo-dkg-onchain-artifacts",
  "tempo-e2e",
  "tempo-evm",
  "tempo-payload-builder",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -20,6 +20,7 @@ tempo-payload-builder.workspace = true
 tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["default"] }
+tempo-dkg-onchain-artifacts.workspace = true
 
 thiserror.workspace = true
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+use tempo_dkg_onchain_artifacts as _;
+
 pub use tempo_payload_types::{TempoExecutionData, TempoPayloadTypes};
 pub use version::{init_version_metadata, version_metadata};
 


### PR DESCRIPTION
This will be useful in the explorer, where we'll be able to query what validators are dealers/players, instead of having to decode the DKG outcome in TypeScript.

A lot of the inspiration was taken from the xtask. Testing pending localnet working - if it doesn't, I'll boot this up on a devnet node.


Amp-Thread-Id: https://ampcode.com/threads/T-019bfb6f-96c9-7288-85f4-d6ca902c1c88