### PR TITLE
TIP-ZZZZ: Dynamic state creation pricing

### DIFF
--- a/tips/tip-zzzz.md
+++ b/tips/tip-zzzz.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-State creation operations are priced dynamically based on recent usage measured via an exponentially decaying average with a 1-hour half-life. When no state is being created, prices are at pre-TIP-1000 levels (25,000 gas). As usage approaches the target rate of 10 billion state elements per year, prices increase exponentially to TIP-1000 levels (250,000 gas). This provides economic back-pressure against state growth while keeping costs low for normal usage.
+State creation operations are priced dynamically based on recent usage measured via an exponentially decaying average with a 1-hour half-life. When no state is being created, prices are at pre-TIP-1000 levels (25,000 gas). As usage approaches the target rate of 33 billion state elements per year, prices increase exponentially to TIP-1000 levels (250,000 gas). This provides economic back-pressure against state growth while keeping costs low for normal usage.
 
 ## Motivation
 
@@ -22,21 +22,6 @@ TIP-1000 set fixed high prices for state creation (250,000 gas per element) to p
 2. **No market signal**: Fixed pricing doesn't signal network capacity or provide economic feedback
 3. **Inefficient resource allocation**: Users pay high costs even when the network has plenty of state capacity
 
-Dynamic pricing solves this by:
-- Keeping costs low when state capacity is available
-- Automatically raising prices as usage approaches sustainability limits
-- Providing market signals about network state capacity
-- Efficiently allocating the scarce resource (persistent state)
-
-### Design Goals
-
-1. **Sustainability**: Cap long-term state growth at a sustainable rate (10B elements/year)
-2. **Responsiveness**: React to usage patterns within hours via exponential decay
-3. **Economic efficiency**: Price low when capacity available, high when scarce
-4. **Simplicity**: Single pricing formula applies to all state creation operations
-
----
-
 # Specification
 
 ## Target State Growth
@@ -44,13 +29,13 @@ Dynamic pricing solves this by:
 The protocol targets a maximum sustainable state growth rate:
 
 ```
-TARGET_ELEMENTS_PER_YEAR = 10,000,000,000  (10 billion elements)
-TARGET_RATE = 10B / 31,557,600 seconds ≈ 316.88 elements/second
+TARGET_ELEMENTS_PER_YEAR = 33,000,000,000  (33 billion elements)
+TARGET_RATE = 33B / 31,557,600 seconds ≈ 1,045.7 elements/second
 ```
 
 **Contract code conversion**: 1 byte of contract code = 1/100th of a state element
 - 100 bytes of contract code = 1 state element equivalent
-- At target rate: 31,688 bytes/second of contract code
+- At target rate: 104,570 bytes/second of contract code
 
 ## Exponentially Decaying Average
 
@@ -171,19 +156,19 @@ def update_state_creation_rate(block):
 - 24KB contract: ~6.2M gas
 
 ### Normal Usage (25% of target)
-- `current_rate = 79.22 elements/second`
+- `current_rate = 261.43 elements/second`
 - `price = 25,000 × 10^0.25 = 44,543 gas`
 - TIP-20 transfer to new account: ~65,543 gas total
 - 24KB contract: ~11M gas
 
 ### Target Usage (100%)
-- `current_rate = 316.88 elements/second`
+- `current_rate = 1,045.7 elements/second`
 - `price = 25,000 × 10^1 = 250,000 gas`
 - TIP-20 transfer to new account: ~271,000 gas total
 - 24KB contract: ~62M gas (same as TIP-1000)
 
 ### Overuse (200% of target)
-- `current_rate = 633.76 elements/second`
+- `current_rate = 2,091.4 elements/second`
 - `price = 25,000 × 10^2 = 2,500,000 gas`
 - TIP-20 transfer to new account: ~2,521,000 gas total
 - 24KB contract: ~619M gas (prevents spam)
@@ -206,14 +191,6 @@ def update_state_creation_rate(block):
 ---
 
 # Key Benefits
-
-1. **Low costs during low usage**: Prices drop to 25,000 gas when network is idle (10x cheaper than TIP-1000)
-2. **Automatic back-pressure**: Prices rise exponentially as usage approaches target, discouraging overuse
-3. **Market efficiency**: Scarce resource (persistent state) priced according to demand
-4. **Fast response**: 1-hour half-life means prices adjust within hours of usage changes
-5. **Attack resistance**: Sustained spam attacks face exponentially increasing costs (200% usage = 10x price)
-6. **Sustainable long-term**: Targets 10B elements/year, manageable state growth
-7. **No breaking changes**: Same transaction format, just dynamic pricing
 
 ## Economic Impact
 
@@ -292,7 +269,7 @@ Updating the EWMA and calculating dynamic price adds minimal overhead:
 **Mitigation**:
 - Exponential curve rises quickly (50% usage → 3.2x higher, 100% → 10x higher)
 - Creating enough state to matter requires paying exponentially increasing costs
