### PR TITLE
tip: add TIP-1015 Compound Transfer Policies

### DIFF
--- a/tips/tip-1015.md
+++ b/tips/tip-1015.md
@@ -182,50 +182,25 @@ interface ITIP403Registry {
     /// @notice The referenced policy is not a simple policy
     error PolicyNotSimple();
 
-    /// @notice The referenced policy does not exist (reuses TIP-403 error)
+    /// @notice The referenced policy does not exist
     error PolicyNotFound();
 }
 ```
 
 ## Authorization Logic
 
-### Internal Helper
-
-The existing `isAuthorized` logic for simple policies is preserved as an internal helper:
-
-```solidity
-function _isAuthorizedSimple(uint64 policyId, address user) internal view returns (bool) {
-    // Handle built-in policies
-    if (policyId < 2) {
-        return policyId == 1; // 0 = always-reject, 1 = always-allow
-    }
-    
-    PolicyData memory data = policyData[policyId];
-    
-    if (data.policyType == PolicyType.WHITELIST) {
-        return policySet[policyId][user];
-    } else {
-        return !policySet[policyId][user];
-    }
-}
-```
-
 ### isAuthorizedSender
 
 ```solidity
 function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
-    // Handle built-in policies
-    if (policyId < 2) {
-        return policyId == 1;
-    }
-    
     PolicyRecord storage record = policyRecords[policyId];
-    
+
     if (record.base.policyType == PolicyType.COMPOUND) {
-        return _isAuthorizedSimple(record.compound.senderPolicyId, user);
+        return isAuthorized(record.compound.senderPolicyId, user);
     }
-    
-    return _isAuthorizedSimple(policyId, user);
+
+    // For simple policies, sender authorization equals general authorization
+    return isAuthorized(policyId, user);
 }
 ```
 
@@ -233,18 +208,14 @@ function isAuthorizedSender(uint64 policyId, address user) external view returns
 
 ```solidity
 function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
-    // Handle built-in policies
-    if (policyId < 2) {
-        return policyId == 1;
-    }
-    
     PolicyRecord storage record = policyRecords[policyId];
-    
+
     if (record.base.policyType == PolicyType.COMPOUND) {
-        return _isAuthorizedSimple(record.compound.recipientPolicyId, user);
+        return isAuthorized(record.compound.recipientPolicyId, user);
     }
-    
-    return _isAuthorizedSimple(policyId, user);
+
+    // For simple policies, recipient authorization equals general authorization
+    return isAuthorized(policyId, user);
 }
 ```
 
@@ -252,18 +223,14 @@ function isAuthorizedRecipient(uint64 policyId, address user) external view retu
 
 ```solidity
 function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
-    // Handle built-in policies
-    if (policyId < 2) {
-        return policyId == 1;
-    }
-    
     PolicyRecord storage record = policyRecords[policyId];
-    
+
     if (record.base.policyType == PolicyType.COMPOUND) {
-        return _isAuthorizedSimple(record.compound.mintRecipientPolicyId, user);
+        return isAuthorized(record.compound.mintRecipientPolicyId, user);
     }
-    
-    return _isAuthorizedSimple(policyId, user);
+
+    // For simple policies, mint recipient authorization equals general authorization
+    return isAuthorized(policyId, user);
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds TIP-1015, which extends TIP-403 with compound policies that specify different authorization rules for senders, recipients, and mint recipients.

## Motivation

Real-world requirements often differ between sending, receiving, and minting tokens. For example:

- **Vendor credits**: Credits that can be minted to anyone and spent to a specific vendor, but cannot be transferred peer-to-peer
- **Sender restrictions**: Block sanctioned addresses from sending, while allowing anyone to receive (for refunds or seizure)
- **Recipient restrictions**: Require KYC for recipients, while allowing any holder to send

## Changes

A compound policy references three simple policies:
- **senderPolicyId**: checked for transfer senders
- **recipientPolicyId**: checked for transfer recipients
- **mintRecipientPolicyId**: checked for mint recipients

### TIP-403 Registry

- New `PolicyType.COMPOUND` enum value
- `createCompoundPolicy(senderPolicyId, recipientPolicyId, mintRecipientPolicyId)`
- `isAuthorizedSender(policyId, user)`
- `isAuthorizedRecipient(policyId, user)`
- `isAuthorizedMintRecipient(policyId, user)`
- `isAuthorized()` returns `isAuthorizedSender() && isAuthorizedRecipient()`
- Compound policies are **immutable** once created

### Required Code Changes

6 direct replacements of `isAuthorized` calls:

| Location | Current | Replace With |
|----------|---------|--------------|
| TIP-20 `_mint` | `isAuthorized(to)` | `isAuthorizedMintRecipient(to)` |
| TIP-20 `burnBlocked` | `isAuthorized(from)` | `isAuthorizedSender(from)` |
| TIP-20 `isTransferAuthorized` | `isAuthorized(from)` | `isAuthorizedSender(from)` |
| TIP-20 `isTransferAuthorized` | `isAuthorized(to)` | `isAuthorizedRecipient(to)` |
| DEX `cancelStaleOrder` | `isAuthorized(maker)` | `isAuthorizedSender(maker)` |
| Fee payer `can_fee_payer_transfer` | `isAuthorized(fee_payer)` | `isAuthorizedSender(fee_payer)` |

All other call sites use `ensureTransferAuthorized(from, to)` which delegates to `isTransferAuthorized`, so they automatically inherit the correct behavior.