### PR TITLE
feat(txpool): evict transactions when keychain keys expire

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -38,6 +38,11 @@ pub struct TempoPooledTransaction {
     nonce_key_slot: OnceLock<Option<U256>>,
     /// Cached prepared [`TempoTxEnv`] for payload building.
     tx_env: OnceLock<TempoTxEnv>,
+    /// Keychain key expiry timestamp (set during validation for keychain-signed txs).
+    ///
+    /// `Some(expiry)` for keychain transactions where expiry < u64::MAX (finite expiry).
+    /// `None` for non-keychain transactions or keys that never expire.
+    key_expiry: OnceLock<Option<u64>>,
 }
 
 impl TempoPooledTransaction {
@@ -58,6 +63,7 @@ impl TempoPooledTransaction {
             is_payment,
             nonce_key_slot: OnceLock::new(),
             tx_env: OnceLock::new(),
+            key_expiry: OnceLock::new(),
         }
     }
 
@@ -173,6 +179,23 @@ impl TempoPooledTransaction {
             tx_env,
             tx: Arc::new(self.inner.transaction),
         }
+    }
+
+    /// Sets the keychain key expiry timestamp for this transaction.
+    ///
+    /// Called during validation when we read the AuthorizedKey from state.
+    /// Pass `Some(expiry)` for keys with finite expiry, `None` for non-keychain txs
+    /// or keys that never expire.
+    pub fn set_key_expiry(&self, expiry: Option<u64>) {
+        let _ = self.key_expiry.set(expiry);
+    }
+
+    /// Returns the keychain key expiry timestamp, if set during validation.
+    ///
+    /// Returns `Some(expiry)` for keychain transactions with finite expiry.
+    /// Returns `None` if not a keychain tx, key never expires, or not yet validated.
+    pub fn key_expiry(&self) -> Option<u64> {
+        self.key_expiry.get().copied().flatten()
     }
 }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -220,6 +220,11 @@ where
             }));
         }
 
+        // Cache key expiry for pool maintenance eviction (only if finite expiry)
+        if authorized_key.expiry < u64::MAX {
+            transaction.set_key_expiry(Some(authorized_key.expiry));
+        }
+
         // Check spending limit for fee token if enforce_limits is enabled.
         // This prevents transactions that would exceed the spending limit from entering the pool.
         if authorized_key.enforce_limits {


### PR DESCRIPTION
Closes CHAIN-551

Evict transactions from the pool when their keychain key expires.

Previously, we only validated key expiry at mempool admission (CHAIN-451). This left a gap: keys could expire while transactions were already in the pool, leaving stale transactions that would fail execution.

This PR adds `KeyExpiryTracker` to track keychain key expiry timestamps. When a keychain-signed transaction enters the pool, we read the key's expiry from AccountKeychain storage and track it. On each block, transactions using expired keys (expiry <= tip_timestamp) are evicted alongside expired `valid_before` transactions.