### PR TITLE
feat(valconfigV2): add manual migration from V1

### DIFF
--- a/docs/pages/protocol/tips/tip-xxxx.mdx
+++ b/docs/pages/protocol/tips/tip-xxxx.mdx
@@ -733,8 +733,7 @@ The test suite must cover:
     after `initialize()`
 38. **initialize owner only**: Non-owner cannot call `initialize`
 39. **isInitialized returns correct value**: Returns false before initialize, true after
-40. **Writes blocked before init**: `addValidator`, `deleteValidator`, `rotateValidator`,
-    `setValidatorAddress` revert if `isInitialized() == false` (only migration functions allowed)
+40. **Writes blocked before init**: `addValidator`, `deleteValidator`, `rotateValidator`
 41. **initialize reverts if not all migrated**: `initialize()` reverts if
     `validatorsArray.length < V1.getValidators().length`
 


### PR DESCRIPTION
## Summary

**Manual migration**: Admin migrates validators one at a time via `migrateValidator(valIdx)`, then calls `initialize()` to flip the flag. CL reads from V1 until the flag is set.

| Change | Description |
|--------|-------------|
| **Read before init** | CL reads directly from V1 (no proxying in V2) |
| **migrateValidator(valIdx)** | Migrates single validator; copies owner on first call; reverts if `valIdx != validatorsArray.length` |
| **initialize()** | Copies `nextDkgCeremony` from V1, sets `initialized = true` |
| **Active validators** | `addedAtHeight = 0`, `deletedAtHeight = 0` |
| **Inactive validators** | `addedAtHeight = deletedAtHeight = block.timestamp` |
| **Filter logic** | `v.addedAtHeight <= H && (deletedAtHeight == 0 \|\| deletedAtHeight > H)` |

## Migration Steps (Existing Networks)

1. Release new node software with Allegro hardfork support
2. Schedule the fork by updating chainspec with target `allegroTime`
3. At fork activation: CL reads from V1 (since `isInitialized() == false`)
4. Admin migrates validators: `migrateValidator(0)`, `migrateValidator(1)`, ...
5. Admin calls `initialize()` → sets `initialized = true`, CL reads from V2
6. Post-migration: All reads/writes use V2 state directly

## New Networks

1. Initialize V2 at genesis with the initial validator set (set `initialized = true`)
2. Set `allegroTime = 0` to activate V2 immediately
3. V1 Validator Config contract/precompile is not necessary