### PR TITLE
tip: add TIP-1013 Recovery Guardian Keys

### DIFF
--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -35,6 +35,15 @@ impl Precompile for AccountKeychain {
                 IAccountKeychainCalls::getAllowedDestinations(call) => {
                     view(call, |c| self.get_allowed_destinations_sol(c))
                 }
+                // TIP-1013: Activation window functions
+                IAccountKeychainCalls::getActivationWindow(call) => {
+                    view(call, |c| self.get_activation_window(c))
+                }
+                IAccountKeychainCalls::extendActivation(call) => {
+                    mutate_void(call, msg_sender, |sender, c| {
+                        self.extend_activation(sender, c)
+                    })
+                }
             },
         )
     }

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -194,16 +194,18 @@ impl reth_codecs::Compact for TokenLimit {
     }
 }
 
-/// Key authorization for provisioning access keys (TIP-1011)
+/// Key authorization for provisioning access keys (TIP-1011, TIP-1013)
 ///
 /// Used in TempoTransaction to add a new key to the AccountKeychain precompile.
 /// The transaction must be signed by the root key to authorize adding this access key.
 ///
-/// RLP encoding: `[chain_id, key_type, key_id, expiry?, limits?, allowed_destinations?]`
+/// RLP encoding: `[chain_id, key_type, key_id, expiry?, limits?, allowed_destinations?, valid_after?, activation_delay?]`
 /// - Non-optional fields come first, followed by optional (trailing) fields
 /// - `expiry`: `None` (omitted or 0x80) = key never expires, `Some(timestamp)` = expires at timestamp
 /// - `limits`: `None` (omitted or 0x80) = unlimited spending, `Some([])` = no spending, `Some([...])` = specific limits
 /// - `allowed_destinations`: `None` (omitted or 0x80) = unrestricted, `Some([])` = unrestricted, `Some([...])` = restricted
+/// - `valid_after`: `None` (omitted or 0x80) = no absolute time constraint, `Some(timestamp)` = key cannot activate before this
+/// - `activation_delay`: `None` (omitted or 0x80) = no delay, `Some(seconds)` = delay after authorization before key is usable
 #[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
 #[rlp(trailing)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -237,6 +239,20 @@ pub struct KeyAuthorization {
     /// - `Some([])` = unrestricted (can call any address)
     /// - `Some([addr1, addr2, ...])` = restricted to only these addresses
     pub allowed_destinations: Option<Vec<Address>>,
+
+    /// TIP-1013: Absolute timestamp before which key cannot be used.
+    /// - `None` (RLP 0x80) = no absolute time constraint
+    /// - `Some(timestamp)` = key cannot activate before this timestamp
+    /// Combined with activation_delay: activatesAt = max(valid_after, auth_time + activation_delay)
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
+    pub valid_after: Option<u64>,
+
+    /// TIP-1013: Seconds after authorization before key is usable.
+    /// - `None` (RLP 0x80) = no delay (immediately usable after authorization)
+    /// - `Some(seconds)` = key becomes usable `seconds` after on-chain authorization
+    /// This guarantees a warning period for recovery guardian patterns.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
+    pub activation_delay: Option<u64>,
 }
 
 impl KeyAuthorization {
@@ -292,6 +308,36 @@ impl KeyAuthorization {
             Some(dests) if dests.is_empty() => true,
             Some(dests) => dests.contains(destination),
         }
+    }
+
+    /// TIP-1013: Returns the valid_after timestamp (0 if not set)
+    pub fn valid_after(&self) -> u64 {
+        self.valid_after.unwrap_or(0)
+    }
+
+    /// TIP-1013: Returns the activation_delay in seconds (0 if not set)
+    pub fn activation_delay(&self) -> u64 {
+        self.activation_delay.unwrap_or(0)
+    }
+
+    /// TIP-1013: Compute the activation timestamp for this key
+    ///
+    /// Returns the timestamp when this key becomes usable:
+    /// `activatesAt = max(valid_after, current_timestamp + activation_delay)`
+    ///
+    /// This ensures that:
+    /// 1. The key cannot be used before `valid_after` (absolute constraint)
+    /// 2. There is always at least `activation_delay` seconds of warning after authorization
+    pub fn compute_activates_at(&self, current_timestamp: u64) -> u64 {
+        let valid_after = self.valid_after();
+        let activation_delay = self.activation_delay();
+        let delay_based = current_timestamp.saturating_add(activation_delay);
+        core::cmp::max(valid_after, delay_based)
+    }
+
+    /// TIP-1013: Returns true if this key has activation constraints
+    pub fn has_activation_constraints(&self) -> bool {
+        self.valid_after.is_some() || self.activation_delay.is_some()
     }
 }
 
@@ -363,6 +409,9 @@ impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
             expiry: u.arbitrary::<Option<u64>>()?.filter(|v| *v != 0),
             limits: u.arbitrary()?,
             allowed_destinations: u.arbitrary()?,
+            // TIP-1013: Ensure that Some(0) is not generated as it's becoming `None` after RLP roundtrip.
+            valid_after: u.arbitrary::<Option<u64>>()?.filter(|v| *v != 0),
+            activation_delay: u.arbitrary::<Option<u64>>()?.filter(|v| *v != 0),
         })
     }
 }
@@ -383,6 +432,8 @@ mod tests {
             expiry,
             limits,
             allowed_destinations: None,
+            valid_after: None,
+            activation_delay: None,
         }
     }
 
@@ -535,6 +586,8 @@ mod tests {
             expiry: None,
             limits: None,
             allowed_destinations: None,
+            valid_after: None,
+            activation_delay: None,
         };
         assert!(!auth.has_destination_restrictions());
         assert!(auth.is_destination_allowed(&dest1));
@@ -556,6 +609,8 @@ mod tests {
             expiry: None,
             limits: None,
             allowed_destinations: Some(vec![dest1, dest2]),
+            valid_after: None,
+            activation_delay: None,
         };
         assert!(auth.has_destination_restrictions());
         assert!(auth.is_destination_allowed(&dest1));
@@ -572,6 +627,8 @@ mod tests {
             expiry: Some(1700000000),
             limits: Some(vec![TokenLimit::one_time(Address::random(), U256::from(100))]),
             allowed_destinations: Some(vec![Address::random(), Address::random()]),
+            valid_after: None,
+            activation_delay: None,
         };
 
         let mut buf = Vec::new();
@@ -579,5 +636,115 @@ mod tests {
 
         let decoded = KeyAuthorization::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded, auth);
