### PR TITLE
fix(evm): charge 250k gas for contract account creation in CREATE/CREATE2

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -392,6 +392,12 @@ where
         // Add nonce gas based on hardfork
         // If tx nonce is 0, it's a new key (0 -> 1 transition), otherwise existing key
         if spec.is_t1() {
+            // TIP-1000: Account creation cost for the new contract account
+            // Contract accounts have their nonce set to 1 on creation (0 -> 1 transition)
+            if aa_env.aa_calls.first().is_some_and(|c| c.to.is_create()) {
+                init_and_floor_gas.initial_gas += gas_params.get(GasId::new_account_cost());
+            }
+
             // Expiring nonce transactions
             if tx.nonce_key == TEMPO_EXPIRING_NONCE_KEY {
                 init_and_floor_gas.initial_gas += EXPIRING_NONCE_GAS;


### PR DESCRIPTION
Closes CHAIN-574

TIP-1000 requires a 250,000 gas charge when an account's nonce transitions from 0->1. While we correctly charge this for sender accounts when `tx.nonce == 0`, we were not charging it for newly created contract accounts via CREATE/CREATE2.

The PR adds the 250k gas charge for the new contract account (nonce 0->1 transition) in:
- Non-AA transaction path in the handler
- AA transaction path in `validate_aa_initial_tx_gas`
- Transaction pool validator

All changes are gated behind `spec.is_t1()` to avoid breaking pre-T1 state transitions.
