### PR TITLE
fix(tip-1015): preserve policy_data storage slot for backward compatibility

### DIFF
--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
@@ -4,7 +4,7 @@
       "storage-layout": {
         "storage": [
           {
-            "astId": 24,
+            "astId": 19,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policyIdCounter",
             "offset": 0,
@@ -12,20 +12,28 @@
             "type": "t_uint64"
           },
           {
-            "astId": 30,
+            "astId": 25,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-            "label": "policyRecords",
+            "label": "policyData",
             "offset": 0,
             "slot": "1",
-            "type": "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)"
+            "type": "t_mapping(t_uint64,t_struct(PolicyData)7_storage)"
           },
           {
-            "astId": 37,
+            "astId": 32,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policySet",
             "offset": 0,
             "slot": "2",
             "type": "t_mapping(t_uint64,t_mapping(t_address,t_bool))"
+          },
+          {
+            "astId": 38,
+            "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
+            "label": "compoundPolicyData",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint64,t_struct(CompoundPolicyData)14_storage)"
           }
         ],
         "types": {
@@ -53,12 +61,19 @@
             "numberOfBytes": "32",
             "value": "t_mapping(t_address,t_bool)"
           },
-          "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)": {
+          "t_mapping(t_uint64,t_struct(PolicyData)7_storage)": {
             "encoding": "mapping",
             "key": "t_uint64",
-            "label": "mapping(uint64 => struct TIP403Registry.PolicyRecord)",
+            "label": "mapping(uint64 => struct TIP403Registry.PolicyData)",
             "numberOfBytes": "32",
-            "value": "t_struct(PolicyRecord)21_storage"
+            "value": "t_struct(PolicyData)7_storage"
+          },
+          "t_mapping(t_uint64,t_struct(CompoundPolicyData)14_storage)": {
+            "encoding": "mapping",
+            "key": "t_uint64",
+            "label": "mapping(uint64 => struct TIP403Registry.CompoundPolicyData)",
+            "numberOfBytes": "32",
+            "value": "t_struct(CompoundPolicyData)14_storage"
           },
           "t_struct(CompoundPolicyData)14_storage": {
             "encoding": "inplace",
@@ -113,29 +128,6 @@
               }
             ],
             "numberOfBytes": "32"
-          },
-          "t_struct(PolicyRecord)21_storage": {
-            "encoding": "inplace",
-            "label": "struct TIP403Registry.PolicyRecord",
-            "members": [
-              {
-                "astId": 17,
-                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-                "label": "base",
-                "offset": 0,
-                "slot": "0",
-                "type": "t_struct(PolicyData)7_storage"
-              },
-              {
-                "astId": 20,
-                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-                "label": "compound",
-                "offset": 0,
-                "slot": "1",
-                "type": "t_struct(CompoundPolicyData)14_storage"
-              }
-            ],
-            "numberOfBytes": "64"
           },
           "t_uint64": {
             "encoding": "inplace",

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
@@ -17,20 +17,19 @@ contract TIP403Registry {
         uint64 mintRecipientPolicyId;
     }
 
-    struct PolicyRecord {
-        PolicyData base;
-        CompoundPolicyData compound;
-    }
-
     // ========== Storage ==========
 
     /// Counter for policy IDs
     uint64 public policyIdCounter;
 
-    /// Mapping of policy ID to policy record (internal, not exposed in ABI)
-    mapping(uint64 => PolicyRecord) internal policyRecords;
+    /// Mapping of policy ID to policy data
+    mapping(uint64 => PolicyData) internal policyData;
 
     /// Nested mapping for policy sets: policy_id -> address -> is_in_set
     /// Used for whitelist/blacklist entries
     mapping(uint64 => mapping(address => bool)) public policySet;
+
+    /// Compound policy data (TIP-1015). Only relevant when policyType == COMPOUND.
+    /// Stored in a separate mapping to preserve storage slot compatibility for policyData.
+    mapping(uint64 => CompoundPolicyData) internal compoundPolicyData;
 }

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1274,9 +1274,7 @@ mod tests {
             policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
             admin: Address::ZERO,
         };
-        let policy_data_slot = TIP403Registry::new().policy_records[policy_id]
-            .base
-            .base_slot();
+        let policy_data_slot = TIP403Registry::new().policy_data[policy_id].base_slot();
         let policy_set_slot = TIP403Registry::new().policy_set[policy_id][fee_payer].slot();
 
         provider.add_account(


### PR DESCRIPTION
## Problem

The TIP-1015 PR changed the storage layout from `policy_data: Mapping<u64, PolicyData>` to `policy_records: Mapping<u64, PolicyRecord>` where PolicyRecord nests PolicyData.

This breaks re-execution of historical blocks because the storage slot calculation is based on field name hashing - changing the field name from `policy_data` to `policy_records` causes reads from wrong storage slots, resulting in a 200 gas difference per policy lookup.

### Re-execution Error
```
Invalid receipt cumulative_gas_used: 6188671 vs correct 6188871
Gas usage mismatch: got 29944, expected 30144
block gas used mismatch: got 6843587, expected 6843787
```

## Solution

1. Keep original field name `policy_data` for PolicyData storage (preserves slot 1)
2. Add separate `compound_policy_data` mapping for compound policy data (new slot 3)
3. Update storage layout tests and Solidity test contract to match

## Testing

- All 41 TIP403 registry tests pass
- All 186 transaction pool tests pass
- Storage layout tests pass