### PR TITLE
test(primitives): add mutation-testing-driven signature tests

### DIFF
--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -1587,8 +1587,10 @@ mod tests {
 
     #[test]
     fn test_keychain_signature_hash_differs_for_different_sigs() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         let sig = PrimitiveSignature::Secp256k1(Signature::test_signature());
         let a = KeychainSignature::new(Address::repeat_byte(0x01), sig.clone());
@@ -1601,7 +1603,11 @@ mod tests {
             h.finish()
         };
 
-        assert_ne!(hash(&a), hash(&b), "different address should produce different hash");
+        assert_ne!(
+            hash(&a),
+            hash(&b),
+            "different address should produce different hash"
+        );
         assert_eq!(hash(&a), hash(&c), "same fields should produce same hash");
     }
 
@@ -1631,7 +1637,8 @@ mod tests {
 
     #[test]
     fn test_is_keychain_returns_false_for_primitive() {
-        let sig = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let sig =
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
         assert!(!sig.is_keychain());
     }
 


### PR DESCRIPTION
## Summary
Add tests to catch mutations missed by `cargo-mutants` in the `tempo-primitives` crate.

## Tests Added (9 tests)
- **test_keychain_signature_eq_same**: Same fields → equal
- **test_keychain_signature_eq_different_address**: Different user_address → not equal
- **test_keychain_signature_eq_different_signature**: Different signature → not equal
- **test_keychain_signature_hash_differs_for_different_sigs**: Different fields → different hash
- **test_primitive_signature_from_bytes_one_byte**: 1-byte input hits boundary check
- **test_tempo_signature_keychain_too_short_for_address**: Keychain with <20 bytes rejected
- **test_tempo_signature_keychain_exactly_20_bytes_inner_empty**: Empty inner sig rejected
- **test_is_keychain_returns_false_for_primitive**: Primitive → false
- **test_is_keychain_returns_true_for_keychain**: Keychain → true

## Context
Identified via mutation testing. Key security gap: `KeychainSignature::eq` mutation to always return `true` was not caught (affects signature deduplication).