### PR TITLE
fix(tip-1015): don't short-circuit errors pre-T1

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -680,7 +680,10 @@ impl TIP20Token {
         let policy_id = self.transfer_policy_id()?;
         let registry = TIP403Registry::new();
 
-        if !registry.is_authorized_as(policy_id, from, AuthRole::sender())? {
+        // (spec: +T1) short-circuit and skip recipient check if sender fails
+        if !registry.is_authorized_as(policy_id, from, AuthRole::sender())?
+            && self.storage.spec().is_t1()
+        {
             return Ok(false);
         }
         registry.is_authorized_as(policy_id, to, AuthRole::recipient())

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -448,10 +448,10 @@ impl TIP403Registry {
                     self.is_authorized_simple_policy(compound.mint_recipient_policy_id, user)
                 }
                 AuthRole::Transfer => {
+                    // (spec: +T1) short-circuit and skip recipient check if sender fails
                     if !self.is_authorized_simple_policy(compound.sender_policy_id, user)?
                         && self.storage.spec().is_t1()
                     {
-                        // (spec: +T1) short-circuit and skip recipient check if sender fails
                         return Ok(false);
                     }
                     self.is_authorized_simple_policy(compound.recipient_policy_id, user)


### PR DESCRIPTION
This PR resolves re-execution.

fixes 2 code instances where an SLOAD was omitted (pre-T1) due to an optimization caused by an early return on execution error.