### PR TITLE
fix(txpool): set minimal_protocol_basefee to TEMPO_T0_BASE_FEE

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -1,7 +1,7 @@
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{DefaultPayloadBuilderValues, DefaultTxPoolValues};
 use std::{borrow::Cow, time::Duration};
-use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use tempo_chainspec::hardfork::TempoHardfork;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/42431";
 
@@ -45,7 +45,7 @@ fn init_txpool_defaults() {
         .with_new_tx_listener_buffer_size(50000)
         .with_disable_transactions_backup(true)
         .with_additional_validation_tasks(8)
-        .with_minimal_protocol_basefee(TEMPO_T0_BASE_FEE)
+        .with_minimal_protocol_basefee(TempoHardfork::default().base_fee())
         .with_minimum_priority_fee(Some(0))
         .with_max_batch_size(50000)
         .try_init()


### PR DESCRIPTION
## Summary
Sets `minimal_protocol_basefee` to `TEMPO_T0_BASE_FEE` (10 gwei) instead of 0 to prevent the txpool from accepting transactions that can never be included.

## Problem
With `minimal_protocol_basefee = 0`, the txpool accepts transactions with `max_fee_per_gas < base_fee`. Since Tempo's base fee is fixed per hardfork (T0: 10 gwei, T1: 20 gwei), these transactions can never be included.

This allows:
- Txpool resource exhaustion (memory/CPU)
- P2P spam propagation
- Degraded handling of legitimate transactions

## Solution
Set `minimal_protocol_basefee` to `TEMPO_T0_BASE_FEE` (the minimum possible base fee on Tempo). This ensures the txpool rejects any transaction with `max_fee_per_gas < 10 gwei`.

## Testing
- Manual verification that transactions with insufficient fees are rejected
- Existing txpool tests continue to pass

Fixes ZELLIC-31