### PR TITLE
perf(tempo-transaction-pool): optimize pool maintainence hot path

### DIFF
--- a/crates/node/tests/it/pool.rs
+++ b/crates/node/tests/it/pool.rs
@@ -306,7 +306,8 @@ async fn test_evict_tx_on_validator_token_change() -> eyre::Result<()> {
         validator_token_changes: vec![(user_addr, attacker_token)],
         ..Default::default()
     };
-    pool.evict_invalidated_transactions(&updates);
+    let amm_cache = pool.amm_liquidity_cache();
+    pool.evict_invalidated_transactions(&updates, &amm_cache);
 
     // Give time for any eviction to complete
     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;


### PR DESCRIPTION
## Summary

Optimizes transaction pool eviction by precomputing derived values and deduplicating storage reads before scanning pooled transactions. Reduces time complexity from O(n·m) to O(n+m) for validator token changes and TIP-403 policy updates.

## Motivation

The `evict_invalidated_transactions` hot path was performing redundant storage reads for every transaction in the pool:
- **Validator token changes**: Each pooled transaction triggered m storage reads to fetch AMM reserves (where m = number of validator changes)
- **TIP-403 policy checks**: Each pooled transaction with a fee token triggered a storage read for policy ID lookup

For a pool with 10k transactions and 50 validator changes, this causes 500k redundant storage operations per eviction cycle.

## Changes

### `AmmLiquidityCache` (amm.rs)
- Add `validator_reserve_for_pair()` method with cache-or-fetch pattern
- Implement double-check locking to prevent race conditions between read/write lock acquisition
- Return `U256::ZERO` for non-existent pools instead of error

### `TempoTransactionPool::evict_invalidated_transactions` (tempo_pool.rs)
- Add `amm_cache: &AmmLiquidityCache` parameter
- **Pre-computation phase**: Single scan to collect unique fee tokens used in pool
- **AMM reserve pre-computation**: Fetch minimum validator reserve per user token upfront
- **TIP-403 policy pre-computation**: Fetch all policy IDs and build lookup HashMaps for blacklist/whitelist
- **Eviction loop optimizations**:
  - Replace per-tx storage reads with O(1) HashMap lookups
  - Add `continue` after evictions to skip redundant checks
  - Pre-allocate HashMaps with capacity hints
  - Add warning logs for storage read failures

## Performance Impact

**Before**: O(n·m) where n = pooled transactions, m = validator changes/policy updates
- 10k pooled txs × 50 active validator changes = 500k storage operations per eviction

**After**: O(n+m) with deduplication and pre-computation
- 100 unique tokens × 50 active validator changes = 5k storage operations
- 10k HashMap lookups per eviction

@mattsse @klkvr any thoughts on this?