### PR TITLE
docs(precompiles): clarify intentional spending limit omission in _transfer_from (TMPO2-39)

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -534,6 +534,9 @@ impl TIP20Token {
         Ok(true)
     }
 
+    /// NOTE: Access key spending limits are intentionally NOT enforced here.
+    /// `transferFrom` is gated by the ERC-20 allowance mechanism, and `approve()` already
+    /// deducts from spending limits, so limits are enforced at approval time. (ref: TMPO2-39)
     fn _transfer_from(
         &mut self,
         msg_sender: Address,


### PR DESCRIPTION
## Summary

Adds a doc comment to `_transfer_from` explicitly documenting that access key spending limits are intentionally not enforced there.

## Motivation

Audit finding TMPO2-39 flagged the inconsistency between docs and code. The docs fix landed in `tempoxyz/docs#87` + `tempoxyz/docs#93`, and the code PR (`#2503`) that would have added enforcement was intentionally closed — confirming the design is: spending limits apply at `approve()` time, not at `transferFrom()` time.

Without a code comment, future developers/auditors will ask the same question. This makes the security property explicit.

## Changes

- Added doc comment on `_transfer_from()` in `crates/precompiles/src/tip20/mod.rs` explaining the design decision and referencing TMPO2-39

## Testing

`cargo check -p tempo-precompiles` passes. Comment-only change, no behavior change.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770659716460929