### PR TITLE
fix(tip-1015): rename policy_records back to policy_data for slot compatibility

### DIFF
--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -14,17 +14,11 @@ use alloy::primitives::{Address, U256};
 #[contract(addr = TIP403_REGISTRY_ADDRESS)]
 pub struct TIP403Registry {
     policy_id_counter: u64,
-    policy_data: Mapping<u64, PolicyRecord>,
+    /// Base policy data - preserves original storage layout for backward compatibility
+    policy_data: Mapping<u64, PolicyData>,
     policy_set: Mapping<u64, Mapping<Address, bool>>,
-}
-
-/// Policy record containing base data and optional data for compound policies (TIP-1015)
-#[derive(Debug, Clone, Storable)]
-pub struct PolicyRecord {
-    /// Base policy data
-    pub base: PolicyData,
-    /// Compound policy data. Only relevant when `base.policy_type == COMPOUND`
-    pub compound: CompoundPolicyData,
+    /// Compound policy data (TIP-1015). Stored separately to preserve policy_data slot layout.
+    compound_policy_data: Mapping<u64, CompoundPolicyData>,
 }
 
 /// Data for compound policies (TIP-1015)
@@ -154,7 +148,7 @@ impl TIP403Registry {
             return Err(TIP403RegistryError::incompatible_policy_type().into());
         }
 
