### PR TITLE
feat: reintroduce background task for commonware gauges

### DIFF
--- a/crates/commonware-node/src/metrics.rs
+++ b/crates/commonware-node/src/metrics.rs
@@ -180,7 +180,7 @@ pub fn install_otlp(context: Context, config: OtlpConfig) -> eyre::Result<OtlpMe
                             counter.add(delta, &attributes);
                         }
                     } else {
-                        // Gauge or histogram bucket - use gauge
+                        // Gauge - use gauge (histograms are handled as counters above)
                         let gauge = {
                             let mut cache = gauges.lock();
                             cache


### PR DESCRIPTION
Reverted in this 6baec8770c052439769e57c7973c2846b7363929.

Don't see another way to discovery unless at startup, in which any newly created gauges wont be registered