### PR TITLE
perf(payload-builder): record tx execution metrics once per block

### DIFF
--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -30,8 +30,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used_last: Gauge,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
-    /// The time it took to execute one transaction in seconds.
-    pub(crate) transaction_execution_duration_seconds: Histogram,
+    /// The maximum time it took to execute a single transaction in the block, in seconds.
+    pub(crate) transaction_execution_max_duration_seconds: Gauge,
+    /// The average time it took to execute a single transaction in the block, in seconds.
+    pub(crate) transaction_execution_avg_duration_seconds: Histogram,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1017,6 +1017,10 @@ mod tests {
     use tempo_primitives::{TempoTxEnvelope, transaction::tempo_transaction::Call};
     use tempo_revm::TempoStateAccess;
 
+    /// Fixed pre-T1 timestamp for tests that rely on T0 gas/fee parameters.
+    /// T1 activates at 1770303600 on Moderato; this is safely before that.
+    const PRE_T1_TIMESTAMP: u64 = 1770300000;
+
     /// Helper to create a mock sealed block with the given timestamp.
     fn create_mock_block(timestamp: u64) -> SealedBlock<reth_ethereum_primitives::Block> {
         let header = Header {
@@ -1432,10 +1436,7 @@ mod tests {
             tt_signed::AASigned,
         };
 
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // Helper to create AA transaction
         let create_aa_tx = |gas_limit: u64, nonce_key: U256, is_create: bool| {
@@ -1734,10 +1735,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fee_cap_below_min_base_fee_rejected() {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // T0 base fee is 10 gwei (10_000_000_000 wei)
         // Create a transaction with max_fee_per_gas below this
@@ -1770,10 +1768,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fee_cap_at_min_base_fee_passes() {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // T0 base fee is 10 gwei (10_000_000_000 wei)
         // Create a transaction with max_fee_per_gas exactly at minimum
@@ -1802,10 +1797,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fee_cap_above_min_base_fee_passes() {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // T0 base fee is 10 gwei (10_000_000_000 wei)
         // Create a transaction with max_fee_per_gas above minimum
@@ -1834,10 +1826,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_eip1559_fee_cap_below_min_base_fee_rejected() {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // T0 base fee is 10 gwei, create EIP-1559 tx with lower fee
         let transaction = TxBuilder::eip1559(Address::random())
@@ -3299,10 +3288,7 @@ mod tests {
     /// Multiple CREATE calls in the same transaction should be rejected.
     #[tokio::test]
     async fn test_aa_multiple_creates_rejected() {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // calls = [CREATE, CALL, CREATE] -> should reject with CreateCallNotFirst
         let calls = vec![
@@ -3357,10 +3343,7 @@ mod tests {
             tt_signature::{PrimitiveSignature, TempoSignature},
         };
 
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let current_time = PRE_T1_TIMESTAMP;
 
         // Create an AA transaction with a CREATE call and a non-empty authorization list
         let calls = vec![Call {


### PR DESCRIPTION
## Summary

Batch per-transaction histogram recording to reduce metrics overhead during block execution.

### Payload Builder (this PR)

Remove per-transaction `transaction_execution_duration_seconds.record()` from the hot execution loop. Previously fired for every transaction, incurring atomic ops + bucket search overhead per tx.

Replace with block-level aggregate metrics:
- `transaction_execution_max_duration_seconds` (Gauge): worst-case single-tx latency
- `transaction_execution_avg_duration_seconds` (Histogram): average tx execution time, recorded once per block

The existing `total_normal_transaction_execution_duration_seconds` already captures overall block execution time.

### reth engine-tree `MeteredStateHook` (follow-up)

`reth-engine-tree` `MeteredStateHook::on_state()` ([tree/mod.rs:210-224](https://github.com/paradigmxyz/reth/blob/c59a12036b738b396d19ed6fab79ce1751ba8afb/crates/engine/tree/src/tree/mod.rs#L210-L224)) records 3 histograms per transaction:
- `accounts_loaded_histogram`
- `storage_slots_loaded_histogram`
- `bytecodes_loaded_histogram`

A patched version is available at [`tempoxyz/reth@yk/perf-batch-histograms-c59a120`](https://github.com/tempoxyz/reth/tree/yk/perf-batch-histograms-c59a120) that accumulates totals during block execution and flushes once via `Drop`. This should be applied when tempo next bumps the reth dependency (or via upstream PR to paradigmxyz/reth).

The patch changes `on_state()` to increment counters instead of recording histograms, and adds a `Drop` impl that records the aggregated values once when the hook is released after block execution.
