### PR TITLE
Add Amp code review workflow

### DIFF
--- a/.github/workflows/amp-review.yml
+++ b/.github/workflows/amp-review.yml
@@ -1,0 +1,30 @@
+name: Amp Code Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
+jobs:
+  review:
+    # Only run on PRs with "amp" label, skip drafts
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'amp') &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    # Ensure only one review runs per PR
+    concurrency:
+      group: amp-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+      checks: write
+      contents: read
+    steps:
+      - name: Run Amp Code Review
+        uses: docker://ghcr.io/sourcegraph/cra-github:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AMP_SERVER_URL: ${{ vars.AMP_SERVER_URL }}
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+        with:
+          args: node /app/dist/bin/review-action.js


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs Amp code review on PRs labeled with `amp`.

Triggers on:
- PR opened, reopened, ready for review, or labeled
- Only runs if the PR has the `amp` label and is not a draft

**Setup required:**
- Add `AMP_API_KEY` secret to repo settings (Settings → Secrets and variables → Actions)