+    }
+
+    #[test]
+    fn test_key_authorization_with_activation_fields_rlp_roundtrip() {
+        // Test with valid_after only
+        let auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::random(),
+            expiry: Some(1700000000),
+            limits: None,
+            allowed_destinations: None,
+            valid_after: Some(1699900000),
+            activation_delay: None,
+        };
+
+        let mut buf = Vec::new();
+        auth.encode(&mut buf);
+        let decoded = KeyAuthorization::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, auth);
+
+        // Test with activation_delay only
+        let auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::random(),
+            expiry: None,
+            limits: None,
+            allowed_destinations: None,
+            valid_after: None,
+            activation_delay: Some(86400 * 30), // 30 days
+        };
+
+        let mut buf = Vec::new();
+        auth.encode(&mut buf);
+        let decoded = KeyAuthorization::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, auth);
+
+        // Test with both fields
+        let auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::random(),
+            expiry: Some(1800000000),
+            limits: Some(vec![TokenLimit::one_time(Address::random(), U256::from(100))]),
+            allowed_destinations: Some(vec![Address::random()]),
+            valid_after: Some(1700000000),
+            activation_delay: Some(604800), // 7 days
+        };
+
+        let mut buf = Vec::new();
+        auth.encode(&mut buf);
+        let decoded = KeyAuthorization::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, auth);
+    }
+
+    #[test]
+    fn test_compute_activates_at() {
+        let current_timestamp = 1700000000u64;
+
+        // No constraints: activates immediately
+        let auth = make_auth(None, None);
+        assert_eq!(auth.compute_activates_at(current_timestamp), current_timestamp);
+
+        // valid_after only: activates at valid_after
+        let mut auth = make_auth(None, None);
+        auth.valid_after = Some(1700100000);
+        assert_eq!(auth.compute_activates_at(current_timestamp), 1700100000);
+
+        // activation_delay only: activates after delay
+        let mut auth = make_auth(None, None);
+        auth.activation_delay = Some(86400); // 1 day
+        assert_eq!(
+            auth.compute_activates_at(current_timestamp),
+            current_timestamp + 86400
+        );
+
+        // Both fields, valid_after dominates
+        let mut auth = make_auth(None, None);
+        auth.valid_after = Some(1700200000);
+        auth.activation_delay = Some(86400);
+        assert_eq!(auth.compute_activates_at(current_timestamp), 1700200000);
+
+        // Both fields, activation_delay dominates
+        let mut auth = make_auth(None, None);
+        auth.valid_after = Some(1700050000);
+        auth.activation_delay = Some(86400);
+        assert_eq!(
+            auth.compute_activates_at(current_timestamp),
+            current_timestamp + 86400
+        );
+    }
+
+    #[test]
+    fn test_has_activation_constraints() {
+        let auth = make_auth(None, None);
+        assert!(!auth.has_activation_constraints());
+
+        let mut auth = make_auth(None, None);
+        auth.valid_after = Some(1700000000);
+        assert!(auth.has_activation_constraints());
+
+        let mut auth = make_auth(None, None);
+        auth.activation_delay = Some(86400);
+        assert!(auth.has_activation_constraints());
+
+        let mut auth = make_auth(None, None);
+        auth.valid_after = Some(1700000000);
+        auth.activation_delay = Some(86400);
+        assert!(auth.has_activation_constraints());
     }
 }

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -1628,6 +1628,8 @@ mod tests {
             )]),
             key_id: address!("0000000000000000000000000000000000000004"),
             allowed_destinations: None,