-- Target of 10B elements/year provides sustainable long-term growth
+- Target of 33B elements/year provides sustainable long-term growth
 
 ## Calculation Precision
 
@@ -351,4 +328,4 @@ Could extend to track multiple resources independently:
 
 ## Adjustable Target
 
-The target rate (10B/year) could be made adjustable via governance as network capacity grows.
+The target rate (33B/year) could be made adjustable via governance as network capacity grows.

--- a/tips/tip-zzzz.md
+++ b/tips/tip-zzzz.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-ZZZZ
 title: Dynamic State Creation Pricing
-description: State creation costs adjust dynamically based on recent usage via exponentially decaying average, keeping prices low when usage is below target and raising them when approaching capacity.
+description: State creation costs adjust dynamically based on exponentially decaying usage average, keeping prices low at low usage while providing economic back-pressure at high usage.
 authors: Dankrad Feist @dankrad
 status: Draft
 related: TIP-1000, TIP-1010
@@ -12,320 +12,129 @@ protocolVersion: TBD
 
 ## Abstract
 
-State creation operations are priced dynamically based on recent usage measured via an exponentially decaying average with a 1-hour half-life. When no state is being created, prices are at pre-TIP-1000 levels (25,000 gas). As usage approaches the target rate of 33 billion state elements per year, prices increase exponentially to TIP-1000 levels (250,000 gas). This provides economic back-pressure against state growth while keeping costs low for normal usage.
+State creation is priced dynamically using an exponentially decaying average (1-hour half-life) tracking recent usage. At 0% of target usage, price is 25,000 gas. At 100% of target, price is 250,000 gas (matching TIP-1000). Pricing follows `25,000 × 10^(usage_ratio)` curve.
+
+Target: 33 billion state elements per year (1 element = 1 storage slot, 1 account, or 100 bytes contract code).
 
 ## Motivation
 
-TIP-1000 set fixed high prices for state creation (250,000 gas per element) to protect against state growth attacks. However:
+TIP-1000's fixed 250,000 gas pricing overcharges during normal operation while providing no market signal about capacity. Dynamic pricing keeps costs low when capacity available while automatically raising prices as usage approaches sustainability limits.
 
-1. **Overpricing during low usage**: When state growth is minimal, high prices unnecessarily burden users
-2. **No market signal**: Fixed pricing doesn't signal network capacity or provide economic feedback
-3. **Inefficient resource allocation**: Users pay high costs even when the network has plenty of state capacity
+---
 
 # Specification
 
-## Target State Growth
-
-The protocol targets a maximum sustainable state growth rate:
+## Constants
 
 ```
-TARGET_ELEMENTS_PER_YEAR = 33,000,000,000  (33 billion elements)
-TARGET_RATE = 33B / 31,557,600 seconds ≈ 1,045.7 elements/second
+TARGET_RATE = 33_000_000_000 / 31_557_600 = 1045.7 elements/second
+HALF_LIFE = 3600 seconds
+PRECISION = 10^18 (fixed-point precision)
+BASE_PRICE = 25_000 gas
+TARGET_PRICE = 250_000 gas
 ```
 
-**Contract code conversion**: 1 byte of contract code = 1/100th of a state element
-- 100 bytes of contract code = 1 state element equivalent
-- At target rate: 104,570 bytes/second of contract code
-
-## Exponentially Decaying Average
-
-The protocol tracks recent state creation using an exponentially weighted moving average (EWMA):
+## State Variables
 
 ```
-HALF_LIFE = 3600 seconds (1 hour)
-DECAY_FACTOR = 0.5^(time_delta / HALF_LIFE)
-
-// Updated per block
-current_rate = previous_rate × DECAY_FACTOR + new_elements_this_block / block_time
+uint256 current_rate_fp;     // elements/second × PRECISION
+uint256 last_update_time;    // timestamp of last update
 ```
 
-Where:
-- `previous_rate`: State creation rate from previous block (elements/second)
-- `DECAY_FACTOR`: Decay applied based on time since last block
-- `new_elements_this_block`: State elements created in current block
-- `block_time`: Time elapsed since previous block
+## State Element Counting
 
-**State element counting:**
-- New storage slot (SSTORE zero → non-zero): 1 element
+Per transaction:
+- SSTORE zero → non-zero: 1 element
 - Account creation: 1 element
-- Contract code: 1 element per 100 bytes
-- Contract metadata (keccak + nonce): 1 element
+- Contract code: 1 element per 100 bytes (rounded up)
+- Contract metadata: 1 element
 
