### PR TITLE
fix(evm): charge TIP-1000 new account cost for expiring nonce CREATE when protocol nonce is 0

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -333,6 +333,10 @@ pub enum TempoPoolTransactionError {
     )]
     ExpiringNonceValidBeforeTooFar { valid_before: u64, max_allowed: u64 },
 
+    /// Thrown when there is an error accessing state provider during validation.
+    #[error("State provider error: {0}")]
+    StateProviderError(String),
+
     /// Thrown when an expiring nonce transaction's hash has already been seen (replay).
     #[error("Expiring nonce transaction replay: tx hash already seen and not expired")]
     ExpiringNonceReplay,
@@ -396,7 +400,8 @@ impl PoolTransactionError for TempoPoolTransactionError {
             | Self::NoCalls
             | Self::CreateCallWithAuthorizationList
             | Self::CreateCallNotFirst
-            | Self::FeeCapBelowMinBaseFee { .. } => true,
+            | Self::FeeCapBelowMinBaseFee { .. }
+            | Self::StateProviderError(_) => true,
         }
     }
 


### PR DESCRIPTION
Closes CHAIN-577

When an AA transaction uses expiring nonce for a CREATE operation, the CREATE execution bumps the protocol nonce from 0 to 1. However, the gas calculation wasn't accounting for this—it only checked the nonce key type, not the underlying protocol nonce state. This meant these transactions avoided the 250k gas charge intended to prevent state bloat.

This PR adds a check in the expiring nonce gas calculation branch: if it's a CREATE transaction AND the caller's protocol nonce is 0, charge the `new_account_cost` (250k gas) in addition to the expiring nonce gas.

Applied to:
- `crates/revm/src/handler.rs` (execution)
- `crates/transaction-pool/src/validator.rs` (pool validation)
