### PR TITLE
fix(tempoup): skip GPG signature verification for versions <= 1.1.0

### DIFF
--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,7 +6,7 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.1"
+TEMPOUP_INSTALLER_VERSION="0.0.2"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
@@ -358,30 +358,34 @@ main() {
 
     info "Checksum verified ✓"
 
-    # GPG signature verification
-    if command -v gpg >/dev/null 2>&1; then
-        info "Verifying GPG signature..."
-        download_file "$VERSION_TAG" "${ARCHIVE_NAME}.asc" "$TMP_DIR"
+    # GPG signature verification (only for versions after 1.1.0, as earlier releases lack .asc files)
+    if version_gt "$VERSION_TAG" "1.1.0"; then
+        if command -v gpg >/dev/null 2>&1; then
+            info "Verifying GPG signature..."
+            download_file "$VERSION_TAG" "${ARCHIVE_NAME}.asc" "$TMP_DIR"
 
-        # Import the release signing key if not already present
-        if ! gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
-            info "Fetching Tempo release signing key from $GPG_KEYSERVER..."
-            if ! gpg --keyserver "$GPG_KEYSERVER" --recv-keys "$GPG_KEY_FINGERPRINT" 2>/dev/null; then
-                warn "Failed to fetch GPG key from keyserver. Skipping signature verification."
-                warn "You can manually import the key: gpg --keyserver $GPG_KEYSERVER --recv-keys $GPG_KEY_FINGERPRINT"
+            # Import the release signing key if not already present
+            if ! gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
+                info "Fetching Tempo release signing key from $GPG_KEYSERVER..."
+                if ! gpg --keyserver "$GPG_KEYSERVER" --recv-keys "$GPG_KEY_FINGERPRINT" 2>/dev/null; then
+                    warn "Failed to fetch GPG key from keyserver. Skipping signature verification."
+                    warn "You can manually import the key: gpg --keyserver $GPG_KEYSERVER --recv-keys $GPG_KEY_FINGERPRINT"
+                fi
             fi
-        fi
 
-        if gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
-            if gpg --batch --verify "$TMP_DIR/${ARCHIVE_NAME}.asc" "$ARCHIVE_PATH" 2>/dev/null; then
-                info "GPG signature verified ✓"
-            else
-                error "GPG signature verification failed. The binary may have been tampered with."
+            if gpg --list-keys "$GPG_KEY_FINGERPRINT" >/dev/null 2>&1; then
+                if gpg --batch --verify "$TMP_DIR/${ARCHIVE_NAME}.asc" "$ARCHIVE_PATH" 2>/dev/null; then
+                    info "GPG signature verified ✓"
+                else
+                    error "GPG signature verification failed. The binary may have been tampered with."
+                fi
             fi
+        else
+            warn "gpg not found. Skipping signature verification."
+            warn "Install gpg to enable signature verification of releases."
         fi
     else
-        warn "gpg not found. Skipping signature verification."
-        warn "Install gpg to enable signature verification of releases."
+        info "Skipping GPG signature verification (not available for versions <= 1.1.0)"
     fi
 
     # Extract archive


### PR DESCRIPTION
## Summary
Fixes `tempoup -i` failing with a 404 when installing versions <= 1.1.0 because those releases don't ship `.asc` GPG signature files.

## Changes
- Wrap GPG signature verification in a `version_gt` check — only runs for versions > 1.1.0
- SHA256 checksum verification still runs for all versions
- Bumped installer version to 0.0.2

## Context
Thread: https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770660657723279

## Testing
Verified logic: `version_gt "1.1.0" "1.1.0"` returns 1 (false), so GPG block is skipped for 1.1.0 and below.