### PR TITLE
ci: trigger precompiles coverage when forge tests change

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -37,7 +37,7 @@ jobs:
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "coverage=false" >> "$GITHUB_OUTPUT"
             echo "Skipping coverage: not a pull_request event (event: ${{ github.event_name }})"
-          elif git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^crates/(precompiles|contracts)/'; then
+          elif git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^(crates/(precompiles|contracts)/|tips/ref-impls/)'; then
             echo "coverage=true" >> "$GITHUB_OUTPUT"
             echo "Running coverage: precompiles/contracts changed"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "coverage=false" >> "$GITHUB_OUTPUT"
             echo "Skipping coverage: not a pull_request event (event: ${{ github.event_name }})"
-          elif git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^crates/(precompiles|contracts)/'; then
+          elif git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^(crates/(precompiles|contracts)/|tips/ref-impls/)'; then
             echo "coverage=true" >> "$GITHUB_OUTPUT"
             echo "Running coverage: precompiles/contracts changed"
           else


### PR DESCRIPTION
## Summary

Fix precompiles coverage not triggering when tips/ref-impls/ forge tests are modified.

## Motivation

PR #2265 modified forge tests in tips/ref-impls/test/ but didn't trigger coverage because the coverage check only looked for changes in crates/(precompiles|contracts)/.

The workflow trigger paths already include tips/ref-impls/**, but the coverage decision logic didn't match.

## Changes

Update grep pattern in specs.yml and test.yml to include tips/ref-impls/ when deciding whether to run coverage
