### PR TITLE
feat(rpc): add eth_sendRawTransactionPrivate

### DIFF
--- a/crates/node/src/rpc/eth_ext/mod.rs
+++ b/crates/node/src/rpc/eth_ext/mod.rs
@@ -1,7 +1,10 @@
 use crate::rpc::eth_ext::transactions::TransactionsResponse;
+use alloy_primitives::{B256, Bytes};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_node_core::rpc::result::internal_rpc_err;
 use reth_rpc_eth_api::RpcNodeCore;
+use reth_rpc_eth_types::utils::recover_raw_transaction;
+use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool};
 use tempo_alloy::rpc::pagination::PaginationParams;
 
 pub mod transactions;
@@ -17,6 +20,11 @@ pub trait TempoEthExtApi {
         &self,
         params: PaginationParams<TransactionsFilter>,
     ) -> RpcResult<TransactionsResponse>;
+
+    /// Submits a raw transaction to the pool with `Private` origin so that it is not propagated
+    /// to other peers. Otherwise behaves identically to `eth_sendRawTransaction`.
+    #[method(name = "sendRawTransactionPrivate")]
+    async fn send_raw_transaction_private(&self, tx: Bytes) -> RpcResult<B256>;
 }
 
 /// The JSON-RPC handlers for the `dex_` namespace.
@@ -38,6 +46,23 @@ impl<EthApi: RpcNodeCore> TempoEthExtApiServer for TempoEthExt<EthApi> {
         _params: PaginationParams<TransactionsFilter>,
     ) -> RpcResult<TransactionsResponse> {
         Err(internal_rpc_err("unimplemented"))
+    }
+
+    async fn send_raw_transaction_private(&self, tx: Bytes) -> RpcResult<B256> {
+        let recovered = recover_raw_transaction::<PoolPooledTx<EthApi::Pool>>(&tx)
+            .map_err(|e| internal_rpc_err(e.to_string()))?;
+
+        let pool_transaction =
+            <EthApi::Pool as TransactionPool>::Transaction::from_pooled(recovered);
+
+        let outcome = self
+            .eth_api
+            .pool()
+            .add_transaction(TransactionOrigin::Private, pool_transaction)
+            .await
+            .map_err(|e| internal_rpc_err(e.to_string()))?;
+
+        Ok(outcome.hash)
     }
 }
 


### PR DESCRIPTION
## Summary
Adds `eth_sendRawTransactionPrivate` RPC method that submits transactions to the pool with `TransactionOrigin::Private`, preventing gossip to other peers.

## Changes
- Added `sendRawTransactionPrivate` to `TempoEthExtApi` trait in `crates/node/src/rpc/eth_ext/mod.rs`
- Decodes + recovers the raw tx, then calls `pool.add_transaction(TransactionOrigin::Private, ...)` directly

## Testing
`cargo check -p tempo-node` and `cargo clippy -p tempo-node` pass cleanly.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770589519258279