### PR TITLE
feat: TIP-1012 Multisig as Primary Signature Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12115,6 +12115,7 @@ dependencies = [
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "arbitrary",
  "base64 0.22.1",
  "derive_more",

--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -267,6 +267,15 @@ fn create_mock_primitive_signature(
                 pub_key_y: alloy_primitives::B256::ZERO,
             })
         }
+        SignatureType::Multisig => {
+            use tempo_primitives::transaction::tt_signature::MultisigSignature;
+            // Create a dummy multisig signature
+            PrimitiveSignature::Multisig(MultisigSignature {
+                multisig_id: alloy_primitives::B256::ZERO,
+                signers: vec![],
+                signatures: vec![],
+            })
+        }
     }
 }
 

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -19,6 +19,7 @@ crate::sol! {
             Secp256k1,
             P256,
             WebAuthn,
+            Multisig,
         }
 
         /// Token spending limit structure

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -168,6 +168,7 @@ impl AccountKeychain {
             SignatureType::Secp256k1 => 0,
             SignatureType::P256 => 1,
             SignatureType::WebAuthn => 2,
+            SignatureType::Multisig => 3,
             _ => return Err(AccountKeychainError::invalid_signature_type().into()),
         };
 
@@ -303,6 +304,7 @@ impl AccountKeychain {
             0 => SignatureType::Secp256k1,
             1 => SignatureType::P256,
             2 => SignatureType::WebAuthn,
+            3 => SignatureType::Multisig,
             _ => SignatureType::Secp256k1, // Default fallback
         };
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -29,6 +29,7 @@ alloy-rlp.workspace = true
 alloy-serde = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
+alloy-sol-types.workspace = true
 
 # Utils
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -8,7 +8,10 @@ pub mod tt_signed;
 pub use tt_authorization::{MAGIC, RecoveredTempoAuthorization, TempoSignedAuthorization};
 // Re-export Authorization from alloy for convenience
 pub use tt_signature::{
-    KeychainSignature, PrimitiveSignature, TempoSignature, derive_p256_address,
+    KeychainSignature, MultisigSignature, PrimitiveSignature, TempoSignature,
+    compute_multisig_id, derive_multisig_address, derive_p256_address,
+    MULTISIG_ADDRESS_DOMAIN, MULTISIG_GENESIS_DOMAIN, MULTISIG_MAX_OWNERS,
+    MULTISIG_MAX_SIGNATURE_DATA,
 };
 
 pub use alloy_eips::eip7702::Authorization;

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -38,6 +38,9 @@ pub enum SignatureType {
     Secp256k1 = 0,
     P256 = 1,
     WebAuthn = 2,
+    /// M-of-N threshold multisig signature as primary account key (TIP-1012).
+    /// Account address is derived from MultisigID (hash of genesis config).
+    Multisig = 3,
 }
 
 impl From<SignatureType> for u8 {
@@ -46,6 +49,7 @@ impl From<SignatureType> for u8 {
             SignatureType::Secp256k1 => 0,
             SignatureType::P256 => 1,
             SignatureType::WebAuthn => 2,
+            SignatureType::Multisig => 3,
         }
     }
 }
@@ -67,6 +71,7 @@ impl alloy_rlp::Decodable for SignatureType {
             0 => Ok(Self::Secp256k1),
             1 => Ok(Self::P256),
             2 => Ok(Self::WebAuthn),
+            3 => Ok(Self::Multisig),
             _ => Err(alloy_rlp::Error::Custom("Invalid signature type")),
         }
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -110,6 +110,11 @@ fn primitive_signature_verification_gas(signature: &PrimitiveSignature) -> u64 {
             let tokens = get_tokens_in_calldata_istanbul(&webauthn_sig.webauthn_data);
             P256_VERIFY_GAS + tokens * STANDARD_TOKEN_COST
         }
+        PrimitiveSignature::Multisig(multisig_sig) => {
+            // Base cost + 3000 gas per signature for ecrecover
+            const ECRECOVER_GAS: u64 = 3000;
+            ECRECOVER_GAS * multisig_sig.signature_count() as u64
+        }
     }
 }
 
@@ -804,6 +809,7 @@ where
                     SignatureType::Secp256k1 => PrecompileSignatureType::Secp256k1,
                     SignatureType::P256 => PrecompileSignatureType::P256,
                     SignatureType::WebAuthn => PrecompileSignatureType::WebAuthn,
