### PR TITLE
feat(tip20): implement TIP-1006 burnAt for TIP-20 tokens (#2171)

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -56,6 +56,7 @@ crate::sol! {
         function paused() external view returns (bool);
         function transferPolicyId() external view returns (uint64);
         function burnBlocked(address from, uint256 amount) external;
+        function burnAt(address from, uint256 amount) external;
         function mintWithMemo(address to, uint256 amount, bytes32 memo) external;
         function burnWithMemo(uint256 amount, bytes32 memo) external;
         function transferWithMemo(address to, uint256 amount, bytes32 memo) external;
@@ -85,6 +86,10 @@ crate::sol! {
         /// @return The burn blocked role identifier
         function BURN_BLOCKED_ROLE() external view returns (bytes32);
 
+        /// @notice Returns the role identifier for burning tokens from any account
+        /// @return The burn-at role identifier
+        function BURN_AT_ROLE() external view returns (bytes32);
+
         struct UserRewardInfo {
             address rewardRecipient;
             uint256 rewardPerToken;
@@ -106,6 +111,7 @@ crate::sol! {
         event Mint(address indexed to, uint256 amount);
         event Burn(address indexed from, uint256 amount);
         event BurnBlocked(address indexed from, uint256 amount);
+        event BurnAt(address indexed from, uint256 amount);
         event TransferWithMemo(address indexed from, address indexed to, uint256 amount, bytes32 indexed memo);
         event TransferPolicyUpdate(address indexed updater, uint64 indexed newPolicyId);
         event SupplyCapUpdate(address indexed updater, uint256 indexed newSupplyCap);

--- a/tips/ref-impls/src/TIP20.sol
+++ b/tips/ref-impls/src/TIP20.sol
@@ -40,6 +40,7 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
     bytes32 public constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
     bytes32 public constant ISSUER_ROLE = keccak256("ISSUER_ROLE");
     bytes32 public constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
+    bytes32 public constant BURN_AT_ROLE = keccak256("BURN_AT_ROLE");
 
     uint64 public transferPolicyId = 1; // "Always-allow" policy by default.
 
@@ -187,7 +188,28 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         emit BurnBlocked(from, amount);
     }
 
-    function mintWithMemo(address to, uint256 amount, bytes32 memo) external onlyRole(ISSUER_ROLE) {
+    function burnAt(address from, uint256 amount) external onlyRole(BURN_AT_ROLE) {
+        // Prevent burning from protected precompile addresses
+        if (from == TIP_FEE_MANAGER_ADDRESS || from == STABLECOIN_DEX_ADDRESS) {
+            revert ProtectedAddress();
+        }
+
+        _transfer(from, address(0), amount);
+        unchecked {
+            _totalSupply -= uint128(amount);
+        }
+
+        emit BurnAt(from, amount);
+    }
+
+    function mintWithMemo(
+        address to,
+        uint256 amount,
+        bytes32 memo
+    )
+        external
+        onlyRole(ISSUER_ROLE)
+    {
         _mint(to, amount);
         emit TransferWithMemo(address(0), to, amount, memo);
         emit Mint(to, amount);
@@ -556,4 +578,4 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         }
     }
 
-    }
+}

--- a/tips/ref-impls/src/interfaces/ITIP20.sol
+++ b/tips/ref-impls/src/interfaces/ITIP20.sol
@@ -50,6 +50,11 @@ interface ITIP20 {
     /// @param amount The amount of tokens burned.
     event BurnBlocked(address indexed from, uint256 amount);
 
+    /// @notice Emitted when tokens are burned from any account by an authorized caller.
+    /// @param from The address from which tokens were burned.
+    /// @param amount The amount of tokens burned.
+    event BurnAt(address indexed from, uint256 amount);
+
     /// @notice Emitted when tokens are minted.
     /// @param to The address that received the newly minted tokens.
     /// @param amount The amount of tokens minted.
@@ -93,6 +98,10 @@ interface ITIP20 {
     /// @return The burn blocked role identifier.
     function BURN_BLOCKED_ROLE() external view returns (bytes32);
 
+    /// @notice Returns the role identifier for burning tokens from any account.
+    /// @return The burn-at role identifier.
+    function BURN_AT_ROLE() external view returns (bytes32);
+
     /// @notice Returns the role identifier for issuing tokens.
     /// @return The issuer role identifier.
     function ISSUER_ROLE() external view returns (bytes32);
@@ -126,6 +135,11 @@ interface ITIP20 {
     /// @param from The address to burn tokens from.
     /// @param amount The amount of tokens to burn.
     function burnBlocked(address from, uint256 amount) external;
+
+    /// @notice Burns tokens from any account (admin function).
+    /// @param from The address to burn tokens from.
+    /// @param amount The amount of tokens to burn.
+    function burnAt(address from, uint256 amount) external;
 
     /// @notice Burns tokens from the caller's balance with an attached memo.
     /// @param amount The amount of tokens to burn.

--- a/tips/ref-impls/test/BaseTest.t.sol
+++ b/tips/ref-impls/test/BaseTest.t.sol
@@ -35,6 +35,7 @@ contract BaseTest is Test {
     bytes32 internal constant _TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
     bytes32 internal constant _RECEIVE_WITH_MEMO_ROLE = keccak256("RECEIVE_WITH_MEMO_ROLE");
     bytes32 internal constant _BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
+    bytes32 internal constant _BURN_AT_ROLE = keccak256("BURN_AT_ROLE");
 
     // Common test addresses
     address public admin = address(this);
@@ -62,8 +63,7 @@ contract BaseTest is Test {
     function setUp() public virtual {
         // Is this tempo chain?
         isTempo = _TIP403REGISTRY.code.length + _TIP20FACTORY.code.length + _PATH_USD.code.length
-                + _STABLECOIN_DEX.code.length + _NONCE.code.length + _ACCOUNT_KEYCHAIN.code.length
-            > 0;
+            + _STABLECOIN_DEX.code.length + _NONCE.code.length + _ACCOUNT_KEYCHAIN.code.length > 0;
 
         console.log("Tests running with isTempo =", isTempo);
 

--- a/tips/tip-1006.md
+++ b/tips/tip-1006.md
@@ -99,6 +99,7 @@ function burnAt(address from, uint256 amount) external;
    - `optedInSupply` must decrease by `amount`
    - Any previously accrued `rewardBalance` remains claimable
 6. **Policy Independence**: `burnAt` must succeed regardless of transfer policy status of `from`
+7. **Activation (Tempo precompiles)**: `burnAt` and `BURN_AT_ROLE()` are enabled for Tempo precompiles at hardfork T2+. Before T2, calls should return an unknown selector.
 
 ## Test Cases
 


### PR DESCRIPTION
## Summary

- Implements `burnAt` function and `BURN_AT_ROLE` for TIP-20 tokens per [TIP-1006](tips/tip-1006.md)
- `BURN_AT_ROLE` holders can burn tokens from **any** address — policy-blocked or authorized — without transfer policy restrictions
- Protected addresses (`TIP_FEE_MANAGER_ADDRESS`, `STABLECOIN_DEX_ADDRESS`) cannot be burned from
- `burnAt` bypasses pause state, matching `burnBlocked` behavior
- Precompile dispatch gates both `burnAt` and `BURN_AT_ROLE()` behind T2 hardfork

## Changes

**Solidity reference implementation** (`tips/ref-impls/`):
- `ITIP20.sol`: Add `burnAt(address,uint256)`, `BURN_AT_ROLE()`, `BurnAt` event
- `TIP20.sol`: Implement `burnAt` with role check and protected address guard
- `TIP20.t.sol`: Add unit tests (role auth, protected address, zero amount, pause bypass)
- `invariants/TIP20.t.sol`: Add `burnAt`, `burnAtProtectedAddress`, `burnAtUnauthorized` handlers
- `BaseTest.t.sol`: Add `_BURN_AT_ROLE` constant

**Rust precompile** (`crates/precompiles/`):
- `tip20/mod.rs`: Implement `burn_at` with role check, protected address guard, and `_transfer` to `Address::ZERO`; add unit tests (success, unauthorized, protected address, zero amount, pause bypass)
- `tip20/dispatch.rs`: Route `burnAt` and `BURN_AT_ROLE()` selectors with T2 hardfork gating

**ABI & integration** (`crates/`):
- `contracts/src/precompiles/tip20.rs`: Add `burnAt`, `BURN_AT_ROLE`, `BurnAt` ABI declarations
- `node/tests/it/tip20.rs`: Integration test covering burn from both blocked and authorized accounts with Transfer event assertions

**Spec**:
- `tips/tip-1006.md`: Add T2+ activation gating invariant

## Test Plan

- [x] Solidity unit tests pass (106 tests including 8 burnAt-specific)
- [x] Solidity invariant handlers added for fuzzing
- [x] Rust unit tests cover: success, unauthorized, protected address, zero amount, pause bypass
- [x] Integration test verifies end-to-end with Transfer event assertions
- [x] `forge fmt` passes
- [x] `cargo fmt` passes

Closes #2171