### PR TITLE
fix(txpool): include expiring nonce txs in pool metrics total

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -102,7 +102,7 @@ impl AA2dPool {
     /// Updates all metrics to reflect the current state of the pool
     fn update_metrics(&self) {
         let (pending, queued) = self.pending_and_queued_txn_count();
-        let total = self.by_id.len();
+        let total = self.by_id.len() + self.expiring_nonce_txs.len();
         self.metrics.set_transaction_counts(total, pending, queued);
     }
 


### PR DESCRIPTION
Closes CHAIN-566

## Summary

Fix pool metrics where `pending > total` when expiring nonce transactions are present.

## Problem

`update_metrics()` uses `by_id.len()` for the total count, but `pending_and_queued_txn_count()` includes `expiring_nonce_txs`. This caused the invariant `pending > total` to be violated once expiring nonce transactions were in the pool.

## Fix

Include `expiring_nonce_txs.len()` in the total count:
```rust
let total = self.by_id.len() + self.expiring_nonce_txs.len();
```

This aligns with how pending/queued counts are calculated.

## Testing

```bash
cargo test -p tempo-transaction-pool
# 175 passed
```

## References

- [Sherlock audit comment](https://github.com/sherlock-audit/2026-01-tempo-jan-25th/pull/152#discussion_r2745998640)