### PR TITLE
feat: add structured overflow logging for TIP-20 operations (#2318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12221,6 +12221,7 @@ dependencies = [
  "tempo-precompiles-macros",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -35,6 +35,7 @@ proptest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempo-evm.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 default = ["rpc"]


### PR DESCRIPTION
## Summary

- Add `tracing::error!` structured logging to all `checked_add`/`checked_sub`/`try_into` overflow detection points in TIP-20 token and rewards precompiles
- Thread `operation: &'static str` through `_transfer` and `handle_rewards_on_transfer` to distinguish `"transfer"`, `"burn"`, `"burn_blocked"`, and `"distribute_reward"` in logs
- Consolidate `capture_error_logs` test helper into `test_util.rs`
- Add 7 tests covering overflow logging across mint, transfer, burn, rewards, and fee operations

## Motivation

When arithmetic overflow occurs during TIP-20 operations, the returned `UnderOverflow` panic carries no context about which operation failed, what token was involved, or what values caused it. This makes production debugging difficult. Each overflow site now logs token address, operation name, account addresses, balances, and amounts before returning the error.

## Test plan

- [x] 7 new overflow logging tests assert structured log output via `capture_error_logs`
- [x] All 552 `tempo-precompiles` tests pass
- [x] `cargo +nightly clippy -p tempo-precompiles --all-targets --all-features --locked` clean
- [x] `cargo +nightly fmt --all --check` clean


Fixes https://github.com/tempoxyz/tempo/issues/2318