### PR TITLE
refactor(revm): consolidate TIP-1000 intrinsic gas logic

### DIFF
--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -1,14 +1,46 @@
+use alloy_primitives::U256;
 use auto_impl::auto_impl;
+use revm::context::transaction::AccessListItemTr;
 use revm::context_interface::cfg::{GasId, GasParams};
+use revm::interpreter::gas::{COLD_SLOAD_COST, SSTORE_SET, WARM_SSTORE_RESET};
 use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
+
+pub const EXISTING_NONCE_KEY_GAS: u64 = COLD_SLOAD_COST + WARM_SSTORE_RESET;
+pub const NEW_NONCE_KEY_GAS: u64 = COLD_SLOAD_COST + SSTORE_SET;
+pub const EXPIRING_NONCE_GAS: u64 = 2 * COLD_SLOAD_COST + 100 + 3 * WARM_SSTORE_RESET;
+
+const GAS_ID_TIP1000_AUTH_ACCOUNT_CREATION: u8 = 255;
 
 /// Extending [`GasParams`] for Tempo use case.
 #[auto_impl(&, Arc, Box, &mut)]
 pub trait TempoGasParams {
     fn gas_params(&self) -> &GasParams;
 
-    fn tx_tip1000_auth_account_creation_cost(&self) -> u64 {
-        self.gas_params().get(GasId::new(255))
+    /// TIP-1000: account creation cost for auth list entries with nonce == 0.
+    fn tip1000_auth_list_creation_gas(&self, nonce_zero_count: u64) -> u64 {
+        nonce_zero_count
+            * self
+                .gas_params()
+                .get(GasId::new(GAS_ID_TIP1000_AUTH_ACCOUNT_CREATION))
+    }
+
+    fn tip1000_nonce_zero_gas(&self, nonce_key: U256) -> u64 {
+        if nonce_key == TEMPO_EXPIRING_NONCE_KEY {
+            EXPIRING_NONCE_GAS
+        } else {
+            self.gas_params().get(GasId::new_account_cost())
+        }
+    }
+
+    fn cold_account_access_cost(&self) -> u64 {
+        self.gas_params().warm_storage_read_cost()
+            + self.gas_params().cold_account_additional_cost()
+    }
+
+    fn access_list_gas(&self, accounts: u64, storage_slots: u64) -> u64 {
+        accounts * self.gas_params().tx_access_list_address_cost()
+            + storage_slots * self.gas_params().tx_access_list_storage_key_cost()
     }
 }
 
@@ -16,6 +48,48 @@ impl TempoGasParams for GasParams {
     fn gas_params(&self) -> &GasParams {
         self
     }
+}
+
+pub fn count_access_list<T: AccessListItemTr>(access_list: impl Iterator<Item = T>) -> (u64, u64) {
+    access_list.fold((0, 0), |(acc_count, storage_count), item| {
+        (
+            acc_count + 1,
+            storage_count + item.storage_slots().count() as u64,
+        )
+    })
+}
+
+/// Counts access list items using a custom closure for storage slot counting.
+/// Used when access list items don't implement AccessListItemTr.
+pub fn count_access_list_raw<T, F>(
+    access_list: impl Iterator<Item = T>,
+    storage_count_fn: F,
+) -> (u64, u64)
+where
+    F: Fn(&T) -> usize,
+{
+    access_list.fold((0, 0), |(acc_count, storage_count), item| {
+        (
+            acc_count + 1,
+            storage_count + storage_count_fn(&item) as u64,
+        )
+    })
+}
+
+/// TIP-1000 intrinsic gas additions for auth list and first-tx costs.
+#[inline]
+pub fn tip1000_intrinsic_gas(
+    gas_params: &GasParams,
+    spec: TempoHardfork,
+    nonce_zero_auths: u64,
+    tx_nonce: u64,
+    nonce_key: U256,
+) -> u64 {
+    let mut gas = gas_params.tip1000_auth_list_creation_gas(nonce_zero_auths);
+    if spec.is_t1() && tx_nonce == 0 {
+        gas += gas_params.tip1000_nonce_zero_gas(nonce_key);
+    }
+    gas
 }
 
 /// Tempo gas params override.
@@ -40,8 +114,8 @@ pub fn tempo_gas_params(spec: TempoHardfork) -> GasParams {
             (GasId::code_deposit_cost(), 1_000),
             // The base cost per authorization is reduced to 12,500 gas
             (GasId::tx_eip7702_per_empty_account_cost(), 12500),
-            // Auth account creation cost.
-            (GasId::new(255), 250_000),
+            // TIP-1000: auth account creation cost.
+            (GasId::new(GAS_ID_TIP1000_AUTH_ACCOUNT_CREATION), 250_000),
         ]);
     }
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,6 +21,10 @@ mod tx;
 pub use block::TempoBlockEnv;
 pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
-pub use handler::{EXISTING_NONCE_KEY_GAS, NEW_NONCE_KEY_GAS, calculate_aa_batch_intrinsic_gas};
+pub use gas_params::{
+    EXISTING_NONCE_KEY_GAS, EXPIRING_NONCE_GAS, NEW_NONCE_KEY_GAS, count_access_list,
+    tip1000_intrinsic_gas,
+};
+pub use handler::calculate_aa_batch_intrinsic_gas;
 pub use revm::interpreter::instructions::utility::IntoAddress;
 pub use tx::{TempoBatchCallEnv, TempoTxEnv};


### PR DESCRIPTION
## Summary
Consolidates duplicated TIP-1000 intrinsic gas logic between handler.rs and validator.rs.

Closes #2222

## Changes
- Extract `tip1000_intrinsic_gas()` shared function to `gas_params.rs`
- Move `EXISTING_NONCE_KEY_GAS`, `NEW_NONCE_KEY_GAS`, `EXPIRING_NONCE_GAS` constants to `gas_params.rs`
- Add helper functions: `count_access_list`, `count_access_list_raw`, `cold_account_access_cost`, `access_list_gas`
- Extract magic number `255` to `GAS_ID_TIP1000_AUTH_ACCOUNT_CREATION` constant
- Remove dead code (unreachable value transfer cost calculation)

## Test plan
- [x] `cargo test --package tempo-revm --package tempo-transaction-pool` (184 passed, 4 pre-existing failures)
- [x] `cargo fmt --all`
- [x] `cargo clippy`