### PR TITLE
fix(evm): add clear panic message for empty validator set division

### DIFF
--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -701,8 +701,9 @@ async fn build_subblock(
     let (transactions, senders) = match evm_at_block(&node, parent_hash) {
         Ok(mut evm) => {
             let (mut selected, mut senders, mut to_remove) = (Vec::new(), Vec::new(), Vec::new());
-            let gas_budget =
-                evm.block().gas_limit / TEMPO_SHARED_GAS_DIVISOR / num_validators as u64;
+            let gas_budget = (evm.block().gas_limit / TEMPO_SHARED_GAS_DIVISOR)
+                .checked_div(num_validators as u64)
+                .expect("validator set must not be empty");
 
             let mut gas_left = gas_budget;
             let txs = transactions.lock().clone();

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -186,7 +186,10 @@ where
         let Some(validator_set) = &self.validator_set else {
             return Ok(());
         };
-        let gas_per_subblock = self.shared_gas_limit / validator_set.len() as u64;
+        let gas_per_subblock = self
+            .shared_gas_limit
+            .checked_div(validator_set.len() as u64)
+            .expect("validator set must not be empty");
 
         let mut incentive_gas = 0;
         let mut seen = HashSet::new();


### PR DESCRIPTION
## Summary

Fixes CHAIN-681 (TMPO2-36): Panic on empty validator set.

Two functions divide by the number of validators without guarding for zero. An empty validator set is a fatal invariant violation (only possible during live consensus, never during sync), so panicking is the correct behavior — but the bare division-by-zero gives an unhelpful panic message.

This replaces the bare divisions with `.checked_div().expect("validator set must not be empty")` for a clear panic message at both sites:

1. **`validate_shared_gas`** in `crates/evm/src/block.rs`
2. **`build_subblock`** in `crates/commonware-node/src/subblocks.rs`