### PR TITLE
fix(gas): charge 250k for contract account creation in TIP-1000

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1687,7 +1687,7 @@ mod tests {
         // T1 costs: CREATE cost (500k) + new account for sender (250k) + new account for contract (250k)
         let tx = TxBuilder::new()
             .create(&initcode)
-            .gas_limit(1_000_000)
+            .gas_limit(1_100_000)
             .build();
 
         let signed_tx = key_pair.sign_tx(tx)?;
@@ -1696,9 +1696,10 @@ mod tests {
         let result = evm.transact_commit(tx_env)?;
         assert!(result.is_success(), "CREATE transaction should succeed");
 
-        // With TIP-1000: CREATE cost (500k) + new account for sender (250k) + base costs
+        // With TIP-1000: CREATE cost (500k) + new account for sender (250k)
+        //                + new account for contract (250k) + base costs
         let gas_used = result.gas_used();
-        assert_eq!(gas_used, 778720, "T1 CREATE contract gas should be exact");
+        assert_eq!(gas_used, 1_028_720, "T1 CREATE contract gas should be exact");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

TIP-1000 requires a 250,000 gas charge whenever an account's nonce transitions from 0 to 1. This includes the newly created contract account in CREATE/CREATE2 operations.

## Problem

Previously, Tempo only charged `new_account_cost` when the **sender's** `tx.nonce == 0`, but did not charge for the **created contract account's** nonce 0→1 transition.

From [TIP-1000](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md#account-creation):
> - For contract accounts: charged when the contract is deployed (CREATE or CREATE2)
> - The account creation cost (250,000 gas) is separate and still applies when the contract account's nonce transitions from 0 to 1

## Solution

Added the 250k charge for contract account creation in two places:

1. **Regular transactions with `TxKind::Create`**: In `validate_initial_tx_gas`
2. **AA transactions with CREATE calls**: In `validate_aa_initial_tx_gas`

## Test Changes

Updated `test_aa_tx_gas_create_contract` to reflect the correct gas cost:
- Before: 778,720 gas (missing contract account creation cost)
- After: 1,028,720 gas (includes contract account creation cost)

## References

- Audit issue: https://github.com/sherlock-audit/2026-01-tempo-jan-25th/pull/138#discussion_r2749776157
- TIP-1000 spec: https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md