### PR TITLE
docs: clarify valid_before/valid_after unit is seconds

### DIFF
--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -73,7 +73,7 @@ pub struct TempoTransactionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_authorization: Option<SignedKeyAuthorization>,
 
-    /// Transaction valid before timestamp (for expiring nonces, TIP-1009).
+    /// Transaction valid before timestamp in seconds (for expiring nonces, TIP-1009).
     /// Transaction can only be included in a block before this timestamp.
     #[serde(
         default,
@@ -82,7 +82,7 @@ pub struct TempoTransactionRequest {
     )]
     pub valid_before: Option<u64>,
 
-    /// Transaction valid after timestamp (for expiring nonces, TIP-1009).
+    /// Transaction valid after timestamp in seconds (for expiring nonces, TIP-1009).
     /// Transaction can only be included in a block after this timestamp.
     #[serde(
         default,


### PR DESCRIPTION
Clarifies that `valid_before` and `valid_after` timestamps are in seconds, as specified in TIP-1009.