-        let compound = self.policy_data[call.policyId].compound.read()?;
+        let compound = self.compound_policy_data[call.policyId].read()?;
         Ok(ITIP403Registry::compoundPolicyDataReturn {
             senderPolicyId: compound.sender_policy_id,
             recipientPolicyId: compound.recipient_policy_id,
@@ -196,7 +190,7 @@ impl TIP403Registry {
         )?;
 
         // Store policy data
-        self.policy_data[new_policy_id].base.write(PolicyData {
+        self.set_policy_data(new_policy_id, PolicyData {
             policy_type,
             admin: call.admin,
         })?;
@@ -404,17 +398,17 @@ impl TIP403Registry {
                 .ok_or(TempoPrecompileError::under_overflow())?,
         )?;
 
-        // Store policy record with COMPOUND type and compound data
-        self.policy_data[new_policy_id].write(PolicyRecord {
-            base: PolicyData {
-                policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-                admin: Address::ZERO,
-            },
-            compound: CompoundPolicyData {
-                sender_policy_id: call.senderPolicyId,
-                recipient_policy_id: call.recipientPolicyId,
-                mint_recipient_policy_id: call.mintRecipientPolicyId,
-            },
+        // Store policy data with COMPOUND type
+        self.set_policy_data(new_policy_id, PolicyData {
+            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+            admin: Address::ZERO,
+        })?;
+
+        // Store compound policy data separately
+        self.compound_policy_data[new_policy_id].write(CompoundPolicyData {
+            sender_policy_id: call.senderPolicyId,
+            recipient_policy_id: call.recipientPolicyId,
+            mint_recipient_policy_id: call.mintRecipientPolicyId,
         })?;
 
         // Emit event
@@ -440,7 +434,7 @@ impl TIP403Registry {
         let data = self.get_policy_data(policy_id)?;
 
         if data.is_compound() {
-            let compound = self.policy_data[policy_id].compound.read()?;
+            let compound = self.compound_policy_data[policy_id].read()?;
             return match role {
                 AuthRole::Sender => {
                     self.is_authorized_simple_policy(compound.sender_policy_id, user)
@@ -533,11 +527,11 @@ impl TIP403Registry {
 
     // Internal helper functions
     fn get_policy_data(&self, policy_id: u64) -> Result<PolicyData> {
-        self.policy_data[policy_id].base.read()
+        self.policy_data[policy_id].read()
     }
 
     fn set_policy_data(&mut self, policy_id: u64, data: PolicyData) -> Result<()> {
-        self.policy_data[policy_id].base.write(data)
+        self.policy_data[policy_id].write(data)
     }
 
     fn set_policy_set(&mut self, policy_id: u64, account: Address, value: bool) -> Result<()> {

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -190,10 +190,13 @@ impl TIP403Registry {
         )?;
 
         // Store policy data
-        self.set_policy_data(new_policy_id, PolicyData {
-            policy_type,
-            admin: call.admin,
-        })?;
+        self.set_policy_data(
+            new_policy_id,
+            PolicyData {
+                policy_type,
+                admin: call.admin,
+            },
+        )?;
 
         self.emit_event(TIP403RegistryEvent::PolicyCreated(
             ITIP403Registry::PolicyCreated {
@@ -399,10 +402,13 @@ impl TIP403Registry {
         )?;
 
         // Store policy data with COMPOUND type
-        self.set_policy_data(new_policy_id, PolicyData {
-            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-            admin: Address::ZERO,
-        })?;
+        self.set_policy_data(
+            new_policy_id,
+            PolicyData {
+                policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+                admin: Address::ZERO,
+            },
+        )?;
 
         // Store compound policy data separately
         self.compound_policy_data[new_policy_id].write(CompoundPolicyData {

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -11,38 +11,34 @@ use utils::*;
 
 #[test]
 fn test_tip403_registry_layout() {
-    use tempo_precompiles::tip403_registry::{__packing_policy_record::*, slots};
+    use tempo_precompiles::tip403_registry::slots;
 
     let sol_path = testdata("tip403_registry.sol");
     let solc_layout = load_solc_layout(&sol_path);
 
     // Verify top-level fields
-    let rust_layout = layout_fields!(policy_id_counter, policy_data, policy_set);
+    let rust_layout =
+        layout_fields!(policy_id_counter, policy_data, policy_set, compound_policy_data);
     if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
         panic_layout_mismatch("Layout", errors, &sol_path);
     }
 
-    // Verify `PolicyRecord` struct members (nested under policyData mapping)
-    let base_slot = slots::POLICY_DATA;
-    let rust_policy_record = struct_fields!(base_slot, base, compound);
-    if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_policy_record) {
-        panic_layout_mismatch("PolicyRecord struct layout", errors, &sol_path);
-    }
-
-    // Verify `PolicyData` struct members (nested in PolicyRecord.base)
+    // Verify `PolicyData` struct members (nested in policyData mapping)
     {
         use tempo_precompiles::tip403_registry::__packing_policy_data::*;
+        let base_slot = slots::POLICY_DATA;
         let rust_policy_data = struct_fields!(base_slot, policy_type, admin);
         if let Err(errors) =
-            compare_nested_struct_type(&solc_layout, "PolicyData", &rust_policy_data)
+            compare_struct_members(&solc_layout, "policyData", &rust_policy_data)
         {
             panic_layout_mismatch("PolicyData struct layout", errors, &sol_path);
         }
     }
 
-    // Verify `CompoundPolicyData` struct members (nested in PolicyRecord.compound)
+    // Verify `CompoundPolicyData` struct members (in compound_policy_data mapping)
     {
         use tempo_precompiles::tip403_registry::__packing_compound_policy_data::*;
+        let base_slot = slots::COMPOUND_POLICY_DATA;
         let rust_compound = struct_fields!(
             base_slot,
             sender_policy_id,
@@ -50,7 +46,7 @@ fn test_tip403_registry_layout() {
             mint_recipient_policy_id
         );
         if let Err(errors) =
-            compare_nested_struct_type(&solc_layout, "CompoundPolicyData", &rust_compound)
+            compare_struct_members(&solc_layout, "compoundPolicyData", &rust_compound)
         {
             panic_layout_mismatch("CompoundPolicyData struct layout", errors, &sol_path);
         }
@@ -220,19 +216,20 @@ fn export_all_storage_constants() {
 
     // TIP403 Registry
     {
-        use tempo_precompiles::tip403_registry::{__packing_policy_record::*, slots};
+        use tempo_precompiles::tip403_registry::slots;
 
-        let fields = layout_fields!(policy_id_counter, policy_data, policy_set);
-        let base_slot = slots::POLICY_DATA;
-        let policy_record_struct = struct_fields!(base_slot, base, compound);
+        let fields =
+            layout_fields!(policy_id_counter, policy_data, policy_set, compound_policy_data);
 
         let policy_data_struct = {
             use tempo_precompiles::tip403_registry::__packing_policy_data::*;
+            let base_slot = slots::POLICY_DATA;
             struct_fields!(base_slot, policy_type, admin)
         };
 
         let compound_policy_data_struct = {
             use tempo_precompiles::tip403_registry::__packing_compound_policy_data::*;
+            let base_slot = slots::COMPOUND_POLICY_DATA;
             struct_fields!(
                 base_slot,
                 sender_policy_id,
@@ -246,7 +243,6 @@ fn export_all_storage_constants() {
             json!({
                 "fields": fields.iter().map(field_to_json).collect::<Vec<_>>(),
                 "structs": {
-                    "policyData": policy_record_struct.iter().map(field_to_json).collect::<Vec<_>>(),
                     "PolicyData": policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>(),
                     "CompoundPolicyData": compound_policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>()
                 }

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -25,8 +25,7 @@ fn test_tip403_registry_layout() {
     // Verify `PolicyRecord` struct members (nested under policyData mapping)
     let base_slot = slots::POLICY_DATA;
     let rust_policy_record = struct_fields!(base_slot, base, compound);
-    if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_policy_record)
-    {
+    if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_policy_record) {
         panic_layout_mismatch("PolicyRecord struct layout", errors, &sol_path);
     }
 

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -17,15 +17,15 @@ fn test_tip403_registry_layout() {
     let solc_layout = load_solc_layout(&sol_path);
 
     // Verify top-level fields
-    let rust_layout = layout_fields!(policy_id_counter, policy_records, policy_set);
+    let rust_layout = layout_fields!(policy_id_counter, policy_data, policy_set);
     if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
         panic_layout_mismatch("Layout", errors, &sol_path);
     }
 
-    // Verify `PolicyRecord` struct members (nested under policyRecords mapping)
-    let base_slot = slots::POLICY_RECORDS;
+    // Verify `PolicyRecord` struct members (nested under policyData mapping)
+    let base_slot = slots::POLICY_DATA;
     let rust_policy_record = struct_fields!(base_slot, base, compound);
-    if let Err(errors) = compare_struct_members(&solc_layout, "policyRecords", &rust_policy_record)
+    if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_policy_record)
     {
         panic_layout_mismatch("PolicyRecord struct layout", errors, &sol_path);
     }
@@ -223,8 +223,8 @@ fn export_all_storage_constants() {
     {
         use tempo_precompiles::tip403_registry::{__packing_policy_record::*, slots};
 
-        let fields = layout_fields!(policy_id_counter, policy_records, policy_set);
-        let base_slot = slots::POLICY_RECORDS;
+        let fields = layout_fields!(policy_id_counter, policy_data, policy_set);
+        let base_slot = slots::POLICY_DATA;
         let policy_record_struct = struct_fields!(base_slot, base, compound);
 
         let policy_data_struct = {
@@ -247,9 +247,9 @@ fn export_all_storage_constants() {
             json!({
                 "fields": fields.iter().map(field_to_json).collect::<Vec<_>>(),
                 "structs": {
-                    "policyRecords": policy_record_struct.iter().map(field_to_json).collect::<Vec<_>>(),
-                    "policyData": policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>(),
-                    "compoundPolicyData": compound_policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>()
+                    "policyData": policy_record_struct.iter().map(field_to_json).collect::<Vec<_>>(),
+                    "PolicyData": policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>(),
+                    "CompoundPolicyData": compound_policy_data_struct.iter().map(field_to_json).collect::<Vec<_>>()
                 }
             }),
         );

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -17,8 +17,12 @@ fn test_tip403_registry_layout() {
     let solc_layout = load_solc_layout(&sol_path);
 
     // Verify top-level fields
-    let rust_layout =
-        layout_fields!(policy_id_counter, policy_data, policy_set, compound_policy_data);
+    let rust_layout = layout_fields!(
+        policy_id_counter,
+        policy_data,
+        policy_set,
+        compound_policy_data
+    );
     if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
         panic_layout_mismatch("Layout", errors, &sol_path);
     }
@@ -28,9 +32,7 @@ fn test_tip403_registry_layout() {
         use tempo_precompiles::tip403_registry::__packing_policy_data::*;
         let base_slot = slots::POLICY_DATA;
         let rust_policy_data = struct_fields!(base_slot, policy_type, admin);
-        if let Err(errors) =
-            compare_struct_members(&solc_layout, "policyData", &rust_policy_data)
-        {
+        if let Err(errors) = compare_struct_members(&solc_layout, "policyData", &rust_policy_data) {
             panic_layout_mismatch("PolicyData struct layout", errors, &sol_path);
         }
     }
@@ -218,8 +220,12 @@ fn export_all_storage_constants() {
     {
         use tempo_precompiles::tip403_registry::slots;
 
-        let fields =
-            layout_fields!(policy_id_counter, policy_data, policy_set, compound_policy_data);
+        let fields = layout_fields!(
+            policy_id_counter,
+            policy_data,
+            policy_set,
+            compound_policy_data
+        );
 
         let policy_data_struct = {
             use tempo_precompiles::tip403_registry::__packing_policy_data::*;

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
@@ -14,7 +14,7 @@
           {
             "astId": 30,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-            "label": "policyRecords",
+            "label": "policyData",
             "offset": 0,
             "slot": "1",
             "type": "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)"

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
@@ -17,21 +17,19 @@ contract TIP403Registry {
         uint64 mintRecipientPolicyId;
     }
 
-    struct PolicyRecord {
-        PolicyData base;
-        CompoundPolicyData compound;
-    }
-
     // ========== Storage ==========
 
     /// Counter for policy IDs
     uint64 public policyIdCounter;
 
-    /// Mapping of policy ID to policy record (internal, not exposed in ABI)
-    /// Field named `policyData` for storage slot compatibility with pre-TIP-1015 layout
-    mapping(uint64 => PolicyRecord) internal policyData;
+    /// Mapping of policy ID to policy data (base policy info)
+    mapping(uint64 => PolicyData) internal policyData;
 
     /// Nested mapping for policy sets: policy_id -> address -> is_in_set
     /// Used for whitelist/blacklist entries
     mapping(uint64 => mapping(address => bool)) public policySet;
+
+    /// Mapping of policy ID to compound policy data (TIP-1015)
+    /// Stored separately to preserve policyData slot layout for backward compatibility
+    mapping(uint64 => CompoundPolicyData) internal compoundPolicyData;
 }

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
@@ -28,7 +28,8 @@ contract TIP403Registry {
     uint64 public policyIdCounter;
 
     /// Mapping of policy ID to policy record (internal, not exposed in ABI)
-    mapping(uint64 => PolicyRecord) internal policyRecords;
+    /// Field named `policyData` for storage slot compatibility with pre-TIP-1015 layout
+    mapping(uint64 => PolicyRecord) internal policyData;
 
     /// Nested mapping for policy sets: policy_id -> address -> is_in_set
     /// Used for whitelist/blacklist entries

--- a/crates/precompiles/tests/storage_tests/solidity/utils.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/utils.rs
@@ -295,6 +295,7 @@ pub(super) fn compare_struct_members(
 /// * `solc_layout` - The parsed Solidity storage layout
 /// * `type_name_pattern` - A substring to match against type names (e.g., "PolicyData")
 /// * `rust_member_fields` - The expected Rust member layout from `struct_fields!`
+#[allow(dead_code)]
 pub(super) fn compare_nested_struct_type(
     solc_layout: &StorageLayout,
     type_name_pattern: &str,

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1274,9 +1274,7 @@ mod tests {
             policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
             admin: Address::ZERO,
         };
-        let policy_data_slot = TIP403Registry::new().policy_data[policy_id]
-            .base
-            .base_slot();
+        let policy_data_slot = TIP403Registry::new().policy_data[policy_id].base_slot();
         let policy_set_slot = TIP403Registry::new().policy_set[policy_id][fee_payer].slot();
 
         provider.add_account(

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1274,7 +1274,7 @@ mod tests {
             policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
             admin: Address::ZERO,
         };
-        let policy_data_slot = TIP403Registry::new().policy_records[policy_id]
+        let policy_data_slot = TIP403Registry::new().policy_data[policy_id]
             .base
             .base_slot();
         let policy_set_slot = TIP403Registry::new().policy_set[policy_id][fee_payer].slot();


### PR DESCRIPTION
## Problem

Storage slot calculation uses `keccak256(field_name)` as the base slot for mappings. The TIP-1015 PR renamed the field from `policy_data` to `policy_records`, which changed the slot hash and broke re-execution of historical blocks (200 gas mismatch per policy lookup).

### How Slot Hash is Derived

For a mapping field like `policy_data: Mapping<u64, PolicyData>`:

1. The macro assigns a **base slot** to each field (slot 0, 1, 2... in declaration order)
2. For mapping lookups like `policy_data[key]`, the actual storage slot is: `keccak256(key || base_slot)`
3. The field **name** determines which base slot it gets - renaming the field changes this

So:
- `policy_data` → base slot 1 → `keccak256(policy_id || 1)`
- `policy_records` → base slot 1 (still), but different variable in generated code

The issue is the macro generates different slot constants based on field name, so `slots::POLICY_DATA` vs `slots::POLICY_RECORDS` are different identifiers that must match between old and new code.

## Solution

Simply rename `policy_records` back to `policy_data` while keeping the `PolicyRecord` type. The nested `.base` access works correctly because `PolicyData` is at offset 0 within `PolicyRecord`.

## Testing

- All 41 TIP403 registry tests pass
- Storage layout tests pass
- Transaction pool tests pass