### PR TITLE
fix(primitives): replace #[expect] with #[allow] for large_enum_variant lint

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -36,7 +36,7 @@ pub const TEMPO_SYSTEM_TX_SENDER: Address = Address::ZERO;
     serde_cfg(feature = "serde")
 )]
 #[cfg_attr(test, reth_codecs::add_arbitrary_tests(compact, rlp))]
-#[expect(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum TempoTxEnvelope {
     /// Legacy transaction (type 0x00)
     #[envelope(ty = 0)]


### PR DESCRIPTION
## Summary
Fixes clippy CI failures caused by an unfulfilled lint expectation on `TempoTxEnvelope`.

## Motivation
`#[expect(clippy::large_enum_variant)]` fails with `unfulfilled_lint_expectations` when building with `--all-targets` because the lint fires for the lib target but not the lib test target (test builds have different type layouts). This breaks the lint CI job on every PR.

Ref: https://github.com/tempoxyz/tempo/actions/runs/21807272397/job/62912680165

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770606674921879

## Changes
- Replaced `#[expect(clippy::large_enum_variant)]` with `#[allow(clippy::large_enum_variant)]` on `TempoTxEnvelope` in `crates/primitives/src/transaction/envelope.rs`

## Testing
`cargo clippy --workspace --all-targets -- -D warnings` passes clean.