### PR TITLE
docs(tip-1006): clarify reward accounting invariants and test cases

### DIFF
--- a/tips/tip-1006.md
+++ b/tips/tip-1006.md
@@ -93,7 +93,11 @@ function burnAt(address from, uint256 amount) external;
    - `totalSupply` decreases by exactly `amount`
    - `balanceOf[from]` decreases by exactly `amount`
 4. **Balance Constraint**: `burnAt` must revert if `amount > balanceOf[from]`
-5. **Reward Accounting**: If `from` is opted into rewards, `optedInSupply` must decrease by `amount`
+5. **Reward Accounting**: If `from` is opted into rewards:
+   - Pending rewards must be accrued to the reward recipient's `rewardBalance` before the balance changes
+   - `from`'s `rewardPerToken` snapshot must be synced to `globalRewardPerToken`
+   - `optedInSupply` must decrease by `amount`
+   - Any previously accrued `rewardBalance` remains claimable
 6. **Policy Independence**: `burnAt` must succeed regardless of transfer policy status of `from`
 
 ## Test Cases
@@ -104,7 +108,8 @@ The test suite must verify:
 2. Revert without `BURN_AT_ROLE` (Unauthorized)
 3. Revert when burning from `TIP_FEE_MANAGER_ADDRESS` (ProtectedAddress)
 4. Revert when burning from `STABLECOIN_DEX_ADDRESS` (ProtectedAddress)
-5. Successful burn from policy-blocked address (differs from `burnBlocked`)
-6. Revert on insufficient balance
-7. Correct event emissions (`Transfer` and `BurnAt`)
-8. Correct reward accounting updates
+5. Successful burn from policy-blocked address (same behavior as `burnBlocked`)
+6. Successful burn from policy-authorized address (differs from `burnBlocked`, which reverts)
+7. Revert on insufficient balance
+8. Correct event emissions (`Transfer` and `BurnAt`)
+9. Correct reward accounting updates (pending rewards accrued before burn, `rewardBalance` remains claimable)


### PR DESCRIPTION
## Summary

Clarifies the reward accounting requirements and test cases in TIP-1006.

## Changes

**Invariant #5 (Reward Accounting)** now specifies:
- Pending rewards must be accrued to the reward recipient's `rewardBalance` before the balance changes
- `from`'s `rewardPerToken` snapshot must be synced to `globalRewardPerToken`
- `optedInSupply` must decrease by `amount`
- Any previously accrued `rewardBalance` remains claimable

**Test Cases** updated:
- Test case 5: Clarified that burning from policy-blocked address is same behavior as `burnBlocked`
- Test case 6 (new): Added test for burning from policy-authorized address (differs from `burnBlocked`, which reverts)
- Test case 9: Clarified reward accounting verification details

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1769797899688529