### PR TITLE
perf(p256): switch P256 verification to aws-lc-sys for ~5.5x speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6467,7 +6467,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "serdect",
  "sha2 0.10.9",
 ]
 
@@ -6898,7 +6897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
- "serdect",
 ]
 
 [[package]]
@@ -12116,6 +12114,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "arbitrary",
+ "aws-lc-sys",
  "base64 0.22.1",
  "derive_more",
  "modular-bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2.15", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
 metrics = "0.24.0"
+aws-lc-sys = "0.36.0"
 p256 = "0.13"
 parking_lot = "0.12.4"
 prometheus-client = "0.24.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -38,7 +38,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
 # Cryptography for P256 and WebAuthn signature verification
-p256 = { workspace = true, features = ["ecdsa"] }
+aws-lc-sys.workspace = true
 sha2.workspace = true
 base64.workspace = true
 
@@ -51,6 +51,7 @@ alloy-consensus = { workspace = true, features = ["arbitrary"] }
 alloy-primitives = { workspace = true, features = ["arbitrary", "getrandom", "rand"] }
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+p256 = { workspace = true, features = ["ecdsa"] }
 rand = "0.9"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
@@ -66,7 +67,6 @@ serde = [
 	"alloy-primitives/serde",
 	"reth-codecs?/serde",
 	"rand/serde",
-	"p256/serde",
 	"tracing-subscriber/serde",
 	"revm/serde",
 ]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -843,7 +843,7 @@ mod tests {
 
         let result1 = evm.transact_commit(tx_env1)?;
         assert!(result1.is_success());
-        assert_eq!(result1.gas_used(), 28_671);
+        assert_eq!(result1.gas_used(), 26_271);
 
         let ctx = &mut evm.ctx;
         let internals = EvmInternals::new(&mut ctx.journaled_state, &block, &ctx.cfg, &ctx.tx);
@@ -858,7 +858,7 @@ mod tests {
         })?;
         drop(provider);
 
-        assert_eq!(slot, U256::from(97_132));
+        assert_eq!(slot, U256::from(97_372));
 
         // Second tx: two calls
         let tx2 = TxBuilder::new()
@@ -875,7 +875,7 @@ mod tests {
 
         let result2 = evm.transact_commit(tx_env2)?;
         assert!(result2.is_success());
-        assert_eq!(result2.gas_used(), 31_286);
+        assert_eq!(result2.gas_used(), 28_886);
 
         let ctx = &mut evm.ctx;
         let internals = EvmInternals::new(&mut ctx.journaled_state, &block, &ctx.cfg, &ctx.tx);
@@ -890,7 +890,7 @@ mod tests {
         })?;
         drop(provider);
 
-        assert_eq!(slot, U256::from(94_003));
+        assert_eq!(slot, U256::from(94_483));
 
         Ok(())
     }