+                    SignatureType::Multisig => PrecompileSignatureType::Multisig,
                 };
 
                 // Handle expiry: None means never expires (store as u64::MAX)

--- a/tips/tip-1012.md
+++ b/tips/tip-1012.md
@@ -1,0 +1,426 @@
+---
+id: TIP-1012
+title: Multisig as Primary Signature Type
+description: Adds Multisig as a first-class signature type for Tempo transactions, enabling M-of-N threshold signing as the primary account key.
+authors: Tempo AI @tempo-ai
+status: Draft
+related: TIP-1000
+protocolVersion: T2
+---
+
+# TIP-1012: Multisig as Primary Signature Type
+
+## Abstract
+
+This TIP introduces `SignatureType::Multisig` as a new primary signature type for Tempo transactions. This makes multisig a first-class citizen that can be the *main key* of an EOA account. The multisig address is derived deterministically from a "MultisigID" (a hash of the genesis configuration), allowing owners and threshold to be updated without changing the account address.
+
+## Motivation
+
+Organizations and DAOs need **multisig-native accounts** where:
+- The multisig IS the account, not a secondary key
+- No single party has unilateral control
+- The account address is stable even as membership changes
+- Setup is atomic in a single transaction
+
+## Design Goals
+
+1. **Stable address**: Account address must not change when owners/threshold are updated
+2. **EOA semantics**: Account behaves as a normal EOA (receives ETH, interacts with contracts)
+3. **DoS resistance**: Bounded owners (max 10), bounded signature size (8KB)
+4. **Backwards compatible**: New signature type 0x04, no changes to existing types
+5. **Atomic bootstrap**: First transaction creates and authorizes the account simultaneously
+
+---
+
+# Specification
+
+## MultisigID: Stable Account Identity
+
+The **MultisigID** is a 32-byte identifier that permanently identifies a multisig account. It is derived from the *genesis configuration* (the initial owners and threshold) and never changes.
+
+```
+MultisigID = keccak256(
+    "tempo:multisig:genesis:v1" ||
+    threshold ||
+    sortedOwners[0] || sortedOwners[1] || ... || sortedOwners[n]
+)
+```
+
+Where (packed encoding):
+- `threshold`: uint8 (1 byte), minimum signatures required (1 ≤ threshold ≤ owners.length)
+- `sortedOwners`: address[] packed (20 bytes each), sorted in ascending order, no duplicates
+
+### Address Derivation
+
+The account address is derived deterministically from the MultisigID:
+
+```
+account = address(keccak256(
+    "tempo:multisig:addr:v1" ||
+    MultisigID
+)[12:32])
+```
+
+This ensures:
+- Same genesis config → same address (deterministic)
+- Different genesis configs → different addresses (collision-resistant)
+- Address is stable regardless of subsequent owner/threshold changes
+
+## SignatureType Extension
+
+```rust
+pub enum SignatureType {
+    Secp256k1 = 0,
+    P256 = 1,
+    WebAuthn = 2,
+    Multisig = 3,     // NEW (this TIP)
+}
+```
+
+## MultisigSignature Structure
+
+```rust
+pub struct MultisigSignature {
+    /// The permanent MultisigID (hash of genesis config)
+    pub multisig_id: B256,
+    
+    /// Signers who provided signatures (sorted ascending)
+    pub signers: Vec<Address>,
+    
+    /// ECDSA signatures from each signer (65 bytes each)
+    pub signatures: Vec<Bytes>,
+}
+```
+
+### Wire Encoding
+
+```
+0x03                           // Signature type identifier
+|| multisig_id[32]             // MultisigID (32 bytes)
+|| abi.encode(signers, sigs)   // Signature data (variable)
+```
+
+Where signature data is ABI-encoded as:
+```solidity
+abi.encode(
+    address[] signers,    // Addresses that signed (ascending order)
+    bytes[] signatures    // Corresponding 65-byte ECDSA signatures
+)
+```
+
+### DoS Limits
+
+| Limit | Value | Rationale |
+|-------|-------|-----------|
+| MAX_OWNERS | 10 | Bounds verification cost and storage |
+| MAX_SIGNATURE_DATA | 8,192 bytes | Prevents oversized transaction payloads |
+| MIN_THRESHOLD | 1 | At least one signature required |
+
+## On-Chain State Storage
+
+Multisig configuration is stored in the `MultiSigSigner` precompile at `0x5159...0000`:
+
+```
+configs[account][multisig_id] → MultisigConfig { threshold, owner_count }
+owners[account][multisig_id][i] → owner address
+```
+
+## Bootstrap: Creating a Multisig Account
+
+The first transaction from a multisig account faces a chicken-and-egg problem: no configuration exists to verify against. This is solved with an inline bootstrap mechanism.
+
+### MultisigInit Field
+
+A new optional field is added to `TempoTransaction`:
+
+```rust
+pub struct TempoTransaction {
+    // ... existing fields ...
+    
+    /// Bootstrap data for first multisig transaction
+    pub multisig_init: Option<MultisigInit>,
+}
+
+pub struct MultisigInit {
+    /// Threshold (must match MultisigID derivation)
+    pub threshold: u8,
+    /// Owners sorted ascending (must match MultisigID derivation)
+    pub owners: Vec<Address>,
+}
+```
+
+### Bootstrap Validation Rules
+
+When verifying a Multisig signature:
+
+1. Parse `MultisigSignature`, extract `multisig_id`
+2. Derive `account` address from `multisig_id`
+3. Check precompile storage for `(account, multisig_id)` config
+
+**If config exists** (normal case):
+- Load owners/threshold from precompile storage
+- Verify signatures against stored config
+
+**If config does NOT exist** (bootstrap case):
+- Require `tx.multisig_init.is_some()`
+- Verify `keccak256("tempo:multisig:genesis:v1" || abi.encode(init.threshold, init.owners)) == multisig_id`
+- Verify signatures against the inline `multisig_init` config
+- Persist config to precompile storage during pre-execution phase
+
+### Bootstrap Persistence
+
+During the pre-execution phase (before EVM execution, similar to `key_authorization` handling):
+
+```rust
+// Pseudo-code
+if multisig_init.is_some() && !config_exists(account, multisig_id) {
+    precompile.init_config(account, multisig_id, init.threshold, init.owners);
+}
+```
+
+This ensures the config is persisted atomically with the first transaction.
+
+## Signature Verification Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Transaction Validation                        │
+├─────────────────────────────────────────────────────────────────┤
+│ 1. Parse signature, detect type 0x03 (Multisig)                 │
+│ 2. Extract multisig_id from signature                            │
+│ 3. Derive account = addr(keccak256(domain || multisig_id))      │
+│ 4. Compute tx_hash = transaction.signature_hash()               │
+├─────────────────────────────────────────────────────────────────┤
+│                    Config Resolution                             │
+├─────────────────────────────────────────────────────────────────┤
+│ 5. Load config from precompile: (account, multisig_id)          │
+│    ├─ If exists: use stored threshold/owners                    │
+│    └─ If missing: require multisig_init, verify ID match        │
+├─────────────────────────────────────────────────────────────────┤
+│                   Signature Verification                         │
+├─────────────────────────────────────────────────────────────────┤
+│ 6. Verify signers.len() >= threshold                            │
+│ 7. Verify signers are sorted ascending (no duplicates)          │
+│ 8. For each (signer, sig):                                      │
+│    ├─ Verify signer ∈ owners                                    │
+│    └─ Verify ecrecover(tx_hash, sig) == signer                  │
+│ 9. Return recovered account address                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Updating Owners and Threshold
+
+After bootstrap, owners and threshold can be updated via the precompile:
+
+```solidity
+interface IMultiSigSigner {
+    /// Update threshold (requires current threshold signatures)
+    function setThreshold(
+        bytes32 multisigId,
+        uint8 newThreshold,
+        bytes calldata signatures
+    ) external;
+    
+    /// Add a new owner (requires current threshold signatures)
+    function addOwner(
+        bytes32 multisigId,
+        address newOwner,
+        bytes calldata signatures
+    ) external;
+    
+    /// Remove an owner (requires current threshold signatures)
+    /// Threshold is reduced if it exceeds new owner count
+    function removeOwner(
+        bytes32 multisigId,
+        address owner,
+        bytes calldata signatures
+    ) external;
+}
+```
+
+Updates are authorized by providing signatures from the current owners meeting the current threshold.
+
+### Update Digest Binding
+
+To prevent replay attacks, update operations sign a digest bound to the specific action:
+
+```
+updateDigest = keccak256(
+    "tempo:multisig:update:v1" ||
+    chainId ||
+    account ||
+    multisigId ||
+    nonce ||
+    abi.encode(action, params)
+)
+```
+
+Where `nonce` is a per-multisig counter stored in the precompile.
+
+## Gas Costs
+
+| Operation | Gas Cost | Notes |
+|-----------|----------|-------|
+| Multisig verification | 3,000 + 3,000/sig | Base + per-signature ecrecover |
+| Bootstrap persistence | 20,000 + 5,000/owner | Initial SSTORE costs |
+| Config read | 2,100 | COLD_SLOAD for config |
+| Owner lookup | 2,100/owner | COLD_SLOAD per owner |
+
+Recommended: Charge `MULTISIG_BASE_GAS + (num_signers * ECRECOVER_GAS)` during pre-charge.
+
+---
+
+# Invariants
+
+## Security Invariants
+
+1. **Address stability**: The account address MUST NOT change when owners/threshold are updated. Address depends only on MultisigID (genesis config hash).
+
+2. **MultisigID authenticity**: During bootstrap, the MultisigID MUST match `keccak256(domain || abi.encode(threshold, sortedOwners))` exactly.
+
+3. **Threshold enforcement**: Verification MUST reject if fewer than `threshold` valid signatures are provided.
+
+4. **Signer ordering**: Signers MUST be in strictly ascending order to prevent signature reuse/reordering attacks.
+
+5. **Owner membership**: Each signer MUST be in the current owners list.
+
+6. **Bootstrap atomicity**: Config persistence MUST occur during pre-execution, before any EVM calls, to prevent reentrancy exploits.
+
+7. **Update authorization**: Owner/threshold updates MUST require current threshold of valid signatures.
+
+## Functional Invariants
+
+8. **Single bootstrap**: `multisig_init` is only valid if no config exists. Re-initialization MUST fail.
+
+9. **Owner limits**: Owner count MUST NOT exceed MAX_OWNERS (10) at any time.
+
+10. **Threshold bounds**: Threshold MUST satisfy: 1 ≤ threshold ≤ owners.length
+
+11. **Signature size limit**: Total signature data MUST NOT exceed MAX_SIGNATURE_DATA (8KB).
+
+---
+
+# Test Cases
+
+## Bootstrap Tests
+
+1. **Valid bootstrap**: First tx with valid `multisig_init`, verify config persisted
+2. **MultisigID mismatch**: Bootstrap with wrong owners/threshold for MultisigID → reject
+3. **Missing init on first tx**: No `multisig_init` when config doesn't exist → reject
+4. **Re-initialization attempt**: Second tx with `multisig_init` → ignore (config exists)
+5. **Below threshold**: Bootstrap with fewer signatures than threshold → reject
+
+## Verification Tests
+
+6. **Valid 2-of-3**: Two valid signatures from 3-owner multisig → accept
+7. **Below threshold**: One signature for 2-of-3 → reject
+8. **Wrong signer**: Signature from non-owner → reject
+9. **Signature reordering**: Signers not ascending → reject
+10. **Duplicate signer**: Same address twice in signers → reject
+11. **Invalid signature**: Corrupted ECDSA signature → reject
+
+## Update Tests
+
+12. **Threshold increase**: 2-of-3 → 3-of-3 with 2 valid sigs → accept
+13. **Add owner**: Add 4th owner with 2-of-3 sigs → accept, verify new owner stored
+14. **Remove owner**: Remove owner with threshold sigs → accept, verify threshold adjusted if needed
+15. **Remove below threshold**: Remove owner when only threshold owners remain → auto-reduce threshold
+
+## Edge Cases
+
+16. **1-of-1 multisig**: Single owner, single signature → works as regular EOA
+17. **Max owners**: 10 owners, 10 signatures → accept
+18. **Exceed max owners**: Try to add 11th owner → reject
+
+---
+
+# Migration Path
+
+## Phase 1: Protocol Upgrade
+- Add `SignatureType::Multisig = 3` to enum
+- Add `MultisigSignature` to `PrimitiveSignature` enum
+- Add `multisig_init` field to `TempoTransaction`
+- Implement validation logic with bootstrap handling
+
+## Phase 2: Precompile Implementation
+- Implement `MultiSigSigner` precompile with storage
+- Add update methods (`setThreshold`, `addOwner`, `removeOwner`)
+- Add nonce tracking for replay protection on updates
+
+## Phase 3: SDK/Wallet Support
+- Update tempo-sdk to support multisig account creation
+- Add multisig signing coordination tooling
+
+---
+
+# Security Considerations
+
+## Replay Protection
+- Transaction signatures include chain ID and nonce in the signed digest
+- Update operations include a per-multisig nonce and action-specific domain separation
+
+## Key Rotation
+- Owners can be added/removed without changing account address
+- Old owners cannot sign after removal (verified against current config)
+
+## Social Engineering
+- High threshold (e.g., 3-of-5) makes social engineering attacks harder
+- Time-delayed updates could be added for critical changes (future enhancement)
+
+## Lost Keys
+- If enough owners lose keys such that threshold cannot be met, the account becomes permanently inaccessible
+- This is an inherent property of threshold signatures; recovery mechanisms can be layered on top
+
+---
+
+# Appendix: Example Transaction Flow
+
+## Creating a 2-of-3 Multisig Account
+
+**Genesis Configuration:**
+```
+threshold = 2
+owners = [0xAAA..., 0xBBB..., 0xCCC...]  // sorted
+```
+
+**MultisigID:**
+```
+multisig_id = keccak256(
+    "tempo:multisig:genesis:v1" ||
+    abi.encode(2, [0xAAA, 0xBBB, 0xCCC])
+)
+= 0x1234...
+```
+
+**Account Address:**
+```
+account = 0x... (last 20 bytes of keccak256("tempo:multisig:addr:v1" || 0x1234...))
+```
+
+**First Transaction (Bootstrap):**
+```
+tx = {
+    to: 0xSomeContract,
+    value: 0,
+    calls: [...],
+    multisig_init: {
+        threshold: 2,
+        owners: [0xAAA, 0xBBB, 0xCCC]
+    },
+    signature: MultisigSignature {
+        multisig_id: 0x1234...,
+        signers: [0xAAA, 0xBBB],
+        signatures: [sigA, sigB]
+    }
+}
+```
+
+**Validation:**
+1. Parse signature, extract multisig_id = 0x1234...
+2. Derive account address from multisig_id
+3. Check precompile: no config exists for (account, 0x1234...)
+4. Verify multisig_init present
+5. Verify keccak256(domain || encode(2, [AAA,BBB,CCC])) == 0x1234... ✓
+6. Verify 2 signatures from AAA, BBB (both in init.owners) ✓
+7. Persist config to precompile storage
+8. Execute transaction calls


