### PR TITLE
test(tip-403): add handler for unknown account authorization

### DIFF
--- a/tips/ref-impls/foundry.lock
+++ b/tips/ref-impls/foundry.lock
@@ -1,7 +1,4 @@
 {
-  "lib/forge-std": {
-    "rev": "f61e4dd133379a4536a54ee57a808c9c00019b60"
-  },
   "lib/tempo-std": {
     "branch": {
       "name": "master",


### PR DESCRIPTION
Adds `checkUnknownAccountAuth` handler to verify default authorization behavior:
- Whitelist policies reject unknown accounts
- Blacklist policies allow unknown accounts

This covers the default authorization behavior for accounts never explicitly added to policies.

Addresses https://github.com/tempoxyz/tempo/pull/2261#issuecomment-3806747610