### PR TITLE
fix(tip-1015): preserve re-execution compatibility for invalid policy types

### DIFF
--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -59,7 +59,9 @@ impl TIP403RegistryError {
 
     /// Creates an error for non-existent policy
     pub const fn policy_not_found(policy_id: u64) -> Self {
-        Self::PolicyNotFound(ITIP403Registry::PolicyNotFound { policyId: policy_id })
+        Self::PolicyNotFound(ITIP403Registry::PolicyNotFound {
+            policyId: policy_id,
+        })
     }
 
     pub const fn policy_not_simple() -> Self {

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -162,16 +162,12 @@ impl TIP403Registry {
         })
     }
 
-
     /// Validates and returns the policy type to store, handling backward compatibility.
     ///
     /// Pre-T1: Converts any value >= 2 to 255 (__Invalid) to match original ABI decoding
     /// behavior where unknown enum values became __Invalid(255).
     /// T1+: Only allows WHITELIST and BLACKLIST; COMPOUND must use createCompoundPolicy.
-    fn validate_simple_policy_type(
-        &self,
-        policy_type: ITIP403Registry::PolicyType,
-    ) -> Result<u8> {
+    fn validate_simple_policy_type(&self, policy_type: ITIP403Registry::PolicyType) -> Result<u8> {
         let policy_type = policy_type as u8;
         if self.storage.spec().is_t1() {
             if policy_type >= 2 {
@@ -243,13 +239,7 @@ impl TIP403Registry {
         )?;
 
         // Store policy data
-        self.set_policy_data(
-            new_policy_id,
-            PolicyData {
-                policy_type,
-                admin,
-            },
-        )?;
+        self.set_policy_data(new_policy_id, PolicyData { policy_type, admin })?;
 
         // Set initial accounts - only emit events for valid policy types
         // Pre-T1 with invalid types: accounts are added but no events emitted (matches original)
@@ -1365,8 +1355,8 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_t1_create_policy_with_accounts_invalid_type_adds_accounts_no_events(
-    ) -> eyre::Result<()> {
+    fn test_pre_t1_create_policy_with_accounts_invalid_type_adds_accounts_no_events()
+    -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T0);
         let admin = Address::random();
         let account1 = Address::random();


### PR DESCRIPTION
## Summary

Fixes re-execution/syncing issues in PR #2344 caused by adding the `COMPOUND` variant to `PolicyType` enum.

## Problem

Adding `COMPOUND(2)` to the enum changes ABI decoding behavior:
- **Before PR**: `policyType=2` in calldata → decoded as `__Invalid(255)` → stored as `255`
- **After PR**: `policyType=2` → decoded as `COMPOUND(2)` → stored as `2`

This causes:
1. Different storage values when re-executing `createPolicy(admin, 2)`
2. Different behavior in `isAuthorized`, `policyData` etc. (revert vs return false)

## Testing Evidence

We created policy 274259 on testnet with `policyType=2`:
- Transaction: https://explore.tempo.xyz/tx/0x687117d619d68a1e729b56e9d5df0b1677d7f26a8570e08937613927ae79d5cd
- Stored `policy_type = 255` (not 2) due to original ABI decoding
- `policyData(274259)` reverts with underflow/overflow
- `isAuthorized(274259, user)` reverts with underflow/overflow

## Fixes

### 1. `createPolicy` / `createPolicyWithAccounts`

Pre-T1: Convert any `policyType >= 2` to `255` (__Invalid) to match original behavior.
T1+: Reject invalid types; COMPOUND must use `createCompoundPolicy`.

### 2. `policyData`

Pre-T1: Revert for any `policy_type >= 2` to match original `try_into` failure.

### 3. `is_simple`

Pre-T1: Revert for `policy_type >= 2`. Also explicitly error on `__Invalid` for safety.

## Result

| Scenario | Original | After Fix |
|----------|----------|-----------|
| `createPolicy(admin, 2)` pre-T1 | Stores 255 | Stores 255 ✓ |
| `isAuthorized` on policy_type=255 | Reverts | Reverts ✓ |
| `isAuthorized` on policy_type=2 pre-T1 | Reverts | Reverts ✓ |
| `policyData` on policy_type>=2 pre-T1 | Reverts | Reverts ✓ |

Thread: https://ampcode.com/threads/T-019c11bb-a2d5-72fc-a0ef-7c9cbb669102