### PR TITLE
fix(tip403): reject COMPOUND type in create_policy

### DIFF
--- a/crates/precompiles/benches/tempo_precompiles.rs
+++ b/crates/precompiles/benches/tempo_precompiles.rs
@@ -5,7 +5,7 @@ use tempo_precompiles::{
     storage::{StorageCtx, hashmap::HashMapStorageProvider},
     test_util::TIP20Setup,
     tip20::{ISSUER_ROLE, ITIP20, PAUSE_ROLE, UNPAUSE_ROLE},
-    tip403_registry::{ITIP403Registry, TIP403Registry},
+    tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
 };
 
 fn tip20_metadata(c: &mut Criterion) {
@@ -545,11 +545,11 @@ fn tip403_registry_view(c: &mut Criterion) {
 
             b.iter(|| {
                 let registry = black_box(&mut registry);
-                let call = black_box(ITIP403Registry::isAuthorizedCall {
-                    policyId: policy_id,
-                    user,
-                });
-                let result = registry.is_authorized(call).unwrap();
+                let policy_id = black_box(policy_id);
+                let user = black_box(user);
+                let result = registry
+                    .is_authorized_as(policy_id, user, AuthRole::Transfer)
+                    .unwrap();
                 black_box(result);
             });
         });

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -28,11 +28,9 @@ impl Precompile for TIP403Registry {
                 }
                 ITIP403RegistryCalls::policyExists(call) => view(call, |c| self.policy_exists(c)),
                 ITIP403RegistryCalls::policyData(call) => view(call, |c| self.policy_data(c)),