-## Dynamic Pricing Formula
-
-State creation gas costs are calculated based on the current rate:
+## Rate Update (Per Block)
 
 ```
-ratio = current_rate / TARGET_RATE
+time_delta = block.timestamp - last_update_time
+elements = count_state_elements(previous_block)
 
-base_price = 25,000     (pre-TIP-1000 price)
-target_price = 250,000  (TIP-1000 price)
+// Exponential decay: decay_factor = 2^(-time_delta / HALF_LIFE)
+// Using integer math: decay_factor_fp = 2^((-time_delta × PRECISION) / HALF_LIFE)
+decay_factor_fp = exp2((-time_delta × PRECISION) / HALF_LIFE)
 
-price = base_price × 10^ratio
-      = 25,000 × 10^(current_rate / TARGET_RATE)
+// Apply decay and add new rate
+decayed_rate_fp = (current_rate_fp × decay_factor_fp) / PRECISION
+new_rate_fp = (elements × PRECISION) / time_delta
+
+current_rate_fp = decayed_rate_fp + new_rate_fp
+last_update_time = block.timestamp
 ```
 
-**Pricing examples:**
+## Price Calculation
 
-| Usage vs Target | Ratio | Price per Element | vs TIP-1000 |
-|----------------|-------|-------------------|-------------|
-| 0% (idle) | 0.0 | 25,000 | 10% |
-| 10% | 0.1 | 31,498 | 13% |
+```
+ratio_fp = (current_rate_fp × PRECISION) / (TARGET_RATE × PRECISION)
+
+// price = 25_000 × 10^ratio = 25_000 × e^(ratio × ln(10))
+ln_10_fp = 2_302585092994045684  // ln(10) × PRECISION
+exponent_fp = (ratio_fp × ln_10_fp) / PRECISION
+price = (BASE_PRICE × exp(exponent_fp)) / PRECISION
+```
+
+All arithmetic uses fixed-point with PRECISION = 10^18.
+
+## Pricing Table
+
+| Usage | Ratio | Price | vs TIP-1000 |
+|-------|-------|-------|-------------|
+| 0% | 0 | 25,000 | 10% |
 | 25% | 0.25 | 44,543 | 18% |
 | 50% | 0.5 | 79,057 | 32% |
-| 75% | 0.75 | 140,538 | 56% |
-| 100% (target) | 1.0 | 250,000 | 100% |
-| 150% | 1.5 | 790,569 | 316% |
+| 100% | 1.0 | 250,000 | 100% |
 | 200% | 2.0 | 2,500,000 | 1000% |
 
-## Gas Cost Calculation
+## Gas Costs
 
 All state creation operations use the dynamic price:
-
-```
-// Per-element costs
-new_storage_slot_gas = price
-account_creation_gas = price
-contract_metadata_gas = price
-
-// Contract code (per 100 bytes = 1 element)
-contract_code_gas_per_100_bytes = price
-contract_code_gas_per_byte = price / 100
-```
-
-**Example for 24KB contract at different usage levels:**
-
-| Usage | Price/Element | Contract Code (24KB) | Account | Metadata | Total |
-|-------|---------------|---------------------|---------|----------|-------|
-| 0% (idle) | 25,000 | 6,144,000 | 25,000 | 25,000 | 6,194,000 |
-| 50% | 79,057 | 19,438,605 | 79,057 | 79,057 | 19,596,719 |
-| 100% (target) | 250,000 | 61,440,000 | 250,000 | 250,000 | 61,940,000 |
-| 150% | 790,569 | 194,380,134 | 790,569 | 790,569 | 195,961,272 |
-
-**Note**: At target usage (100%), costs match TIP-1000. Below target, costs are lower. Above target, costs increase exponentially to discourage overuse.
-
-## Protocol State
-
-The protocol maintains the following state variables:
-
-```solidity
-// Stored in consensus state
-uint256 current_rate;          // elements per second (fixed-point)
-uint256 last_update_timestamp; // timestamp of last update
-uint256 last_update_block;     // block number of last update
-```
-
-These values are updated at the beginning of each block:
-
-```python
-def update_state_creation_rate(block):
-    time_delta = block.timestamp - last_update_timestamp
-    decay_factor = 0.5 ** (time_delta / HALF_LIFE)
-
-    # Decay previous rate
-    decayed_rate = current_rate * decay_factor
-
-    # Add new elements from previous block
-    elements_in_block = count_state_elements(previous_block)
-    new_rate = elements_in_block / time_delta
-
-    # Update EWMA
-    current_rate = decayed_rate + new_rate
-    last_update_timestamp = block.timestamp
-    last_update_block = block.number
-
-    return calculate_price(current_rate)
-```
-
-## Examples
-
-### Idle Network (0% usage)
-- `current_rate = 0`
-- `price = 25,000 × 10^0 = 25,000 gas`
-- TIP-20 transfer to new account: ~46,000 gas total
-- 24KB contract: ~6.2M gas
-
-### Normal Usage (25% of target)
-- `current_rate = 261.43 elements/second`
-- `price = 25,000 × 10^0.25 = 44,543 gas`
-- TIP-20 transfer to new account: ~65,543 gas total
-- 24KB contract: ~11M gas
-
-### Target Usage (100%)
-- `current_rate = 1,045.7 elements/second`
-- `price = 25,000 × 10^1 = 250,000 gas`
-- TIP-20 transfer to new account: ~271,000 gas total
-- 24KB contract: ~62M gas (same as TIP-1000)
-
-### Overuse (200% of target)
-- `current_rate = 2,091.4 elements/second`
-- `price = 25,000 × 10^2 = 2,500,000 gas`
-- TIP-20 transfer to new account: ~2,521,000 gas total
-- 24KB contract: ~619M gas (prevents spam)
+- New storage slot: `price` gas
+- Account creation: `price` gas
+- Contract metadata: `price` gas
+- Contract code: `price / 100` gas per byte
 
 ---
 
