### PR TITLE
feat(txpool): add one-time T1 transition cleanup for underpriced transactions

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -373,7 +373,7 @@ where
                 // T1 transition: one-time cleanup of underpriced transactions.
                 // When T1 activates, transactions with max_fee_per_gas < 20 gwei become
                 // never-includable and should be evicted. This check runs once per node lifetime.
-                // TODO: Remove this after T1 is activated on mainnet (CHAIN-562).
+                // TODO: Remove this after T1 is activated on mainnet.
                 if !state.t1_transition_cleanup_done {
                     let chain_spec = pool.client().chain_spec();
                     if chain_spec.is_t1_active_at_timestamp(tip_timestamp) {


### PR DESCRIPTION
## Summary

When the T0 → T1 hardfork transition is detected, evict transactions with `max_fee_per_gas < 20 gwei` from the pool. These transactions become never-includable after T1's fixed 20 gwei base fee activates.

## Motivation

During the T1 hardfork, `minimal_protocol_basefee` can be stale around activation, which means the txpool may still contain never-includable transactions (e.g. `max_fee_per_gas < 20 gwei`) even after T1's fixed 20 gwei base fee is active.

## Changes

- Added `evict_underpriced_transactions_for_t1()` standalone function in `maintain.rs`
- Added `t1_transition_cleanup_done` flag to `TempoPoolState` to ensure one-time execution
- Integrated into the maintenance loop to run once when T1 becomes active

## Notes

This is a standalone function designed for easy removal after T1 is activated on mainnet.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1769706455252949

Closes: CHAIN-562