### PR TITLE
fix(revm): use TIP-1000 state creation cost for new 2D nonce keys

### DIFF
--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,6 +21,9 @@ mod tx;
 pub use block::TempoBlockEnv;
 pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
-pub use handler::{EXISTING_NONCE_KEY_GAS, NEW_NONCE_KEY_GAS, calculate_aa_batch_intrinsic_gas};
+pub use handler::{
+    EXISTING_NONCE_KEY_GAS, NEW_NONCE_KEY_GAS, calculate_aa_batch_intrinsic_gas,
+    new_nonce_key_gas_t1,
+};
 pub use revm::interpreter::instructions::utility::IntoAddress;
 pub use tx::{TempoBatchCallEnv, TempoTxEnv};


### PR DESCRIPTION
## Summary

According to TIP-1000, the gas cost for new state elements (including nonce keys) should be 250,000 gas, not the pre-TIP-1000 `SSTORE_SET` cost of 20,000.

## Changes

- Adds `new_nonce_key_gas()` function that reads state creation cost from `GasParams` (`GasId::sstore_set_without_load_cost()`)
- Updates T1 branch in `validate_aa_initial_tx_gas` to use `new_nonce_key_gas()` for 2D nonce key creation
- Updates transaction-pool validator to use `new_nonce_key_gas()` for T1
- Adds test that verifies TIP-1000 pricing is correctly applied

The constant `NEW_NONCE_KEY_GAS` is preserved for pre-T1 hardforks which still use the old `SSTORE_SET` pricing.

## References

- Fixes: https://github.com/sherlock-audit/2026-01-tempo-jan-25th/pull/138#discussion_r2735526346
- TIP-1000 spec: [tips/tip-1000.md](tips/tip-1000.md)