+            valid_after: None,
+            activation_delay: None,
         }
         .into_signed(PrimitiveSignature::Secp256k1(Signature::test_signature()));
 

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -937,6 +937,9 @@ mod tests {
             key_id: caller,
             expiry: None,
             limits: None,
+            valid_after: None,
+            activation_delay: None,
+            allowed_destinations: None,
         };
         let key_auth_webauthn_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
         let signed_key_auth =

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1673,6 +1673,7 @@ mod tests {
                 expiry: u64::MAX,  // never expires
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -1706,6 +1707,7 @@ mod tests {
                 expiry: 0, // revoked keys have expiry=0
                 enforce_limits: false,
                 is_revoked: true,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -1743,6 +1745,7 @@ mod tests {
                 expiry: 0, // expiry = 0 means key doesn't exist
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -1807,6 +1810,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None, // never expires
                 limits: None, // unlimited
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -1851,6 +1857,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -1898,6 +1907,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -1942,6 +1954,9 @@ mod tests {
                 key_id: different_key_id, // Different from access_key_address
                 expiry: None,
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -1991,6 +2006,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2088,6 +2106,7 @@ mod tests {
                 expiry: u64::MAX,
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
             let validator = setup_validator_with_keychain_storage(
@@ -2181,6 +2200,7 @@ mod tests {
                 expiry: current_time - 1, // Expired (in the past)
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -2219,6 +2239,7 @@ mod tests {
                 expiry: current_time, // Expiry at exactly current time should be rejected
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -2256,6 +2277,7 @@ mod tests {
                 expiry: current_time + 100, // Valid (in the future)
                 enforce_limits: false,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 
@@ -2289,6 +2311,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time - 1), // Expired
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2337,6 +2362,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time), // Expired at exactly current time
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2384,6 +2412,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time + 100), // Valid (in the future)
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2429,6 +2460,9 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None, // Never expires
                 limits: None,
+                valid_after: None,
+                activation_delay: None,
+                allowed_destinations: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2487,6 +2521,7 @@ mod tests {
                 expiry: u64::MAX,
                 enforce_limits,
                 is_revoked: false,
+                activates_at: 0,
             }
             .encode_to_slot();
 

--- a/tips/tip-1013.md
+++ b/tips/tip-1013.md
@@ -129,72 +129,120 @@ struct KeyAuthorization {
     TokenLimit[] spendingLimits;
     uint64 expiry;              // Key becomes invalid after this time
     address[] allowedDestinations;
-    uint64 validAfter;          // Key becomes valid after this time (0 = immediately valid)
+    uint64 validAfter;          // Absolute: key cannot be used before this timestamp
+    uint64 activationDelay;     // Relative: seconds after authorization before key is usable
 }
 ```
 
-### Validity Window
+### Two-Field Activation Model
 
-A key is **usable** for signing transactions when: `validAfter <= block.timestamp < expiry`
+The key activation time is determined by **two independent constraints**:
 
-| `validAfter` | `expiry` | Behavior |
-|--------------|----------|----------|
-| 0 | 0 | Always valid (no time constraints) |
-| 0 | T | Valid until T |
-| T | 0 | Valid after T (no expiry) |
-| T1 | T2 | Valid between T1 and T2 |
+| Field | Type | Purpose |
+|-------|------|---------|
+| `validAfter` | Absolute timestamp | "Key cannot be used before January 1st" |
+| `activationDelay` | Duration (seconds) | "Key cannot be used until 30 days after authorization" |
 
-**Constraint**: `validAfter < expiry` when both are non-zero, otherwise the key would never be valid.
+**Activation time calculation** (computed on-chain when key is authorized):
+
+```solidity
+activatesAt = max(validAfter, block.timestamp + activationDelay)
+```
+
+A key is **usable** when: `activatesAt <= block.timestamp < expiry`
+
+### Use Case Examples
+
+| Scenario | `validAfter` | `activationDelay` | Effect |
+|----------|--------------|-------------------|--------|
+| Standard guardian | 0 | 30 days | Always 30-day warning after authorization |
+| Scheduled handoff | Jan 1, 2027 | 0 | Usable on Jan 1, regardless of when authorized |
+| Scheduled + warning | Jan 1, 2027 | 7 days | Usable on Jan 1 OR 7 days after auth, whichever is later |
+| Immediate (legacy) | 0 | 0 | Usable immediately upon authorization |
+
+### Why Two Fields?
+
+**Problem with `validAfter` alone**: If the user signs `validAfter = now + 30 days` and the guardian waits 45 days to submit, the key is immediately active—no warning period.
+
+**Problem with `activationDelay` alone**: Cannot express "this key should never be valid before a specific date" (e.g., inheritance scenarios).
+
+**Solution**: Both fields together allow:
+1. **Guaranteed warning period** via `activationDelay` (guardian cannot bypass by waiting)
+2. **Scheduled activation** via `validAfter` (key cannot activate before a fixed date)
 
 ### Authorization vs. Activation
 
 **Important distinction**:
 
-- **Authorization**: A key MAY be authorized on-chain at any time, regardless of `validAfter`. The `authorizeKey` function does not check whether `validAfter` is in the future.
+- **Authorization**: A key MAY be authorized on-chain at any time. The precompile computes `activatesAt = max(validAfter, block.timestamp + activationDelay)` and stores it.
   
-- **Activation**: A key can only be USED to sign transactions after `validAfter` has passed. Until then, the key exists on-chain but is dormant.
+- **Activation**: A key can only be USED to sign transactions after `activatesAt` has passed. Until then, the key exists on-chain but is dormant.
 
 This separation is critical for the recovery guardian flow:
 
 1. Guardian submits the signed authorization → key is now **authorized** (on-chain)
-2. User sees the authorization event and has time to react
-3. Only after `validAfter` passes does the key become **active** (usable)
+2. `activatesAt` is computed and stored; user sees the authorization event
+3. User has until `activatesAt` to revoke (guaranteed by `activationDelay`)
+4. Only after `activatesAt` passes does the key become **active** (usable)
 
-If authorization itself required `validAfter` to have passed, there would be no warning period—the guardian could use the key immediately upon authorization.
+The `activationDelay` field **guarantees** a warning period regardless of when the guardian submits the authorization.
 
 ## Interface Changes
 
 ### IAccountKeychain.sol
 
 ```solidity
-/// @notice Authorizes a key with a validity window
+/// @notice Authorizes a key with activation constraints
 /// @param key The public key to authorize
 /// @param expiry Block timestamp when key expires (0 = no expiry)
-/// @param validAfter Block timestamp when key becomes valid (0 = immediately valid)
+/// @param validAfter Absolute timestamp before which key cannot be used (0 = no constraint)
+/// @param activationDelay Seconds after authorization before key is usable (0 = no delay)
 /// @param spendingLimits Token spending limits
 /// @param allowedDestinations Addresses the key may call (empty = unrestricted)
+/// @dev On authorization, activatesAt = max(validAfter, block.timestamp + activationDelay)
 function authorizeKey(
     bytes calldata key,
     uint64 expiry,
     uint64 validAfter,
+    uint64 activationDelay,
     TokenLimit[] calldata spendingLimits,
     address[] calldata allowedDestinations
 ) external;
 
-/// @notice Returns the validity window for a key
+/// @notice Returns the activation and expiry times for a key
 /// @param key The public key to query
-/// @return validAfter Timestamp when key becomes valid (0 = immediately valid)
+/// @return activatesAt Computed timestamp when key becomes usable
 /// @return expiry Timestamp when key expires (0 = no expiry)
-function getValidityWindow(bytes calldata key) external view returns (uint64 validAfter, uint64 expiry);
+function getActivationWindow(bytes calldata key) external view returns (uint64 activatesAt, uint64 expiry);
 
-/// @notice Updates the validAfter timestamp for an existing key
-/// @dev Can only increase validAfter (push activation further into the future)
+/// @notice Extends the activation time for an existing key
+/// @dev Can only increase activatesAt (push activation further into the future)
 /// @param key The public key to update
-/// @param newValidAfter New timestamp when key becomes valid
-function updateValidAfter(bytes calldata key, uint64 newValidAfter) external;
+/// @param newActivatesAt New timestamp when key becomes usable (must be > current activatesAt)
+function extendActivation(bytes calldata key, uint64 newActivatesAt) external;
 ```
 
 ## Semantic Behavior
+
+### Key Authorization Logic
+
+When a key is authorized on-chain:
+
+```
+function authorizeKey(key, expiry, validAfter, activationDelay, ...):
+    // Compute activation time
+    activatesAt = max(validAfter, block.timestamp + activationDelay)
+    
+    // Validate constraints
+    if expiry > 0 and activatesAt >= expiry:
+        revert ActivationExceedsExpiry()
+    
+    // Store computed activatesAt (not the original fields)
+    storage.activatesAt[key] = activatesAt
+    storage.expiry[key] = expiry
+    
+    emit KeyAuthorized(key, activatesAt, expiry)
+```
 
 ### Key Validation Logic
 
@@ -202,15 +250,16 @@ When a transaction is submitted with an Access Key:
 
 ```
 function validateKeyTiming(key):
-    auth = getKeyAuthorization(key)
+    activatesAt = storage.activatesAt[key]
+    expiry = storage.expiry[key]
     
-    // Check validAfter constraint
-    if auth.validAfter > 0 and block.timestamp < auth.validAfter:
-        revert KeyNotYetValid(auth.validAfter)
+    // Check activation constraint
+    if block.timestamp < activatesAt:
+        revert KeyNotYetActive(activatesAt)
     
-    // Check expiry constraint (existing behavior)
-    if auth.expiry > 0 and block.timestamp >= auth.expiry:
-        revert KeyExpired(auth.expiry)
+    // Check expiry constraint
+    if expiry > 0 and block.timestamp >= expiry:
+        revert KeyExpired(expiry)
     
     return true
 ```
@@ -218,33 +267,36 @@ function validateKeyTiming(key):
 ### Guardian Key Update Rules
 
 1. **Revocation**: The account owner can always revoke a guardian key entirely
-2. **Delay extension**: The owner can call `updateValidAfter` to push `validAfter` further into the future
-3. **Delay reduction**: The owner CANNOT reduce `validAfter`—this would defeat the security model
+2. **Activation extension**: The owner can call `extendActivation` to push `activatesAt` further into the future
+3. **Activation reduction**: The owner CANNOT reduce `activatesAt`—this would defeat the security model
 4. **Re-provisioning**: To reduce the delay, the owner must revoke and create a new key
 
 ```
-function updateValidAfter(key, newValidAfter):
-    auth = getKeyAuthorization(key)
+function extendActivation(key, newActivatesAt):
+    currentActivatesAt = storage.activatesAt[key]
+    expiry = storage.expiry[key]
     
-    if newValidAfter <= auth.validAfter:
-        revert CannotReduceValidAfter()
+    if newActivatesAt <= currentActivatesAt:
+        revert CannotReduceActivation()
     
-    if auth.expiry > 0 and newValidAfter >= auth.expiry:
-        revert ValidAfterExceedsExpiry()
+    if expiry > 0 and newActivatesAt >= expiry:
+        revert ActivationExceedsExpiry()
     
-    auth.validAfter = newValidAfter
+    storage.activatesAt[key] = newActivatesAt
+    
+    emit ActivationExtended(key, newActivatesAt)
 ```
 
 ### Interaction with Other Permissions
 
-The `validAfter` check is evaluated **first**, before any other permission checks:
+The `activatesAt` check is evaluated **first**, before any other permission checks:
 
-1. `validAfter` check (is the key active yet?)
+1. `activatesAt` check (is the key active yet?)
 2. `expiry` check (has the key expired?)
 3. `allowedDestinations` check (can this key call this address?)
 4. `spendingLimits` check (does this key have sufficient allowance?)
 
-If `validAfter` has not passed, the transaction reverts immediately without consuming spending limits or evaluating other constraints.
+If `activatesAt` has not passed, the transaction reverts immediately without consuming spending limits or evaluating other constraints.
 
 ## Recovery Guardian Configuration
 
@@ -254,54 +306,73 @@ A typical recovery guardian key would be configured as:
 authorizeKey(
     guardianPublicKey,
     0,                          // No expiry
-    uint64(block.timestamp + 30 days),  // Active in 30 days
+    0,                          // No absolute time constraint
+    30 days,                    // 30-day warning period after authorization
     [],                         // No spending limits (unlimited)
     []                          // No destination restrictions
 );
 ```
 
 This creates a key that:
-- Cannot be used for 30 days
+- Has a guaranteed 30-day warning period after authorization
 - Has no expiry (valid indefinitely once active)
 - Has no spending limits (full account access)
 - Can interact with any contract
+
+For inheritance/scheduled handoff scenarios:
+
+```solidity
+authorizeKey(
+    heirPublicKey,
+    0,                          // No expiry
+    uint64(targetDate),         // Cannot activate before target date
+    7 days,                     // Plus 7-day warning when authorized
+    [],                         // Unlimited
+    []                          // Unrestricted
+);
+```
+
+This ensures the key cannot be used before `targetDate`, AND there's always at least a 7-day warning after authorization.
 
 ## Encoding
 
 ### RLP Encoding
 
-The `KeyAuthorization` struct is extended with `validAfter` as a trailing optional field:
+The `KeyAuthorization` struct is extended with activation fields as trailing optional fields:
 
 ```
 KeyAuthorization := RLP([
     spendingLimits: [TokenLimit, ...],
     expiry: uint64,
     allowedDestinations: [address, ...],  // From TIP-1011
-    validAfter: uint64                    // New field
+    validAfter: uint64,                   // New: absolute timestamp constraint
+    activationDelay: uint64               // New: relative delay in seconds
 ])
 ```
 
 Using `#[rlp(trailing)]` semantics:
-- Old encodings (without `validAfter`) decode as `validAfter = 0` (immediately valid)
-- New encodings include `validAfter` explicitly
+- Old encodings (without new fields) decode as `validAfter = 0, activationDelay = 0` (immediately valid)
+- New encodings include both fields explicitly
 
 ## Precompile Storage
 
-New storage slot for the `validAfter` field:
+New storage slot for the computed activation time:
 
 | Mapping | Type | Description |
 |---------|------|-------------|
-| `valid_after[key]` | `u64` | Timestamp when key becomes valid |
+| `activates_at[key]` | `u64` | Computed timestamp when key becomes usable |
 
-Legacy keys (pre-fork) have `validAfter = 0` (immediately valid).
+**Note**: We store the computed `activatesAt`, not the original `validAfter` and `activationDelay`. This simplifies validation and ensures the activation time is immutable once set (can only be extended).
+
+Legacy keys (pre-fork) have `activatesAt = 0` (immediately valid).
 
 ## Gas Costs
 
 | Operation | Gas Cost |
 |-----------|----------|
-| `authorizeKey` with `validAfter` | +2,000 (additional SSTORE for timestamp) |
-| `updateValidAfter` | ~5,000 (single SSTORE update) |
-| Validity check (per tx) | ~100 (timestamp comparison) |
+| `authorizeKey` with activation fields | +2,000 (additional SSTORE for timestamp) |
+| `extendActivation` | ~5,000 (single SSTORE update) |
+| Activation check (per tx) | ~100 (timestamp comparison) |
 
 ---
 
@@ -311,64 +382,86 @@ This TIP requires a **hardfork** due to changes in transaction encoding and exec
 
 ## RLP Encoding Changes
 
-`KeyAuthorization` gains a new trailing field `validAfter`. Using `#[rlp(trailing)]`:
-- Pre-fork keys decode with `validAfter = 0` (immediately valid)
-- Post-fork keys may include `validAfter`
+`KeyAuthorization` gains two new trailing fields: `validAfter` and `activationDelay`. Using `#[rlp(trailing)]`:
+- Pre-fork keys decode with `validAfter = 0, activationDelay = 0` (immediately valid)
+- Post-fork keys may include either or both fields
 
 ## Hardfork-Gated Features
 
 The following MUST be gated behind hardfork activation:
 
-1. **RLP decoding**: Accept `validAfter` field in `KeyAuthorization`
-2. **Validity window enforcement**: Check `validAfter` before allowing key usage
-3. **New precompile storage**: Write to `valid_after[key]` slot
-4. **New interface methods**: `getValidityWindow()`, `updateValidAfter()`
+1. **RLP decoding**: Accept `validAfter` and `activationDelay` fields in `KeyAuthorization`
+2. **Activation time computation**: Compute `activatesAt = max(validAfter, block.timestamp + activationDelay)`
+3. **Activation enforcement**: Check `activatesAt` before allowing key usage
+4. **New precompile storage**: Write to `activates_at[key]` slot
+5. **New interface methods**: `getActivationWindow()`, `extendActivation()`
 
 ---
 
 # Invariants
 
-1. **Validity window**: A key MUST only be usable when `validAfter <= block.timestamp < expiry` (with 0 meaning unbounded)
+1. **Activation computation**: On authorization, `activatesAt` MUST be computed as `max(validAfter, block.timestamp + activationDelay)`
 
-2. **Monotonic validAfter**: `validAfter` can only be increased via `updateValidAfter()`, never decreased
+2. **Activation window**: A key MUST only be usable when `activatesAt <= block.timestamp < expiry` (with 0 meaning unbounded)
 
-3. **Window consistency**: When both `validAfter` and `expiry` are non-zero, `validAfter < expiry` MUST hold
+3. **Monotonic activation**: `activatesAt` can only be increased via `extendActivation()`, never decreased
 
-4. **Backward compatibility**: Keys authorized without `validAfter` MUST behave as if `validAfter = 0` (immediately valid)
+4. **Window consistency**: When both `activatesAt` and `expiry` are non-zero, `activatesAt < expiry` MUST hold
 
-5. **Check ordering**: The `validAfter` check MUST be evaluated before spending limits or destination restrictions
+5. **Backward compatibility**: Keys authorized without activation fields MUST behave as if `activatesAt = 0` (immediately valid)
 
-6. **Revocation precedence**: Account owners MUST always be able to revoke guardian keys regardless of their validity window
+6. **Check ordering**: The `activatesAt` check MUST be evaluated before spending limits or destination restrictions
+
+7. **Revocation precedence**: Account owners MUST always be able to revoke guardian keys regardless of their activation status
 
 ## Test Cases
 
-1. **Basic validity window**: Verify key with `validAfter` in future cannot be used until that time
-2. **Expiry interaction**: Verify key with both `validAfter` and `expiry` works correctly within window
-3. **Update validAfter**: Verify `updateValidAfter` can only increase the timestamp
-4. **Revocation**: Verify owner can revoke guardian key before it becomes valid
-5. **Zero values**: Verify `validAfter = 0` means immediately valid, `expiry = 0` means no expiry
-6. **Invalid window**: Verify authorization fails if `validAfter >= expiry`
-7. **Upgrade path**: Verify existing keys continue to work (interpreted as `validAfter = 0`)
-8. **Full recovery flow**: End-to-end test of guardian provisioning, waiting, and recovery
+1. **Activation delay only**: Key with `validAfter=0, activationDelay=30 days` activates 30 days after authorization
+2. **Valid after only**: Key with `validAfter=Jan1, activationDelay=0` activates on Jan 1 (or immediately if authorized after Jan 1)
+3. **Both fields (delay dominates)**: `validAfter=Jan1, activationDelay=30 days`, authorized Dec 15 → activates Jan 14 (30 days from auth)
+4. **Both fields (validAfter dominates)**: `validAfter=Jan1, activationDelay=7 days`, authorized Dec 15 → activates Jan 1 (validAfter is later)
+5. **Stale authorization protection**: Key with `activationDelay=30 days` authorized 45 days after signing still requires 30-day wait
+6. **Extend activation**: Verify `extendActivation` can only increase the timestamp
+7. **Revocation**: Verify owner can revoke guardian key before it activates
+8. **Zero values**: Verify `validAfter=0, activationDelay=0` means immediately valid
+9. **Invalid window**: Verify authorization fails if computed `activatesAt >= expiry`
+10. **Upgrade path**: Verify existing keys continue to work (interpreted as `activatesAt = 0`)
+11. **Full recovery flow**: End-to-end test of off-chain signing, guardian submission, warning period, and recovery
 
 ## Security Considerations
 
 ### Attack Vectors
 
-1. **Guardian collusion**: Mitigated by the delay period—owner has time to react
-2. **Key theft**: If the owner's main key is stolen, the guardian key provides a recovery path
-3. **Guardian key theft**: Attacker must also wait for `validAfter`, giving owner time to revoke
-4. **Time manipulation**: `block.timestamp` manipulation is bounded by consensus rules
+1. **Guardian collusion**: Mitigated by `activationDelay`—owner always has the configured warning period to react
+2. **Stale authorization attack**: **MITIGATED** by the two-field model. Even if guardian waits until `validAfter` passes, `activationDelay` still applies from authorization time
+3. **Key theft**: If the owner's main key is stolen, the guardian key provides a recovery path
+4. **Guardian key theft**: Attacker must wait for `activatesAt`, giving owner time to revoke
+5. **Time manipulation**: `block.timestamp` manipulation is bounded by consensus rules
+6. **Off-chain authorization theft**: If someone steals the signed authorization, they can submit it—but `activationDelay` ensures a warning period
 
 ### Recommended Practices
 
-1. **Multiple guardians**: Use 2-3 guardians with staggered `validAfter` times
-2. **Monitoring**: Set up alerts when guardian keys approach their `validAfter` time
-3. **Reasonable delays**: 7-30 days is recommended; too short reduces security, too long reduces recoverability
-4. **Regular review**: Periodically verify guardian keys are still appropriate
+1. **Always set activationDelay**: Use `activationDelay` (not just `validAfter`) to guarantee a warning period
+2. **Multiple guardians**: Use 2-3 guardians with TIP-1012 multisig for threshold recovery
+3. **Monitoring**: Set up alerts for `KeyAuthorized` events on your account
+4. **Reasonable delays**: 7-30 days `activationDelay` recommended; too short reduces security, too long reduces recoverability
+5. **Regular review**: Periodically verify guardian configurations are still appropriate
+
+## Open Questions & Future Work
+
+The following are known limitations that may be addressed in future TIPs:
+
+1. **Guardian rotation cooldown**: An attacker who compromises the primary key can instantly revoke all guardians and add malicious ones. A cooldown on guardian changes would mitigate this but adds complexity.
+
+2. **Heartbeat/dead man's switch**: No automatic guardian activation if the owner becomes inactive. Would require an external keeper or protocol-level check-in mechanism.
+
+3. **Recovery cancellation**: Once a guardian submits an authorization, they cannot "cancel" if it was a mistake. The only recourse is for the owner to revoke.
+
+4. **Minimum activation delay**: The protocol does not enforce a minimum `activationDelay`. Users could accidentally set very short delays. This is intentional (user choice) but risky.
 
 ## References
 
 - [TIP-1011: Enhanced Access Key Permissions](./tip-1011.md)
+- [TIP-1012: Multisig as Primary Signature Type](./tip-1012.md) ([PR #2298](https://github.com/tempoxyz/tempo/pull/2298))
 - [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
 - [Social Recovery Wallets](https://vitalik.eth.limo/general/2021/01/11/recovery.html) - Vitalik Buterin

--- a/tips/tip-1013.md
+++ b/tips/tip-1013.md
@@ -28,23 +28,33 @@ Current Access Key permissions (spending limits, expiry, destination scoping) do
 
 ### Recovery Guardian Pattern
 
-A **recovery guardian** is a trusted party (friend, family member, institution, or hardware backup) that can take over an account, but only after a time delay:
+A **recovery guardian** is a trusted party (friend, family member, institution, or hardware backup) that can take over an account, but only after a time delay.
 
-1. **Setup**: User provisions an Access Key to their guardian with:
+#### Intended Flow
+
+1. **Setup (off-chain)**: User creates and signs an Access Key authorization with:
    - No spending limits (unlimited access)
    - No destination restrictions (can interact with any contract)
    - `validAfter = now + 30 days` (or any delay period)
+   
+   The user sends this **signed authorization to the guardian off-chain** (e.g., via encrypted message, in-person handoff, or secure storage). The authorization is NOT submitted on-chain yet.
 
-2. **Normal operation**: The guardian key cannot be used—it's not yet valid
+2. **Normal operation**: The guardian holds the signed authorization but does not submit it. No on-chain footprint exists.
 
 3. **Recovery scenario**: If the user loses access:
-   - Wait for the delay period to elapse
-   - Guardian can now use the key to recover funds or transfer ownership
+   - Guardian submits the signed authorization on-chain, activating the key
+   - The `validAfter` countdown begins from the original signature timestamp
+   - After the delay period elapses, guardian can use the key to recover funds
 
-4. **Attack prevention**: If the user still has access and the guardian acts maliciously:
-   - User sees the guardian key approaching validity
-   - User revokes the guardian key before `validAfter`
+4. **Attack prevention**: If the guardian submits the authorization maliciously while the user still has access:
+   - User sees the `KeyAuthorized` event on-chain
+   - User has until `validAfter` to revoke the guardian key
    - User can provision a new guardian with a fresh delay
+
+This off-chain-first approach ensures:
+- **No on-chain cost** until recovery is actually needed
+- **Privacy**: Guardian relationship is not publicly visible until activated
+- **Clear signal**: On-chain authorization serves as an explicit "recovery initiated" event
 
 This mirrors social recovery patterns in smart contract wallets but at the protocol level.
 
@@ -125,7 +135,7 @@ struct KeyAuthorization {
 
 ### Validity Window
 
-A key is valid when: `validAfter <= block.timestamp < expiry`
+A key is **usable** for signing transactions when: `validAfter <= block.timestamp < expiry`
 
 | `validAfter` | `expiry` | Behavior |
 |--------------|----------|----------|
@@ -135,6 +145,22 @@ A key is valid when: `validAfter <= block.timestamp < expiry`
 | T1 | T2 | Valid between T1 and T2 |
 
 **Constraint**: `validAfter < expiry` when both are non-zero, otherwise the key would never be valid.
+
+### Authorization vs. Activation
+
+**Important distinction**:
+
+- **Authorization**: A key MAY be authorized on-chain at any time, regardless of `validAfter`. The `authorizeKey` function does not check whether `validAfter` is in the future.
+  
+- **Activation**: A key can only be USED to sign transactions after `validAfter` has passed. Until then, the key exists on-chain but is dormant.
+
+This separation is critical for the recovery guardian flow:
+
+1. Guardian submits the signed authorization → key is now **authorized** (on-chain)
+2. User sees the authorization event and has time to react
+3. Only after `validAfter` passes does the key become **active** (usable)
+
+If authorization itself required `validAfter` to have passed, there would be no warning period—the guardian could use the key immediately upon authorization.
 
 ## Interface Changes
 

--- a/tips/tip-1013.md
+++ b/tips/tip-1013.md
@@ -4,7 +4,7 @@ title: Recovery Guardian Keys
 description: Adds a valid_after timestamp to Access Keys enabling time-delayed recovery guardian patterns.
 authors: Tanishk Goyal
 status: Draft
-related: TIP-1011, TIP-1000, AccountKeychain, IAccountKeychain.sol
+related: TIP-1011, TIP-1012, TIP-1000, AccountKeychain, IAccountKeychain.sol
 protocolVersion: TBD (requires hardfork)
 ---
 
@@ -55,6 +55,18 @@ This mirrors social recovery patterns in smart contract wallets but at the proto
 3. **Institutional recovery**: Enterprise accounts with IT department as guardian
 4. **Dead man's switch**: Automatic inheritance if the owner becomes inactive
 5. **Multi-guardian setup**: Multiple guardian keys with staggered `validAfter` times
+
+### Threshold Recovery with Multisig Guardians
+
+While this TIP defines single-key guardians, **threshold recovery** (M-of-N guardians) is achieved by setting the guardian key to a multisig account as defined in [TIP-1012](./tip-1012.md) ([PR #2298](https://github.com/tempoxyz/tempo/pull/2298)).
+
+For example, to require 2-of-3 family members to recover an account:
+
+1. Create a multisig account with 3 family members as owners and threshold of 2
+2. Provision a guardian Access Key to the multisig address with `validAfter = 30 days`
+3. If recovery is needed, 2 of the 3 family members sign a transaction from the multisig to recover the account
+
+This composability allows TIP-1013 to remain simple (single timestamp field) while supporting arbitrarily complex guardian configurations through TIP-1012 multisig accounts.
 
 ---
 

--- a/tips/tip-1013.md
+++ b/tips/tip-1013.md
@@ -1,0 +1,308 @@
+---
+id: TIP-1013
+title: Recovery Guardian Keys
+description: Adds a valid_after timestamp to Access Keys enabling time-delayed recovery guardian patterns.
+authors: Tanishk Goyal
+status: Draft
+related: TIP-1011, TIP-1000, AccountKeychain, IAccountKeychain.sol
+protocolVersion: TBD (requires hardfork)
+---
+
+# TIP-1013: Recovery Guardian Keys
+
+## Abstract
+
+This TIP extends Access Keys with a `validAfter` timestamp field, enabling time-delayed key activation. Combined with unlimited spending limits and unrestricted address scoping, this creates a **recovery guardian** pattern where a trusted third party can recover an account only after a configurable delay period—giving the original owner time to revoke the guardian if they still have access.
+
+## Motivation
+
+Users face a fundamental tradeoff between security and recoverability:
+
+- **High security** (hardware wallets, multi-sig): Risk permanent loss if keys are lost
+- **High recoverability** (custodial, social recovery): Trust third parties with immediate access
+
+Current Access Key permissions (spending limits, expiry, destination scoping) don't solve this because they either:
+1. Expire (useless for long-term recovery)
+2. Have spending limits (can't recover full account)
+3. Are immediately active (guardian could act maliciously)
+
+### Recovery Guardian Pattern
+
+A **recovery guardian** is a trusted party (friend, family member, institution, or hardware backup) that can take over an account, but only after a time delay:
+
+1. **Setup**: User provisions an Access Key to their guardian with:
+   - No spending limits (unlimited access)
+   - No destination restrictions (can interact with any contract)
+   - `validAfter = now + 30 days` (or any delay period)
+
+2. **Normal operation**: The guardian key cannot be used—it's not yet valid
+
+3. **Recovery scenario**: If the user loses access:
+   - Wait for the delay period to elapse
+   - Guardian can now use the key to recover funds or transfer ownership
+
+4. **Attack prevention**: If the user still has access and the guardian acts maliciously:
+   - User sees the guardian key approaching validity
+   - User revokes the guardian key before `validAfter`
+   - User can provision a new guardian with a fresh delay
+
+This mirrors social recovery patterns in smart contract wallets but at the protocol level.
+
+### Use Cases
+
+1. **Personal backup**: Provision a guardian key to a hardware wallet stored in a safe
+2. **Family recovery**: Give a guardian key to a trusted family member
+3. **Institutional recovery**: Enterprise accounts with IT department as guardian
+4. **Dead man's switch**: Automatic inheritance if the owner becomes inactive
+5. **Multi-guardian setup**: Multiple guardian keys with staggered `validAfter` times
+
+---
+
+# Specification
+
+## Extended Data Structures
+
+### KeyAuthorization
+
+**Current fields (from TIP-1011):**
+```solidity
+struct KeyAuthorization {
+    TokenLimit[] spendingLimits;
+    uint64 expiry;
+    address[] allowedDestinations;
+}
+```
+
+**Proposed addition:**
+```solidity
+struct KeyAuthorization {
+    TokenLimit[] spendingLimits;
+    uint64 expiry;              // Key becomes invalid after this time
+    address[] allowedDestinations;
+    uint64 validAfter;          // Key becomes valid after this time (0 = immediately valid)
+}
+```
+
+### Validity Window
+
+A key is valid when: `validAfter <= block.timestamp < expiry`
+
+| `validAfter` | `expiry` | Behavior |
+|--------------|----------|----------|
+| 0 | 0 | Always valid (no time constraints) |
+| 0 | T | Valid until T |
+| T | 0 | Valid after T (no expiry) |
+| T1 | T2 | Valid between T1 and T2 |
+
+**Constraint**: `validAfter < expiry` when both are non-zero, otherwise the key would never be valid.
+
+## Interface Changes
+
+### IAccountKeychain.sol
+
+```solidity
+/// @notice Authorizes a key with a validity window
+/// @param key The public key to authorize
+/// @param expiry Block timestamp when key expires (0 = no expiry)
+/// @param validAfter Block timestamp when key becomes valid (0 = immediately valid)
+/// @param spendingLimits Token spending limits
+/// @param allowedDestinations Addresses the key may call (empty = unrestricted)
+function authorizeKey(
+    bytes calldata key,
+    uint64 expiry,
+    uint64 validAfter,
+    TokenLimit[] calldata spendingLimits,
+    address[] calldata allowedDestinations
+) external;
+
+/// @notice Returns the validity window for a key
+/// @param key The public key to query
+/// @return validAfter Timestamp when key becomes valid (0 = immediately valid)
+/// @return expiry Timestamp when key expires (0 = no expiry)
+function getValidityWindow(bytes calldata key) external view returns (uint64 validAfter, uint64 expiry);
+
+/// @notice Updates the validAfter timestamp for an existing key
+/// @dev Can only increase validAfter (push activation further into the future)
+/// @param key The public key to update
+/// @param newValidAfter New timestamp when key becomes valid
+function updateValidAfter(bytes calldata key, uint64 newValidAfter) external;
+```
+
+## Semantic Behavior
+
+### Key Validation Logic
+
+When a transaction is submitted with an Access Key:
+
+```
+function validateKeyTiming(key):
+    auth = getKeyAuthorization(key)
+    
+    // Check validAfter constraint
+    if auth.validAfter > 0 and block.timestamp < auth.validAfter:
+        revert KeyNotYetValid(auth.validAfter)
+    
+    // Check expiry constraint (existing behavior)
+    if auth.expiry > 0 and block.timestamp >= auth.expiry:
+        revert KeyExpired(auth.expiry)
+    
+    return true
+```
+
+### Guardian Key Update Rules
+
+1. **Revocation**: The account owner can always revoke a guardian key entirely
+2. **Delay extension**: The owner can call `updateValidAfter` to push `validAfter` further into the future
+3. **Delay reduction**: The owner CANNOT reduce `validAfter`—this would defeat the security model
+4. **Re-provisioning**: To reduce the delay, the owner must revoke and create a new key
+
+```
+function updateValidAfter(key, newValidAfter):
+    auth = getKeyAuthorization(key)
+    
+    if newValidAfter <= auth.validAfter:
+        revert CannotReduceValidAfter()
+    
+    if auth.expiry > 0 and newValidAfter >= auth.expiry:
+        revert ValidAfterExceedsExpiry()
+    
+    auth.validAfter = newValidAfter
+```
+
+### Interaction with Other Permissions
+
+The `validAfter` check is evaluated **first**, before any other permission checks:
+
+1. `validAfter` check (is the key active yet?)
+2. `expiry` check (has the key expired?)
+3. `allowedDestinations` check (can this key call this address?)
+4. `spendingLimits` check (does this key have sufficient allowance?)
+
+If `validAfter` has not passed, the transaction reverts immediately without consuming spending limits or evaluating other constraints.
+
+## Recovery Guardian Configuration
+
+A typical recovery guardian key would be configured as:
+
+```solidity
+authorizeKey(
+    guardianPublicKey,
+    0,                          // No expiry
+    uint64(block.timestamp + 30 days),  // Active in 30 days
+    [],                         // No spending limits (unlimited)
+    []                          // No destination restrictions
+);
+```
+
+This creates a key that:
+- Cannot be used for 30 days
+- Has no expiry (valid indefinitely once active)
+- Has no spending limits (full account access)
+- Can interact with any contract
+
+## Encoding
+
+### RLP Encoding
+
+The `KeyAuthorization` struct is extended with `validAfter` as a trailing optional field:
+
+```
+KeyAuthorization := RLP([
+    spendingLimits: [TokenLimit, ...],
+    expiry: uint64,
+    allowedDestinations: [address, ...],  // From TIP-1011
+    validAfter: uint64                    // New field
+])
+```
+
+Using `#[rlp(trailing)]` semantics:
+- Old encodings (without `validAfter`) decode as `validAfter = 0` (immediately valid)
+- New encodings include `validAfter` explicitly
+
+## Precompile Storage
+
+New storage slot for the `validAfter` field:
+
+| Mapping | Type | Description |
+|---------|------|-------------|
+| `valid_after[key]` | `u64` | Timestamp when key becomes valid |
+
+Legacy keys (pre-fork) have `validAfter = 0` (immediately valid).
+
+## Gas Costs
+
+| Operation | Gas Cost |
+|-----------|----------|
+| `authorizeKey` with `validAfter` | +2,000 (additional SSTORE for timestamp) |
+| `updateValidAfter` | ~5,000 (single SSTORE update) |
+| Validity check (per tx) | ~100 (timestamp comparison) |
+
+---
+
+# Backward Compatibility
+
+This TIP requires a **hardfork** due to changes in transaction encoding and execution semantics.
+
+## RLP Encoding Changes
+
+`KeyAuthorization` gains a new trailing field `validAfter`. Using `#[rlp(trailing)]`:
+- Pre-fork keys decode with `validAfter = 0` (immediately valid)
+- Post-fork keys may include `validAfter`
+
+## Hardfork-Gated Features
+
+The following MUST be gated behind hardfork activation:
+
+1. **RLP decoding**: Accept `validAfter` field in `KeyAuthorization`
+2. **Validity window enforcement**: Check `validAfter` before allowing key usage
+3. **New precompile storage**: Write to `valid_after[key]` slot
+4. **New interface methods**: `getValidityWindow()`, `updateValidAfter()`
+
+---
+
+# Invariants
+
+1. **Validity window**: A key MUST only be usable when `validAfter <= block.timestamp < expiry` (with 0 meaning unbounded)
+
+2. **Monotonic validAfter**: `validAfter` can only be increased via `updateValidAfter()`, never decreased
+
+3. **Window consistency**: When both `validAfter` and `expiry` are non-zero, `validAfter < expiry` MUST hold
+
+4. **Backward compatibility**: Keys authorized without `validAfter` MUST behave as if `validAfter = 0` (immediately valid)
+
+5. **Check ordering**: The `validAfter` check MUST be evaluated before spending limits or destination restrictions
+
+6. **Revocation precedence**: Account owners MUST always be able to revoke guardian keys regardless of their validity window
+
+## Test Cases
+
+1. **Basic validity window**: Verify key with `validAfter` in future cannot be used until that time
+2. **Expiry interaction**: Verify key with both `validAfter` and `expiry` works correctly within window
+3. **Update validAfter**: Verify `updateValidAfter` can only increase the timestamp
+4. **Revocation**: Verify owner can revoke guardian key before it becomes valid
+5. **Zero values**: Verify `validAfter = 0` means immediately valid, `expiry = 0` means no expiry
+6. **Invalid window**: Verify authorization fails if `validAfter >= expiry`
+7. **Upgrade path**: Verify existing keys continue to work (interpreted as `validAfter = 0`)
+8. **Full recovery flow**: End-to-end test of guardian provisioning, waiting, and recovery
+
+## Security Considerations
+
+### Attack Vectors
+
+1. **Guardian collusion**: Mitigated by the delay period—owner has time to react
+2. **Key theft**: If the owner's main key is stolen, the guardian key provides a recovery path
+3. **Guardian key theft**: Attacker must also wait for `validAfter`, giving owner time to revoke
+4. **Time manipulation**: `block.timestamp` manipulation is bounded by consensus rules
+
+### Recommended Practices
+
+1. **Multiple guardians**: Use 2-3 guardians with staggered `validAfter` times
+2. **Monitoring**: Set up alerts when guardian keys approach their `validAfter` time
+3. **Reasonable delays**: 7-30 days is recommended; too short reduces security, too long reduces recoverability
+4. **Regular review**: Periodically verify guardian keys are still appropriate
+
+## References
+
+- [TIP-1011: Enhanced Access Key Permissions](./tip-1011.md)
+- [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
+- [Social Recovery Wallets](https://vitalik.eth.limo/general/2021/01/11/recovery.html) - Vitalik Buterin

--- a/tips/tip-1013.md
+++ b/tips/tip-1013.md
@@ -68,6 +68,34 @@ For example, to require 2-of-3 family members to recover an account:
 
 This composability allows TIP-1013 to remain simple (single timestamp field) while supporting arbitrarily complex guardian configurations through TIP-1012 multisig accounts.
 
+### Account Locking via Scoped Guardians
+
+Account locking (freezing funds during a suspected compromise) can be achieved by combining `validAfter` with destination address scoping from [TIP-1011](./tip-1011.md).
+
+**Setup**: Provision a "lockdown guardian" Access Key with:
+- Unlimited spending limits (can move all funds)
+- `allowedDestinations = [vaultContract]` (can ONLY send to a recovery vault)
+- `validAfter = 7 days` (short delay for emergency response)
+
+**The vault contract** is a simple timelock that:
+1. Accepts deposits from anyone
+2. Only releases funds to the original depositor after a delay (e.g., 30 days)
+3. Allows the original account owner to claim immediately with their primary key
+
+**Lockdown flow**:
+1. Guardian detects suspicious activity on the account
+2. After `validAfter` passes, guardian moves all funds to the vault
+3. Attacker cannot access the funds—they're locked in the vault
+4. Original owner recovers their primary key and claims from the vault immediately
+
+**Why this works**:
+- Guardian cannot steal funds (destination-scoped to vault only)
+- Guardian cannot interact with DeFi or drain value (no other destinations allowed)
+- Attacker cannot front-run (vault only releases to original owner)
+- Owner retains ultimate control (can claim from vault anytime)
+
+This pattern provides "emergency freeze" capability without giving guardians custody of funds.
+
 ---
 
 # Specification


### PR DESCRIPTION
## Summary
Stacked on #2299 
Adds TIP-1013 which introduces a `validAfter` timestamp field to Access Keys, enabling **recovery guardian** patterns.

## Recovery Guardian Pattern

Users can provision an Access Key to a trusted guardian with:
- Unlimited spending limits (unlimited access)
- Unlimited destination restrictions
- `validAfter = now + 30 days` (or any delay)

**If user loses access**: Guardian can recover after the delay period.  
**If guardian acts maliciously**: User can revoke the key before `validAfter` passes.

## Key Changes

- New `validAfter` field in `KeyAuthorization` struct
- Keys are only valid when `validAfter <= block.timestamp < expiry`
- New `updateValidAfter()` function - can only increase delay (never reduce)
- Owner can always revoke guardian keys regardless of validity window

## Use Cases

1. Personal backup to hardware wallet in safe
2. Family recovery with trusted relatives
3. Institutional recovery for enterprise accounts
4. Dead man's switch for inheritance

---