-# Invariants
+# Examples
 
-1. **Price Bounds**: State creation price MUST be at least 25,000 gas (at 0% usage) and increases exponentially with usage
-2. **Target Price**: At exactly target usage rate, price MUST equal 250,000 gas per element
-3. **Rate Tracking**: `current_rate` MUST be updated every block using exponential decay with 1-hour half-life
-4. **Element Counting**: State elements MUST be counted consistently:
-   - 1 element per new storage slot
-   - 1 element per account creation
-   - 1 element per 100 bytes of contract code
-   - 1 element for contract metadata
-5. **Monotonic Within Block**: Price MUST remain constant within a block (updated at block start)
-6. **Decay Function**: Rate MUST decay by factor of 0.5 every 3600 seconds when no new state is created
+## 24KB Contract Deployment
 
----
+| Usage | Price/Element | Total Gas |
+|-------|---------------|-----------|
+| 0% idle | 25,000 | ~6.2M |
+| 25% normal | 44,543 | ~11M |
+| 100% target | 250,000 | ~62M |
+| 200% spam | 2,500,000 | ~619M |
 
-# Key Benefits
+## TIP-20 Transfer to New Account
 
-## Economic Impact
-
-At typical usage levels (25-50% of target):
-
-| Operation | TIP-1000 Cost | TIP-ZZZZ Cost (25% usage) | Savings |
-|-----------|---------------|---------------------------|---------|
-| TIP-20 transfer (new) | 271,000 gas | 65,543 gas | 76% |
-| Account creation | 250,000 gas | 44,543 gas | 82% |
-| 1KB contract | 3.25M gas | 577k gas | 82% |
-| 24KB contract | 62M gas | 11M gas | 82% |
-
-During idle periods (0% usage), costs are 90% lower than TIP-1000.
-
-During sustained heavy usage (100%+ of target), costs match or exceed TIP-1000, providing economic protection.
+| Usage | Price | Total Gas |
+|-------|-------|-----------|
+| 0% | 25,000 | ~46k |
+| 25% | 44,543 | ~66k |
+| 100% | 250,000 | ~271k |
 
 ---
 
-# Implementation Notes
+# Key Properties
 
-## Fixed-Point Arithmetic
-
-The `current_rate` should use fixed-point arithmetic for precision:
-
-```solidity
-uint256 constant PRECISION = 1e18;
-uint256 current_rate;  // elements per second × PRECISION
-```
-
-## Exponential Calculation
-
-The price formula `25,000 × 10^ratio` can be computed using logarithms:
-
-```solidity
-price = 25_000 * exp10(ratio)
-      = 25_000 * exp(ratio * ln(10))
-      = 25_000 * exp(ratio * 2.302585)
-```
-
-Use fixed-point exponential libraries (e.g., PRBMath) for precision.
-
-## Decay Calculation
-
-The decay factor `0.5^(time_delta / HALF_LIFE)` can be precomputed for common time deltas or computed using:
-
-```solidity
-decay_factor = exp(-(time_delta / HALF_LIFE) * ln(2))
-             = exp(-time_delta * 0.000192367)  // for HALF_LIFE=3600
-```
-
-## Gas Overhead
-
-Updating the EWMA and calculating dynamic price adds minimal overhead:
-- One exponential calculation per block (decay)
-- One exponential calculation per state operation (price)
-- ~5,000-10,000 gas overhead per block
+1. **Price bounds**: Minimum 25,000 gas (at 0%), exponentially increasing
+2. **Target convergence**: At target rate, price equals 250,000 gas
+3. **Fast response**: 1-hour half-life responds within hours
+4. **Attack resistance**: Sustained spam faces 10x+ cost increase (200% → 2.5M gas)
+5. **Sustainable growth**: Caps long-term state growth at 33B elements/year
 
 ---
 
-# Security Considerations
+# Trade-offs
 
-## Price Manipulation
+**vs TIP-1000**: More efficient (82-90% cheaper at normal usage) but adds complexity (EWMA tracking, exponential math)
 
-**Risk**: Could an attacker manipulate the price by creating/not creating state?
+**vs TIP-YYYY**: Different approach (pricing vs limits); could be combined
 
