### PR TITLE
chore: update ci log level to `warn`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUST_LOG: warn
   RUSTC_WRAPPER: "sccache"
 
 jobs:


### PR DESCRIPTION
This PR updates CI to use `RUST_LOG=warn` to reduce verbosity when there are failures in CI. 