### PR TITLE
perf(db): default to safe-no-sync MDBX sync mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11783,6 +11783,7 @@ dependencies = [
  "reth-cli-commands",
  "reth-cli-runner",
  "reth-cli-util",
+ "reth-db",
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-node-builder",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -46,6 +46,7 @@ tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 reth-cli-commands.workspace = true
+reth-db.workspace = true
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli"] }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -25,6 +25,7 @@ use clap::Parser;
 use commonware_runtime::{Metrics, Runner};
 use eyre::WrapErr as _;
 use futures::{FutureExt as _, future::FusedFuture as _};
+use reth_db::mdbx::SyncMode;
 use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands, evm::revm::primitives::B256};
 use reth_ethereum_cli::Cli;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
@@ -120,6 +121,13 @@ fn main() -> eyre::Result<()> {
         DefaultRpcModuleValidator,
         tempo_cmd::TempoSubcommand,
     >::parse();
+
+    if let Commands::Node(ref mut node_cmd) = cli.command {
+        if node_cmd.db.sync_mode.is_none() {
+            node_cmd.db.sync_mode = Some(SyncMode::SafeNoSync);
+            info!(target: "tempo::cli", "Defaulting to --db.sync-mode=safe-no-sync for improved persistence throughput");
+        }
+    }
 
     // If telemetry is enabled, set logs OTLP (conflicts_with in TelemetryArgs prevents both being set)
     let mut telemetry_config = None;


### PR DESCRIPTION
## Summary

Defaults MDBX sync mode to `safe-no-sync` when the user has not explicitly set `--db.sync-mode`. This removes the per-commit `fsync` from the persistence hot path (`advance_persistence` → `save_blocks` → MDBX commit), which is the confirmed bottleneck in our persistence pipeline.

## What changed

- **`bin/tempo/src/main.rs`**: After CLI parsing, if `--db.sync-mode` was not provided, set it to `SafeNoSync`. Logs the override at startup.
- **`bin/tempo/Cargo.toml`**: Added `reth-db` dependency for `SyncMode` import.

## Why safe-no-sync is safe for Tempo

| Crash type | Behavior |
|-----------|----------|
| **App crash** | No data loss — OS flushes mmap pages |
| **Power loss / kernel crash** | Last few commits may roll back; DB remains structurally intact (no corruption) |
| **Recovery** | Tempo CL→EL backfill automatically recovers any missing blocks on restart |

Users can always override with `--db.sync-mode=durable` if they need strict per-commit durability.

## How to measure on Grafana

### Key metrics to watch

| Metric | Prometheus query | What it tells you |
|--------|-----------------|-------------------|
| **Persistence duration** | `rate(reth_persistence_duration_seconds_sum[5m]) / rate(reth_persistence_duration_seconds_count[5m])` | Average time per persistence round-trip |
| **Save blocks duration** | `rate(reth_save_blocks_duration_seconds_sum[5m]) / rate(reth_save_blocks_duration_seconds_count[5m])` | Average time inside `save_blocks()` |
| **MDBX commit latency** | `rate(reth_db_commit_duration_seconds_sum[5m]) / rate(reth_db_commit_duration_seconds_count[5m])` | MDBX commit time (dominated by fsync in Durable mode) |
| **MDBX commit sync phase** | `histogram_quantile(0.99, rate(reth_db_commit_sync_duration_seconds_bucket[5m]))` | p99 of the sync/fsync phase inside commit |
| **Batch size** | `rate(reth_save_blocks_batch_size_sum[5m]) / rate(reth_save_blocks_batch_size_count[5m])` | Blocks per persistence batch |
| **Canonical chain height** | `reth_canonical_chain_height` | Verify chain is advancing normally |

### Comparison approach

1. Run baseline benchmark on `main` (with default `Durable` mode)
2. Run benchmark on this branch (with `SafeNoSync` default)
3. Compare the MDBX commit duration — expect **5-10x reduction** in commit latency
4. Verify chain height advances at same or faster rate
5. Check that `save_blocks_duration` decreases proportionally

### Grafana dashboard filters

Filter by instance/pod to isolate the benchmark node:
```
{instance=~".*bench.*"}
```

## Override

To revert to durable mode:
```bash
tempo node --db.sync-mode=durable
```