### PR TITLE
TIP-1017: Protocol-Enshrined Subaccounts

### DIFF
--- a/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
+++ b/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/**
+ * @title Account Keychain Subaccount Extension Interface
+ * @notice Extension to IAccountKeychain for TIP-1017 subaccount primitives
+ * @dev These functions are added to the AccountKeychain precompile at
+ *      address `0xaAAAaaAA00000000000000000000000000000000`
+ */
+interface IAccountKeychainSubaccounts {
+
+    /*//////////////////////////////////////////////////////////////
+                                STRUCTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Auto-funding rule for a subaccount
+    struct AutoFundRule {
+        address token;         // TIP-20 token address
+        uint256 minBalance;    // Trigger auto-fund when sub-balance drops below this
+        uint256 refillAmount;  // Amount to transfer from root to subaccount
+    }
+
+    /// @notice Subaccount configuration for an access key
+    struct SubaccountConfig {
+        bool enabled;             // Whether this key operates as a subaccount
+        AutoFundRule[] autoFund;  // Auto-funding rules
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when tokens are deposited into a subaccount
+    event SubaccountDeposit(
+        address indexed account,
+        address indexed keyId,
+        address indexed token,
+        uint256 amount
+    );
+
+    /// @notice Emitted when tokens are withdrawn from a subaccount
+    event SubaccountWithdrawal(
+        address indexed account,
+        address indexed keyId,
+        address indexed token,
+        uint256 amount
+    );
+
+    /// @notice Emitted when auto-funding is triggered
+    event SubaccountAutoFunded(
+        address indexed account,
+        address indexed keyId,
+        address indexed token,
+        uint256 amount
+    );
+
+    /*//////////////////////////////////////////////////////////////
+                                ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error SubaccountNotEnabled();
+    error InsufficientSubBalance();
+    error InsufficientRootBalance();
+    error AutoFundFailed();
+
+    /*//////////////////////////////////////////////////////////////
+                        MANAGEMENT FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Deposit tokens from root account balance into a key's subaccount
+     * @dev MUST only be called in transactions signed by the Root Key.
+     *      Debits the root account's TIP-20 balance and credits the sub-balance.
+     * @param keyId The access key identifier
+     * @param token The TIP-20 token address
+     * @param amount The amount to deposit
+     */
+    function depositToSubaccount(address keyId, address token, uint256 amount) external;
+
+    /**
+     * @notice Withdraw tokens from a key's subaccount back to the root account
+     * @dev MUST only be called in transactions signed by the Root Key.
+     *      Debits the sub-balance and credits the root account's TIP-20 balance.
+     *      Can be called even after the key is revoked (to recover remaining funds).
+     * @param keyId The access key identifier
+     * @param token The TIP-20 token address
+     * @param amount The amount to withdraw
+     */
+    function withdrawFromSubaccount(address keyId, address token, uint256 amount) external;
+
+    /**
+     * @notice Update auto-funding rules for a key's subaccount
+     * @dev MUST only be called in transactions signed by the Root Key.
+     *      Replaces all existing auto-fund rules for the key.
+     * @param keyId The access key identifier
+     * @param rules The new auto-funding rules
+     */
+    function updateAutoFundRules(address keyId, AutoFundRule[] calldata rules) external;
+
+    /*//////////////////////////////////////////////////////////////
+                        VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Returns the deterministic subaccount address for a given account and key
+     * @dev Derived as: address(uint160(uint256(keccak256(
+     *      abi.encodePacked(bytes1(0xff), account, keyId)
+     *      ))))
+     * @param account The root account address
+     * @param keyId The access key identifier
+     * @return The deterministic subaccount address
+     */
+    function getSubaccountAddress(address account, address keyId)
+        external pure returns (address);
+
+    /**
+     * @notice Returns the sub-balance of a token for a specific key's subaccount
+     * @param account The root account address
+     * @param keyId The access key identifier
+     * @param token The TIP-20 token address
+     * @return The sub-balance amount
+     */
+    function getSubBalance(address account, address keyId, address token)
+        external view returns (uint256);
+
+    /**
+     * @notice Returns the subaccount configuration for a key
+     * @param account The root account address
+     * @param keyId The access key identifier
+     * @return config The subaccount configuration
+     */
+    function getSubaccountConfig(address account, address keyId)
+        external view returns (SubaccountConfig memory config);
+}

