### PR TITLE
fix(dex): use AuthRole::sender() in blacklist test

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -3803,7 +3803,7 @@ mod tests {
                     restricted: true,
                 },
             )?;
-            assert!(!registry.is_authorized_as(policy_id, alice, AuthRole::Transfer)?);
+            assert!(!registry.is_authorized_as(policy_id, alice, AuthRole::sender())?);
 
             // Attempt to place order using internal balance - should fail
             let tick = 0i16;


### PR DESCRIPTION
Fixes the test assertion to use `AuthRole::sender()` instead of `AuthRole::Transfer`.

The test was using the symmetric check which happens to work for simple blacklist policies, but is semantically wrong for compound policies where sender and recipient can be different sub-policies.

This matches what the DEX actually checks during order placement.

Thread: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1769740197003979