### PR TITLE
fix(precompiles): deduct gas before state mutation in T1 sstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12089,6 +12089,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles-macros",
+ "tempo-revm",
  "thiserror 2.0.17",
  "tracing",
 ]

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -35,6 +35,7 @@ proptest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempo-evm.workspace = true
+tempo-revm.workspace = true
 
 [features]
 default = ["rpc"]


### PR DESCRIPTION
Closes CHAIN-540

In precompile sstore operations, gas was deducted after mutating state. If an OOG error occurred mid-operation, partial state changes were already committed, leaving the chain in an inconsistent state.

* For T1+: Deduct all gas costs upfront before performing any state mutation. OOG errors now leave state unchanged.
* Pre-T1: Preserve legacy behavior (mutate-then-deduct) for backward compatibility with existing blocks.
* Added unit tests verifying hardfork-specific behavior for both T0 (legacy) and T1+ (fixed).
