### PR TITLE
test(revm): verify T1 charges 250k gas for new 2D nonce keys

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -3093,12 +3093,16 @@ mod tests {
         // Case 1: nonce == 0 with 2D nonce key -> should include new_account_cost
         let mut evm_nonce_zero = make_evm(cfg.clone(), 0, TEST_NONCE_KEY);
         let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-        let gas_nonce_zero = handler.validate_initial_tx_gas(&mut evm_nonce_zero).unwrap();
+        let gas_nonce_zero = handler
+            .validate_initial_tx_gas(&mut evm_nonce_zero)
+            .unwrap();
 
         // Case 2: nonce > 0 with same 2D nonce key -> should NOT include new_account_cost
         // This tests that only nonce == 0 triggers the +250k charge, regardless of nonce_key state
         let mut evm_nonce_five = make_evm(cfg.clone(), 5, TEST_NONCE_KEY);
-        let gas_nonce_five = handler.validate_initial_tx_gas(&mut evm_nonce_five).unwrap();
+        let gas_nonce_five = handler
+            .validate_initial_tx_gas(&mut evm_nonce_five)
+            .unwrap();
 
         // Delta-based assertion: the difference should be exactly new_account_cost
         let gas_delta = gas_nonce_zero.initial_gas - gas_nonce_five.initial_gas;
@@ -3115,7 +3119,9 @@ mod tests {
 
         // Case 3: nonce == 0 with regular nonce (nonce_key=0) -> same +250k charge
         let mut evm_regular_nonce = make_evm(cfg, 0, U256::ZERO);
-        let gas_regular = handler.validate_initial_tx_gas(&mut evm_regular_nonce).unwrap();
+        let gas_regular = handler
+            .validate_initial_tx_gas(&mut evm_regular_nonce)
+            .unwrap();
 
         assert_eq!(
             gas_nonce_zero.initial_gas, gas_regular.initial_gas,


### PR DESCRIPTION
## Summary

Adds a test to prove the [audit finding](https://github.com/sherlock-audit/2026-01-tempo-jan-25th/pull/138) is a **false positive**.

## Test Cases

The test validates TIP-1000's requirement:
> "Tempo transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas"

| Case | nonce_key | nonce | Expected Gas | Description |
|------|-----------|-------|--------------|-------------|
| 1 | 42 | 0 | 271,000 (21k + 250k) | NEW 2D nonce key creation - charges 250k |
| 2 | 42 | 5 | 21,000 | EXISTING 2D nonce key - no extra charge |
| 3 | 0 | 0 | 271,000 (21k + 250k) | Regular nonce, new account - charges 250k |

## What This Proves

1. **T1 correctly charges 250k gas** for new 2D nonce keys (nonce_key != 0, nonce == 0)
2. **NOT the pre-T1 22,100 gas** (`NEW_NONCE_KEY_GAS` = COLD_SLOAD_COST + SSTORE_SET)
3. The existing pre-T1 tests use `CfgEnv::<TempoHardfork>::default()` which defaults to T0, not T1

## References

- Audit finding: https://github.com/sherlock-audit/2026-01-tempo-jan-25th/pull/138
- Related PR (to be closed): https://github.com/tempoxyz/tempo/pull/2300
- TIP-1000 spec: tips/tip-1000.md