-**Mitigation**:
-- Exponential pricing means sustained attacks become prohibitively expensive
-- At 200% usage, price is 10x higher (2.5M gas per element)
-- Attack to raise prices costs attacker same increased prices
-- 1-hour half-life limits impact of short-term manipulation
-
-## State Bloat
-
-**Risk**: Could someone spam state before prices rise?
-
-**Mitigation**:
-- Exponential curve rises quickly (50% usage → 3.2x higher, 100% → 10x higher)
-- Creating enough state to matter requires paying exponentially increasing costs
-- Target of 33B elements/year provides sustainable long-term growth
-
-## Calculation Precision
-
-**Risk**: Could rounding errors accumulate in EWMA?
-
-**Mitigation**:
-- Use high-precision fixed-point arithmetic (1e18)
-- Decay and price calculations use well-tested math libraries
-- Rounding always rounds up for safety (never underprices)
-
-## Block Timing Attacks
-
-**Risk**: Could manipulating block times affect pricing?
-
-**Mitigation**:
-- Block timestamps are consensus-validated
-- Large timestamp manipulation would be obvious and rejected
-- Decay based on actual time elapsed, not block numbers
-
----
-
-# Comparison with Alternatives
-
-## vs TIP-1000 (Fixed High Pricing)
-- **TIP-ZZZZ**: Dynamic pricing, low cost at low usage, high cost at high usage
-- **TIP-1000**: Fixed high cost always
-- **Trade-off**: TIP-ZZZZ is more efficient but adds complexity
-
-## vs TIP-YYYY (Exempt from Limits)
-- **TIP-ZZZZ**: Uses dynamic pricing to manage state growth
-- **TIP-YYYY**: Uses gas limit exemption to enable high pricing without block limit impact
-- **Compatible**: Could combine both approaches (dynamic pricing + exemption from limits)
-
-## vs Storage Rent
-- **TIP-ZZZZ**: One-time dynamic cost based on current usage
-- **Storage Rent**: Recurring cost over time
-- **Trade-off**: TIP-ZZZZ simpler UX, rent provides ongoing revenue
-
----
-
-# Future Extensions
-
-## Combining with TIP-YYYY
-
-This TIP could be combined with TIP-YYYY's approach:
-- Dynamic pricing for cost calculation
-- Gas limit exemption for protocol constraints
-- Best of both: responsive pricing + flexible limits
-
-## Multiple Resource Dimensions
-
-Could extend to track multiple resources independently:
-- Storage elements (this TIP)
-- Compute time (separate EWMA)
-- Bandwidth (separate EWMA)
-
-## Adjustable Target
-
-The target rate (33B/year) could be made adjustable via governance as network capacity grows.
+**Implementation cost**: ~5-10k gas per block for EWMA update + price calculation per state operation

--- a/tips/tip-zzzz.md
+++ b/tips/tip-zzzz.md
@@ -32,6 +32,7 @@ HALF_LIFE = 3_600_000 milliseconds (1 hour)
 PRECISION = 10^18 (fixed-point precision)
 BASE_PRICE = 25_000 gas
 TARGET_PRICE = 250_000 gas
+LOG2_10 = 3_321928094887362347  // log2(10) × PRECISION
 ```
 
 **Note**: Tempo timestamps have millisecond precision (`timestamp_millis()` = seconds × 1000 + `timestamp_millis_part`).
@@ -74,13 +75,13 @@ last_update_time_ms = block.timestamp_millis()
 ```
 ratio_fp = (current_rate_fp × PRECISION) / (TARGET_RATE × PRECISION)
 
