### PR TITLE
feat: support per-call value transfers in batch transactions

### DIFF
--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -111,10 +111,6 @@ pub enum TempoInvalidTransaction {
     #[error("value transfer not allowed")]
     ValueTransferNotAllowed,
 
-    /// Value transfer in Tempo Transaction not allowed.
-    #[error("value transfer in Tempo Transaction not allowed")]
-    ValueTransferNotAllowedInAATx,
-
     /// Failed to recover access key address from signature.
     ///
     /// This error occurs when attempting to recover the access key address from a Keychain signature fails.

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1278,9 +1278,11 @@ mod tests {
     }
 
     /// Test validate_aa_initial_tx_gas error cases and valid paths.
+    ///
     /// Tests error paths in the AA initial transaction gas validation:
     /// - CreateInitCodeSizeLimit: when initcode exceeds max size
     /// - InsufficientGasForIntrinsicCost: when gas_limit < intrinsic_gas
+    ///
     /// Also tests that value transfers in batch calls are supported.
     #[test]
     fn test_validate_aa_initial_tx_gas_errors() -> eyre::Result<()> {


### PR DESCRIPTION
## Summary

Removes the restriction that prevented value transfers in AA batch transactions. The Tempo transaction spec defines per-call value support in the Call struct, and this change enables that functionality.

## Changes

- Remove `ValueTransferNotAllowedInAATx` error and its check in `handler.rs`
- Update gas calculation to properly charge 9000 gas for value transfers
- Update tests to verify value transfers work and charge correct gas

## Context

The spec already supports per-call value in the `Call` struct:

```rust
pub struct Call {
    to: TxKind,
    value: U256,  // ← This was being rejected
    input: Bytes
}
```

The original restriction was added in #759 with a note that it was temporary: "no balances in accounts yet". This is no longer the case.

## Testing

- Updated `test_aa_gas_value_transfer` to verify value transfers add 9000 gas
- Updated `test_validate_aa_initial_tx_gas_errors` to verify value transfers succeed

## Follow-up

Once merged, re-enable the `CAST BATCH-SEND WITH VALUE` test in tempo-foundry CI (tempoxyz/tempo-foundry#218).

Closes #2293