### PR TITLE
fix(tips): correct IAccountKeychain.sol reference path in TIP-1011

### DIFF
--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -308,6 +308,6 @@ Pre-fork blocks MUST be replayed with old semantics to preserve state root consi
 ## References
 
 - [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
-- [IAccountKeychain.sol](docs/specs/src/interfaces/IAccountKeychain.sol)
+- [IAccountKeychain.sol](tips/ref-impls/src/interfaces/IAccountKeychain.sol)
 - [GitHub Issue #1865](https://github.com/tempoxyz/tempo/issues/1865) - Periodic spending limits
 - [GitHub Issue #1491](https://github.com/tempoxyz/tempo/issues/1491) - Destination address scoping


### PR DESCRIPTION
The reference link pointed to a non-existent path `docs/specs/src/interfaces/IAccountKeychain.sol`. Updated to the correct path `tips/ref-impls/src/interfaces/IAccountKeychain.sol`.

This was causing dead link warnings in the docs build.