-// price = 25_000 × 10^ratio = 25_000 × e^(ratio × ln(10))
-ln_10_fp = 2_302585092994045684  // ln(10) × PRECISION
-exponent_fp = (ratio_fp × ln_10_fp) / PRECISION
-price = (BASE_PRICE × exp(exponent_fp)) / PRECISION
+// price = ceil(25_000 × 10^ratio) = ceil(25_000 × 2^(ratio × log2(10)))
+exponent_fp = (ratio_fp × LOG2_10) / PRECISION
+price_fp = (BASE_PRICE × exp2(exponent_fp))
+price = (price_fp + PRECISION - 1) / PRECISION  // ceiling division
 ```
 
-All arithmetic uses fixed-point with PRECISION = 10^18.
+All arithmetic uses fixed-point with PRECISION = 10^18. Final price is rounded up to nearest integer.
 
 ## Pricing Table
 

--- a/tips/tip-zzzz.md
+++ b/tips/tip-zzzz.md
@@ -1,0 +1,354 @@
+---
+id: TIP-ZZZZ
+title: Dynamic State Creation Pricing
+description: State creation costs adjust dynamically based on recent usage via exponentially decaying average, keeping prices low when usage is below target and raising them when approaching capacity.
+authors: Dankrad Feist @dankrad
+status: Draft
+related: TIP-1000, TIP-1010
+protocolVersion: TBD
+---
+
+# TIP-ZZZZ: Dynamic State Creation Pricing
+
+## Abstract
+
+State creation operations are priced dynamically based on recent usage measured via an exponentially decaying average with a 1-hour half-life. When no state is being created, prices are at pre-TIP-1000 levels (25,000 gas). As usage approaches the target rate of 10 billion state elements per year, prices increase exponentially to TIP-1000 levels (250,000 gas). This provides economic back-pressure against state growth while keeping costs low for normal usage.
+
+## Motivation
+
+TIP-1000 set fixed high prices for state creation (250,000 gas per element) to protect against state growth attacks. However:
+
+1. **Overpricing during low usage**: When state growth is minimal, high prices unnecessarily burden users
+2. **No market signal**: Fixed pricing doesn't signal network capacity or provide economic feedback
+3. **Inefficient resource allocation**: Users pay high costs even when the network has plenty of state capacity
+
+Dynamic pricing solves this by:
+- Keeping costs low when state capacity is available
+- Automatically raising prices as usage approaches sustainability limits
+- Providing market signals about network state capacity
+- Efficiently allocating the scarce resource (persistent state)
+
+### Design Goals
+
+1. **Sustainability**: Cap long-term state growth at a sustainable rate (10B elements/year)
+2. **Responsiveness**: React to usage patterns within hours via exponential decay
+3. **Economic efficiency**: Price low when capacity available, high when scarce
+4. **Simplicity**: Single pricing formula applies to all state creation operations
+
+---
+
+# Specification
+
+## Target State Growth
+
+The protocol targets a maximum sustainable state growth rate:
+
+```
+TARGET_ELEMENTS_PER_YEAR = 10,000,000,000  (10 billion elements)
+TARGET_RATE = 10B / 31,557,600 seconds ≈ 316.88 elements/second
+```
+
+**Contract code conversion**: 1 byte of contract code = 1/100th of a state element
+- 100 bytes of contract code = 1 state element equivalent
+- At target rate: 31,688 bytes/second of contract code
+
+## Exponentially Decaying Average
+
+The protocol tracks recent state creation using an exponentially weighted moving average (EWMA):
+
+```
+HALF_LIFE = 3600 seconds (1 hour)
+DECAY_FACTOR = 0.5^(time_delta / HALF_LIFE)
+
+// Updated per block
+current_rate = previous_rate × DECAY_FACTOR + new_elements_this_block / block_time
+```
+
+Where:
+- `previous_rate`: State creation rate from previous block (elements/second)
+- `DECAY_FACTOR`: Decay applied based on time since last block
+- `new_elements_this_block`: State elements created in current block
+- `block_time`: Time elapsed since previous block
+
+**State element counting:**
+- New storage slot (SSTORE zero → non-zero): 1 element
+- Account creation: 1 element
+- Contract code: 1 element per 100 bytes
+- Contract metadata (keccak + nonce): 1 element
+
+## Dynamic Pricing Formula
+
+State creation gas costs are calculated based on the current rate:
+
+```
+ratio = current_rate / TARGET_RATE
+
+base_price = 25,000     (pre-TIP-1000 price)
+target_price = 250,000  (TIP-1000 price)
+
+price = base_price × 10^ratio
+      = 25,000 × 10^(current_rate / TARGET_RATE)
+```
+
+**Pricing examples:**
+
+| Usage vs Target | Ratio | Price per Element | vs TIP-1000 |
+|----------------|-------|-------------------|-------------|
+| 0% (idle) | 0.0 | 25,000 | 10% |
+| 10% | 0.1 | 31,498 | 13% |
+| 25% | 0.25 | 44,543 | 18% |
+| 50% | 0.5 | 79,057 | 32% |
+| 75% | 0.75 | 140,538 | 56% |
+| 100% (target) | 1.0 | 250,000 | 100% |
+| 150% | 1.5 | 790,569 | 316% |
+| 200% | 2.0 | 2,500,000 | 1000% |
+
+## Gas Cost Calculation
+
+All state creation operations use the dynamic price:
+
+```
+// Per-element costs
+new_storage_slot_gas = price
+account_creation_gas = price
+contract_metadata_gas = price
+
+// Contract code (per 100 bytes = 1 element)
+contract_code_gas_per_100_bytes = price
+contract_code_gas_per_byte = price / 100
+```
+
+**Example for 24KB contract at different usage levels:**
+
+| Usage | Price/Element | Contract Code (24KB) | Account | Metadata | Total |
+|-------|---------------|---------------------|---------|----------|-------|
+| 0% (idle) | 25,000 | 6,144,000 | 25,000 | 25,000 | 6,194,000 |
+| 50% | 79,057 | 19,438,605 | 79,057 | 79,057 | 19,596,719 |
+| 100% (target) | 250,000 | 61,440,000 | 250,000 | 250,000 | 61,940,000 |
+| 150% | 790,569 | 194,380,134 | 790,569 | 790,569 | 195,961,272 |
+
+**Note**: At target usage (100%), costs match TIP-1000. Below target, costs are lower. Above target, costs increase exponentially to discourage overuse.
+
+## Protocol State
+
+The protocol maintains the following state variables:
+
+```solidity
+// Stored in consensus state
+uint256 current_rate;          // elements per second (fixed-point)
+uint256 last_update_timestamp; // timestamp of last update
+uint256 last_update_block;     // block number of last update
+```
+
+These values are updated at the beginning of each block:
+
+```python
+def update_state_creation_rate(block):
+    time_delta = block.timestamp - last_update_timestamp
+    decay_factor = 0.5 ** (time_delta / HALF_LIFE)
+
+    # Decay previous rate
+    decayed_rate = current_rate * decay_factor
+
+    # Add new elements from previous block
+    elements_in_block = count_state_elements(previous_block)
+    new_rate = elements_in_block / time_delta
+
+    # Update EWMA
+    current_rate = decayed_rate + new_rate
+    last_update_timestamp = block.timestamp
+    last_update_block = block.number
+
+    return calculate_price(current_rate)
+```
+
+## Examples
+
+### Idle Network (0% usage)
+- `current_rate = 0`
+- `price = 25,000 × 10^0 = 25,000 gas`
+- TIP-20 transfer to new account: ~46,000 gas total
+- 24KB contract: ~6.2M gas
+
+### Normal Usage (25% of target)
+- `current_rate = 79.22 elements/second`
+- `price = 25,000 × 10^0.25 = 44,543 gas`
+- TIP-20 transfer to new account: ~65,543 gas total
+- 24KB contract: ~11M gas
+
+### Target Usage (100%)
+- `current_rate = 316.88 elements/second`
+- `price = 25,000 × 10^1 = 250,000 gas`
+- TIP-20 transfer to new account: ~271,000 gas total
+- 24KB contract: ~62M gas (same as TIP-1000)
+
+### Overuse (200% of target)
+- `current_rate = 633.76 elements/second`
+- `price = 25,000 × 10^2 = 2,500,000 gas`
+- TIP-20 transfer to new account: ~2,521,000 gas total
+- 24KB contract: ~619M gas (prevents spam)
+
+---
+
+# Invariants
+
+1. **Price Bounds**: State creation price MUST be at least 25,000 gas (at 0% usage) and increases exponentially with usage
+2. **Target Price**: At exactly target usage rate, price MUST equal 250,000 gas per element
+3. **Rate Tracking**: `current_rate` MUST be updated every block using exponential decay with 1-hour half-life
+4. **Element Counting**: State elements MUST be counted consistently:
+   - 1 element per new storage slot
+   - 1 element per account creation
+   - 1 element per 100 bytes of contract code
+   - 1 element for contract metadata
+5. **Monotonic Within Block**: Price MUST remain constant within a block (updated at block start)
+6. **Decay Function**: Rate MUST decay by factor of 0.5 every 3600 seconds when no new state is created
+
+---
+
+# Key Benefits
+
+1. **Low costs during low usage**: Prices drop to 25,000 gas when network is idle (10x cheaper than TIP-1000)
+2. **Automatic back-pressure**: Prices rise exponentially as usage approaches target, discouraging overuse
+3. **Market efficiency**: Scarce resource (persistent state) priced according to demand
+4. **Fast response**: 1-hour half-life means prices adjust within hours of usage changes
+5. **Attack resistance**: Sustained spam attacks face exponentially increasing costs (200% usage = 10x price)
+6. **Sustainable long-term**: Targets 10B elements/year, manageable state growth
+7. **No breaking changes**: Same transaction format, just dynamic pricing
+
+## Economic Impact
+
+At typical usage levels (25-50% of target):
+
+| Operation | TIP-1000 Cost | TIP-ZZZZ Cost (25% usage) | Savings |
+|-----------|---------------|---------------------------|---------|
+| TIP-20 transfer (new) | 271,000 gas | 65,543 gas | 76% |
+| Account creation | 250,000 gas | 44,543 gas | 82% |
+| 1KB contract | 3.25M gas | 577k gas | 82% |
+| 24KB contract | 62M gas | 11M gas | 82% |
+
+During idle periods (0% usage), costs are 90% lower than TIP-1000.
+
+During sustained heavy usage (100%+ of target), costs match or exceed TIP-1000, providing economic protection.
+
+---
+
+# Implementation Notes
+
+## Fixed-Point Arithmetic
+
+The `current_rate` should use fixed-point arithmetic for precision:
+
+```solidity
+uint256 constant PRECISION = 1e18;
+uint256 current_rate;  // elements per second × PRECISION
+```
+
+## Exponential Calculation
+
+The price formula `25,000 × 10^ratio` can be computed using logarithms:
+
+```solidity
+price = 25_000 * exp10(ratio)
+      = 25_000 * exp(ratio * ln(10))
+      = 25_000 * exp(ratio * 2.302585)
+```
+
+Use fixed-point exponential libraries (e.g., PRBMath) for precision.
+
+## Decay Calculation
+
+The decay factor `0.5^(time_delta / HALF_LIFE)` can be precomputed for common time deltas or computed using:
+
+```solidity
+decay_factor = exp(-(time_delta / HALF_LIFE) * ln(2))
+             = exp(-time_delta * 0.000192367)  // for HALF_LIFE=3600
+```
+
+## Gas Overhead
+
+Updating the EWMA and calculating dynamic price adds minimal overhead:
+- One exponential calculation per block (decay)
+- One exponential calculation per state operation (price)
+- ~5,000-10,000 gas overhead per block
+
+---
+
+# Security Considerations
+
+## Price Manipulation
+
+**Risk**: Could an attacker manipulate the price by creating/not creating state?
+
+**Mitigation**:
+- Exponential pricing means sustained attacks become prohibitively expensive
+- At 200% usage, price is 10x higher (2.5M gas per element)
+- Attack to raise prices costs attacker same increased prices
+- 1-hour half-life limits impact of short-term manipulation
+
+## State Bloat
+
+**Risk**: Could someone spam state before prices rise?
+
+**Mitigation**:
+- Exponential curve rises quickly (50% usage → 3.2x higher, 100% → 10x higher)
+- Creating enough state to matter requires paying exponentially increasing costs
+- Target of 10B elements/year provides sustainable long-term growth
+
+## Calculation Precision
+
+**Risk**: Could rounding errors accumulate in EWMA?
+
+**Mitigation**:
+- Use high-precision fixed-point arithmetic (1e18)
+- Decay and price calculations use well-tested math libraries
+- Rounding always rounds up for safety (never underprices)
+
+## Block Timing Attacks
+
+**Risk**: Could manipulating block times affect pricing?
+
+**Mitigation**:
+- Block timestamps are consensus-validated
+- Large timestamp manipulation would be obvious and rejected
+- Decay based on actual time elapsed, not block numbers
+
+---
+
+# Comparison with Alternatives
+
+## vs TIP-1000 (Fixed High Pricing)
+- **TIP-ZZZZ**: Dynamic pricing, low cost at low usage, high cost at high usage
+- **TIP-1000**: Fixed high cost always
+- **Trade-off**: TIP-ZZZZ is more efficient but adds complexity
+
+## vs TIP-YYYY (Exempt from Limits)
+- **TIP-ZZZZ**: Uses dynamic pricing to manage state growth
+- **TIP-YYYY**: Uses gas limit exemption to enable high pricing without block limit impact
+- **Compatible**: Could combine both approaches (dynamic pricing + exemption from limits)
+
+## vs Storage Rent
+- **TIP-ZZZZ**: One-time dynamic cost based on current usage
+- **Storage Rent**: Recurring cost over time
+- **Trade-off**: TIP-ZZZZ simpler UX, rent provides ongoing revenue
+
+---
+
+# Future Extensions
+
+## Combining with TIP-YYYY
+
+This TIP could be combined with TIP-YYYY's approach:
+- Dynamic pricing for cost calculation
+- Gas limit exemption for protocol constraints
+- Best of both: responsive pricing + flexible limits
+
+## Multiple Resource Dimensions
+
+Could extend to track multiple resources independently:
+- Storage elements (this TIP)
+- Compute time (separate EWMA)
+- Bandwidth (separate EWMA)
+
+## Adjustable Target
+
+The target rate (10B/year) could be made adjustable via governance as network capacity grows.


### PR DESCRIPTION
## Summary

State creation pricing mechanism that targets a limited state growth rate, and only escalates TIP-1000 state creation pricing when unsustainable state growth levels are reached

 - keeps low prices in average case
 - short bursts of a few seconds remain cheap (due to 1h decaying exponential average)
 - does not solve problem of deploying max size contract if high state creation rate leads to escalated costs

## Key Design

**Target**: 33 billion state elements per year (ca 1000/second)
- 1 storage slot = 1 element
- 1 account = 1 element
- 100 bytes contract code = 1 element

**Tracking**: Exponentially decaying average with 1-hour half-life

**Pricing**: `price = 25,000 × 10^(current_rate / target_rate)`

| Usage | Price/Element | vs TIP-1000 |
|-------|---------------|-------------|
| 0% (idle) | 25,000 | 10% |
| 25% | 44,543 | 18% |
| 50% | 79,057 | 32% |
| 100% | 250,000 | 100% |
| 200% | 2,500,000 | 1000% |

## Examples

**24KB Contract Deployment:**
- Idle (0%): 6.2M gas (90% cheaper)
- Normal (25%): 11M gas (82% cheaper)
- Target (100%): 62M gas (same as TIP-1000)
- Spam (200%): 619M gas (10x more expensive)

**TIP-20 Transfer to New Account:**
- Idle: 46k gas vs 271k (83% cheaper)
- Normal (25%): 65.5k gas (76% cheaper)
- Target: 271k gas (same as TIP-1000)
- Spam: 2.5M gas (attack deterrent)