### PR TITLE
TIP-1017: Subblocks v2 - Builder Delegation

### DIFF
--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -617,6 +617,31 @@ Validators deduplicate received subblocks by `(builder, parent_hash)`. Only the 
 
 ---
 
+# Design Rationale
+
+## Root-Only Signing for Subblock Transactions
+
+Subblock transactions (0x5b prefix) require root EOA signatures and reject keychain (access key) signatures. This is intentional due to a race condition with key revocation:
+
+1. User signs a 0x5b tx with an access key, submits to builder
+2. Builder validates signature against current keychain state, includes in subblock
+3. In the same block, a main block tx revokes that access key
+4. Block execution order: main txs execute first, then subblock txs
+5. When the subblock tx executes, the key is already revoked
+
+The problem: signature validation happens at subblock validation time (before block building), not during execution. The subblock tx would still execute even though the key was revoked in the same block.
+
+This violates user expectations. When a user revokes an access key, they expect immediate effect. Allowing keychain signatures for subblock txs would create a window where revoked keys can still authorize transactions.
+
+**Alternative considered**: Re-validate keychain signatures during execution. This was rejected because:
+- Adds execution-time overhead for every subblock tx
+- Creates griefing vector: users could intentionally revoke keys to cause builder's subblock to fail
+- Complicates the execution model
+
+Root-only signing is the simplest solution that maintains user expectations around key revocation.
+
+---
+
 # Implementation Notes
 
 ## Relationship to Current Implementation


### PR DESCRIPTION
## Summary

**TIP-1017** redesigns the subblock system to decouple builder identity from validator identity, based on customer feedback and internal review.

### Key Changes

1. **Many-to-one builder delegation**: Validators call `delegateToBuilder(builder)` to delegate their gas budget. Multiple validators can share the same builder, who accumulates their combined gas allocation.

2. **ECDSA signing**: Builders sign subblocks with their Ethereum key (standard ECDSA) instead of ed25519, since subblock signing is not part of consensus.

3. **Builder-controlled config**: Builders call `setBuilderConfig(feeRecipient, feeToken)` to configure where fees go and their preferred fee token.

4. **New nonce key format**: `0x5b | builder_address (20 bytes) | nonce (11 bytes)` — builder identity is embedded directly in the transaction.

5. **Expiring nonces in subblocks**: When nonce = `type(uint88).max`, the transaction uses TIP-1009 expiring nonce semantics for replay protection.

### What's NOT included (simplified from earlier draft)

- **No fallback 0x5b transactions**: Dropped for simplicity. If builder is offline, txs wait.
- **No fee_recipient uniqueness constraint**: Multiple builders can share a fee recipient.

### Design Decisions

| Decision | Rationale |
|----------|-----------|
| ECDSA not ed25519 | Subblock signing is not consensus-critical |
| Many-to-one delegation | Allows shared builder infrastructure |
| gasWeight tracking | Explicit counter for efficient gas budget computation |
| Root-only tx signing | Prevents race condition with keychain revocation |
| Builder sets config | Decouples fee routing from validator identity |

See [tips/tip-1017.md](https://github.com/tempoxyz/tempo/blob/TIP-1017/tips/tip-1017.md) for full spec.