@@ -1520,7 +1520,7 @@ mod tests {
         // With T1 TIP-1000: new account cost (250k) + base intrinsic (21k) + WebAuthn (~3.4k) + calldata
         let gas_used = result.gas_used();
         assert_eq!(
-            gas_used, 278738,
+            gas_used, 276338,
             "T1 baseline identity call gas should be exact"
         );
 
@@ -1565,7 +1565,7 @@ mod tests {
         // With TIP-1000: new account (250k) + SSTORE to new slot (250k) + base costs
         let gas_used = result.gas_used();
         assert_eq!(
-            gas_used, 530863,
+            gas_used, 528463,
             "T1 SSTORE to new slot gas should be exact"
         );
 
@@ -1619,7 +1619,7 @@ mod tests {
         // But still has new account cost (250k) + cold SLOAD (2100) + warm SSTORE reset (~2900)
         let gas_used = result.gas_used();
         assert_eq!(
-            gas_used, 283663,
+            gas_used, 281263,
             "T1 SSTORE to existing slot gas should be exact"
         );
 
@@ -1666,7 +1666,7 @@ mod tests {
 
         // With TIP-1000: new account (250k) + 2 SSTOREs to new slots (2 * 250k) = 750k + base
         let gas_used = result.gas_used();
-        assert_eq!(gas_used, 783069, "T1 multiple SSTOREs gas should be exact");
+        assert_eq!(gas_used, 780669, "T1 multiple SSTOREs gas should be exact");
 
         Ok(())
     }
@@ -1698,7 +1698,7 @@ mod tests {
 
         // With TIP-1000: CREATE cost (500k) + new account for sender (250k) + base costs
         let gas_used = result.gas_used();
-        assert_eq!(gas_used, 778720, "T1 CREATE contract gas should be exact");
+        assert_eq!(gas_used, 776320, "T1 CREATE contract gas should be exact");
 
         Ok(())
     }
@@ -1741,8 +1741,8 @@ mod tests {
         let gas_triple = result2.gas_used();
 
         // Three calls should cost more than single call
-        assert_eq!(gas_single, 278738, "T1 single call gas should be exact");
-        assert_eq!(gas_triple, 284102, "T1 triple call gas should be exact");
+        assert_eq!(gas_single, 276338, "T1 single call gas should be exact");
+        assert_eq!(gas_triple, 281702, "T1 triple call gas should be exact");
         assert!(
             gas_triple > gas_single,
             "3 calls should cost more than 1 call"
@@ -1798,7 +1798,7 @@ mod tests {
 
         // T1 costs: new account (250k) + cold SLOAD (2100) + warm SLOAD (100) + cold account (~2.6k)
         let gas_used = result.gas_used();
-        assert_eq!(gas_used, 280866, "T1 SLOAD cold/warm gas should be exact");
+        assert_eq!(gas_used, 278466, "T1 SLOAD cold/warm gas should be exact");
 
         Ok(())
     }

--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -78,8 +78,8 @@ Gas costs follow the [Tempo Transaction Signature Gas Schedule](https://docs.tem
 | Type | Gas Cost |
 |------|----------|
 | secp256k1 | 3,000 |
-| P256 | 8,000 |
-| WebAuthn | 8,000 |
+| P256 | 5,600 |
+| WebAuthn | 5,600 |
 | Keychain | Inner signature cost + 3,000 |
 
 **Note**: Unlike transaction signature verification, WebAuthn signatures do not incur additional calldata gas in the precompile. The EVM already charges calldata gas when the signature is passed as a function argument, so adding it again would result in double-charging.


### PR DESCRIPTION
## Summary

Switch P256 ECDSA prehash verification from pure-Rust `p256` crate to `aws-lc-sys` (BoringSSL/AWS-LC) for ~5.5x faster signature verification.

## Motivation

Benchmarking showed P256 verify with the `p256` crate takes ~190µs vs ecrecover at ~26µs (7.2x slower). At the proposed 8,000 gas, P256 was ~2.5x underpriced relative to ecrecover. AWS-LC has hand-optimized x86-64 assembly for NIST P-256 that brings verify down to ~34µs (1.3x ecrecover).

Context: https://tempoxyz.slack.com/archives/C0AAWUVM2T0/p1770059541126029

## Benchmark Results

| Operation | Library | Time (µs) | vs ecrecover |
|---|---|---|---|
| ecrecover | libsecp256k1 (C) | 26.0 | 1.0x |
| P256 verify | **aws-lc-sys** (C/asm) | **33.7** | **1.3x** |
| P256 verify | p256 crate (Rust) | 189.7 | 7.3x |

## Changes

- `crates/primitives/src/transaction/tt_signature.rs`: Replace `p256` crate verify with `aws-lc-sys` `ECDSA_verify` FFI. Uses RAII guards for EC_KEY/EC_POINT cleanup. DER-encodes (r,s) for the C API. Low-s malleability check unchanged.
- `crates/revm/src/handler.rs`: `P256_VERIFY_GAS` 5000 → 2600 (1500 crypto overhead + 1100 calldata)
- `tips/tip-1020.md`: P256/WebAuthn gas 8000 → 5600
- `crates/primitives/Cargo.toml`: Add `aws-lc-sys` dep, move `p256` to dev-deps (still used for test signing)
- `crates/revm/src/evm.rs`: Update hardcoded gas assertions (-2400 each)

## Security

- `aws-lc-sys` is already in the dependency tree (via `commonware-cryptography` → `aws-lc-rs`). No new C library added, just a direct dep on the same `aws-lc-sys 0.36.0`.
- AWS-LC is FIPS validated and formally verified (symbolic execution).
- The same kind of C crypto dependency as `secp256k1-sys` which is already used for ecrecover.
- Includes RAII guards (`EcKeyGuard`, `EcPointGuard`) for leak-free cleanup on all error paths.

## Testing

- All 32 `tt_signature` tests pass (P256 verify, WebAuthn, keychain)
- All AA gas tests pass with updated values
- `cargo clippy -p tempo-primitives -p tempo-revm -- -D warnings` clean
- Pre-existing SIGSEGV in `test_access_millis_timestamp` (reproduces on base branch too, unrelated)

## Reviewers

Requesting review from people who own the relevant code and the new dependency decision:
- @jxom — TIP-1020 PR author
- @0xrusowsky — most commits to `tt_signature.rs`
- @legion2002 — most commits to `handler.rs`
- @0xKitsune — approved TIP-1020, handler.rs contributor
- @danrobinson @dankrad — gas cost calibration discussion