### PR TITLE
refactor(precompiles): add gas_limit parameter to enter_evm()

### DIFF
--- a/crates/commonware-node/src/dkg/manager/validators.rs
+++ b/crates/commonware-node/src/dkg/manager/validators.rs
@@ -75,6 +75,7 @@ fn read_validator_config_at_height<T>(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || read_fn(&ValidatorConfig::new()),
     )
 }

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -133,29 +133,36 @@ impl Builder {
 
         {
             let cx = evm.ctx_mut();
-            StorageCtx::enter_evm(&mut cx.journaled_state, &cx.block, &cx.cfg, &cx.tx, || {
-                // TODO(janis): figure out the owner of the test-genesis.json
-                let mut validator_config = ValidatorConfig::new();
-                validator_config
-                    .initialize(admin())
-                    .wrap_err("Failed to initialize validator config")
-                    .unwrap();
-
-                for (peer, (net_addr, chain_addr)) in validators.iter_pairs() {
+            StorageCtx::enter_evm(
+                &mut cx.journaled_state,
+                &cx.block,
+                &cx.cfg,
+                &cx.tx,
+                None,
+                || {
+                    // TODO(janis): figure out the owner of the test-genesis.json
+                    let mut validator_config = ValidatorConfig::new();
                     validator_config
-                        .add_validator(
-                            admin(),
-                            IValidatorConfig::addValidatorCall {
-                                newValidatorAddress: *chain_addr,
-                                publicKey: peer.encode().as_ref().try_into().unwrap(),
-                                active: true,
-                                inboundAddress: net_addr.to_string(),
-                                outboundAddress: net_addr.to_string(),
-                            },
-                        )
+                        .initialize(admin())
+                        .wrap_err("Failed to initialize validator config")
                         .unwrap();
-                }
-            })
+
+                    for (peer, (net_addr, chain_addr)) in validators.iter_pairs() {
+                        validator_config
+                            .add_validator(
+                                admin(),
+                                IValidatorConfig::addValidatorCall {
+                                    newValidatorAddress: *chain_addr,
+                                    publicKey: peer.encode().as_ref().try_into().unwrap(),
+                                    active: true,
+                                    inboundAddress: net_addr.to_string(),
+                                    outboundAddress: net_addr.to_string(),
+                                },
+                            )
+                            .unwrap();
+                    }
+                },
+            )
         }
 
         let evm_state = evm.ctx_mut().journaled_state.evm_state();

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -616,7 +616,7 @@ where
 
         // Set tx.origin in the keychain's transient storage for spending limit checks.
         // This must be done for ALL transactions so precompiles can access it.
-        StorageCtx::enter_evm(journal, block, cfg, tx, || {
+        StorageCtx::enter_evm(journal, block, cfg, tx, None, || {
             let mut keychain = AccountKeychain::new();
             keychain.set_tx_origin(tx.caller())
         })
@@ -677,7 +677,7 @@ where
                 .valid_before
                 .ok_or(TempoInvalidTransaction::ExpiringNonceMissingValidBefore)?;
 
-            StorageCtx::enter_evm(journal, block, cfg, tx, || {
+            StorageCtx::enter_evm(journal, block, cfg, tx, None, || {
                 let mut nonce_manager = NonceManager::new();
 
                 nonce_manager
@@ -691,7 +691,7 @@ where
             })?;
         } else if !nonce_key.is_zero() {
             // 2D nonce transaction
-            StorageCtx::enter_evm(journal, block, cfg, tx, || {
+            StorageCtx::enter_evm(journal, block, cfg, tx, None, || {
                 let mut nonce_manager = NonceManager::new();
 
                 if !cfg.is_nonce_check_disabled() {
@@ -986,7 +986,7 @@ where
 
         let checkpoint = journal.checkpoint();
 
-        let result = StorageCtx::enter_evm(journal, &block, cfg, tx, || {
+        let result = StorageCtx::enter_evm(journal, &block, cfg, tx, None, || {
             TipFeeManager::new().collect_fee_pre_tx(
                 self.fee_payer,
                 self.fee_token,
@@ -1065,7 +1065,7 @@ where
         let (journal, block, tx) = (&mut context.journaled_state, &context.block, &context.tx);
         let beneficiary = context.block.beneficiary();
 
-        StorageCtx::enter_evm(&mut *journal, block, &context.cfg, tx, || {
+        StorageCtx::enter_evm(&mut *journal, block, &context.cfg, tx, None, || {
             let mut fee_manager = TipFeeManager::new();
 
             if !actual_spending.is_zero() || !refund_amount.is_zero() {

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -581,6 +581,7 @@ fn initialize_tip20_factory(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Resul
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || TIP20Factory::new().initialize(),
     )?;
     Ok(())
@@ -600,6 +601,7 @@ fn create_path_usd_token(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || {
             TIP20Factory::new().create_token_reserved_address(
                 PATH_USD_ADDRESS,
@@ -657,6 +659,7 @@ fn create_and_mint_token(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || {
             let mut factory = TIP20Factory::new();
             assert!(
@@ -745,6 +748,7 @@ fn initialize_fee_manager(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || {
             let mut fee_manager = TipFeeManager::new();
             fee_manager
@@ -788,6 +792,7 @@ fn initialize_registry(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Result<()>
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || TIP403Registry::new().initialize(),
     )?;
 
@@ -801,6 +806,7 @@ fn initialize_stablecoin_dex(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Resu
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || StablecoinDEX::new().initialize(),
     )?;
 
@@ -814,6 +820,7 @@ fn initialize_nonce_manager(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Resul
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || NonceManager::new().initialize(),
     )?;
 
@@ -828,6 +835,7 @@ fn initialize_account_keychain(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Re
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || AccountKeychain::new().initialize(),
     )?;
 
@@ -851,6 +859,7 @@ fn initialize_validator_config(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || {
             let mut validator_config = ValidatorConfig::new();
             validator_config
@@ -975,6 +984,7 @@ fn mint_pairwise_liquidity(
         &ctx.block,
         &ctx.cfg,
         &ctx.tx,
+        None,
         || {
             let mut fee_manager = TipFeeManager::new();
 


### PR DESCRIPTION
## Summary

Adds an optional `gas_limit` parameter to `StorageCtx::enter_evm()` to prepare for TIP-1000 gas metering.

## Changes

- `enter_evm()` now accepts `gas_limit: Option<u64>`
- When `Some(limit)` is passed, uses `new_with_gas_limit` for proper gas accounting
- When `None` is passed, uses `new_max_gas` (unlimited gas) for backward compatibility
- All existing call sites updated to pass `None`

## Motivation

Follow-up from PR #2325 ([discussion](https://github.com/tempoxyz/tempo/pull/2325#discussion_r2742480953)).

This refactoring moves the gas limit logic into `enter_evm()` to avoid dangling usages of `EvmPrecompileStorageProvider::new_max_gas` in T1 and enables future callers to use proper gas metering.

Closes https://linear.app/tempoxyz/issue/CHAIN-547