### PR DESCRIPTION
## Summary

Adds `SignatureType::Multisig` as a new primary signature type for Tempo transactions (TIP-1012). This enables M-of-N threshold signing as the primary account key, where the account address is derived deterministically from the "MultisigID" (hash of genesis config).

## Key Features

- **Stable Address**: Account address never changes when owners/threshold are updated
- **MultisigID**: Permanent identifier derived from `keccak256("tempo:multisig:genesis:v1" || threshold || owners_packed)`
- **Address Derivation**: `last20bytes(keccak256("tempo:multisig:addr:v1" || multisig_id))`
- **DoS Protection**: Max 10 owners, max 8KB signature data
- **Gas Cost**: 3000 gas per signature for ecrecover

## Changes

- Add `SignatureType::Multisig = 3` to enum
- Add `MultisigSignature` struct with `multisig_id`, `signers`, `signatures`
- Add `derive_multisig_address()` and `compute_multisig_id()` helper functions
- Update `PrimitiveSignature` to include Multisig variant
- Implement wire encoding (type identifier `0x04`)
- Add gas cost calculation for signature verification
- Update account_keychain precompile to handle Multisig type
- Create TIP-1012.md specification document

## Wire Format

```
0x04 || multisig_id[32] || abi.encode(signers, signatures)
```

## Future Work

The `multisig_init` bootstrap field (for first transaction when no config exists) and precompile storage integration are specified in TIP-1012 but not yet implemented.

## Testing

- [x] `cargo check --workspace` passes
