### PR TITLE
feat(tempo): user override for consensus storage

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -140,6 +140,11 @@ pub struct Args {
     /// Cache for the signing key loaded from CLI-provided file.
     #[clap(skip)]
     loaded_signing_key: OnceLock<Option<SigningKey>>,
+
+    /// Where to store consensus data. If not set, this will be derived from
+    /// `--datadir`.
+    #[arg(long = "consensus.datadir", value_name = "PATH")]
+    pub storage_dir: Option<PathBuf>,
 }
 
 impl Args {


### PR DESCRIPTION
Allows users to override the consensus data directory by providing `--consensus.datadir <PATH>`.