### PR TITLE
feat(valconfig): change to manual batched migration

### DIFF
--- a/docs/pages/protocol/tips/tip-xxxx.mdx
+++ b/docs/pages/protocol/tips/tip-xxxx.mdx
@@ -690,8 +690,8 @@ The test suite must cover:
 
 28. **migrateValidator imports validator**: Calling `migrateValidator(i)`
     correctly imports validator at index i from V1
-29. **migrateValidator is idempotent**: Calling `migrateValidator(i)` multiple times
-    for the same index reverts or is a no-op
+29. **migrateValidator reverts on duplicate**: Calling `migrateValidator(i)` reverts
+    if `i != validatorsArray.length`
 30. **migrateValidator owner only**: Non-owner cannot call `migrateValidator`
 31. **All validators imported on migration**: Both V1 active and inactive validators
     are imported; inactive ones have `addedAtHeight == deletedAtHeight == block.timestamp`,


### PR DESCRIPTION
## Summary

Stacked on #2275. Changes lazy initialization to manual batched migration based on [Slack discussion](https://tempoxyz.slack.com/archives/C0AA3FYNFH8/p1770117395147649).

### Problem

The lazy init approach triggers migration on first write, which:
- Risks hitting tx gas limits with many validators (11 SSTOREs × 250k gas each)
- Could fail mid-migration leaving inconsistent state

### Solution

**CL reads from V1 until V2's `isInitialized()` returns true:**

```
if v2.isInitialized() {
    read_from_v2()
} else {
    read_from_v1()  // continue using V1 until migration complete
}
```

**Admin migrates manually in batches:**
1. `migrateValidators(0, 10)` - migrate first batch
2. `migrateValidators(10, 20)` - migrate next batch
3. ... repeat until all migrated
4. `finalizeMigration()` - flip the `initialized` flag

### Key Changes

| Before (lazy init) | After (manual migration) |
|---|---|
| `initialize()` callable by anyone | `migrateValidators()` + `finalizeMigration()` owner-only |
| V2 proxies reads to V1 before init | CL handles V1/V2 switching |
| First write triggers full migration | Admin controls migration timing |
| Gas limit risk | Batched, no gas limit risk |

### Invariants

- Writes (`addValidator`, `deleteValidator`, `rotateValidator`) blocked until `initialized == true`
- Only migration functions work before initialization
- Migration must complete before epoch boundary to avoid DKG disruption

cc @howy @janis @zygimantas