--- a/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
+++ b/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
@@ -13,7 +13,7 @@ interface IAccountKeychainSubaccounts {
                                 STRUCTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Auto-funding rule for a subaccount
+    /// @notice Auto-funding rule for a subaccount (max 4 rules per key)
     struct AutoFundRule {
         address token;         // TIP-20 token address
         uint256 minBalance;    // Trigger auto-fund when sub-balance drops below this
@@ -61,7 +61,9 @@ interface IAccountKeychainSubaccounts {
     error SubaccountNotEnabled();
     error InsufficientSubBalance();
     error InsufficientRootBalance();
-    error AutoFundFailed();
+    error ApproveBlockedForSubaccount();
+    error TooManyAutoFundRules();
+    error FeeExceedsCap();
 
     /*//////////////////////////////////////////////////////////////
                         MANAGEMENT FUNCTIONS
@@ -106,6 +108,7 @@ interface IAccountKeychainSubaccounts {
      * @dev Derived as: address(uint160(uint256(keccak256(
      *      abi.encodePacked(bytes1(0xff), account, keyId)
      *      ))))
+     *      Uses 0xff prefix for collision resistance with regular account addresses
      * @param account The root account address
      * @param keyId The access key identifier
      * @return The deterministic subaccount address
@@ -131,4 +134,11 @@ interface IAccountKeychainSubaccounts {
      */
     function getSubaccountConfig(address account, address keyId)
         external view returns (SubaccountConfig memory config);
+
+    /// @notice Looks up the (account, keyId) pair for a registered subaccount address
+    /// @param subAddr The subaccount address to look up
+    /// @return account The root account (address(0) if not registered)
+    /// @return keyId The access key identifier (address(0) if not registered)
+    function resolveSubaccountAddress(address subAddr)
+        external view returns (address account, address keyId);
 }

--- a/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
+++ b/tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol
@@ -15,15 +15,15 @@ interface IAccountKeychainSubaccounts {
 
     /// @notice Auto-funding rule for a subaccount (max 4 rules per key)
     struct AutoFundRule {
-        address token;         // TIP-20 token address
-        uint256 minBalance;    // Trigger auto-fund when sub-balance drops below this
-        uint256 refillAmount;  // Amount to transfer from root to subaccount
+        address token; // TIP-20 token address
+        uint256 minBalance; // Trigger auto-fund when sub-balance drops below this
+        uint256 refillAmount; // Amount to transfer from root to subaccount
     }
 
     /// @notice Subaccount configuration for an access key
     struct SubaccountConfig {
-        bool enabled;             // Whether this key operates as a subaccount
-        AutoFundRule[] autoFund;  // Auto-funding rules
+        bool enabled; // Whether this key operates as a subaccount
+        AutoFundRule[] autoFund; // Auto-funding rules
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -32,26 +32,17 @@ interface IAccountKeychainSubaccounts {
 
     /// @notice Emitted when tokens are deposited into a subaccount
     event SubaccountDeposit(
-        address indexed account,
-        address indexed keyId,
-        address indexed token,
-        uint256 amount
+        address indexed account, address indexed keyId, address indexed token, uint256 amount
     );
 
     /// @notice Emitted when tokens are withdrawn from a subaccount
     event SubaccountWithdrawal(
-        address indexed account,
-        address indexed keyId,
-        address indexed token,
-        uint256 amount
+        address indexed account, address indexed keyId, address indexed token, uint256 amount
     );
 
     /// @notice Emitted when auto-funding is triggered
     event SubaccountAutoFunded(
-        address indexed account,
-        address indexed keyId,
-        address indexed token,
-        uint256 amount
+        address indexed account, address indexed keyId, address indexed token, uint256 amount
     );
 
     /*//////////////////////////////////////////////////////////////
@@ -113,8 +104,7 @@ interface IAccountKeychainSubaccounts {
      * @param keyId The access key identifier
      * @return The deterministic subaccount address
      */
-    function getSubaccountAddress(address account, address keyId)
-        external pure returns (address);
+    function getSubaccountAddress(address account, address keyId) external pure returns (address);
 
     /**
      * @notice Returns the sub-balance of a token for a specific key's subaccount
@@ -123,8 +113,14 @@ interface IAccountKeychainSubaccounts {
      * @param token The TIP-20 token address
      * @return The sub-balance amount
      */
-    function getSubBalance(address account, address keyId, address token)
-        external view returns (uint256);
+    function getSubBalance(
+        address account,
+        address keyId,
+        address token
+    )
+        external
+        view
+        returns (uint256);
 
     /**
      * @notice Returns the subaccount configuration for a key
@@ -132,13 +128,21 @@ interface IAccountKeychainSubaccounts {
      * @param keyId The access key identifier
      * @return config The subaccount configuration
      */
-    function getSubaccountConfig(address account, address keyId)
-        external view returns (SubaccountConfig memory config);
+    function getSubaccountConfig(
+        address account,
+        address keyId
+    )
+        external
+        view
+        returns (SubaccountConfig memory config);
 
     /// @notice Looks up the (account, keyId) pair for a registered subaccount address
     /// @param subAddr The subaccount address to look up
     /// @return account The root account (address(0) if not registered)
     /// @return keyId The access key identifier (address(0) if not registered)
     function resolveSubaccountAddress(address subAddr)
-        external view returns (address account, address keyId);
+        external
+        view
+        returns (address account, address keyId);
+
 }

--- a/tips/ref-impls/src/subaccounts.rs
+++ b/tips/ref-impls/src/subaccounts.rs
@@ -1,0 +1,550 @@
+//! TIP-1017: Protocol-Enshrined Subaccounts — Reference Implementation
+//!
+//! This module extends the AccountKeychain precompile with sub-balance isolation,
+//! deterministic subaccount addresses, a subaccount registry, and auto-funding.
+//!
+//! This is a reference implementation illustrating the logic. It is NOT compiled
+//! as part of the production precompile; production integration requires extending
+//! the existing `AccountKeychain` struct in `crates/precompiles/src/account_keychain/`.
+//!
+//! # Overview
+//!
+//! Subaccounts give each access key an isolated token balance carved from the root
+//! account. When a transaction is signed by an access key whose subaccount is
+//! enabled, TIP-20 transfers debit the sub-balance instead of the root balance.
+//! The root key can deposit/withdraw tokens to/from any sub-balance at will.
+//!
+//! ## Key design decisions
+//!
+//! 1. **Deterministic addresses** — Each subaccount has a derived address computed
+//!    as `keccak256(0xff ‖ account ‖ keyId)[12..]`. This allows external contracts
+//!    and indexers to reference a subaccount without on-chain lookups.
+//!
+//! 2. **Registry for reverse lookups** — Although addresses are deterministic, the
+//!    hash is not reversible. The on-chain registry maps `derivedAddr → (account, keyId)`
+//!    so that the protocol can resolve which root account owns a given subaccount.
+//!    *(Audit finding D1: without the registry, the protocol cannot enforce access
+//!    control on incoming transfers or resolve ownership disputes.)*
+//!
+//! 3. **Approve/permit blocking** — When a subaccount key is active, `approve` and
+//!    `permit` calls where `msg_sender == tx_origin` are blocked. Without this,
+//!    a compromised key could set a large allowance to an attacker-controlled
+//!    spender, then the attacker could drain the sub-balance via `transferFrom`
+//!    without further key involvement — effectively bypassing spending limits.
+//!    *(Audit finding A1: the allowance vector is the primary bypass risk.)*
+//!
+//! 4. **Auto-fund counts against spending limits** — When auto-fund moves tokens
+//!    from the root balance into a sub-balance, the transferred amount is deducted
+//!    from the key's TIP-1011 spending limit. This prevents a misconfigured
+//!    auto-fund rule from draining the root balance beyond the intended limit.
+//!    *(Audit finding B1: without this, auto-fund is an unlimited spending vector.)*
+//!
+//! ## Enforcement order
+//!
+//! During a TIP-20 `transfer` call the checks execute in this order:
+//!
+//! 1. `maybe_auto_fund` — top up sub-balance if below threshold (pre-tx hook).
+//! 2. `enforce_approve_block` — revert if this is an approve/permit and the key
+//!    has an active subaccount.
+//! 3. `enforce_sub_balance` — debit the sub-balance instead of the root balance.
+//! 4. TIP-1011 spending-limit check (existing `verify_and_update_spending`).
+//!
+//! ## Gas cost implications
+//!
+//! Each sub-balance check adds roughly:
+//! - 1 transient SLOAD (`transaction_key`)
+//! - 1 cold SLOAD (`subaccount_enabled`)
+//! - 1 cold SLOAD + SSTORE (`sub_balances` read + write)
+//!
+//! Auto-fund adds up to `MAX_AUTO_FUND_RULES` additional SLOAD pairs (min_balance
+//! + root balance check) per rule, but only fires when the balance is actually
+//! below the threshold.
+
+use alloy::primitives::{Address, B256, U256};
+
+use crate::{
+    error::Result,
+    storage::Mapping,
+};
+use tempo_contracts::precompiles::{AccountKeychainError, AccountKeychainEvent};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Configuration for a subaccount associated with an access key.
+#[derive(Debug, Clone, Default)]
+pub struct SubaccountConfig {
+    pub enabled: bool,
+    pub auto_fund_rules: Vec<AutoFundRule>,
+}
+
+/// Rule for automatically refilling a subaccount from the root balance.
+/// Auto-fund amounts count against the key's spending limits (TIP-1011).
+#[derive(Debug, Clone)]
+pub struct AutoFundRule {
+    /// TIP-20 token address. Use `Address::ZERO` for the native token.
+    pub token: Address,
+    /// When the sub-balance drops below this value, trigger a refill.
+    pub min_balance: U256,
+    /// Amount to transfer from the root balance into the sub-balance.
+    pub refill_amount: U256,
+}
+
+/// Maximum number of auto-fund rules per key (protocol-enforced).
+///
+/// Keeping this small bounds the worst-case gas overhead of `maybe_auto_fund`
+/// to a predictable constant (4 × ~2 SLOADs per rule ≈ 8 extra SLOADs).
+pub const MAX_AUTO_FUND_RULES: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Storage extensions (to be added to the AccountKeychain struct)
+// ---------------------------------------------------------------------------
+//
+// The fields below show what would be added to the `#[contract(addr = …)]`
+// struct. They are written as comments because this file is a reference
+// implementation — the real storage lives in AccountKeychain.
+//
+// ```rust
+// #[contract(addr = ACCOUNT_KEYCHAIN_ADDRESS)]
+// pub struct AccountKeychain {
+//     // … existing fields …
+//
+//     // Sub-balance: hash(account, keyId) → token → amount
+//     sub_balances: Mapping<B256, Mapping<Address, U256>>,
+//
+//     // Whether a subaccount is enabled for a given key.
+//     // account → keyId → enabled
+//     subaccount_enabled: Mapping<Address, Mapping<Address, bool>>,
+//
+//     // Reverse registry: derivedAddr → (account, keyId).
+//     // Needed because keccak256 is not reversible (audit finding D1).
+//     subaccount_registry: Mapping<Address, (Address, Address)>,
+//
+//     // Auto-fund rule storage (flattened — Solidity-style dynamic arrays
+//     // are not available, so we store length + indexed fields separately).
+//     //
+//     // hash(account, keyId) → rule count
+//     auto_fund_rules_len: Mapping<B256, u64>,
+//     // hash(account, keyId) → index → token
+//     auto_fund_token: Mapping<B256, Mapping<u64, Address>>,
+//     // hash(account, keyId) → index → min_balance
+//     auto_fund_min_balance: Mapping<B256, Mapping<u64, U256>>,
+//     // hash(account, keyId) → index → refill_amount
+//     auto_fund_refill_amount: Mapping<B256, Mapping<u64, U256>>,
+// }
+// ```
+
+// ---------------------------------------------------------------------------
+// Implementation (reference — methods to be added to `impl AccountKeychain`)
+// ---------------------------------------------------------------------------
+
+impl AccountKeychain {
+    // ------------------------------------------------------------------
+    // Address derivation
+    // ------------------------------------------------------------------
+
+    /// Compute the deterministic subaccount address for a given (account, keyId).
+    ///
+    /// The derivation mirrors CREATE2 style addressing:
+    ///   `keccak256(0xff ‖ account ‖ keyId)[12..]`
+    ///
+    /// The `0xff` prefix prevents collisions with regular EOA addresses and
+    /// with CREATE2 (which uses `0xff ‖ deployer ‖ salt ‖ initCodeHash`).
+    pub fn subaccount_address(account: Address, key_id: Address) -> Address {
+        use alloy::primitives::keccak256;
+        let mut data = [0u8; 41];
+        data[0] = 0xff;
+        data[1..21].copy_from_slice(account.as_slice());
+        data[21..41].copy_from_slice(key_id.as_slice());
+        Address::from_slice(&keccak256(data)[12..])
+    }
+
+    // ------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------
+
+    /// Enable a subaccount for a key during (or after) key authorization.
+    ///
+    /// Must be called by the root key (`transaction_key == Address::ZERO`).
+    ///
+    /// # What this does
+    /// 1. Sets `subaccount_enabled[account][keyId] = true`.
+    /// 2. Derives the subaccount address and writes the registry entry
+    ///    `subaccount_registry[derivedAddr] = (account, keyId)`.
+    /// 3. Persists the auto-fund rules (up to `MAX_AUTO_FUND_RULES`).
+    /// 4. Emits `SubaccountEnabled`.
+    pub fn enable_subaccount(
+        &mut self,
+        account: Address,
+        key_id: Address,
+        config: SubaccountConfig,
+    ) -> Result<()> {
+        let transaction_key = self.transaction_key.t_read()?;
+        if transaction_key != Address::ZERO {
+            return Err(AccountKeychainError::unauthorized_caller().into());
+        }
+
+        if config.auto_fund_rules.len() > MAX_AUTO_FUND_RULES {
+            return Err(AccountKeychainError::too_many_auto_fund_rules().into());
+        }
+
+        // 1. Mark as enabled
+        self.subaccount_enabled[account][key_id].write(true)?;
+
+        // 2. Register derived address for reverse lookups
+        let derived = Self::subaccount_address(account, key_id);
+        self.subaccount_registry[derived].write((account, key_id))?;
+
+        // 3. Persist auto-fund rules
+        let composite = Self::spending_limit_key(account, key_id);
+        let rule_count = config.auto_fund_rules.len() as u64;
+        self.auto_fund_rules_len[composite].write(rule_count)?;
+
+        for (i, rule) in config.auto_fund_rules.iter().enumerate() {
+            let idx = i as u64;
+            self.auto_fund_token[composite][idx].write(rule.token)?;
+            self.auto_fund_min_balance[composite][idx].write(rule.min_balance)?;
+            self.auto_fund_refill_amount[composite][idx].write(rule.refill_amount)?;
+        }
+
+        // 4. Emit event
+        self.emit_event(AccountKeychainEvent::SubaccountEnabled(
+            IAccountKeychain::SubaccountEnabled {
+                account,
+                keyId: key_id,
+                subaccountAddr: derived,
+            },
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // Deposits & withdrawals (root-only)
+    // ------------------------------------------------------------------
+
+    /// Move tokens from the root TIP-20 balance into a sub-balance.
+    ///
+    /// Only the root key may call this. The root's TIP-20 balance is debited
+    /// and the sub-balance is credited by `amount`.
+    ///
+    /// In production this would invoke the TIP-20 precompile to debit the
+    /// root balance. Here we represent that as a conceptual step.
+    pub fn deposit_to_subaccount(
+        &mut self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+        amount: U256,
+    ) -> Result<()> {
+        // --- Root-only guard ---
+        let transaction_key = self.transaction_key.t_read()?;
+        if transaction_key != Address::ZERO {
+            return Err(AccountKeychainError::unauthorized_caller().into());
+        }
+
+        // --- Subaccount must be enabled ---
+        let enabled = self.subaccount_enabled[account][key_id].read()?;
+        if !enabled {
+            return Err(AccountKeychainError::subaccount_not_enabled().into());
+        }
+
+        // --- Debit root balance (conceptual — calls TIP-20 precompile) ---
+        // let root_balance = tip20.balance_of(account, token)?;
+        // if root_balance < amount {
+        //     return Err(AccountKeychainError::insufficient_root_balance().into());
+        // }
+        // tip20.internal_debit(account, token, amount)?;
+
+        // --- Credit sub-balance ---
+        let composite = Self::spending_limit_key(account, key_id);
+        let current = self.sub_balances[composite][token].read()?;
+        self.sub_balances[composite][token].write(current + amount)?;
+
+        self.emit_event(AccountKeychainEvent::SubaccountDeposit(
+            IAccountKeychain::SubaccountDeposit {
+                account,
+                keyId: key_id,
+                token,
+                amount,
+            },
+        ))
+    }
+
+    /// Move tokens from a sub-balance back to the root TIP-20 balance.
+    ///
+    /// Only the root key may call this. Notably, withdrawal is permitted even
+    /// if the key has been revoked — this allows the root account to recover
+    /// any remaining funds from a decommissioned key's sub-balance.
+    pub fn withdraw_from_subaccount(
+        &mut self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+        amount: U256,
+    ) -> Result<()> {
+        // --- Root-only guard ---
+        let transaction_key = self.transaction_key.t_read()?;
+        if transaction_key != Address::ZERO {
+            return Err(AccountKeychainError::unauthorized_caller().into());
+        }
+
+        // --- No enabled check: allow withdrawal even for revoked keys ---
+
+        // --- Debit sub-balance ---
+        let composite = Self::spending_limit_key(account, key_id);
+        let current = self.sub_balances[composite][token].read()?;
+        if current < amount {
+            return Err(AccountKeychainError::insufficient_sub_balance().into());
+        }
+        self.sub_balances[composite][token].write(current - amount)?;
+
+        // --- Credit root balance (conceptual — calls TIP-20 precompile) ---
+        // tip20.internal_credit(account, token, amount)?;
+
+        self.emit_event(AccountKeychainEvent::SubaccountWithdrawal(
+            IAccountKeychain::SubaccountWithdrawal {
+                account,
+                keyId: key_id,
+                token,
+                amount,
+            },
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // View functions
+    // ------------------------------------------------------------------
+
+    /// Return the sub-balance for a given (account, keyId, token) triple.
+    pub fn get_sub_balance(
+        &self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+    ) -> Result<U256> {
+        let composite = Self::spending_limit_key(account, key_id);
+        self.sub_balances[composite][token].read()
+    }
+
+    /// Resolve a derived subaccount address back to its (account, keyId).
+    ///
+    /// Returns `(Address::ZERO, Address::ZERO)` if the address is not
+    /// registered (i.e., it is not a known subaccount).
+    ///
+    /// This registry lookup is the only way to reverse the derivation since
+    /// keccak256 is a one-way function (audit finding D1).
+    pub fn resolve_subaccount_address(
+        &self,
+        sub_addr: Address,
+    ) -> Result<(Address, Address)> {
+        self.subaccount_registry[sub_addr].read()
+    }
+
+    // ------------------------------------------------------------------
+    // Enforcement hooks (called during TIP-20 operations)
+    // ------------------------------------------------------------------
+
+    /// Enforce sub-balance debit during a TIP-20 transfer.
+    ///
+    /// This is the critical security function invoked by the TIP-20 precompile
+    /// on every `transfer` / `transferFrom` call. It runs **after** auto-fund
+    /// and **after** the approve block check.
+    ///
+    /// # Logic
+    ///
+    /// 1. Read `transaction_key` from transient storage.
+    /// 2. If ZERO (root key) → skip. Root transfers debit the normal balance.
+    /// 3. If subaccount is not enabled for this key → skip. This preserves
+    ///    backward compatibility for keys authorized before TIP-1017.
+    /// 4. Debit `amount` from `sub_balances[hash(account, keyId)][token]`.
+    /// 5. If insufficient → revert with `InsufficientSubBalance`.
+    pub fn enforce_sub_balance(
+        &mut self,
+        account: Address,
+        token: Address,
+        amount: U256,
+    ) -> Result<()> {
+        let transaction_key = self.transaction_key.t_read()?;
+
+        // Root key: normal balance path
+        if transaction_key == Address::ZERO {
+            return Ok(());
+        }
+
+        // Backward compat: key without subaccount uses root balance
+        let enabled = self.subaccount_enabled[account][transaction_key].read()?;
+        if !enabled {
+            return Ok(());
+        }
+
+        // Debit sub-balance
+        let composite = Self::spending_limit_key(account, transaction_key);
+        let current = self.sub_balances[composite][token].read()?;
+        if current < amount {
+            return Err(AccountKeychainError::insufficient_sub_balance().into());
+        }
+        self.sub_balances[composite][token].write(current - amount)
+    }
+
+    /// Block `approve` and `permit` calls for subaccount keys.
+    ///
+    /// **Why this exists (audit finding A1):**
+    ///
+    /// Without this check a compromised access key could call
+    /// `token.approve(attacker, type(uint256).max)` and then the attacker
+    /// could drain the sub-balance via `transferFrom` at leisure — completely
+    /// bypassing spending limits since `transferFrom` is initiated by the
+    /// spender (attacker), not the key holder.
+    ///
+    /// The block only applies when:
+    /// - `transaction_key != Address::ZERO` (access key is active), AND
+    /// - subaccount is enabled for this key, AND
+    /// - `account == tx_origin` (the EOA itself is calling approve, not a
+    ///   contract acting on its own behalf).
+    ///
+    /// If the caller is a contract (`account != tx_origin`), the approve is
+    /// allowed because the contract is managing its own allowances.
+    pub fn enforce_approve_block(
+        &mut self,
+        account: Address,
+    ) -> Result<()> {
+        let transaction_key = self.transaction_key.t_read()?;
+
+        if transaction_key == Address::ZERO {
+            return Ok(());
+        }
+
+        let enabled = self.subaccount_enabled[account][transaction_key].read()?;
+        if !enabled {
+            return Ok(());
+        }
+
+        let tx_origin = self.tx_origin.t_read()?;
+        if account == tx_origin {
+            return Err(AccountKeychainError::approve_blocked_for_subaccount().into());
+        }
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Auto-fund
+    // ------------------------------------------------------------------
+
+    /// Pre-transaction hook: automatically refill sub-balances that have
+    /// dropped below their configured thresholds.
+    ///
+    /// Called by the transaction execution pipeline **before** the user's
+    /// call is executed, only when `transaction_key != Address::ZERO` and
+    /// the key has a subaccount enabled.
+    ///
+    /// For each auto-fund rule where `sub_balance < min_balance`:
+    ///
+    /// 1. Compute the effective refill: `min(refill_amount, remaining_spend_limit, root_balance)`.
+    /// 2. If effective refill > 0, transfer from root → sub-balance.
+    /// 3. **Deduct the transfer from the key's TIP-1011 spending limit**
+    ///    (audit finding B1). This is critical — without it, auto-fund
+    ///    becomes an unlimited spending vector that can drain the root.
+    /// 4. Emit `SubaccountAutoFunded` event.
+    ///
+    /// # Gas considerations
+    ///
+    /// Each rule costs ~2 SLOADs (min_balance + sub_balance read). Rules
+    /// that do not trigger a refill are cheap. The protocol caps the number
+    /// of rules at `MAX_AUTO_FUND_RULES` to bound worst-case gas.
+    pub fn maybe_auto_fund(
+        &mut self,
+        account: Address,
+    ) -> Result<()> {
+        let transaction_key = self.transaction_key.t_read()?;
+        if transaction_key == Address::ZERO {
+            return Ok(());
+        }
+
+        let enabled = self.subaccount_enabled[account][transaction_key].read()?;
+        if !enabled {
+            return Ok(());
+        }
+
+        let composite = Self::spending_limit_key(account, transaction_key);
+        let rule_count = self.auto_fund_rules_len[composite].read()?;
+
+        for i in 0..rule_count {
+            let token = self.auto_fund_token[composite][i].read()?;
+            let min_balance = self.auto_fund_min_balance[composite][i].read()?;
+            let refill_amount = self.auto_fund_refill_amount[composite][i].read()?;
+
+            let sub_bal = self.sub_balances[composite][token].read()?;
+            if sub_bal >= min_balance {
+                continue;
+            }
+
+            // --- Determine effective refill amount ---
+            // Cap at remaining spending limit (TIP-1011 integration).
+            let remaining_limit = self.spending_limits[composite][token].read()?;
+            let capped = refill_amount.min(remaining_limit);
+
+            // Cap at available root balance (conceptual — real impl queries TIP-20).
+            // let root_balance = tip20.balance_of(account, token)?;
+            // let effective = capped.min(root_balance);
+            let effective = capped; // placeholder — root balance check omitted
+
+            if effective.is_zero() {
+                continue;
+            }
+
+            // --- Transfer root → sub-balance ---
+            // tip20.internal_debit(account, token, effective)?;
+            self.sub_balances[composite][token].write(sub_bal + effective)?;
+
+            // --- Deduct from spending limit (audit finding B1) ---
+            self.spending_limits[composite][token].write(remaining_limit - effective)?;
+
+            self.emit_event(AccountKeychainEvent::SubaccountAutoFunded(
+                IAccountKeychain::SubaccountAutoFunded {
+                    account,
+                    keyId: transaction_key,
+                    token,
+                    amount: effective,
+                },
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Key revocation hook
+    // ------------------------------------------------------------------
+
+    /// Called when a key is revoked via `revoke_key`.
+    ///
+    /// Cleans up the subaccount registry entry and disables the subaccount,
+    /// but intentionally **preserves the sub-balance** so the root key can
+    /// withdraw remaining funds via `withdraw_from_subaccount`.
+    pub fn on_key_revoked(
+        &mut self,
+        account: Address,
+        key_id: Address,
+    ) -> Result<()> {
+        let enabled = self.subaccount_enabled[account][key_id].read()?;
+        if !enabled {
+            return Ok(());
+        }
+
+        // Remove from registry
+        let derived = Self::subaccount_address(account, key_id);
+        self.subaccount_registry[derived].write((Address::ZERO, Address::ZERO))?;
+
+        // Disable (but keep sub-balance intact for withdrawal)
+        self.subaccount_enabled[account][key_id].write(false)?;
+
+        self.emit_event(AccountKeychainEvent::SubaccountDisabled(
+            IAccountKeychain::SubaccountDisabled {
+                account,
+                keyId: key_id,
+                subaccountAddr: derived,
+            },
+        ))
+    }
+}

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -1,0 +1,417 @@
+---
+id: TIP-1017
+title: Protocol-Enshrined Subaccounts
+description: Extends Access Keys with sub-balance isolation, deterministic subaccount addresses, and auto-funding to enable secure app-specific account partitions with global passkey UX.
+authors: Tempo AI (on behalf of Georgios Konstantopoulos, Dan Robinson, Tanishk Goyal, Jake)
+status: Draft
+related: TIP-1011, AccountKeychain, IAccountKeychain.sol
+protocolVersion: TBD (requires hardfork)
+---
+
+# TIP-1017: Protocol-Enshrined Subaccounts
+
+## Abstract
+
+This TIP introduces protocol-level subaccount primitives that partition a single Tempo account into isolated, app-specific compartments. Each Access Key can optionally operate as a **subaccount** with its own token balances, deterministic address, and auto-funding rules — all enforced natively by the protocol. This enables users to authenticate once with a global passkey while limiting the blast radius of any compromised or malicious application to only the funds in that app's subaccount.
+
+## Motivation
+
+### The Global Passkey Security Problem
+
+Tempo and Porto accounts use WebAuthn passkeys bound to a single relying party domain (e.g., `tempo.xyz`). When a user authenticates on any third-party app via Porto's iframe, the same passkey signs permission grants for the user's **entire** account. This creates a fundamental tension:
+
+**Security risk**: A phishing site that tricks a user into signing a broad permission grant can drain the entire account. Even with spend-limit scopes (TIP-1011), users routinely rubber-stamp permission dialogs, and scopes are hard to reason about — especially with auto fee-token conversion making total costs unpredictable.
+
+**Current workaround — separate accounts**: Users could create separate accounts per app, but this has terrible UX:
+- Each account needs its own address, making portfolio management fragmented
+- Users must manually fund each account
+- No unified view of total holdings
+- Bridging and cross-chain operations become complex
+- Tax and accounting are painful
+
+**Current workaround — scoped Access Keys**: TIP-1011 adds destination scoping and periodic spend limits, but scopes only limit *what* the key can do, not *what funds* it can access. A key scoped to `transfer()` on any address can still drain the account up to its spend limit. There is no fund isolation.
+
+### What Subaccounts Solve
+
+Subaccounts provide **blast-radius containment**: even if an Access Key is fully compromised, the attacker can only access funds explicitly deposited into that key's subaccount. The root account balance is never at risk.
+
+Combined with TIP-1011's destination scoping and periodic limits, subaccounts create defense-in-depth:
+
+| Layer | What it limits | Enforced by |
+|-------|---------------|-------------|
+| **Expiry** | Time window | AccountKeychain |
+| **Destination scoping** | Which contracts | TIP-1011 |
+| **Spend limits** | How much per period | TIP-1011 |
+| **Sub-balance isolation** | Which funds are at risk | **This TIP** |
+
+---
+
+# Specification
+
+## Overview
+
+This TIP adds four primitives to the AccountKeychain precompile:
+
+1. **Sub-balances**: Per-key token balance tracking
+2. **Subaccount addresses**: Deterministic address derivation from `(account, keyId)`
+3. **Sub-balance enforcement**: Transactions signed by a subaccount key debit the sub-balance, not the root balance
+4. **Auto-funding**: Optional rules to automatically refill sub-balances from the root account
+
+## Extended Data Structures
+
+### SubaccountConfig
+
+A new struct stored per-key that controls subaccount behavior:
+
+```solidity
+struct SubaccountConfig {
+    bool enabled;           // Whether this key operates as a subaccount
+    AutoFundRule[] autoFund; // Auto-funding rules (may be empty)
+}
+
+struct AutoFundRule {
+    address token;         // TIP-20 token address
+    uint256 minBalance;    // Trigger auto-fund when sub-balance drops below this
+    uint256 refillAmount;  // Amount to transfer from root to subaccount
+}
+```
+
+### Extended KeyAuthorization
+
+```solidity
+struct KeyAuthorization {
+    TokenLimit[] spendingLimits;     // Existing (TIP-1011)
+    uint64 expiry;                   // Existing
+    address[] allowedDestinations;   // Existing (TIP-1011)
+    SubaccountConfig subaccount;     // NEW: subaccount configuration
+}
+```
+
+The `subaccount` field uses RLP trailing field semantics: omitting it is equivalent to `SubaccountConfig { enabled: false, autoFund: [] }`, preserving backward compatibility with pre-TIP-1017 key authorizations.
+
+## Interface Changes
+
+### New Functions in IAccountKeychain
+
+```solidity
+/// @notice Returns the deterministic subaccount address for a given account and key.
+/// @dev The subaccount address is derived as:
+///      address(uint160(uint256(keccak256(abi.encodePacked(
+///          bytes1(0xff), account, keyId
+///      )))))
+///      This matches CREATE2 semantics for predictability.
+/// @param account The root account address
+/// @param keyId The access key identifier
+/// @return The deterministic subaccount address
+function getSubaccountAddress(address account, address keyId) 
+    external pure returns (address);
+
+/// @notice Returns the sub-balance of a token for a specific key's subaccount.
+/// @param account The root account address
+/// @param keyId The access key identifier
+/// @param token The TIP-20 token address
+/// @return The sub-balance amount
+function getSubBalance(address account, address keyId, address token) 
+    external view returns (uint256);
+
+/// @notice Deposits tokens from the root account balance into a key's subaccount.
+/// @dev MUST only be called in transactions signed by the Root Key.
+///      Debits the root account's token balance and credits the subaccount's sub-balance.
+///      Emits SubaccountDeposit.
+/// @param keyId The access key identifier
+/// @param token The TIP-20 token address
+/// @param amount The amount to deposit
+function depositToSubaccount(address keyId, address token, uint256 amount) external;
+
+/// @notice Withdraws tokens from a key's subaccount back to the root account.
+/// @dev MUST only be called in transactions signed by the Root Key.
+///      Debits the subaccount's sub-balance and credits the root account's token balance.
+///      Emits SubaccountWithdrawal.
+/// @param keyId The access key identifier
+/// @param token The TIP-20 token address
+/// @param amount The amount to withdraw
+function withdrawFromSubaccount(address keyId, address token, uint256 amount) external;
+
+/// @notice Returns the subaccount configuration for a key.
+/// @param account The root account address
+/// @param keyId The access key identifier
+/// @return config The subaccount configuration
+function getSubaccountConfig(address account, address keyId) 
+    external view returns (SubaccountConfig memory config);
+
+/// @notice Updates auto-funding rules for a key's subaccount.
+/// @dev MUST only be called in transactions signed by the Root Key.
+/// @param keyId The access key identifier
+/// @param rules The new auto-funding rules (replaces existing rules)
+function updateAutoFundRules(address keyId, AutoFundRule[] calldata rules) external;
+```
+
+### New Events
+
+```solidity
+/// @notice Emitted when tokens are deposited into a subaccount
+event SubaccountDeposit(
+    address indexed account, 
+    address indexed keyId, 
+    address indexed token, 
+    uint256 amount
+);
+
+/// @notice Emitted when tokens are withdrawn from a subaccount
+event SubaccountWithdrawal(
+    address indexed account, 
+    address indexed keyId, 
+    address indexed token, 
+    uint256 amount
+);
+
+/// @notice Emitted when auto-funding is triggered
+event SubaccountAutoFunded(
+    address indexed account, 
+    address indexed keyId, 
+    address indexed token, 
+    uint256 amount
+);
+```
+
+### New Errors
+
+```solidity
+error SubaccountNotEnabled();
+error InsufficientSubBalance();
+error InsufficientRootBalance();
+error AutoFundFailed();
+```
+
+## Semantic Behavior
+
+### Sub-Balance Enforcement
+
+When a transaction is signed by an Access Key with `subaccount.enabled = true`:
+
+```
+function enforceSubBalance(account, keyId, token, amount):
+    config = getSubaccountConfig(account, keyId)
+    
+    if !config.enabled:
+        // Not a subaccount key — use root balance (existing behavior)
+        return SKIP
+    
+    subBal = getSubBalance(account, keyId, token)
+    
+    if amount > subBal:
+        revert InsufficientSubBalance()
+    
+    subBalances[account][keyId][token] -= amount
+```
+
+**Integration point**: The protocol calls `enforceSubBalance` during TIP-20 transfer execution, *in addition to* the existing spending limit checks from TIP-1011. The enforcement order is:
+
+1. Check key expiry
+2. Check destination scoping (TIP-1011)
+3. Check spending limits (TIP-1011)
+4. **Check and debit sub-balance (this TIP)**
+5. Execute the TIP-20 transfer
+
+Both spending limits and sub-balance checks must pass. Spending limits track cumulative spend per period; sub-balances track actual available funds.
+
+### Auto-Funding Logic
+
+Before executing a subaccount transaction, the protocol checks auto-fund rules:
+
+```
+function maybeAutoFund(account, keyId):
+    config = getSubaccountConfig(account, keyId)
+    
+    for rule in config.autoFund:
+        subBal = getSubBalance(account, keyId, rule.token)
+        
+        if subBal < rule.minBalance:
+            rootBal = tip20Balance(account, rule.token)
+            fundAmount = min(rule.refillAmount, rootBal)
+            
+            if fundAmount > 0:
+                tip20Balance(account, rule.token) -= fundAmount
+                subBalances[account][keyId][rule.token] += fundAmount
+                emit SubaccountAutoFunded(account, keyId, rule.token, fundAmount)
+```
+
+**Timing**: Auto-funding runs **before** transaction execution but **after** transaction validation. If the root account has insufficient balance, auto-funding is silently skipped (no revert) — the transaction may still succeed if the existing sub-balance is sufficient.
+
+**Root key behavior**: Auto-funding only triggers on Access Key transactions, never on Root Key transactions.
+
+### Subaccount Address Derivation
+
+The deterministic subaccount address allows third parties to send funds directly to a subaccount:
+
+```
+subaccountAddr = address(uint160(uint256(keccak256(
+    abi.encodePacked(bytes1(0xff), account, keyId)
+))))
+```
+
+**Receiving funds**: When a TIP-20 transfer targets a subaccount address, the protocol:
+1. Identifies the (account, keyId) pair from the address
+2. Credits the sub-balance instead of creating a new account
+
+**Sending funds**: When a subaccount key signs a `transfer(to, amount)`:
+- `msg.sender` = root account address (unchanged EVM semantics)
+- Funds are debited from the sub-balance
+- Contracts can call `getTransactionKey()` to identify the originating subaccount
+
+### Interaction with `msg.sender`
+
+This TIP does **not** change EVM `msg.sender` semantics. The root account address remains `msg.sender` for all transactions. This is a deliberate design choice:
+
+1. **Compatibility**: Changing `msg.sender` would break existing contract patterns (token allowances, access control, etc.)
+2. **Composability**: DeFi protocols (DEXes, lending) work correctly because balances remain associated with the root account address
+3. **Introspection**: Contracts that need to differentiate subaccounts use `getTransactionKey()` which is already available
+
+Applications that want app-specific `msg.sender` isolation should use EIP-7702 with separate EOAs — subaccounts solve the fund isolation problem without requiring identity isolation.
+
+### Interaction with Spending Limits
+
+Sub-balances and spending limits are independent but complementary:
+
+| Scenario | Spending Limit | Sub-Balance | Result |
+|----------|---------------|-------------|--------|
+| Limit: 100 USDC/day, Sub-bal: 50 USDC | Spend 50 | ✅ within limit | ✅ sufficient | ✅ succeeds |
+| Limit: 100 USDC/day, Sub-bal: 50 USDC | Spend 80 | ✅ within limit | ❌ insufficient | ❌ reverts |
+| Limit: 30 USDC/day, Sub-bal: 100 USDC | Spend 50 | ❌ exceeds limit | ✅ sufficient | ❌ reverts |
+| No limit enforced, Sub-bal: 100 USDC | Spend 100 | ✅ no limit | ✅ sufficient | ✅ succeeds |
+
+### Gas Payment
+
+Subaccount transactions pay gas from the **root account balance**, not the sub-balance. This is because:
+- Gas is paid in the fee token, which may differ from sub-balance tokens
+- Requiring sub-balance gas funding would degrade UX
+- The root account already authorized the key, implicitly accepting gas costs
+
+If gas sponsorship is used (fee payer), no gas is charged to either root or sub-balance.
+
+## Precompile Storage Changes
+
+New storage mappings in the AccountKeychain precompile (additive, no migration required):
+
+| Mapping | Type | Description |
+|---------|------|-------------|
+| `sub_balances[account][keyId][token]` | `uint256` | Sub-balance for a token |
+| `subaccount_enabled[account][keyId]` | `bool` | Whether subaccount mode is enabled |
+| `auto_fund_rules_len[account][keyId]` | `uint64` | Number of auto-fund rules |
+| `auto_fund_rules[account][keyId][index].token` | `address` | Auto-fund rule token |
+| `auto_fund_rules[account][keyId][index].minBalance` | `uint256` | Auto-fund trigger threshold |
+| `auto_fund_rules[account][keyId][index].refillAmount` | `uint256` | Auto-fund refill amount |
+
+## Encoding
+
+### KeyAuthorization RLP Extension
+
+```
+KeyAuthorization := RLP([
+    spendingLimits: [TokenLimit, ...],
+    expiry: uint64,
+    allowedDestinations: [address, ...],     // TIP-1011
+    subaccountConfig: SubaccountConfig       // NEW (trailing, optional)
+])
+
+SubaccountConfig := RLP([
+    enabled: bool,
+    autoFundRules: [AutoFundRule, ...]
+])
+
+AutoFundRule := RLP([
+    token: address,
+    minBalance: uint256,
+    refillAmount: uint256
+])
+```
+
+Trailing field semantics: if `subaccountConfig` is absent, decode as `{ enabled: false, autoFundRules: [] }`.
+
+## Gas Costs
+
+| Operation | Gas Cost | Notes |
+|-----------|----------|-------|
+| `depositToSubaccount` | ~10,000 | 2 SSTORE (root balance update + sub-balance update) |
+| `withdrawFromSubaccount` | ~10,000 | 2 SSTORE |
+| Sub-balance check per tx | ~2,100 | 1 SLOAD |
+| Sub-balance debit per tx | ~5,000 | 1 SSTORE (non-zero to non-zero) |
+| Auto-fund trigger | ~15,000 | 1 SLOAD + 2 SSTORE |
+| `authorizeKey` with subaccount config | +250,000 per auto-fund rule | New state creation (0→non-zero) |
+| `getSubBalance` (view) | ~2,100 | 1 SLOAD |
+| `getSubaccountAddress` (pure) | ~100 | Hash computation only |
+
+---
+
+# Backward Compatibility
+
+This TIP requires a **hardfork** due to changes in transaction encoding and new precompile behavior.
+
+## RLP Encoding Changes
+
+### KeyAuthorization (trailing field addition)
+
+`SubaccountConfig` is appended as a trailing RLP field to `KeyAuthorization`. Existing key authorizations (without the field) decode with `subaccount.enabled = false`, preserving backward compatibility.
+
+Old nodes cannot decode transactions containing `SubaccountConfig`. New nodes handle both formats via version-tolerant decoding.
+
+## Precompile Storage Changes
+
+All new storage mappings are additive. Existing keys have no sub-balance entries, which default to zero. No database migration is required.
+
+## Behavioral Changes
+
+Pre-fork keys continue to work identically: they have no sub-balance enforcement, and TIP-20 transfers debit the root balance as before. Sub-balance enforcement only activates for keys authorized with `subaccount.enabled = true` post-fork.
+
+## Hardfork-Gated Features
+
+1. **RLP decoding**: Accept `SubaccountConfig` in `KeyAuthorization`
+2. **Sub-balance enforcement**: Check sub-balance on TIP-20 transfers for subaccount keys
+3. **Auto-funding logic**: Run auto-fund checks before subaccount transaction execution
+4. **Subaccount address resolution**: Recognize subaccount addresses in TIP-20 transfer targets
+5. **New precompile interface methods**: `depositToSubaccount`, `withdrawFromSubaccount`, `getSubBalance`, `getSubaccountAddress`, `getSubaccountConfig`, `updateAutoFundRules`
+
+---
+
+# Invariants
+
+1. **Balance conservation**: For any token, the sum of the root balance and all sub-balances for an account MUST equal the total tokens held by that account. `depositToSubaccount` and `withdrawFromSubaccount` MUST be zero-sum operations.
+
+2. **Sub-balance isolation**: A transaction signed by an Access Key with `subaccount.enabled = true` MUST NOT debit the root account's token balance (except for gas). It MUST only debit from the key's sub-balance.
+
+3. **Root key supremacy**: Only Root Key transactions may call `depositToSubaccount`, `withdrawFromSubaccount`, and `updateAutoFundRules`.
+
+4. **Auto-fund safety**: Auto-funding MUST NOT overdraw the root balance. If the root balance is insufficient for the full `refillAmount`, the protocol MUST fund up to the available root balance.
+
+5. **Subaccount address uniqueness**: `getSubaccountAddress(account, keyId)` MUST return a unique address for each unique `(account, keyId)` pair.
+
+6. **Non-subaccount backward compatibility**: Keys authorized without `subaccount.enabled = true` MUST behave identically to pre-TIP-1017 keys: no sub-balance checks, TIP-20 transfers debit root balance.
+
+7. **Revoked key isolation**: When a key is revoked, its sub-balance MUST remain intact. The Root Key can withdraw remaining sub-balance via `withdrawFromSubaccount`.
+
+8. **Spending limit independence**: Sub-balance checks and spending limit checks (TIP-1011) are independent. Both MUST pass for a transaction to succeed.
+
+## Test Cases
+
+1. **Deposit and withdraw**: Verify root→subaccount and subaccount→root transfers conserve total balance
+2. **Sub-balance enforcement**: Verify subaccount key cannot spend more than sub-balance
+3. **Root balance isolation**: Verify subaccount key transaction does not affect root balance
+4. **Auto-funding**: Verify sub-balance is refilled when below threshold before tx execution
+5. **Auto-fund insufficient root**: Verify partial auto-fund when root balance < refillAmount
+6. **Auto-fund skip**: Verify no revert when auto-fund cannot fulfill
+7. **Subaccount address derivation**: Verify deterministic address matches expected computation
+8. **Direct deposit to subaccount address**: Verify TIP-20 transfer to subaccount address credits sub-balance
+9. **Non-subaccount key**: Verify keys without subaccount flag use root balance (backward compat)
+10. **Revoked key withdrawal**: Verify root can withdraw sub-balance of revoked key
+11. **Combined limits**: Verify spending limit + sub-balance both enforced independently
+12. **Gas from root**: Verify gas is always paid from root balance, not sub-balance
+13. **Multiple subaccounts**: Verify independent sub-balance tracking across multiple keys
+14. **Subaccount + destination scoping**: Verify TIP-1011 destination scoping works alongside sub-balance
+
+## References
+
+- [TIP-1011: Enhanced Access Key Permissions](./tip-1011.md)
+- [AccountKeychain Reference Implementation](./ref-impls/src/AccountKeychain.sol)
+- [IAccountKeychain Interface](./ref-impls/src/interfaces/IAccountKeychain.sol)
+- [Porto Account Contracts — GuardedExecutor](https://github.com/ithacaxyz/account/blob/main/src/GuardedExecutor.sol)
+- [ithacaxyz/account PR #232 — Subaccount exploration](https://github.com/ithacaxyz/account/pull/232)

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -84,6 +84,7 @@ struct KeyAuthorization {
     uint64 expiry;                   // Existing
     address[] allowedDestinations;   // Existing (TIP-1011)
     SubaccountConfig subaccount;     // NEW: subaccount configuration
+    uint256 maxFeePerTransaction;    // NEW: optional fee cap in fee-token units (0 = no cap)
 }
 ```
 
@@ -99,7 +100,7 @@ The `subaccount` field uses RLP trailing field semantics: omitting it is equival
 ///      address(uint160(uint256(keccak256(abi.encodePacked(
 ///          bytes1(0xff), account, keyId
 ///      )))))
-///      This matches CREATE2 semantics for predictability.
+///      Uses the 0xff prefix for collision resistance with regular account addresses.
 /// @param account The root account address
 /// @param keyId The access key identifier
 /// @return The deterministic subaccount address
@@ -180,7 +181,6 @@ event SubaccountAutoFunded(
 error SubaccountNotEnabled();
 error InsufficientSubBalance();
 error InsufficientRootBalance();
-error AutoFundFailed();
 ```
 
 ## Semantic Behavior
@@ -205,13 +205,20 @@ function enforceSubBalance(account, keyId, token, amount):
     subBalances[account][keyId][token] -= amount
 ```
 
-**Integration point**: The protocol calls `enforceSubBalance` during TIP-20 transfer execution, *in addition to* the existing spending limit checks from TIP-1011. The enforcement order is:
+#### Blocked Operations for Subaccount Keys
+
+When `subaccount.enabled = true`, the protocol MUST block `approve()`, `permit()`, `increaseAllowance()`, and `decreaseAllowance()` calls where `msg.sender == tx.origin` (i.e., the account itself is calling). Subaccount keys MUST NOT set allowances on the root account.
+
+This prevents a bypass where a subaccount key grants an allowance to an attacker who then calls `transferFrom` from outside the subaccount context, circumventing sub-balance enforcement.
+
+**Integration point**: The protocol calls `enforceSubBalance` during ALL TIP-20 balance-debiting operations, *in addition to* the existing spending limit checks from TIP-1011. Enforcement applies to: `transfer`, `transferWithMemo`, `transferFrom` (when `from == tx.origin`), `burn`, and `startReward`. This is a **consensus-critical rule**: any TIP-20 operation that debits the account's balance MUST be subject to sub-balance enforcement when the signing key has `subaccount.enabled = true`. The enforcement order is:
 
 1. Check key expiry
 2. Check destination scoping (TIP-1011)
-3. Check spending limits (TIP-1011)
-4. **Check and debit sub-balance (this TIP)**
-5. Execute the TIP-20 transfer
+3. Execute auto-funding (capped by spending limits)
+4. Check spending limits (TIP-1011)
+5. **Check and debit sub-balance (this TIP)**
+6. Execute the TIP-20 operation
 
 Both spending limits and sub-balance checks must pass. Spending limits track cumulative spend per period; sub-balances track actual available funds.
 
@@ -228,7 +235,8 @@ function maybeAutoFund(account, keyId):
         
         if subBal < rule.minBalance:
             rootBal = tip20Balance(account, rule.token)
-            fundAmount = min(rule.refillAmount, rootBal)
+            remainingSpendLimit = getRemainingSpendLimit(account, keyId, rule.token)
+            fundAmount = min(rule.refillAmount, remainingSpendLimit, rootBal)
             
             if fundAmount > 0:
                 tip20Balance(account, rule.token) -= fundAmount
@@ -237,6 +245,10 @@ function maybeAutoFund(account, keyId):
 ```
 
 **Timing**: Auto-funding runs **before** transaction execution but **after** transaction validation. If the root account has insufficient balance, auto-funding is silently skipped (no revert) — the transaction may still succeed if the existing sub-balance is sufficient.
+
+**Spending limit integration**: Auto-fund transfers MUST count against the key's spending limits (TIP-1011). If the auto-fund amount would exceed the remaining spending limit, auto-fund is capped at the remaining spending limit. The refill formula is: `min(refillAmount, remainingSpendLimit, rootBalance)`.
+
+**Maximum rules**: A maximum of 4 auto-fund rules per key is protocol-enforced. Attempting to authorize a key or call `updateAutoFundRules` with more than 4 rules MUST revert.
 
 **Root key behavior**: Auto-funding only triggers on Access Key transactions, never on Root Key transactions.
 
@@ -250,9 +262,12 @@ subaccountAddr = address(uint160(uint256(keccak256(
 ))))
 ```
 
+**Registry**: When a key is authorized with `subaccount.enabled = true`, the protocol MUST write a registry entry: `subaccount_registry[derivedAddr] = (account, keyId)`. Only addresses present in this registry receive subaccount routing for inbound transfers. Transfers to unregistered derived addresses create normal accounts.
+
 **Receiving funds**: When a TIP-20 transfer targets a subaccount address, the protocol:
-1. Identifies the (account, keyId) pair from the address
-2. Credits the sub-balance instead of creating a new account
+1. Looks up `subaccount_registry[targetAddr]` to resolve the `(account, keyId)` pair
+2. If the address is registered, credits the sub-balance instead of creating a new account
+3. If the address is not registered, treats it as a normal transfer (creates a new account)
 
 **Sending funds**: When a subaccount key signs a `transfer(to, amount)`:
 - `msg.sender` = root account address (unchanged EVM semantics)
@@ -289,6 +304,8 @@ Subaccount transactions pay gas from the **root account balance**, not the sub-b
 
 If gas sponsorship is used (fee payer), no gas is charged to either root or sub-balance.
 
+**Fee cap**: `KeyAuthorization` MUST include an optional `maxFeePerTransaction: Option<U256>` field (in fee-token units). When set, the protocol rejects transactions whose fee exceeds this cap. This prevents a compromised key from draining the root account via gas fees.
+
 ## Precompile Storage Changes
 
 New storage mappings in the AccountKeychain precompile (additive, no migration required):
@@ -301,6 +318,7 @@ New storage mappings in the AccountKeychain precompile (additive, no migration r
 | `auto_fund_rules[account][keyId][index].token` | `address` | Auto-fund rule token |
 | `auto_fund_rules[account][keyId][index].minBalance` | `uint256` | Auto-fund trigger threshold |
 | `auto_fund_rules[account][keyId][index].refillAmount` | `uint256` | Auto-fund refill amount |
+| `subaccount_registry[address]` | `(address, address)` | Maps derived subaccount address to `(account, keyId)` pair |
 
 ## Encoding
 
@@ -311,7 +329,8 @@ KeyAuthorization := RLP([
     spendingLimits: [TokenLimit, ...],
     expiry: uint64,
     allowedDestinations: [address, ...],     // TIP-1011
-    subaccountConfig: SubaccountConfig       // NEW (trailing, optional)
+    subaccountConfig: SubaccountConfig,      // NEW (trailing, optional)
+    maxFeePerTransaction: uint256            // NEW (trailing, optional; 0 = no cap)
 ])
 
 SubaccountConfig := RLP([
@@ -373,6 +392,14 @@ Pre-fork keys continue to work identically: they have no sub-balance enforcement
 
 ---
 
+## Consensus-Critical Definitions
+
+- `balanceOf(account)` returns the ROOT partition balance only (not including sub-balances). Sub-balances are separate and queryable via `getSubBalance()`.
+- `depositToSubaccount` debits the TIP-20 `balanceOf` of the root account and credits the sub-balance (which is NOT reflected in `balanceOf`).
+- Sub-balances are internal accounting within the AccountKeychain precompile. They are NOT visible via standard TIP-20 `balanceOf`.
+
+---
+
 # Invariants
 
 1. **Balance conservation**: For any token, the sum of the root balance and all sub-balances for an account MUST equal the total tokens held by that account. `depositToSubaccount` and `withdrawFromSubaccount` MUST be zero-sum operations.
@@ -391,6 +418,14 @@ Pre-fork keys continue to work identically: they have no sub-balance enforcement
 
 8. **Spending limit independence**: Sub-balance checks and spending limit checks (TIP-1011) are independent. Both MUST pass for a transaction to succeed.
 
+9. **Approve isolation**: Subaccount-enabled keys MUST NOT be able to set allowances on the root account.
+
+10. **Auto-fund spending limit integration**: Auto-fund amounts MUST count against the key's spending limits.
+
+11. **Gas fee cap**: If `maxFeePerTransaction` is set, transactions whose fee exceeds the cap MUST be rejected at validation time.
+
+12. **Registry consistency**: A subaccount address MUST be registered if and only if the corresponding key has `subaccount.enabled = true` and has not been revoked.
+
 ## Test Cases
 
 1. **Deposit and withdraw**: Verify root→subaccount and subaccount→root transfers conserve total balance
@@ -407,6 +442,13 @@ Pre-fork keys continue to work identically: they have no sub-balance enforcement
 12. **Gas from root**: Verify gas is always paid from root balance, not sub-balance
 13. **Multiple subaccounts**: Verify independent sub-balance tracking across multiple keys
 14. **Subaccount + destination scoping**: Verify TIP-1011 destination scoping works alongside sub-balance
+15. **Approve blocked**: Verify subaccount key calling `approve()` on root account reverts
+16. **transferFrom enforcement**: Verify sub-balance checked when `transferFrom(root, ...)` is called by root-signed subaccount tx
+17. **Auto-fund spend limit cap**: Verify auto-fund is capped at remaining spending limit
+18. **Auto-fund max rules**: Verify authorizing key with >4 auto-fund rules reverts
+19. **Gas fee cap**: Verify transaction with fee exceeding `maxFeePerTransaction` is rejected
+20. **Registry routing**: Verify inbound transfer to unregistered derived address creates normal account
+21. **balanceOf isolation**: Verify `balanceOf(account)` does not include sub-balances
 
 ## References
 


### PR DESCRIPTION
## Summary

Introduces protocol-level subaccount primitives that partition a single Tempo account into isolated, app-specific compartments via Access Keys.

### Problem
Global passkeys mean any app can rug you if you get phished. Scopes (TIP-1011) limit *what* a key can do, but not *which funds* are at risk. Separate accounts solve isolation but have garbage UX.

### Solution
Make the chain aware of subaccounts: each Access Key can optionally have its own token balances, enforced at the protocol level. Users authenticate once with a passkey, but each app only accesses its own funding pool.

### Key Features
- **Sub-balance isolation**: Per-key token balances enforced in AccountKeychain precompile
- **Deterministic subaccount addresses**: Predictable addresses for direct deposits
- **Auto-funding**: Optional rules to automatically refill sub-balances from root
- **Gas from root**: Subaccount txs pay gas from root balance (no gas funding needed)
- **Defense-in-depth**: Works alongside TIP-1011 spend limits and destination scoping

### Files
- `tips/tip-1017.md` — Full TIP specification
- `tips/ref-impls/src/interfaces/IAccountKeychainSubaccounts.sol` — Interface definition

### Related
- TIP-1011: Enhanced Access Key Permissions
- [ithacaxyz/account PR #232](https://github.com/ithacaxyz/account/pull/232) — Subaccount exploration
- Slack thread: [Global Passkey x Subaccounts x Security](https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1770334393219269)

cc @gakonst @danrobinson @tanishk