### PR TITLE
perf(txpool): cache is_expiring_nonce in TempoPooledTransaction

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -33,6 +33,8 @@ pub struct TempoPooledTransaction {
     inner: EthPooledTransaction<TempoTxEnvelope>,
     /// Cached payment classification for efficient block building
     is_payment: bool,
+    /// Cached expiring nonce classification
+    is_expiring_nonce: bool,
     /// Cached slot of the 2D nonce, if any.
     nonce_key_slot: OnceLock<Option<U256>>,
     /// Cached prepared [`TempoTxEnv`] for payload building.
@@ -48,6 +50,10 @@ impl TempoPooledTransaction {
     /// Create new instance of [Self] from the given consensus transactions and the encoded size.
     pub fn new(transaction: Recovered<TempoTxEnvelope>) -> Self {
         let is_payment = transaction.is_payment();
+        let is_expiring_nonce = transaction
+            .as_aa()
+            .map(|tx| tx.tx().is_expiring_nonce_tx())
+            .unwrap_or(false);
         Self {
             inner: EthPooledTransaction {
                 cost: calc_gas_balance_spending(
@@ -60,6 +66,7 @@ impl TempoPooledTransaction {
                 transaction,
             },
             is_payment,
+            is_expiring_nonce,
             nonce_key_slot: OnceLock::new(),
             tx_env: OnceLock::new(),
             key_expiry: OnceLock::new(),
@@ -115,11 +122,7 @@ impl TempoPooledTransaction {
 
     /// Returns true if this is an expiring nonce transaction.
     pub(crate) fn is_expiring_nonce(&self) -> bool {
-        self.inner
-            .transaction
-            .as_aa()
-            .map(|tx| tx.tx().is_expiring_nonce_tx())
-            .unwrap_or(false)
+        self.is_expiring_nonce
     }
 
     /// Extracts the keychain subject (account, key_id, fee_token) from this transaction.

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1489,7 +1489,7 @@ impl BestAA2dTransactions {
             }
             // Advance transaction that just got unlocked, if any.
             // Skip for expiring nonce transactions as they are always independent.
-            if !id.seq_id.is_expiring_nonce()
+            if !best.transaction.transaction.is_expiring_nonce()
                 && let Some(unlocked) = self.by_id.get(&id.unlocks())
             {
                 self.independent.insert(unlocked.clone());
@@ -1540,14 +1540,6 @@ impl AASequenceId {
     /// Creates a new instance with the address and nonce key.
     pub const fn new(address: Address, nonce_key: U256) -> Self {
         Self { address, nonce_key }
-    }
-
-    /// Returns `true` if this sequence ID represents an expiring nonce transaction.
-    ///
-    /// Expiring nonce transactions use `nonce_key == U256::MAX` and are always independent,
-    /// meaning they don't have sequential nonce dependencies.
-    pub(crate) fn is_expiring_nonce(&self) -> bool {
-        self.nonce_key == U256::MAX
     }
 
     const fn start_bound(self) -> std::ops::Bound<AA2dTransactionId> {


### PR DESCRIPTION
Ref CHAIN-573
Followup https://github.com/tempoxyz/tempo/pull/2392#discussion_r2756112515

Cache `is_expiring_nonce` as a bool field in `TempoPooledTransaction` instead of computing it on each access. The value is now computed once at construction time.

Also removes the now-unused `AASequenceId::is_expiring_nonce()` method.