### PR TITLE
fix(tip403): hardfork-gate PolicyNotFound error parameter

### DIFF
--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -34,7 +34,10 @@ crate::sol! {
         // Errors
         error Unauthorized();
         error IncompatiblePolicyType();
+        /// Pre-T1 error for non-existent policy (no parameter)
         error PolicyNotFound();
+        /// T1+ error for non-existent policy (includes policy ID)
+        error PolicyIdNotFound(uint64 policyId);
     }
 }
 
@@ -49,8 +52,15 @@ impl TIP403RegistryError {
         Self::IncompatiblePolicyType(ITIP403Registry::IncompatiblePolicyType {})
     }
 
-    /// Creates an error for non-existent policy
+    /// Creates an error for non-existent policy (pre-T1, no policy ID)
     pub const fn policy_not_found() -> Self {
         Self::PolicyNotFound(ITIP403Registry::PolicyNotFound {})
+    }
+
+    /// Creates an error for non-existent policy with ID (T1+)
+    pub const fn policy_id_not_found(policy_id: u64) -> Self {
+        Self::PolicyIdNotFound(ITIP403Registry::PolicyIdNotFound {
+            policyId: policy_id,
+        })
     }
 }


### PR DESCRIPTION
## Summary

Addresses review comment: https://github.com/tempoxyz/tempo/pull/2344#pullrequestreview-3732023724

PR #2344 changes `PolicyNotFound()` to `PolicyNotFound(uint64 policyId)`, which is a breaking change.

## Fix

1. Keep the original `PolicyNotFound()` error for pre-T1 compatibility
2. Add new `PolicyNotFoundWithId(uint64 policyId)` error for T1+
3. Add `policy_not_found_error()` helper that auto-routes based on hardfork

## Changes

### tempo-contracts
- Keep `error PolicyNotFound()` (pre-T1, no parameter)
- Add `error PolicyNotFoundWithId(uint64 policyId)` (T1+)
- Add `policy_not_found_with_id()` builder function

### tempo-precompiles
- Add `policy_not_found_error()` helper that checks hardfork and returns correct error
- Update `policy_data()` to use the new helper
- Add tests for both pre-T1 and T1 error behavior

## Testing
- `cargo check -p tempo-precompiles` passes
- Added unit tests for pre-T1 and T1 error variants