### PR TITLE
fix: resolve CI failures in forge fmt and fuzz test

### DIFF
--- a/tips/ref-impls/test/StablecoinDEX.t.sol
+++ b/tips/ref-impls/test/StablecoinDEX.t.sol
@@ -881,6 +881,10 @@ contract StablecoinDEXTest is BaseTest {
 
     // Test price conversion validates bounds and reverts for out-of-range prices
     function testFuzz_PriceToTick_Conversion(uint32 price) public view {
+        // Bound price to avoid int32 overflow when computing expectedTick
+        // int32 max is 2^31-1, so price must be < 2^31 to safely cast to int32
+        price = uint32(bound(price, 0, uint32(type(int32).max)));
+
         int16 expectedTick = int16(int32(price) - int32(exchange.PRICE_SCALE()));
 
         if (price < exchange.MIN_PRICE() || price > exchange.MAX_PRICE()) {

--- a/tips/ref-impls/test/invariants/TIP20Factory.t.sol
+++ b/tips/ref-impls/test/invariants/TIP20Factory.t.sol
@@ -540,7 +540,6 @@ contract TIP20FactoryInvariantTest is InvariantBaseTest {
         }
     }
 
-
     /// @notice Called after each invariant run to log final state
     function afterInvariant() public {
         if (!_loggingEnabled) return;


### PR DESCRIPTION
## Summary

Fixes two CI failures from [run #21641850929](https://github.com/tempoxyz/tempo/actions/runs/21641850929):

### 1. Forge fmt check failure
- Removed extra blank line in `test/invariants/TIP20Factory.t.sol` at line 543

### 2. Fuzz test arithmetic overflow
- `testFuzz_PriceToTick_Conversion(uint32)` failed with counterexample `2147483648` (2^31)
- The test computed `int16(int32(price) - int32(PRICE_SCALE))` which overflows when price >= 2^31
- Added `bound(price, 0, uint32(type(int32).max))` to constrain inputs to valid int32 range

## Testing
- `forge fmt --check` passes
- `forge test --match-test testFuzz_PriceToTick_Conversion` passes with 256 runs