-                ITIP403RegistryCalls::isAuthorized(call) => {
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
-                    })
-                }
+                ITIP403RegistryCalls::isAuthorized(call) => view(call, |c| {
+                    self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
+                }),
                 // TIP-1015: T1+ only
                 ITIP403RegistryCalls::isAuthorizedSender(call) => {
                     if !self.storage.spec().is_t1() {

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Precompile, dispatch_call, input_cost, mutate, mutate_void, tip403_registry::TIP403Registry,
+    Precompile, dispatch_call, input_cost, mutate, mutate_void,
+    tip403_registry::{AuthRole, TIP403Registry},
     unknown_selector, view,
 };
 use alloy::{
@@ -27,7 +28,11 @@ impl Precompile for TIP403Registry {
                 }
                 ITIP403RegistryCalls::policyExists(call) => view(call, |c| self.policy_exists(c)),
                 ITIP403RegistryCalls::policyData(call) => view(call, |c| self.policy_data(c)),
-                ITIP403RegistryCalls::isAuthorized(call) => view(call, |c| self.is_authorized(c)),
+                ITIP403RegistryCalls::isAuthorized(call) => {
+                    view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
+                    })
+                }
                 // TIP-1015: T1+ only
                 ITIP403RegistryCalls::isAuthorizedSender(call) => {
                     if !self.storage.spec().is_t1() {
@@ -36,7 +41,9 @@ impl Precompile for TIP403Registry {
                             self.storage.gas_used(),
                         );
                     }
-                    view(call, |c| self.is_authorized_sender(c))
+                    view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
+                    })
                 }
                 ITIP403RegistryCalls::isAuthorizedRecipient(call) => {
                     if !self.storage.spec().is_t1() {
@@ -45,7 +52,9 @@ impl Precompile for TIP403Registry {
                             self.storage.gas_used(),
                         );
                     }
-                    view(call, |c| self.is_authorized_recipient(c))
+                    view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
+                    })
                 }
                 ITIP403RegistryCalls::isAuthorizedMintRecipient(call) => {
                     if !self.storage.spec().is_t1() {
@@ -54,7 +63,9 @@ impl Precompile for TIP403Registry {
                             self.storage.gas_used(),
                         );
                     }
-                    view(call, |c| self.is_authorized_mint_recipient(c))
+                    view(call, |c| {
+                        self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
+                    })
                 }
                 ITIP403RegistryCalls::compoundPolicyData(call) => {
                     if !self.storage.spec().is_t1() {

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -11,22 +11,50 @@ use utils::*;
 
 #[test]
 fn test_tip403_registry_layout() {
-    use tempo_precompiles::tip403_registry::{__packing_policy_data::*, slots};
+    use tempo_precompiles::tip403_registry::{__packing_policy_record::*, slots};
 
     let sol_path = testdata("tip403_registry.sol");
     let solc_layout = load_solc_layout(&sol_path);
 
     // Verify top-level fields
-    let rust_layout = layout_fields!(policy_id_counter, policy_data, policy_set);
+    let rust_layout = layout_fields!(policy_id_counter, policy_records, policy_set);
     if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
         panic_layout_mismatch("Layout", errors, &sol_path);
     }
 
-    // Verify `PolicyData` struct members
-    let base_slot = slots::POLICY_DATA;
-    let rust_struct = struct_fields!(base_slot, policy_type, admin);
-    if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_struct) {
-        panic_layout_mismatch("Struct member layout", errors, &sol_path);
+    // Verify `PolicyRecord` struct members (nested under policyRecords mapping)
+    let base_slot = slots::POLICY_RECORDS;
+    let rust_policy_record = struct_fields!(base_slot, base, compound);
+    if let Err(errors) = compare_struct_members(&solc_layout, "policyRecords", &rust_policy_record)
+    {
+        panic_layout_mismatch("PolicyRecord struct layout", errors, &sol_path);
+    }
+
+    // Verify `PolicyData` struct members (nested in PolicyRecord.base)
+    {
+        use tempo_precompiles::tip403_registry::__packing_policy_data::*;
+        let rust_policy_data = struct_fields!(base_slot, policy_type, admin);
+        if let Err(errors) =
+            compare_nested_struct_type(&solc_layout, "PolicyData", &rust_policy_data)
+        {
+            panic_layout_mismatch("PolicyData struct layout", errors, &sol_path);
+        }
+    }
+
+    // Verify `CompoundPolicyData` struct members (nested in PolicyRecord.compound)
+    {
+        use tempo_precompiles::tip403_registry::__packing_compound_policy_data::*;
+        let rust_compound = struct_fields!(
+            base_slot,
+            sender_policy_id,
+            recipient_policy_id,
+            mint_recipient_policy_id
+        );
+        if let Err(errors) =
+            compare_nested_struct_type(&solc_layout, "CompoundPolicyData", &rust_compound)
+        {
+            panic_layout_mismatch("CompoundPolicyData struct layout", errors, &sol_path);
+        }
     }
 }
 
@@ -193,18 +221,35 @@ fn export_all_storage_constants() {
 
     // TIP403 Registry
     {
-        use tempo_precompiles::tip403_registry::{__packing_policy_data::*, slots};
+        use tempo_precompiles::tip403_registry::{__packing_policy_record::*, slots};
 
-        let fields = layout_fields!(policy_id_counter, policy_data, policy_set);
-        let base_slot = slots::POLICY_DATA;
-        let policy_data_struct = struct_fields!(base_slot, policy_type, admin);
+        let fields = layout_fields!(policy_id_counter, policy_records, policy_set);
+        let base_slot = slots::POLICY_RECORDS;
+        let policy_record_struct = struct_fields!(base_slot, base, compound);
+
+        let policy_data_struct = {
+            use tempo_precompiles::tip403_registry::__packing_policy_data::*;
+            struct_fields!(base_slot, policy_type, admin)
+        };
+
+        let compound_policy_data_struct = {
+            use tempo_precompiles::tip403_registry::__packing_compound_policy_data::*;
+            struct_fields!(
+                base_slot,
+                sender_policy_id,
+                recipient_policy_id,
+                mint_recipient_policy_id
+            )
+        };
 
         all_constants.insert(
             "tip403_registry".to_string(),
             json!({
                 "fields": fields.iter().map(field_to_json).collect::<Vec<_>>(),
                 "structs": {
-                    "policyData": policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>()
+                    "policyRecords": policy_record_struct.iter().map(field_to_json).collect::<Vec<_>>(),
+                    "policyData": policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>(),
+                    "compoundPolicyData": compound_policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>()
                 }
             }),
         );

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
@@ -4,7 +4,7 @@
       "storage-layout": {
         "storage": [
           {
-            "astId": 10,
+            "astId": 24,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policyIdCounter",
             "offset": 0,
@@ -12,15 +12,15 @@
             "type": "t_uint64"
           },
           {
-            "astId": 16,
+            "astId": 30,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-            "label": "policyData",
+            "label": "policyRecords",
             "offset": 0,
             "slot": "1",
-            "type": "t_mapping(t_uint64,t_struct(PolicyData)7_storage)"
+            "type": "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)"
           },
           {
-            "astId": 23,
+            "astId": 37,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policySet",
             "offset": 0,
@@ -53,12 +53,43 @@
             "numberOfBytes": "32",
             "value": "t_mapping(t_address,t_bool)"
           },
-          "t_mapping(t_uint64,t_struct(PolicyData)7_storage)": {
+          "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
-            "label": "mapping(uint64 => struct TIP403Registry.PolicyData)",
+            "label": "mapping(uint64 => struct TIP403Registry.PolicyRecord)",
             "numberOfBytes": "32",
-            "value": "t_struct(PolicyData)7_storage"
+            "value": "t_struct(PolicyRecord)21_storage"
+          },
+          "t_struct(CompoundPolicyData)14_storage": {
+            "encoding": "inplace",
+            "label": "struct TIP403Registry.CompoundPolicyData",
+            "members": [
+              {
+                "astId": 9,
+                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+                "label": "senderPolicyId",
+                "offset": 0,
+                "slot": "0",
+                "type": "t_uint64"
+              },
+              {
+                "astId": 11,
+                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+                "label": "recipientPolicyId",
+                "offset": 8,
+                "slot": "0",
+                "type": "t_uint64"
+              },
+              {
+                "astId": 13,
+                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+                "label": "mintRecipientPolicyId",
+                "offset": 16,
+                "slot": "0",
+                "type": "t_uint64"
+              }
+            ],
+            "numberOfBytes": "32"
           },
           "t_struct(PolicyData)7_storage": {
             "encoding": "inplace",
@@ -83,6 +114,29 @@
             ],
             "numberOfBytes": "32"
           },
+          "t_struct(PolicyRecord)21_storage": {
+            "encoding": "inplace",
+            "label": "struct TIP403Registry.PolicyRecord",
+            "members": [
+              {
+                "astId": 17,
+                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+                "label": "base",
+                "offset": 0,
+                "slot": "0",
+                "type": "t_struct(PolicyData)7_storage"
+              },
+              {
+                "astId": 20,
+                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+                "label": "compound",
+                "offset": 0,
+                "slot": "1",
+                "type": "t_struct(CompoundPolicyData)14_storage"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
           "t_uint64": {
             "encoding": "inplace",
             "label": "uint64",
@@ -97,5 +151,5 @@
       }
     }
   },
-  "version": "0.8.30+commit.73712a01.Darwin.appleclang"
+  "version": "0.8.33+commit.64118f21.Darwin.appleclang"
 }

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
@@ -11,13 +11,24 @@ contract TIP403Registry {
         address admin;
     }
 
+    struct CompoundPolicyData {
+        uint64 senderPolicyId;
+        uint64 recipientPolicyId;
+        uint64 mintRecipientPolicyId;
+    }
+
+    struct PolicyRecord {
+        PolicyData base;
+        CompoundPolicyData compound;
+    }
+
     // ========== Storage ==========
 
     /// Counter for policy IDs
     uint64 public policyIdCounter;
 
-    /// Mapping of policy ID to policy data
-    mapping(uint64 => PolicyData) public policyData;
+    /// Mapping of policy ID to policy record (internal, not exposed in ABI)
+    mapping(uint64 => PolicyRecord) internal policyRecords;
 
     /// Nested mapping for policy sets: policy_id -> address -> is_in_set
     /// Used for whitelist/blacklist entries

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -249,13 +249,12 @@ pub trait TempoStateAccess<M = ()> {
             let policy_id = TIP20Token::from_address(fee_token)?
                 .transfer_policy_id
                 .read()?;
-            let registry = TIP403Registry::new();
             let role = if spec.is_t1() {
                 AuthRole::Sender
             } else {
                 AuthRole::Transfer
             };
-            registry.is_authorized_as(policy_id, fee_payer, role)
+            TIP403Registry::new().is_authorized_as(policy_id, fee_payer, role)
         })
     }
 

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -10,7 +10,7 @@ use revm::{
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
-    DEFAULT_FEE_TOKEN, IFeeManager, IStablecoinDEX, ITIP403Registry, STABLECOIN_DEX_ADDRESS,
+    DEFAULT_FEE_TOKEN, IFeeManager, IStablecoinDEX, STABLECOIN_DEX_ADDRESS,
 };
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
@@ -18,7 +18,7 @@ use tempo_precompiles::{
     storage::{Handler, PrecompileStorageProvider, StorageCtx},
     tip_fee_manager::TipFeeManager,
     tip20::{ITIP20, TIP20Token, is_tip20_prefix},
-    tip403_registry::TIP403Registry,
+    tip403_registry::{AuthRole, TIP403Registry},
 };
 use tempo_primitives::TempoTxEnvelope;
 
@@ -246,21 +246,16 @@ pub trait TempoStateAccess<M = ()> {
         self.with_read_only_storage_ctx(spec, || {
             // Ensure the fee payer is not blacklisted (sender authorization)
             // TIP-1015: Use isAuthorizedSender for T1+, isAuthorized for pre-T1
-            let transfer_policy_id = TIP20Token::from_address(fee_token)?
+            let policy_id = TIP20Token::from_address(fee_token)?
                 .transfer_policy_id
                 .read()?;
             let registry = TIP403Registry::new();
-            if spec.is_t1() {
-                registry.is_authorized_sender(ITIP403Registry::isAuthorizedSenderCall {
-                    policyId: transfer_policy_id,
-                    user: fee_payer,
-                })
+            let role = if spec.is_t1() {
+                AuthRole::Sender
             } else {
-                registry.is_authorized(ITIP403Registry::isAuthorizedCall {
-                    policyId: transfer_policy_id,
-                    user: fee_payer,
-                })
-            }
+                AuthRole::Transfer
+            };
+            registry.is_authorized_as(policy_id, fee_payer, role)
         })
     }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1231,7 +1231,9 @@ mod tests {
             policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
             admin: Address::ZERO,
         };
-        let policy_data_slot = TIP403Registry::new().policy_data[policy_id].base_slot();
+        let policy_data_slot = TIP403Registry::new().policy_records[policy_id]
+            .base
+            .base_slot();
         let policy_set_slot = TIP403Registry::new().policy_set[policy_id][fee_payer].slot();
 
         provider.add_account(

--- a/tips/tip-1015.md
+++ b/tips/tip-1015.md
@@ -55,6 +55,38 @@ struct CompoundPolicyData {
 
 All three referenced policies MUST be simple policies (WHITELIST or BLACKLIST), not compound policies. This prevents circular references and unbounded recursion.
 
+## Storage Layout
+
+Policy data is stored in a unified `PolicyRecord` struct that contains both base policy data and compound policy data:
+
+```solidity
+struct PolicyData {
+    uint8 policyType;   // 0 = WHITELIST, 1 = BLACKLIST, 2 = COMPOUND
+    address admin;      // Policy administrator (zero for immutable compound policies)
+}
+
+struct PolicyRecord {
+    PolicyData base;          // offset 0: base policy data
+    CompoundPolicyData compound;  // offset 1: compound policy data (only used when policyType == COMPOUND)
+}
+```
+
+The TIP403Registry storage layout:
+
+| Slot | Field | Description |
+|------|-------|-------------|
+| 0 | `policyIdCounter` | Counter for generating unique policy IDs |
+| 1 | `policyRecords` (private) | `mapping(uint64 => PolicyRecord)` - Policy ID to policy record |
+| 2 | `policySet` | `mapping(uint64 => mapping(address => bool))` - Whitelist/blacklist membership |
+
+The `policyRecords` mapping is private (not exposed in the ABI). The existing `policyData(uint64 policyId)` view function provides backwards-compatible access to `PolicyData`.
+
+For a given policy ID, storage locations are:
+- **PolicyData**: `keccak256(policyId, 1)` (offset 0 within PolicyRecord)
+- **CompoundPolicyData**: `keccak256(policyId, 1) + 1` (offset 1 within PolicyRecord)
+
+This unified layout requires only **1 keccak computation + 2 SLOADs** for compound policy authorization, compared to 2 keccak computations with separate mappings.
+
 ## Interface Additions
 
 The TIP403Registry interface is extended with the following:
@@ -161,11 +193,10 @@ interface ITIP403Registry {
 
 ```solidity
 function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
-    PolicyData memory data = policyData[policyId];
+    PolicyRecord storage record = policyRecords[policyId];
     
-    if (data.policyType == PolicyType.COMPOUND) {
-        CompoundPolicyData memory compound = compoundPolicyData[policyId];
-        return isAuthorized(compound.senderPolicyId, user);
+    if (record.base.policyType == PolicyType.COMPOUND) {
+        return isAuthorized(record.compound.senderPolicyId, user);
     }
     
     // For simple policies, sender authorization equals general authorization
@@ -177,11 +208,10 @@ function isAuthorizedSender(uint64 policyId, address user) external view returns
 
 ```solidity
 function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
-    PolicyData memory data = policyData[policyId];
+    PolicyRecord storage record = policyRecords[policyId];
     
-    if (data.policyType == PolicyType.COMPOUND) {
-        CompoundPolicyData memory compound = compoundPolicyData[policyId];
-        return isAuthorized(compound.recipientPolicyId, user);
+    if (record.base.policyType == PolicyType.COMPOUND) {
+        return isAuthorized(record.compound.recipientPolicyId, user);
     }
     
     // For simple policies, recipient authorization equals general authorization
@@ -193,11 +223,10 @@ function isAuthorizedRecipient(uint64 policyId, address user) external view retu
 
 ```solidity
 function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
-    PolicyData memory data = policyData[policyId];
+    PolicyRecord storage record = policyRecords[policyId];
     
-    if (data.policyType == PolicyType.COMPOUND) {
-        CompoundPolicyData memory compound = compoundPolicyData[policyId];
-        return isAuthorized(compound.mintRecipientPolicyId, user);
+    if (record.base.policyType == PolicyType.COMPOUND) {
+        return isAuthorized(record.compound.mintRecipientPolicyId, user);
     }
     
     // For simple policies, mint recipient authorization equals general authorization


### PR DESCRIPTION
## Summary
Prevents creating invalid COMPOUND policies via `createPolicy` or `createPolicyWithAccounts`. COMPOUND policies must use `createCompoundPolicy`.

## Motivation
PR #2354 introduced `PolicyType::COMPOUND`, but didn't add validation to `create_policy` to reject it. This could allow creating malformed compound policies with zeroed compound fields.

This fix returns `IncompatiblePolicyType` error, matching pre-hardfork behavior for invalid policy types.

## Changes
- Added guard in `create_policy` to reject COMPOUND and __Invalid types
- Added 7 comprehensive tests covering edge cases:
  - `create_policy` rejecting COMPOUND/\_\_Invalid
  - `create_policy_with_accounts` rejecting COMPOUND
  - Non-existent policy behavior (deny, not panic)
  - Builtin policies work for all AuthRole variants
  - Simple policies return consistent results across roles
  - Transfer short-circuit optimization

## Testing
```
cargo test -p tempo-precompiles tip403_registry
# 32 passed
```

Thread: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1769790171554909