### PR TITLE
fix(primitives): bound RLP-encoded tx size before deserialization

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -636,6 +636,15 @@ where
             );
         }
 
+        // Validate AA transaction field limits (calls, access list, token limits).
+        // Run before intrinsic gas to reject oversized transactions cheaply.
+        if let Err(err) = self.ensure_aa_field_limits(&transaction) {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::other(err),
+            );
+        }
+
         if transaction.inner().is_aa() {
             // Validate AA transaction intrinsic gas.
             // This ensures the gas limit covers all AA-specific costs (per-call overhead,
@@ -652,15 +661,6 @@ where
             if let Err(err) = ensure_intrinsic_gas_tempo_tx(&transaction, spec) {
                 return TransactionValidationOutcome::Invalid(transaction, err);
             }
-        }
-
-        // Validate AA transaction field limits (calls, access list, token limits).
-        // This prevents DoS attacks via oversized transactions.
-        if let Err(err) = self.ensure_aa_field_limits(&transaction) {
-            return TransactionValidationOutcome::Invalid(
-                transaction,
-                InvalidPoolTransactionError::other(err),
-            );
         }
 
         let fee_payer = match transaction.inner().fee_payer(transaction.sender()) {


### PR DESCRIPTION
Closes SIGP-31

Adds a `MAX_TEMPO_TX_RLP_BYTES` (8 MiB) size check in `TempoTransaction::decode` and `AASigned::rlp_decode` to reject oversized encoded transactions before field deserialization allocates memory. This prevents resource pressure from unbounded vector fields (calls, access list, authorization list) during RLP decoding.

Also reorders `ensure_aa_field_limits` in the tx pool validator to run before intrinsic gas checks.

## Changes
- `crates/primitives/src/transaction/tempo_transaction.rs`: Add `MAX_TEMPO_TX_RLP_BYTES` constant, enforce in `Decodable::decode`
- `crates/primitives/src/transaction/tt_signed.rs`: Enforce same limit in `AASigned::rlp_decode`
- `crates/transaction-pool/src/validator.rs`: Move field limits check earlier in validation pipeline

## Testing
```
cargo test -p tempo-primitives --lib  # 103 passed
cargo test -p tempo-transaction-pool --lib  # 188 passed
cargo clippy -p tempo-primitives -p tempo-transaction-pool -- -D warnings  # clean
```

Slack thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770528128122509