### PR TITLE
chore: bump `reth` to `c59a120` / `release/tempo-30012026`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,7 +4719,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7605,7 +7605,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7629,7 +7629,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7772,7 +7772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7782,7 +7782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7830,7 +7830,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7897,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7923,7 +7923,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7996,7 +7996,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8045,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8069,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8162,7 +8162,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8213,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "futures",
  "pin-project",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8345,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8360,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8398,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8437,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "clap",
  "eyre",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8537,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8597,7 +8597,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8617,7 +8617,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8686,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,7 +8704,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8742,7 +8742,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "serde",
  "serde_json",
@@ -8766,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bytes",
  "futures",
@@ -8814,7 +8814,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "futures",
  "metrics",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8930,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9258,7 +9258,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bytes",
  "eyre",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9335,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9370,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9380,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9469,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9525,7 +9525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9700,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9836,7 +9836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9852,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9942,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9962,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "clap",
  "eyre",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "clap",
  "eyre",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10135,7 +10135,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10161,7 +10161,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10188,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10265,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bb1df5b#bb1df5b0fe9b9fe8a124976bbb43346012dd51bb"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,51 +119,51 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 # reth v1.10.1
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bb1df5b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
## Summary
Bumps reth from `bb1df5b0fe9b9fe8a124976bbb43346012dd51bb` to `c59a12036b738b396d19ed6fab79ce1751ba8afb`.

* Includes fix for `RPC` / `--follow` nodes

## Changes
https://github.com/paradigmxyz/reth/compare/tempo-revm-34...release/tempo-30012026?expand=1

## Testing
CI will validate the build.