### PR TITLE
docs(txpool): document why AA2dPool::discard ignores max_size limit

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -921,6 +921,9 @@ impl AA2dPool {
     ///
     /// Evicts queued transactions first (up to queued_limit), then pending if needed.
     /// Counts are computed lazily by scanning the eviction set.
+    ///
+    /// Note: Only `max_txs` is enforced here; `max_size` is intentionally not checked for 2D pools
+    /// since the protocol pool already enforces size-based limits as a primary defense.
     fn discard(&mut self) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
         let mut removed = Vec::new();
 


### PR DESCRIPTION
Closes CHAIN-569

Document that `AA2dPool::discard` intentionally only enforces `max_txs` and ignores `max_size`.

The `max_size` limit is not needed here because the protocol pool already enforces size-based limits as the primary defense against memory exhaustion.