### PR TITLE
feat: TIP-1020 TempoID — Unified ZK Identity, Agent Auth & Account Recovery

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -1,0 +1,814 @@
+---
+id: TIP-1020
+title: "TempoID: Unified ZK Identity, Agent Auth & Account Recovery"
+description: A ZK-first identity layer combining zkLogin, zkEmail, zkPassport, zkTLS, and EAS-style attestations into a unified identity primitive that solves auth for agents, enables ZK KYC, and provides privacy-preserving service linking.
+authors: Georgios, Zygimantas, Connor, Dan
+status: Draft
+related: TIP-1000, TIP-1011, AccountKeychain, IAccountKeychain.sol
+protocolVersion: TBD (requires hardfork)
+---
+
+# TIP-1020: TempoID — Unified ZK Identity, Agent Auth & Account Recovery
+
+## Abstract
+
+TempoID is a ZK-first identity layer for Tempo that unifies OAuth login (zkLogin), email verification (zkEmail), passport verification (zkPassport), web2 data proofs (zkTLS), and attestation-based credentials (EAS-style) into a single coherent system. It introduces four new precompiles that, together with the existing AccountKeychain (TIP-1011), provide:
+
+1. **"Login with Google/Apple/GitHub"** without revealing your identity on-chain
+2. **KYC once, auth everywhere** — prove KYC to one provider, use the credential across all Tempo services
+3. **Agent authentication** — AI agents run on scoped Access Keys with spending budgets, rate limits, and auditable receipts via MPP
+4. **Account recovery** — recover accounts via social guardians, credential re-proof, or cold keys
+5. **Privacy-preserving service linking** — per-service unlinkable pseudonyms via stealth addresses and Semaphore-style nullifiers
+
+All heavy cryptographic verification (JWT parsing, DKIM, passport signatures, TLS transcripts) happens off-chain in ZK circuits. On-chain, Tempo only verifies succinct proofs (~200k gas) and manages nullifiers, commitments, and attestations.
+
+## Motivation
+
+Auth today is designed for humans-in-browsers. AI agents hit a wall at every step — OAuth redirects, CAPTCHAs, email confirmation codes, API key plumbing. The entire identity + authorization stack assumes a human with eyeballs.
+
+Tempo already has the building blocks:
+- **AccountKeychain** with session keys, spending limits, and signature type support (Secp256k1, P256, WebAuthn)
+- **TIP-1011** extending Access Keys with periodic spending limits and destination scoping
+- **Sub-accounts** and **stealth addresses** for privacy
+- **MPP** (Machine Payments Protocol) for agent-to-service payments
+- **TIP-20 tokens** as the payment primitive
+
+What's missing is the **identity layer** that ties these together: a way to prove who you are (or that you're authorized) without revealing who you are, and a way to delegate that proof to autonomous agents.
+
+### Problems Solved
+
+| Problem | Solution |
+|---------|----------|
+| "Someone please solve auth for agents" | Scoped Access Keys minted after ZK identity proof |
+| OAuth redirects can't work for agents | zkLogin: prove JWT in ZK, get session key |
+| KYC fragmentation (re-KYC for every service) | ZK KYC groups: prove once, present membership proof everywhere |
+| Identity leaks across services | Per-service pseudonyms via Semaphore nullifiers |
+| Account recovery requires seed phrases | Multi-path recovery: guardians, credential re-proof, cold keys |
+| No way to prove web2 credentials on-chain | zkTLS + zkEmail attestations |
+| Compliance without privacy sacrifice | Predicate proofs: "age >= 18" without revealing birthdate |
+
+---
+
+# Specification
+
+## New Precompiles
+
+### 1. ZKProofVerifier
+
+**Address:** `0xaAAAaaAA00000000000000000000000000000005`
+
+Verifies succinct ZK proofs on-chain. Supports Plonk/Halo2-style proofs over BN254 with a universal setup (no per-circuit ceremonies). Also manages nullifiers for replay prevention.
+
+```solidity
+interface IZKProofVerifier {
+    struct VerificationResult {
+        bool valid;
+        bytes32 publicInputsHash;
+    }
+
+    error InvalidProof();
+    error NullifierAlreadyUsed();
+    error UnknownVerifierKey();
+    error ProofTooLarge();
+
+    event ProofVerified(bytes32 indexed vkId, bytes32 indexed publicInputsHash, address indexed caller);
+    event NullifierConsumed(bytes32 indexed domain, bytes32 indexed nullifier);
+    event VerifierKeyRegistered(bytes32 indexed vkId, address indexed registrar);
+
+    /// @notice Register a verifier key for a circuit
+    /// @param vkId Unique identifier for the verifier key
+    /// @param vkData Serialized verifier key
+    function registerVerifierKey(bytes32 vkId, bytes calldata vkData) external;
+
+    /// @notice Verify a ZK proof against a registered verifier key
+    /// @param vkId The verifier key to use
+    /// @param publicInputs ABI-encoded public inputs
+    /// @param proof Serialized proof bytes
+    /// @return valid Whether the proof is valid
+    function verify(bytes32 vkId, bytes calldata publicInputs, bytes calldata proof) external view returns (bool valid);
+
+    /// @notice Verify a proof AND consume a nullifier atomically
+    /// @dev Reverts if nullifier already consumed or proof invalid
+    /// @param vkId The verifier key to use
+    /// @param publicInputs ABI-encoded public inputs (must include nullifier as first 32 bytes)
+    /// @param proof Serialized proof bytes
+    /// @param domain Domain separator for nullifier scoping
+    function verifyAndConsumeNullifier(
+        bytes32 vkId,
+        bytes calldata publicInputs,
+        bytes calldata proof,
+        bytes32 domain
+    ) external;
+
+    /// @notice Check if a nullifier has been consumed
+    function isNullifierUsed(bytes32 domain, bytes32 nullifier) external view returns (bool);
+}
+```
+
+**Storage Layout:**
+
+| Mapping | Type | Description |
+|---------|------|-------------|
+| `verifier_keys[vkId]` | `bytes` | Serialized verifier key data |
+| `vk_registrar[vkId]` | `address` | Who registered the VK (for governance) |
+| `nullifiers[domain][nullifier]` | `bool` | Whether nullifier has been consumed |
+
+**Gas Costs:**
+
+| Operation | Estimated Gas |
+|-----------|--------------|
+| `verify` (Plonk BN254) | ~180,000 |
+| `verifyAndConsumeNullifier` | ~200,000 |
+| `registerVerifierKey` | ~50,000 + 200/byte |
+| `isNullifierUsed` | ~2,600 |
+
+---
+
+### 2. TempoIDRegistry
+
+**Address:** `0xaAAAaaAA00000000000000000000000000000006`
+
+Manages identity commitments and account-to-identity mappings. An identity commitment is a Poseidon hash of secret values that the user controls, enabling privacy-preserving identity proofs.
+
+```solidity
+interface ITempoIDRegistry {
+    struct IdentityInfo {
+        bytes32 idCommitment;      // Poseidon(trapdoor, nullifierSecret)
+        address controller;         // Current root controller (account)
+        uint64 createdAt;          // Registration timestamp
+        uint8 recoveryDelay;       // Days before recovery finalizes
+        bool frozen;               // Emergency freeze flag
+    }
+
+    error IdentityAlreadyRegistered();
+    error IdentityNotFound();
+    error NotController();
+    error IdentityFrozen();
+    error RecoveryPending();
+    error RecoveryDelayNotElapsed();
+    error InvalidCommitment();
+
+    event IdentityRegistered(bytes32 indexed idCommitment, address indexed controller);
+    event ControllerRotated(bytes32 indexed idCommitment, address indexed oldController, address indexed newController);
+    event RecoveryInitiated(bytes32 indexed idCommitment, address indexed newController, uint64 executeAfter);
+    event RecoveryFinalized(bytes32 indexed idCommitment, address indexed newController);
+    event RecoveryCancelled(bytes32 indexed idCommitment);
+    event IdentityFreezeToggled(bytes32 indexed idCommitment, bool frozen);
+
+    /// @notice Register a new TempoID
+    /// @param idCommitment The identity commitment (Poseidon hash)
+    /// @param recoveryDelay Days before recovery can be finalized
+    function register(bytes32 idCommitment, uint8 recoveryDelay) external;
+
+    /// @notice Bind a Tempo account to an identity
+    function bindAccount(bytes32 idCommitment, address account) external;
+
+    /// @notice Rotate the controller for an identity (requires current controller)
+    function rotateController(bytes32 idCommitment, address newController) external;
+
+    /// @notice Initiate recovery (called by recovery proof after verification)
+    function initiateRecovery(bytes32 idCommitment, address newController, bytes calldata recoveryProof) external;
+
+    /// @notice Finalize recovery after delay has elapsed
+    function finalizeRecovery(bytes32 idCommitment) external;
+
+    /// @notice Cancel a pending recovery (by current controller)
+    function cancelRecovery(bytes32 idCommitment) external;
+
+    /// @notice Emergency freeze/unfreeze (by current controller)
+    function setFrozen(bytes32 idCommitment, bool frozen) external;
+
+    /// @notice Get identity info
+    function getIdentity(bytes32 idCommitment) external view returns (IdentityInfo memory);
+
+    /// @notice Get the identity bound to an account
+    function getAccountIdentity(address account) external view returns (bytes32 idCommitment);
+}
+```
+
+**Storage Layout:**
+
+| Mapping | Type | Description |
+|---------|------|-------------|
+| `identities[idCommitment]` | `IdentityInfo` | Identity metadata |
+| `account_to_identity[account]` | `bytes32` | Account → identity commitment |
+| `recovery_pending[idCommitment]` | `RecoveryRequest` | Pending recovery info |
+| `guardians[idCommitment][index]` | `address` | Recovery guardians |
+| `guardian_count[idCommitment]` | `uint8` | Number of guardians |
+| `guardian_threshold[idCommitment]` | `uint8` | Required guardian approvals |
+
+---
+
+### 3. TempoAttestationRegistry
+
+**Address:** `0xaAAAaaAA00000000000000000000000000000007`
+
+EAS-inspired attestation system supporting both public and private (commitment-based) attestations. Attestations are the universal glue for KYC, email proofs, TLS proofs, passport proofs, and any other credential.
+
+```solidity
+interface ITempoAttestationRegistry {
+    struct Schema {
+        bytes32 schemaId;          // keccak256 of schema definition
+        string definition;          // ABI-like schema string (e.g., "bool isKYCd, uint8 level")
+        address resolver;           // Optional resolver contract
+        bool revocable;            // Whether attestations can be revoked
+    }
+
+    struct Attestation {
+        bytes32 uid;               // Unique attestation ID
+        bytes32 schemaId;          // Schema this follows
+        address attester;          // Who made the attestation
+        bytes32 recipient;         // TempoID commitment OR address (for public)
+        bytes data;                // Attestation data (public) or commitment (private)
+        uint64 timestamp;          // When created
+        uint64 expirationTime;     // When it expires (0 = never)
+        bool revoked;              // Whether revoked
+        bool isPrivate;            // Whether data is a commitment
+        bytes32 refUID;            // Reference to another attestation
+    }
+
+    error SchemaAlreadyExists();
+    error SchemaNotFound();
+    error AttestationNotFound();
+    error NotAttester();
+    error NotRevocable();
+    error AlreadyRevoked();
+
+    event SchemaRegistered(bytes32 indexed schemaId, address indexed registrar);
+    event Attested(bytes32 indexed uid, bytes32 indexed schemaId, address indexed attester, bytes32 recipient);
+    event Revoked(bytes32 indexed uid, address indexed attester);
+
+    /// @notice Register a new attestation schema
+    function registerSchema(string calldata definition, address resolver, bool revocable) external returns (bytes32 schemaId);
+
+    /// @notice Create a public attestation
+    function attest(
+        bytes32 schemaId,
+        bytes32 recipient,
+        bytes calldata data,
+        uint64 expirationTime,
+        bytes32 refUID
+    ) external returns (bytes32 uid);
+
+    /// @notice Create a private attestation (data is a Poseidon commitment)
+    function attestPrivate(
+        bytes32 schemaId,
+        bytes32 recipientCommitment,
+        bytes32 dataCommitment,
+        uint64 expirationTime,
+        bytes32 refUID
+    ) external returns (bytes32 uid);
+
+    /// @notice Revoke an attestation
+    function revoke(bytes32 uid) external;
+
+    /// @notice Get an attestation by UID
+    function getAttestation(bytes32 uid) external view returns (Attestation memory);
+
+    /// @notice Check if an attestation exists and is valid
+    function isValid(bytes32 uid) external view returns (bool);
+}
+```
+
+**Predefined Schemas:**
+
+| Schema ID | Definition | Use |
+|-----------|------------|-----|
+| `OIDC_LOGIN` | `bytes32 issuerHash, bytes32 subjectHash, bytes32 audienceHash` | zkLogin attestation |
+| `EMAIL_OWNERSHIP` | `bytes32 domainHash, bytes32 addressHash` | zkEmail proof |
+| `PASSPORT_PREDICATE` | `bool ageOver18, bytes32 nationalitySetHash, bool isValid` | zkPassport predicate |
+| `KYC_LEVEL` | `uint8 level, bytes32 providerHash, uint64 verifiedAt` | ZK KYC credential |
+| `TLS_PROOF` | `bytes32 domainHash, bytes32 claimHash, bytes32 notaryHash` | zkTLS attestation |
+| `AGENT_RECEIPT` | `bytes32 serviceHash, uint256 amount, bytes32 resultHash` | MPP agent receipt |
+
+---
+
+### 4. TempoGroups
+
+**Address:** `0xaAAAaaAA00000000000000000000000000000008`
+
+Semaphore-style group membership with Merkle tree roots and domain-separated nullifiers. Enables "KYC once, auth everywhere" and unlinkable service authentication.
+
+```solidity
+interface ITempoGroups {
+    struct Group {
+        bytes32 groupId;
+        bytes32 currentRoot;       // Current Merkle root
+        uint256 memberCount;
+        address admin;
+        uint8 depth;               // Merkle tree depth (e.g., 20 = 1M members)
+        bool frozen;
+    }
+
+    error GroupNotFound();
+    error GroupFrozen();
+    error NotGroupAdmin();
+    error MemberAlreadyExists();
+    error InvalidMerkleProof();
+    error NullifierAlreadyUsed();
+
+    event GroupCreated(bytes32 indexed groupId, address indexed admin, uint8 depth);
+    event MemberAdded(bytes32 indexed groupId, bytes32 indexed identityCommitment);
+    event MembershipProofVerified(bytes32 indexed groupId, bytes32 indexed nullifier, bytes32 indexed domain);
+
+    /// @notice Create a new group
+    function createGroup(bytes32 groupId, uint8 depth) external;
+
+    /// @notice Add a member to a group (after verification)
+    /// @dev Typically called after a ZK proof verifies the member's credential
+    function addMember(bytes32 groupId, bytes32 identityCommitment) external;
+
+    /// @notice Verify a membership proof and consume nullifier
+    /// @param groupId The group to verify against
+    /// @param merkleRoot The root the proof was generated against
+    /// @param nullifier Domain-separated nullifier
+    /// @param domain Service domain for nullifier scoping
+    /// @param proof ZK proof of membership
+    /// @return valid Whether the proof is valid
+    function verifyMembership(
+        bytes32 groupId,
+        bytes32 merkleRoot,
+        bytes32 nullifier,
+        bytes32 domain,
+        bytes calldata proof
+    ) external returns (bool valid);
+
+    /// @notice Get group info
+    function getGroup(bytes32 groupId) external view returns (Group memory);
+
+    /// @notice Check if a nullifier has been used in a group×domain
+    function isNullifierUsed(bytes32 groupId, bytes32 domain, bytes32 nullifier) external view returns (bool);
+}
+```
+
+**Predefined Groups:**
+
+| Group | Purpose | Admission |
+|-------|---------|-----------|
+| `PERSONHOOD` | Proof of unique human (Sybil resistance) | Passport predicate proof |
+| `KYC_LEVEL_1` | Email-verified identity | zkEmail proof of unique email |
+| `KYC_LEVEL_2` | Passport-verified identity | zkPassport proof |
+| `KYC_LEVEL_3` | Full KYC (provider-attested) | KYC attestation from approved provider |
+| `EMAIL_DOMAIN_{hash}` | Employees/members of a domain | zkEmail proof for specific domain |
+
+---
+
+## Identity Verification Flows
+
+### Flow 1: zkLogin (OAuth/OIDC)
+
+```
+User                    SDK                  OIDC Provider      Tempo Chain
+  │                      │                       │                  │
+  ├─ Click "Login" ──────►                       │                  │
+  │                      ├─ Generate ephemeral ──►                  │
+  │                      │   keypair + nonce      │                  │
+  │                      ├─ Redirect to OIDC ────►                  │
+  │                      │                       ├─ Return JWT ────►│
+  │                      ├─ Generate ZK proof ───►                  │
+  │                      │   (JWT valid, iss/aud  │                  │
+  │                      │    match, nonce binds  │                  │
+  │                      │    to tempoIdCommit +  │                  │
+  │                      │    ephemeral key)      │                  │
+  │                      ├─ Submit proof ─────────────────────────►│
+  │                      │                       │     verify(vkId, │
+  │                      │                       │     inputs,proof)│
+  │                      │                       │     + attest()   │
+  │                      │                       │     + authorizeKey()
+  │                      ◄─ Session key active ──────────────────◄─┤
+```
+
+**ZK Circuit public inputs:**
+- `tempoIdCommit` (or target account)
+- `ephemeralPubKey` (to be added as Access Key)
+- `issuerHash` (H(iss))
+- `audienceHash` (H(aud))
+- `expiryEpoch`
+
+**ZK Circuit private inputs:**
+- Full JWT
+- JWT signature
+- Issuer JWK (public key)
+- User salt (unlinkability factor)
+- `trapdoor`, `nullifierSecret` (identity secrets)
+
+**What's verified in the circuit:**
+1. JWT signature is valid against issuer JWK
+2. `iss` matches expected issuer
+3. `aud` matches expected application
+4. `nonce` field contains `H(ephemeralPubKey || expiryEpoch || randomness)`
+5. `tempoIdCommit = Poseidon(trapdoor, nullifierSecret)`
+6. Output: `addressSeed = Poseidon(sub, iss, aud, salt)` (for deterministic address derivation)
+
+### Flow 2: zkEmail
+
+**ZK Circuit verifies:**
+1. DKIM-Signature RSA verification (RSA-2048 with SHA-256)
+2. Email header parsing (From domain extraction)
+3. Nonce in subject/body binds to tempoIdCommit
+4. Domain hash output for group membership
+
+### Flow 3: zkPassport
+
+**ZK Circuit verifies:**
+1. Document Signing Certificate chain up to Country Signing CA (CSCA)
+2. DG1 (MRZ) data integrity
+3. Predicate extraction (age >= threshold, nationality in set)
+4. Identity commitment derivation from document data
+5. Nullifier for uniqueness (prevents double-registration)
+
+### Flow 4: zkTLS
+
+**ZK Circuit verifies:**
+1. TLS session transcript integrity (server certificate chain)
+2. Domain matches expected service
+3. Response content matches predicate (e.g., "balance > X", "member of org Y")
+4. Binding to tempoIdCommit
+
+---
+
+## Agent Authentication Model
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Human (Root Key)                          │
+│                                                              │
+│  1. Proves identity (zkLogin/zkEmail/zkPassport)             │
+│  2. Calls AccountKeychain.authorizeKey(agentKey, policy)     │
+│                                                              │
+├──────────────┬───────────────────────────────────────────────┤
+│              │                                               │
+│    ┌─────────▼─────────┐    ┌──────────────────────┐        │
+│    │   Agent Key #1     │    │    Agent Key #2       │        │
+│    │ ┌───────────────┐  │    │ ┌──────────────────┐  │        │
+│    │ │ Policy:       │  │    │ │ Policy:          │  │        │
+│    │ │ - DEX only    │  │    │ │ - Any target     │  │        │
+│    │ │ - 100 USDC/hr │  │    │ │ - 10 USDC/day   │  │        │
+│    │ │ - No MPP      │  │    │ │ - MPP: 5 USDC   │  │        │
+│    │ │ - Expires 24h │  │    │ │ - Receipts req'd │  │        │
+│    │ └───────────────┘  │    │ └──────────────────┘  │        │
+│    └────────────────────┘    └──────────────────────┘        │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Extended Policy Object (extends TIP-1011)
+
+```solidity
+struct AgentPolicy {
+    // From TIP-1011
+    address[] allowedDestinations;
+    TokenLimit[] spendingLimits;        // With periodic resets
+    uint64 expiry;
+
+    // New: Agent-specific extensions
+    bytes4[] allowedSelectors;          // Method selectors agent can call (empty = any)
+    uint32 maxCallsPerHour;            // Rate limit (0 = unlimited)
+    uint256 mppBudget;                 // Max MPP spend for external services
+    bytes32[] allowedPrivacyZones;     // Privacy zones agent can operate in
+    bool requireReceipts;              // Agent must attach service receipts
+    bytes32 delegatorIdentity;         // TempoID of the delegating human
+}
+```
+
+### Off-chain Service Authentication
+
+Services verify agent authorization in two ways:
+
+**Method A: On-chain verification (simple)**
+```
+Agent → Service: "I'm key 0x123 acting for account 0xABC"
+Service → Tempo RPC: AccountKeychain.getKey(0xABC, 0x123) 
+Service: Verify key is active, not expired, has sufficient limits
+Service: Proceed with request
+```
+
+**Method B: ZK presentation (private)**
+```
+Agent → ZK Prover: Generate membership proof for group "KYC_LEVEL_2"
+  with domain = H("service.example.com")
+  outputs nullifier (unique per service, unlinkable)
+Agent → Service: Present proof + nullifier
+Service → Verifier: Verify proof against group root
+Service: Proceed with pseudonymous identity
+```
+
+---
+
+## Account Recovery
+
+### Recovery Paths
+
+| Path | Trigger | Proof Required | Delay |
+|------|---------|---------------|-------|
+| **Social** | Guardian threshold (e.g., 2-of-3) | Guardian signatures | User-configured (1-30 days) |
+| **Credential** | Re-prove OIDC, email, or passport | ZK proof against same identity commitment | 3 days minimum |
+| **Cold Key** | Hardware-backed P256/WebAuthn key | Signature from cold key | 1 day |
+| **Emergency Freeze** | Current controller suspects compromise | Controller signature | Immediate (freezes all operations) |
+
+### Recovery Flow
+
+```
+1. initiateRecovery(idCommitment, newController, proof)
+   → Validates proof (guardian sigs, ZK credential proof, or cold key sig)
+   → Sets pendingRecovery with executeAfter = now + recoveryDelay
+   → Emits RecoveryInitiated event (notifies current controller)
+
+2. [Recovery delay period - current controller can cancelRecovery()]
+
+3. finalizeRecovery(idCommitment)
+   → Checks executeAfter has passed
+   → Rotates controller to newController
+   → Resets AccountKeychain root key
+   → Emits RecoveryFinalized event
+```
+
+---
+
+## Private Relay / Service Linking
+
+### Per-Service Pseudonyms
+
+For service domain `D`, the user generates:
+```
+externalNullifier = Poseidon(D, serviceContext)
+serviceNullifier = Poseidon(nullifierSecret, externalNullifier)
+servicePseudonym = Poseidon(idCommitment, D)  // Stable per service
+```
+
+The service sees `servicePseudonym` — stable for repeat visits but unlinkable across services. The `serviceNullifier` prevents the same identity from creating multiple pseudonyms for the same service.
+
+### Stealth Service Addresses
+
+Each service interaction can derive a stealth address:
+```
+stealthAddr = StealthDerive(tempoIdViewKey, serviceTag, index)
+```
+
+This enables:
+- Private inbound payments per service
+- Private notifications via relay
+- No cross-service linkability
+
+### ServiceLinkCommitment
+
+Stored on-chain as a commitment:
+```
+commit = Poseidon(idCommitment, serviceHash, relayPubKey, salt)
+```
+
+Enables authorized relays to forward notifications/payments without knowing the user's identity or which service the link is for.
+
+---
+
+## ZK KYC System
+
+### Leveled KYC Groups
+
+| Level | Requirement | What It Proves |
+|-------|-------------|----------------|
+| KYC-0 | Account exists | Sybil resistance (one per human) |
+| KYC-1 | Email verified (zkEmail) | Reachability + basic identity |
+| KYC-2 | Passport verified (zkPassport) | Government-issued identity |
+| KYC-3 | Provider-attested KYC | Full regulatory compliance |
+
+### Predicate Proofs
+
+Users never reveal raw data. Instead, they prove predicates:
+
+| Predicate | What's Proved | What's Hidden |
+|-----------|--------------|---------------|
+| `age >= 18` | User is an adult | Exact birthdate |
+| `nationality NOT IN {sanctioned_set}` | User is not sanctioned | Exact nationality |
+| `residency IN {EU}` | User is EU resident | Exact country |
+| `kyc_level >= 2` | User has passport-level KYC | All KYC details |
+
+### Flow: "KYC Once, Auth Everywhere"
+
+```
+1. User does KYC with Provider A (via zkPassport or traditional KYC)
+2. Provider A creates private attestation on Tempo:
+   attestPrivate(KYC_LEVEL schema, userIdCommitment, dataCommitment, expiry)
+3. User is added to KYC_LEVEL_2 group
+4. Later, Service B requires KYC-2:
+   - User generates membership proof for KYC_LEVEL_2 group
+   - Proof includes domain-separated nullifier for Service B
+   - Service B verifies proof on-chain or off-chain
+   - Service B never sees KYC data, only "this unique human is KYC-2 verified"
+```
+
+---
+
+## SDK Design
+
+### `@tempo/identity`
+
+```typescript
+import { TempoID, Providers, Agent, Recovery, Groups } from '@tempo/identity';
+
+// === Create Identity ===
+const id = await TempoID.create({
+  provider: Providers.OIDC('google'),    // or 'apple', 'github'
+  // OR
+  provider: Providers.Email('user@example.com'),
+  // OR  
+  provider: Providers.Passport(),        // triggers NFC scan
+});
+
+// === Login (zkLogin) ===
+const session = await id.login({
+  provider: 'google',
+  scopes: ['openid', 'email'],
+  sessionKeyPolicy: {
+    expiry: '24h',
+    spendingLimits: [{ token: 'USDC', amount: '100', period: '1h' }],
+    allowedDestinations: ['0xDEX...'],
+  },
+});
+// session.key is now an active Access Key on AccountKeychain
+
+// === Delegate to Agent ===
+const agentKey = await Agent.delegate({
+  account: session.account,
+  policy: {
+    allowedDestinations: ['0xDEX...', '0xLending...'],
+    spendingLimits: [{ token: 'USDC', amount: '50', period: '1d' }],
+    maxCallsPerHour: 100,
+    mppBudget: '10 USDC',
+    requireReceipts: true,
+    expiry: '7d',
+  },
+});
+// agentKey.privateKey → give to agent runtime
+// agentKey.address → the Access Key ID on AccountKeychain
+
+// === Prove Email ===
+await id.prove.email({
+  rawEmail: emailWithDKIM,
+  claims: ['domain'],     // selectively disclose domain only
+});
+
+// === Prove Passport ===
+await id.prove.passport({
+  predicates: { ageOver: 18, nationalityNotIn: ['XX', 'YY'] },
+  joinGroups: ['KYC_LEVEL_2', 'PERSONHOOD'],
+});
+
+// === Prove for Service (Private) ===
+const presentation = await Groups.proveMembership({
+  groupId: 'KYC_LEVEL_2',
+  domain: 'service.example.com',
+});
+// presentation.proof + presentation.nullifier → send to service
+
+// === Configure Recovery ===
+await Recovery.configure({
+  identity: id.commitment,
+  guardians: ['0xAlice...', '0xBob...', '0xCarol...'],
+  threshold: 2,
+  delay: '7d',
+  coldKey: hardwareKey.publicKey,
+});
+```
+
+### Proving Infrastructure
+
+| Mode | Latency | Use Case |
+|------|---------|----------|
+| **Browser WASM** | 3-10s | User-facing login flows |
+| **Native Rust** | 0.5-2s | Server-side, agent proving |
+| **Hosted Prover** | 1-3s | Default for SDK (non-custodial) |
+| **Self-hosted** | 0.5-2s | Privacy-sensitive deployments |
+
+All provers are non-custodial: the prover sees private inputs transiently to generate the proof, but the proof is the only thing submitted on-chain. Users can self-host for maximum privacy.
+
+---
+
+## Gas Costs Summary
+
+| Operation | Estimated Gas | Notes |
+|-----------|--------------|-------|
+| ZK proof verification | 180,000 | Plonk BN254 |
+| Nullifier consumption | 22,000 | SSTORE |
+| Identity registration | 65,000 | |
+| Attestation creation (public) | 80,000 | |
+| Attestation creation (private) | 55,000 | |
+| Group member addition | 45,000 | Merkle tree update |
+| Membership proof verification | 200,000 | Proof + nullifier |
+| zkLogin full flow | ~280,000 | Verify + attest + authorizeKey |
+| Agent key delegation | ~25,000 | Via AccountKeychain |
+| Recovery initiation | 50,000 | |
+| Recovery finalization | 40,000 | |
+
+---
+
+# Backward Compatibility
+
+This TIP requires a **hardfork** for the new precompiles.
+
+Existing AccountKeychain functionality is fully preserved. The new precompiles are additive — they provide identity verification and attestation infrastructure that feeds into the existing Access Key system.
+
+**No breaking changes:**
+- Existing accounts continue to work without TempoID registration
+- AccountKeychain `authorizeKey` works the same; TempoID just provides a new way to trigger it
+- All new precompiles are at new addresses
+
+---
+
+# Security Considerations
+
+### Circuit Integrity
+- Verifier keys are registered on-chain with governance controls
+- Emergency pause mechanism if circuit vulnerability discovered
+- Version registry enables smooth circuit upgrades without breaking existing proofs
+
+### Issuer Trust
+- OIDC: JWK sets cached on-chain with rotation detection; proofs bind to specific key IDs
+- DKIM: Public key registry mirrors DNS records; rotation handling via archive
+- Passport: CSCA trust anchors managed by governance; country-level allowlists
+
+### Privacy
+- Default SDK flows use domain-separated nullifiers (no cross-service linkability)
+- Private attestations use commitments (no plaintext data on-chain)
+- Stealth addresses prevent payment graph analysis
+- Group membership proofs reveal nothing beyond "member of group X"
+
+### Recovery Abuse
+- Configurable timelock (1-30 days) gives controller time to react
+- Emergency freeze immediately halts all operations
+- Guardian notification events enable monitoring
+- Recovery requires valid proof (not just guardian signatures for credential-based recovery)
+
+### Prover Trust
+- All prover implementations are non-custodial
+- Self-hosting supported and documented
+- Hosted prover processes inputs transiently; audit logging without data retention
+
+---
+
+# Invariants
+
+1. **Identity uniqueness**: Each `idCommitment` can be registered at most once
+2. **Controller authority**: Only the current controller can rotate to a new controller (outside recovery)
+3. **Nullifier finality**: Once consumed, a nullifier can never be un-consumed
+4. **Group monotonicity**: Group membership is append-only (members are never removed, only groups can be frozen)
+5. **Recovery delay**: Recovery cannot finalize before `executeAfter` timestamp
+6. **Attestation immutability**: Attestation data cannot be modified after creation (only revoked)
+7. **Proof soundness**: `verify()` returns true only for valid proofs against registered verifier keys
+8. **Domain separation**: Nullifiers from different domains are always distinct for the same identity
+
+---
+
+# Phased Rollout
+
+### Phase 0: zkLogin + Agent Delegation (4-6 weeks)
+- `ZKProofVerifier` precompile (Plonk BN254)
+- `TempoIDRegistry` (registration + controller management)
+- zkLogin circuits for Google + Apple
+- SDK: `login.oidc()` + `agent.delegate()`
+- Integration with existing AccountKeychain
+
+### Phase 1: Groups + Unlinkable Service Auth (4-6 weeks)
+- `TempoGroups` precompile
+- Semaphore-style circuits for membership proofs
+- Per-service pseudonyms + nullifiers
+- Stealth service-link commitments
+- SDK: `groups.proveMembership()`
+
+### Phase 2: zkEmail + Recovery (6-8 weeks)
+- zkEmail circuits (DKIM RSA-2048 + SHA-256)
+- `RecoveryManager` in TempoIDRegistry
+- Guardian management
+- SDK: `prove.email()` + `recovery.configure()`
+
+### Phase 3: ZK KYC (6-8 weeks)
+- `TempoAttestationRegistry` precompile
+- KYC group leveling (KYC-1 through KYC-3)
+- Predicate proof circuits (age, nationality, residency)
+- Privacy zone integration
+- SDK: `prove.passport()` predicates
+
+### Phase 4: zkPassport + zkTLS + Hardening (8-12 weeks)
+- Full zkPassport NFC pipeline
+- CSCA trust anchor governance
+- zkTLS notary integration
+- Circuit upgrade governance
+- Production audits
+
+---
+
+# References
+
+- [Sui zkLogin](https://docs.sui.io/concepts/cryptography/zklogin) — OIDC + ZK proof architecture
+- [Aptos Keyless](https://aptos.dev/build/guides/aptos-keyless/how-keyless-works) — Ephemeral key + JWT + ZK flow
+- [ZK Email](https://docs.zk.email/) — DKIM verification in ZK circuits
+- [zkPassport](https://docs.zkpassport.id/) — Passport NFC + ZK predicate proofs
+- [zkTLS / TLSNotary](https://tlsnotary.org/) — TLS session proofs
+- [Ethereum Attestation Service](https://docs.attest.org/) — Schema + attestation architecture
+- [Semaphore](https://semaphore.pse.dev/) — Anonymous group membership with nullifiers
+- [World ID](https://world.org/world-id) — Proof of personhood (we use passport-based, no orbs)
+- [AccountKeychain](tips/ref-impls/src/interfaces/IAccountKeychain.sol) — Existing Tempo session key system
+- [TIP-1011](tips/tip-1011.md) — Enhanced Access Key Permissions
+- [OpenID Foundation AI Agent Identity](https://openid.net/wp-content/uploads/2025/10/Identity-Management-for-Agentic-AI.pdf) — Agent identity challenges


### PR DESCRIPTION
## Summary

TIP-1020 introduces **TempoID** — a ZK-first unified identity layer for Tempo that combines the best of zkLogin (Sui), Aptos Keyless, zkEmail, zkPassport, zkTLS, EAS, and WorldID (without orbs) into a single cohesive system.

**Thread context:** https://tempoxyz.slack.com/archives/C0A99L9RLHZ/p1770485215633749

## Motivation

Auth today is designed for humans-in-browsers. AI agents hit a wall at every step. This TIP adds the missing identity layer that connects Tempo's existing primitives (AccountKeychain, sub-accounts, stealth addresses, MPP) into a complete identity + auth + recovery system.

## What's in the TIP

**Four new precompiles:**
- `ZKProofVerifier` — fast on-chain SNARK verification (Plonk/BN254, ~180k gas)
- `TempoIDRegistry` — identity commitments + controller management + recovery
- `TempoAttestationRegistry` — EAS-inspired public + private attestations
- `TempoGroups` — Semaphore-style membership groups + nullifiers

**Five identity verification flows** (all ZK, all privacy-preserving):
1. zkLogin (OAuth/OIDC — Google, Apple, GitHub)
2. zkEmail (DKIM verification)
3. zkPassport (NFC chip, predicate proofs)
4. zkTLS (web2 data proofs)
5. Personhood (passport-based Sybil resistance)

**Agent auth:** Extends TIP-1011 Access Keys with policy objects (rate limits, MPP budgets, receipts). Human proves identity → agents get scoped delegation.

**Account recovery:** Social guardians + credential re-proof + cold keys + emergency freeze.

**Private relay:** Per-service unlinkable pseudonyms via Semaphore nullifiers + stealth addresses.

**ZK KYC:** Leveled groups (email → passport → full KYC). Predicate proofs (age >= 18, not sanctioned). KYC once, auth everywhere.

## Phased Rollout
- Phase 0: zkLogin + agent delegation (4-6 weeks)
- Phase 1: Groups + unlinkable service auth
- Phase 2: zkEmail + recovery
- Phase 3: ZK KYC
- Phase 4: zkPassport + zkTLS + hardening