### PR TITLE
chore: bump reth to 70bfdaf (historical state fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1582933a9fc27c0953220eb4f18f6492ff577822e9a8d848890ff59f6b4f5beb"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -506,7 +506,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.1.0",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -1837,7 +1837,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "dynify",
  "fast-float2",
  "float16",
@@ -2021,6 +2021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2088,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
@@ -2092,12 +2107,25 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -3188,6 +3216,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -3424,7 +3465,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3722,7 +3763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -3895,16 +3945,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "fixed-cache"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aaafa7294e9617eb29e5c684a3af33324ef512a1bf596af2d1938a03798da29"
-dependencies = [
- "equivalent",
- "typeid",
 ]
 
 [[package]]
@@ -4271,7 +4311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 6.1.0",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -4661,7 +4701,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4679,7 +4719,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5799,6 +5839,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,7 +6053,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7088,6 +7143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pyroscope"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7159,7 +7225,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7196,9 +7262,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7538,8 +7604,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7562,8 +7628,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7575,7 +7641,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7594,8 +7659,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7614,8 +7679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7628,8 +7693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7688,7 +7753,6 @@ dependencies = [
  "reth-stages",
  "reth-static-file",
  "reth-static-file-types",
- "reth-storage-api",
  "reth-tasks",
  "reth-trie",
  "reth-trie-common",
@@ -7707,8 +7771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7717,8 +7781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7735,8 +7799,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7755,8 +7819,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7765,8 +7829,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7781,8 +7845,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7794,8 +7858,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7806,8 +7870,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7832,8 +7896,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7858,24 +7922,23 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
- "arrayvec",
  "bytes",
  "derive_more",
  "metrics",
  "modular-bitfield",
- "op-alloy-consensus",
  "parity-scale-codec",
  "proptest",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
+ "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
@@ -7887,8 +7950,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7917,8 +7980,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7932,8 +7995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7957,8 +8020,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7981,8 +8044,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8005,8 +8068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8040,8 +8103,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8098,8 +8161,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8126,8 +8189,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8149,8 +8212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8174,8 +8237,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "futures",
  "pin-project",
@@ -8192,13 +8255,12 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8208,11 +8270,11 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
- "fixed-cache",
  "futures",
  "metrics",
+ "mini-moka",
  "moka",
  "parking_lot",
  "rayon",
@@ -8240,8 +8302,6 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
@@ -8256,8 +8316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8284,8 +8344,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8299,8 +8359,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8315,8 +8375,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8337,8 +8397,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8348,8 +8408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8376,8 +8436,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8397,8 +8457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8438,8 +8498,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "clap",
  "eyre",
@@ -8460,8 +8520,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8476,8 +8536,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8494,8 +8554,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8507,8 +8567,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8536,8 +8596,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8556,8 +8616,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8566,8 +8626,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8590,8 +8650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8612,8 +8672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8625,8 +8685,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8643,8 +8703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8681,8 +8741,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8695,8 +8755,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -8705,8 +8765,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8733,8 +8793,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "bytes",
  "futures",
@@ -8753,12 +8813,12 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
  "parking_lot",
  "reth-mdbx-sys",
@@ -8769,8 +8829,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8778,8 +8838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "futures",
  "metrics",
@@ -8790,8 +8850,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8799,8 +8859,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8813,8 +8873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8843,7 +8903,6 @@ dependencies = [
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
- "reth-evm-ethereum",
  "reth-fs-util",
  "reth-metrics",
  "reth-net-banlist",
@@ -8870,8 +8929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8895,8 +8954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8918,8 +8977,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8933,8 +8992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8947,8 +9006,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8964,8 +9023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8988,8 +9047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9047,7 +9106,6 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9057,8 +9115,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9088,6 +9146,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
+ "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -9112,8 +9171,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9150,8 +9209,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9174,8 +9233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9198,8 +9257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "bytes",
  "eyre",
@@ -9227,8 +9286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9238,9 +9297,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-primitives"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "op-alloy-consensus",
+ "reth-primitives-traits",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "reth-payload-builder"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9260,8 +9334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9272,8 +9346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9295,8 +9369,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9305,8 +9379,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9318,8 +9392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9351,14 +9425,14 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "dashmap",
+ "dashmap 6.1.0",
  "eyre",
  "itertools 0.14.0",
  "metrics",
@@ -9394,8 +9468,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9413,7 +9487,6 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
- "reth-storage-api",
  "reth-tokio-util",
  "rustc-hash",
  "thiserror 2.0.17",
@@ -9423,8 +9496,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9434,13 +9507,12 @@ dependencies = [
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.17",
- "tracing",
 ]
 
 [[package]]
 name = "reth-revm"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9452,8 +9524,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9534,8 +9606,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9559,13 +9631,14 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9605,8 +9678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9626,8 +9699,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9656,8 +9729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9700,8 +9773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9748,8 +9821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9762,8 +9835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9778,8 +9851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9827,8 +9900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9854,8 +9927,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9868,8 +9941,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9888,8 +9961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9901,8 +9974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,8 +9998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9942,8 +10015,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9960,8 +10033,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9976,8 +10049,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9986,8 +10059,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "clap",
  "eyre",
@@ -10003,8 +10076,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "clap",
  "eyre",
@@ -10020,8 +10093,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10040,15 +10113,12 @@ dependencies = [
  "reth-chainspec",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
- "reth-evm",
- "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "revm",
  "revm-interpreter",
  "revm-primitives",
  "rustc-hash",
@@ -10064,8 +10134,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10090,8 +10160,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10117,40 +10187,34 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
- "metrics",
- "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
- "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
- "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
  "reth-trie",
@@ -10163,8 +10227,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10182,8 +10246,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10200,8 +10264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=70bfdaf#70bfdafd26905a19beb22bc1db7012494919fa22"
+version = "1.10.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
 dependencies = [
  "zstd",
 ]
@@ -10650,7 +10714,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11240,6 +11304,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11553,7 +11632,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12858,6 +12937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12881,12 +12966,6 @@ dependencies = [
  "thiserror 2.0.17",
  "utf-8",
 ]
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -13088,7 +13167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -13358,7 +13437,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,51 +119,51 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 # reth v1.10.1
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "70bfdaf", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", features = [
   "std",
   "optional-checks",
 ] }
@@ -173,7 +173,7 @@ alloy = { version = "1.4.3", default-features = false }
 alloy-consensus = { version = "1.4.3", default-features = false }
 alloy-contract = { version = "1.4.3", default-features = false }
 alloy-eips = { version = "1.4.3", default-features = false }
-alloy-evm = "0.27.0"
+alloy-evm = "0.26.3"
 revm-inspectors = "0.34.0"
 alloy-genesis = "1.4.3"
 alloy-hardforks = "0.4.5"


### PR DESCRIPTION
Updates reth to main commit with fix for checking executed block before returning historical state.

Simplifying: querying for historical state at block N + M was giving out plainstate for block N if execution stage/reth was still at block N.

https://github.com/paradigmxyz/reth/commit/70bfdafd26905a19beb22bc1db7012494919fa22

Thread: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1769696163215859