### PR TITLE
feat(precompiles): add TLSNotary precompile for on-chain TLS attestation verification

### DIFF
--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -6,6 +6,7 @@ pub mod tip20;
 pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
+pub mod tls_notary;
 pub mod validator_config;
 
 pub use account_keychain::*;
@@ -17,6 +18,7 @@ pub use tip_fee_manager::*;
 pub use tip20::*;
 pub use tip20_factory::*;
 pub use tip403_registry::*;
+pub use tls_notary::*;
 pub use validator_config::*;
 
 pub const TIP_FEE_MANAGER_ADDRESS: Address = address!("0xfeec000000000000000000000000000000000000");
@@ -31,3 +33,4 @@ pub const VALIDATOR_CONFIG_ADDRESS: Address =
     address!("0xCCCCCCCC00000000000000000000000000000000");
 pub const ACCOUNT_KEYCHAIN_ADDRESS: Address =
     address!("0xAAAAAAAA00000000000000000000000000000000");
+pub const TLS_NOTARY_ADDRESS: Address = address!("0x714E000000000000000000000000000000000000");

--- a/crates/contracts/src/precompiles/tls_notary.rs
+++ b/crates/contracts/src/precompiles/tls_notary.rs
@@ -1,0 +1,120 @@
+pub use ITLSNotary::{
+    ITLSNotaryErrors as TLSNotaryError, ITLSNotaryEvents as TLSNotaryEvent,
+};
+
+crate::sol! {
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    interface ITLSNotary {
+        /// Verify a validator quorum attestation over a TLSNotary proof.
+        /// @param attestation ABI-encoded attestation (epoch, proofHash, statementHash, serverNameHash, bitmap, signatures)
+        /// @return ok Whether the attestation is valid and meets quorum
+        /// @return epoch The epoch at which the attestation was created
+        /// @return signedPower The total voting power that signed
+        /// @return totalPower The total voting power of the validator set
+        function verifyAttestation(bytes calldata attestation) external view returns (bool ok, uint64 epoch, uint256 signedPower, uint256 totalPower);
+
+        /// Register an attestation on-chain for indexing and replay prevention.
+        /// @param epoch The epoch at which the attestation was created
+        /// @param proofHash The keccak256 hash of the TLSNotary proof body
+        /// @param statementHash The keccak256 hash of the revealed/proven statement
+        /// @param serverNameHash The keccak256 hash of the TLS server name
+        /// @param signatures Concatenated ECDSA signatures from validators (65 bytes each: r[32] || s[32] || v[1])
+        /// @param bitmap Packed bitmap indicating which validators signed (bit i = validator at index i)
+        /// @return sessionId A unique session identifier derived from epoch and proofHash
+        function registerAttestation(
+            uint64 epoch,
+            bytes32 proofHash,
+            bytes32 statementHash,
+            bytes32 serverNameHash,
+            bytes calldata signatures,
+            bytes calldata bitmap
+        ) external returns (bytes32 sessionId);
+
+        /// Get a registered session by its ID.
+        /// @param sessionId The session identifier
+        /// @return epoch The epoch at which the session was attested
+        /// @return proofHash The proof hash
+        /// @return statementHash The statement hash
+        /// @return serverNameHash The server name hash
+        /// @return submitter The address that registered the session
+        /// @return timestamp The block timestamp when it was registered
+        function getSession(bytes32 sessionId) external view returns (
+            uint64 epoch,
+            bytes32 proofHash,
+            bytes32 statementHash,
+            bytes32 serverNameHash,
+            address submitter,
+            uint64 timestamp
+        );
+
+        /// Check if a proof hash has been registered.
+        /// @param proofHash The proof hash to check
+        /// @return Whether the proof has been registered
+        function isProofRegistered(bytes32 proofHash) external view returns (bool);
+
+        /// Get the session ID for a given epoch and proof hash.
+        /// @param epoch The epoch
+        /// @param proofHash The proof hash
+        /// @return sessionId The derived session ID
+        function getSessionId(uint64 epoch, bytes32 proofHash) external pure returns (bytes32 sessionId);
+
+        // Events
+        event AttestationRegistered(
+            bytes32 indexed sessionId,
+            bytes32 indexed proofHash,
+            uint64 epoch,
+            bytes32 statementHash,
+            bytes32 serverNameHash,
+            address indexed submitter
+        );
+
+        // Errors
+        error InvalidAttestation();
+        error InsufficientQuorum(uint256 signedPower, uint256 requiredPower);
+        error SessionAlreadyRegistered(bytes32 sessionId);
+        error SessionNotFound(bytes32 sessionId);
+        error InvalidSignatureLength();
+        error InvalidBitmapLength();
+        error SignatureVerificationFailed(uint64 validatorIndex);
+    }
+}
+
+impl TLSNotaryError {
+    pub const fn invalid_attestation() -> Self {
+        Self::InvalidAttestation(ITLSNotary::InvalidAttestation {})
+    }
+
+    pub fn insufficient_quorum(signed_power: alloy_primitives::U256, required_power: alloy_primitives::U256) -> Self {
+        Self::InsufficientQuorum(ITLSNotary::InsufficientQuorum {
+            signedPower: signed_power,
+            requiredPower: required_power,
+        })
+    }
+
+    pub fn session_already_registered(session_id: alloy_primitives::B256) -> Self {
+        Self::SessionAlreadyRegistered(ITLSNotary::SessionAlreadyRegistered {
+            sessionId: session_id,
+        })
+    }
+
+    pub fn session_not_found(session_id: alloy_primitives::B256) -> Self {
+        Self::SessionNotFound(ITLSNotary::SessionNotFound {
+            sessionId: session_id,
+        })
+    }
+
+    pub const fn invalid_signature_length() -> Self {
+        Self::InvalidSignatureLength(ITLSNotary::InvalidSignatureLength {})
+    }
+
+    pub const fn invalid_bitmap_length() -> Self {
+        Self::InvalidBitmapLength(ITLSNotary::InvalidBitmapLength {})
+    }
+
+    pub fn signature_verification_failed(validator_index: u64) -> Self {
+        Self::SignatureVerificationFailed(ITLSNotary::SignatureVerificationFailed {
+            validatorIndex: validator_index,
+        })
+    }
+}

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -14,8 +14,8 @@ use revm::{
 };
 use tempo_contracts::precompiles::{
     AccountKeychainError, FeeManagerError, NonceError, RolesAuthError, StablecoinDEXError,
-    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector,
-    ValidatorConfigError,
+    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, TLSNotaryError,
+    UnknownFunctionSelector, ValidatorConfigError,
 };
 
 /// Top-level error type for all Tempo precompile operations
@@ -65,6 +65,10 @@ pub enum TempoPrecompileError {
     /// Error from account keychain precompile
     #[error("Account keychain error: {0:?}")]
     AccountKeychainError(AccountKeychainError),
+
+    /// Error from TLS notary precompile
+    #[error("TLS notary error: {0:?}")]
+    TLSNotaryError(TLSNotaryError),
 
     #[error("Gas limit exceeded")]
     OutOfGas,
@@ -117,6 +121,7 @@ impl TempoPrecompileError {
             }
             Self::ValidatorConfigError(e) => e.abi_encode().into(),
             Self::AccountKeychainError(e) => e.abi_encode().into(),
+            Self::TLSNotaryError(e) => e.abi_encode().into(),
             Self::OutOfGas => {
                 return Err(PrecompileError::OutOfGas);
             }
@@ -179,6 +184,7 @@ pub fn error_decoder_registry() -> TempoPrecompileErrorRegistry {
     add_errors_to_registry(&mut registry, TempoPrecompileError::NonceError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ValidatorConfigError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::AccountKeychainError);
+    add_errors_to_registry(&mut registry, TempoPrecompileError::TLSNotaryError);
 
     registry
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -14,6 +14,7 @@ pub mod tip20;
 pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
+pub mod tls_notary;
 pub mod validator_config;
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -28,6 +29,7 @@ use crate::{
     tip20::{TIP20Token, is_tip20_prefix},
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
+    tls_notary::TLSNotary,
     validator_config::ValidatorConfig,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -48,7 +50,7 @@ use revm::{
 pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
     STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
-    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, TLS_NOTARY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -90,6 +92,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(ValidatorConfigPrecompile::create(&cfg))
         } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
             Some(AccountKeychainPrecompile::create(&cfg))
+        } else if *address == TLS_NOTARY_ADDRESS {
+            Some(TLSNotaryPrecompile::create(&cfg))
         } else {
             None
         }
@@ -174,6 +178,13 @@ pub struct AccountKeychainPrecompile;
 impl AccountKeychainPrecompile {
     pub fn create(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
         tempo_precompile!("AccountKeychain", cfg, |input| { AccountKeychain::new() })
+    }
+}
+
+pub struct TLSNotaryPrecompile;
+impl TLSNotaryPrecompile {
+    pub fn create(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
+        tempo_precompile!("TLSNotary", cfg, |input| { TLSNotary::new() })
     }
 }
 

--- a/crates/precompiles/src/tls_notary/dispatch.rs
+++ b/crates/precompiles/src/tls_notary/dispatch.rs
@@ -1,0 +1,42 @@
+use crate::{
+    Precompile, dispatch_call, input_cost, mutate, view,
+    tls_notary::TLSNotary,
+};
+use alloy::{
+    primitives::Address,
+    sol_types::SolInterface,
+};
+use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_contracts::precompiles::ITLSNotary::ITLSNotaryCalls;
+
+impl Precompile for TLSNotary {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        self.storage
+            .deduct_gas(input_cost(calldata.len()))
+            .map_err(|_| PrecompileError::OutOfGas)?;
+
+        dispatch_call(
+            calldata,
+            ITLSNotaryCalls::abi_decode,
+            |call| match call {
+                ITLSNotaryCalls::verifyAttestation(call) => {
+                    view(call, |c| self.verify_attestation(c))
+                }
+                ITLSNotaryCalls::registerAttestation(call) => {
+                    mutate(call, msg_sender, |s, c| self.register_attestation(s, c))
+                }
+                ITLSNotaryCalls::getSession(call) => {
+                    view(call, |c| self.get_session(c))
+                }
+                ITLSNotaryCalls::isProofRegistered(call) => {
+                    view(call, |c| self.is_proof_registered(c))
+                }
+                ITLSNotaryCalls::getSessionId(call) => {
+                    view(call, |c| {
+                        Ok(TLSNotary::get_session_id(c.epoch, c.proofHash))
+                    })
+                }
+            },
+        )
+    }
+}

--- a/crates/precompiles/src/tls_notary/dispatch.rs
+++ b/crates/precompiles/src/tls_notary/dispatch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Precompile, dispatch_call, input_cost, mutate, view,
+    Precompile, dispatch_call, input_cost, metadata, mutate, mutate_void, view,
     tls_notary::TLSNotary,
 };
 use alloy::{
@@ -7,6 +7,7 @@ use alloy::{
     sol_types::SolInterface,
 };
 use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_contracts::precompiles::ITLSNotary;
 use tempo_contracts::precompiles::ITLSNotary::ITLSNotaryCalls;
 
 impl Precompile for TLSNotary {
@@ -19,22 +20,39 @@ impl Precompile for TLSNotary {
             calldata,
             ITLSNotaryCalls::abi_decode,
             |call| match call {
-                ITLSNotaryCalls::verifyAttestation(call) => {
-                    view(call, |c| self.verify_attestation(c))
+                // Notary management
+                ITLSNotaryCalls::addNotary(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.add_notary(s, c))
                 }
+                ITLSNotaryCalls::removeNotary(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.remove_notary(s, c))
+                }
+                ITLSNotaryCalls::isNotary(call) => {
+                    view(call, |c| self.is_notary(c))
+                }
+                ITLSNotaryCalls::owner(_) => {
+                    metadata::<ITLSNotary::ownerCall>(|| self.owner())
+                }
+                ITLSNotaryCalls::transferOwnership(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.transfer_ownership(s, c))
+                }
+                // Attestations
                 ITLSNotaryCalls::registerAttestation(call) => {
                     mutate(call, msg_sender, |s, c| self.register_attestation(s, c))
                 }
+                // Email claims
+                ITLSNotaryCalls::claimEmail(call) => {
+                    mutate(call, msg_sender, |s, c| self.claim_email(s, c))
+                }
+                ITLSNotaryCalls::emailOwner(call) => {
+                    view(call, |c| self.email_owner(c))
+                }
+                // Queries
                 ITLSNotaryCalls::getSession(call) => {
                     view(call, |c| self.get_session(c))
                 }
                 ITLSNotaryCalls::isProofRegistered(call) => {
                     view(call, |c| self.is_proof_registered(c))
-                }
-                ITLSNotaryCalls::getSessionId(call) => {
-                    view(call, |c| {
-                        Ok(TLSNotary::get_session_id(c.epoch, c.proofHash))
-                    })
                 }
             },
         )

--- a/crates/precompiles/src/tls_notary/mod.rs
+++ b/crates/precompiles/src/tls_notary/mod.rs
@@ -8,25 +8,14 @@ use crate::{
     error::Result,
     storage::{Handler, Mapping, StorageCtx},
 };
-use alloy::primitives::{Address, B256, U256, keccak256};
+use alloy::primitives::{Address, B256, Signature, U256, keccak256};
 
-/// Domain separator prefix for attestation messages.
 const ATTESTATION_DOMAIN: &[u8] = b"TEMPO_TLSNOTARY_V1";
-
-/// Required quorum: 2/3 of total voting power (expressed as numerator/denominator).
-const QUORUM_NUMERATOR: u64 = 2;
-const QUORUM_DENOMINATOR: u64 = 3;
-
-/// Maximum number of validator signatures accepted (DoS protection).
+const SIGNATURE_LENGTH: usize = 65;
 const MAX_SIGNATURES: usize = 200;
 
-/// ECDSA signature length (r[32] + s[32] + v[1]).
-const SIGNATURE_LENGTH: usize = 65;
-
-/// Session record stored on-chain for registered attestations.
 #[derive(Debug, Clone, Default, Storable)]
 pub struct SessionRecord {
-    pub epoch: u64,
     pub proof_hash: B256,
     pub statement_hash: B256,
     pub server_name_hash: B256,
@@ -34,273 +23,209 @@ pub struct SessionRecord {
     pub timestamp: u64,
 }
 
-/// TLSNotary precompile: verifies and registers TLSNotary attestations
-/// where Tempo validators act as MPC participants in the TLSNotary protocol.
-///
-/// Validators run MPC-TLS off-chain and produce attestations (signed proof hashes).
-/// This precompile verifies validator quorum signatures and optionally stores
-/// session metadata on-chain for indexing and replay prevention.
+#[derive(Debug, Clone, Default, Storable)]
+pub struct EmailClaim {
+    pub claimant: Address,
+    pub timestamp: u64,
+}
+
 #[contract(addr = TLS_NOTARY_ADDRESS)]
 pub struct TLSNotary {
+    owner: Address,
+    notaries: Mapping<Address, bool>,
     sessions: Mapping<B256, SessionRecord>,
     registered_proofs: Mapping<B256, bool>,
+    email_claims: Mapping<B256, EmailClaim>,
 }
 
 impl TLSNotary {
-    /// Initialize the TLSNotary precompile.
-    pub fn initialize(&mut self) -> Result<()> {
-        self.__initialize()
+    pub fn initialize(&mut self, owner: Address) -> Result<()> {
+        self.__initialize()?;
+        self.owner.write(owner)
     }
 
-    /// Derive a deterministic session ID from epoch and proof hash.
-    pub fn derive_session_id(epoch: u64, proof_hash: B256) -> B256 {
-        let mut data = Vec::with_capacity(8 + 32);
-        data.extend_from_slice(&epoch.to_be_bytes());
-        data.extend_from_slice(proof_hash.as_slice());
-        keccak256(&data)
+    fn check_owner(&self, caller: Address) -> Result<()> {
+        let owner = self.owner.read()?;
+        if owner != caller {
+            return Err(TLSNotaryError::unauthorized().into());
+        }
+        Ok(())
     }
 
-    /// Compute the canonical attestation message that validators sign.
+    pub fn owner(&self) -> Result<Address> {
+        self.owner.read()
+    }
+
+    pub fn transfer_ownership(
+        &mut self,
+        sender: Address,
+        call: ITLSNotary::transferOwnershipCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+        self.owner.write(call.newOwner)
+    }
+
+    // ──── Notary Management ────
+
+    pub fn add_notary(
+        &mut self,
+        sender: Address,
+        call: ITLSNotary::addNotaryCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+
+        let already = self.notaries[call.notary].read()?;
+        if already {
+            return Err(TLSNotaryError::notary_already_registered(call.notary).into());
+        }
+
+        self.notaries[call.notary].write(true)?;
+
+        self.emit_event(TLSNotaryEvent::NotaryAdded(ITLSNotary::NotaryAdded {
+            notary: call.notary,
+            addedBy: sender,
+        }))
+    }
+
+    pub fn remove_notary(
+        &mut self,
+        sender: Address,
+        call: ITLSNotary::removeNotaryCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+
+        let exists = self.notaries[call.notary].read()?;
+        if !exists {
+            return Err(TLSNotaryError::notary_not_found(call.notary).into());
+        }
+
+        self.notaries[call.notary].write(false)?;
+
+        self.emit_event(TLSNotaryEvent::NotaryRemoved(ITLSNotary::NotaryRemoved {
+            notary: call.notary,
+            removedBy: sender,
+        }))
+    }
+
+    pub fn is_notary(&self, call: ITLSNotary::isNotaryCall) -> Result<bool> {
+        self.notaries[call.notary].read()
+    }
+
+    // ──── Attestation message ────
+
     pub fn compute_attestation_message(
         chain_id: u64,
-        epoch: u64,
         proof_hash: B256,
         statement_hash: B256,
         server_name_hash: B256,
     ) -> B256 {
-        let mut data = Vec::with_capacity(ATTESTATION_DOMAIN.len() + 8 + 8 + 32 + 32 + 32);
+        let mut data = Vec::with_capacity(ATTESTATION_DOMAIN.len() + 8 + 32 * 3);
         data.extend_from_slice(ATTESTATION_DOMAIN);
         data.extend_from_slice(&chain_id.to_be_bytes());
-        data.extend_from_slice(&epoch.to_be_bytes());
         data.extend_from_slice(proof_hash.as_slice());
         data.extend_from_slice(statement_hash.as_slice());
         data.extend_from_slice(server_name_hash.as_slice());
         keccak256(&data)
     }
 
-    /// Parse a bitmap to determine which validator indices have signed.
-    fn parse_bitmap(bitmap: &[u8], validator_count: usize) -> Vec<usize> {
-        let mut indices = Vec::new();
-        for (byte_idx, &byte) in bitmap.iter().enumerate() {
-            for bit_idx in 0..8 {
-                let global_idx = byte_idx * 8 + bit_idx;
-                if global_idx >= validator_count {
-                    break;
-                }
-                if byte & (1 << bit_idx) != 0 {
-                    indices.push(global_idx);
-                }
-            }
-        }
-        indices
-    }
-
-    /// Verify an attestation: check validator quorum signatures over the attestation message.
-    ///
-    /// This is a view function that does not modify state. It verifies:
-    /// 1. The attestation message format
-    /// 2. Each validator signature in the bitmap
-    /// 3. That the total signed voting power meets quorum (2/3)
-    pub fn verify_attestation(
+    fn verify_notary_signatures(
         &self,
-        call: ITLSNotary::verifyAttestationCall,
-    ) -> Result<ITLSNotary::verifyAttestationReturn> {
-        let attestation_data = &call.attestation;
-
-        if attestation_data.len() < 8 + 32 + 32 + 32 {
-            return Err(TLSNotaryError::invalid_attestation().into());
-        }
-
-        let mut offset = 0;
-
-        // Parse epoch (8 bytes)
-        let epoch = u64::from_be_bytes(
-            attestation_data[offset..offset + 8]
-                .try_into()
-                .map_err(|_| TLSNotaryError::invalid_attestation())?,
-        );
-        offset += 8;
-
-        // Parse proofHash (32 bytes)
-        let proof_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
-        offset += 32;
-
-        // Parse statementHash (32 bytes)
-        let statement_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
-        offset += 32;
-
-        // Parse serverNameHash (32 bytes)
-        let server_name_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
-        offset += 32;
-
-        if attestation_data.len() < offset + 4 {
-            return Err(TLSNotaryError::invalid_attestation().into());
-        }
-
-        // Parse bitmap length (4 bytes) then bitmap
-        let bitmap_len = u32::from_be_bytes(
-            attestation_data[offset..offset + 4]
-                .try_into()
-                .map_err(|_| TLSNotaryError::invalid_attestation())?,
-        ) as usize;
-        offset += 4;
-
-        if attestation_data.len() < offset + bitmap_len {
-            return Err(TLSNotaryError::invalid_bitmap_length().into());
-        }
-
-        let bitmap = &attestation_data[offset..offset + bitmap_len];
-        offset += bitmap_len;
-
-        // Remaining bytes are signatures
-        let signatures_data = &attestation_data[offset..];
-
-        // Get validator count from ValidatorConfig precompile
-        let validator_count = self.get_validator_count()?;
-
-        // Parse bitmap to get signing validator indices
-        let signing_indices = Self::parse_bitmap(bitmap, validator_count as usize);
-
-        if signing_indices.len() > MAX_SIGNATURES {
-            return Err(TLSNotaryError::invalid_attestation().into());
-        }
-
-        // Verify signature count matches bitmap
-        if signatures_data.len() != signing_indices.len() * SIGNATURE_LENGTH {
+        message: B256,
+        signatures: &[u8],
+    ) -> Result<u64> {
+        if signatures.len() % SIGNATURE_LENGTH != 0 {
             return Err(TLSNotaryError::invalid_signature_length().into());
         }
 
-        // Compute the message that should have been signed
-        let chain_id = StorageCtx.chain_id();
-        let attestation_message = Self::compute_attestation_message(
-            chain_id,
-            epoch,
-            proof_hash,
-            statement_hash,
-            server_name_hash,
-        );
+        let sig_count = signatures.len() / SIGNATURE_LENGTH;
+        if sig_count > MAX_SIGNATURES {
+            return Err(TLSNotaryError::invalid_signature_length().into());
+        }
 
-        // Verify each signature and sum voting power
-        // For simplicity, each active validator has equal voting power of 1
-        let mut signed_power = U256::ZERO;
-        let total_power = U256::from(validator_count);
+        let mut valid_count = 0u64;
 
-        for (i, &validator_idx) in signing_indices.iter().enumerate() {
-            let sig_start = i * SIGNATURE_LENGTH;
-            let sig_bytes = &signatures_data[sig_start..sig_start + SIGNATURE_LENGTH];
+        for i in 0..sig_count {
+            let offset = i * SIGNATURE_LENGTH;
+            let sig_bytes = &signatures[offset..offset + SIGNATURE_LENGTH];
 
-            // Extract r, s, v from signature
             let r = B256::from_slice(&sig_bytes[..32]);
             let s = B256::from_slice(&sig_bytes[32..64]);
             let v = sig_bytes[64];
 
-            // Recover signer address from signature
-            let recovered = Self::ecrecover(attestation_message, v, r, s);
-
+            let recovered = Self::ecrecover(message, v, r, s);
             match recovered {
-                Some(recovered_addr) => {
-                    // Get the validator address at this index
-                    let expected_addr = self.get_validator_address(validator_idx as u64)?;
-
-                    if recovered_addr != expected_addr {
+                Some(addr) => {
+                    let is_notary = self.notaries[addr].read()?;
+                    if !is_notary {
                         return Err(TLSNotaryError::signature_verification_failed(
-                            validator_idx as u64,
+                            U256::from(i),
                         )
                         .into());
                     }
-
-                    // Add voting power (1 per active validator)
-                    signed_power += U256::from(1);
+                    valid_count += 1;
                 }
                 None => {
                     return Err(TLSNotaryError::signature_verification_failed(
-                        validator_idx as u64,
+                        U256::from(i),
                     )
                     .into());
                 }
             }
         }
 
-        // Check quorum: signed_power * QUORUM_DENOMINATOR >= total_power * QUORUM_NUMERATOR
-        let quorum_met = signed_power * U256::from(QUORUM_DENOMINATOR)
-            >= total_power * U256::from(QUORUM_NUMERATOR);
-
-        Ok(ITLSNotary::verifyAttestationReturn {
-            ok: quorum_met,
-            epoch,
-            signedPower: signed_power,
-            totalPower: total_power,
-        })
+        Ok(valid_count)
     }
 
-    /// Register an attestation on-chain after verifying the quorum.
+    // ──── Register Attestation ────
+
     pub fn register_attestation(
         &mut self,
         msg_sender: Address,
         call: ITLSNotary::registerAttestationCall,
     ) -> Result<B256> {
-        let epoch = call.epoch;
         let proof_hash = call.proofHash;
         let statement_hash = call.statementHash;
         let server_name_hash = call.serverNameHash;
-        let signatures = &call.signatures;
-        let bitmap = &call.bitmap;
 
-        // Derive session ID
-        let session_id = Self::derive_session_id(epoch, proof_hash);
-
-        // Check if already registered
-        let already_registered = self.registered_proofs[proof_hash].read()?;
-        if already_registered {
-            return Err(TLSNotaryError::session_already_registered(session_id).into());
+        let already = self.registered_proofs[proof_hash].read()?;
+        if already {
+            return Err(TLSNotaryError::proof_already_registered(proof_hash).into());
         }
 
-        // Verify quorum by building attestation bytes and calling verify
-        let mut attestation_data = Vec::new();
-        attestation_data.extend_from_slice(&epoch.to_be_bytes());
-        attestation_data.extend_from_slice(proof_hash.as_slice());
-        attestation_data.extend_from_slice(statement_hash.as_slice());
-        attestation_data.extend_from_slice(server_name_hash.as_slice());
-        attestation_data.extend_from_slice(&(bitmap.len() as u32).to_be_bytes());
-        attestation_data.extend_from_slice(bitmap);
-        attestation_data.extend_from_slice(signatures);
+        let chain_id = StorageCtx.chain_id();
+        let message = Self::compute_attestation_message(
+            chain_id,
+            proof_hash,
+            statement_hash,
+            server_name_hash,
+        );
 
-        let verify_result = self.verify_attestation(ITLSNotary::verifyAttestationCall {
-            attestation: attestation_data.into(),
-        })?;
-
-        if !verify_result.ok {
-            let required_power =
-                verify_result.totalPower * U256::from(QUORUM_NUMERATOR) / U256::from(QUORUM_DENOMINATOR);
+        let valid_count = self.verify_notary_signatures(message, &call.signatures)?;
+        if valid_count == 0 {
             return Err(
-                TLSNotaryError::insufficient_quorum(verify_result.signedPower, required_power)
-                    .into(),
+                TLSNotaryError::insufficient_signatures(U256::ZERO, U256::from(1)).into(),
             );
         }
 
-        // Get block timestamp
-        let timestamp = StorageCtx.timestamp();
-        let timestamp_u64 = timestamp.as_limbs()[0];
+        let session_id =
+            keccak256(&[proof_hash.as_slice(), msg_sender.as_slice()].concat());
 
-        // Store session record
-        let session = SessionRecord {
-            epoch,
+        let timestamp = StorageCtx.timestamp();
+        let ts_u64 = timestamp.as_limbs()[0];
+
+        self.sessions[session_id].write(SessionRecord {
             proof_hash,
             statement_hash,
             server_name_hash,
             submitter: msg_sender,
-            timestamp: timestamp_u64,
-        };
-
-        self.sessions[session_id].write(session)?;
+            timestamp: ts_u64,
+        })?;
         self.registered_proofs[proof_hash].write(true)?;
 
-        // Emit event
         self.emit_event(TLSNotaryEvent::AttestationRegistered(
             ITLSNotary::AttestationRegistered {
                 sessionId: session_id,
                 proofHash: proof_hash,
-                epoch,
                 statementHash: statement_hash,
                 serverNameHash: server_name_hash,
                 submitter: msg_sender,
@@ -310,20 +235,85 @@ impl TLSNotary {
         Ok(session_id)
     }
 
-    /// Get a registered session by ID.
+    // ──── Email Claims ────
+
+    pub fn claim_email(
+        &mut self,
+        msg_sender: Address,
+        call: ITLSNotary::claimEmailCall,
+    ) -> Result<B256> {
+        let email_hash = keccak256(call.email.as_bytes());
+        let server_name_hash = call.serverNameHash;
+        let proof_hash = call.proofHash;
+
+        let existing = self.email_claims[email_hash].read()?;
+        if existing.claimant != Address::ZERO {
+            return Err(
+                TLSNotaryError::email_already_claimed(email_hash, existing.claimant).into(),
+            );
+        }
+
+        let statement = format!("email:{} owner:{}", call.email, msg_sender);
+        let statement_hash = keccak256(statement.as_bytes());
+
+        let chain_id = StorageCtx.chain_id();
+        let message = Self::compute_attestation_message(
+            chain_id,
+            proof_hash,
+            statement_hash,
+            server_name_hash,
+        );
+
+        let valid_count = self.verify_notary_signatures(message, &call.signatures)?;
+        if valid_count == 0 {
+            return Err(
+                TLSNotaryError::insufficient_signatures(U256::ZERO, U256::from(1)).into(),
+            );
+        }
+
+        let timestamp = StorageCtx.timestamp();
+        let ts_u64 = timestamp.as_limbs()[0];
+
+        self.email_claims[email_hash].write(EmailClaim {
+            claimant: msg_sender,
+            timestamp: ts_u64,
+        })?;
+
+        let claim_id = email_hash;
+        self.registered_proofs[proof_hash].write(true)?;
+
+        self.emit_event(TLSNotaryEvent::EmailClaimed(ITLSNotary::EmailClaimed {
+            emailHash: email_hash,
+            claimant: msg_sender,
+            proofHash: proof_hash,
+            serverNameHash: server_name_hash,
+        }))?;
+
+        Ok(claim_id)
+    }
+
+    pub fn email_owner(
+        &self,
+        call: ITLSNotary::emailOwnerCall,
+    ) -> Result<ITLSNotary::emailOwnerReturn> {
+        let claim = self.email_claims[call.emailHash].read()?;
+        Ok(ITLSNotary::emailOwnerReturn {
+            claimant: claim.claimant,
+            timestamp: claim.timestamp,
+        })
+    }
+
+    // ──── Queries ────
+
     pub fn get_session(
         &self,
         call: ITLSNotary::getSessionCall,
     ) -> Result<ITLSNotary::getSessionReturn> {
         let session = self.sessions[call.sessionId].read()?;
-
-        // Check if session exists (proof_hash will be zero for non-existent sessions)
         if session.proof_hash.is_zero() {
             return Err(TLSNotaryError::session_not_found(call.sessionId).into());
         }
-
         Ok(ITLSNotary::getSessionReturn {
-            epoch: session.epoch,
             proofHash: session.proof_hash,
             statementHash: session.statement_hash,
             serverNameHash: session.server_name_hash,
@@ -332,60 +322,22 @@ impl TLSNotary {
         })
     }
 
-    /// Check if a proof hash has been registered.
-    pub fn is_proof_registered(&self, call: ITLSNotary::isProofRegisteredCall) -> Result<bool> {
+    pub fn is_proof_registered(
+        &self,
+        call: ITLSNotary::isProofRegisteredCall,
+    ) -> Result<bool> {
         self.registered_proofs[call.proofHash].read()
     }
 
-    /// Get the session ID for a given epoch and proof hash (pure computation).
-    pub fn get_session_id(
-        epoch: u64,
-        proof_hash: B256,
-    ) -> B256 {
-        Self::derive_session_id(epoch, proof_hash)
-    }
+    // ──── Internal ────
 
-    // --- Internal helpers ---
-
-    /// Get validator count by reading from the ValidatorConfig precompile's storage.
-    fn get_validator_count(&self) -> Result<u64> {
-        use tempo_contracts::precompiles::VALIDATOR_CONFIG_ADDRESS;
-
-        // ValidatorConfig layout: slot 0 = owner, slot 1 = validators_array length
-        // The array length is stored at the base slot for Vec fields
-        let count_slot = U256::from(1);
-        let count = StorageCtx.sload(VALIDATOR_CONFIG_ADDRESS, count_slot)?;
-        Ok(count.as_limbs()[0])
-    }
-
-    /// Get validator address at a specific index from ValidatorConfig storage.
-    fn get_validator_address(&self, index: u64) -> Result<Address> {
-        use tempo_contracts::precompiles::VALIDATOR_CONFIG_ADDRESS;
-
-        // ValidatorConfig: slot 1 = validators_array
-        // Array elements at keccak256(1) + index
-        let base_slot = U256::from(1);
-        let array_base = keccak256(B256::from(base_slot));
-        let element_slot = U256::from_be_bytes(*array_base) + U256::from(index);
-
-        let value = StorageCtx.sload(VALIDATOR_CONFIG_ADDRESS, element_slot)?;
-
-        // Address is stored in the lower 20 bytes
-        let bytes: [u8; 32] = value.to_be_bytes();
-        Ok(Address::from_slice(&bytes[12..32]))
-    }
-
-    /// Perform ECDSA recovery to get the signer address.
     fn ecrecover(message: B256, v: u8, r: B256, s: B256) -> Option<Address> {
-        use alloy::primitives::Signature;
-
         let v_normalized = if v >= 27 { v - 27 } else { v };
         let sig = Signature::new(
             U256::from_be_bytes(*r),
             U256::from_be_bytes(*s),
             v_normalized != 0,
         );
-
         sig.recover_address_from_prehash(&message).ok()
     }
 }

--- a/crates/precompiles/src/tls_notary/mod.rs
+++ b/crates/precompiles/src/tls_notary/mod.rs
@@ -1,0 +1,391 @@
+pub mod dispatch;
+
+use tempo_contracts::precompiles::TLS_NOTARY_ADDRESS;
+pub use tempo_contracts::precompiles::{ITLSNotary, TLSNotaryError, TLSNotaryEvent};
+use tempo_precompiles_macros::{Storable, contract};
+
+use crate::{
+    error::Result,
+    storage::{Handler, Mapping, StorageCtx},
+};
+use alloy::primitives::{Address, B256, U256, keccak256};
+
+/// Domain separator prefix for attestation messages.
+const ATTESTATION_DOMAIN: &[u8] = b"TEMPO_TLSNOTARY_V1";
+
+/// Required quorum: 2/3 of total voting power (expressed as numerator/denominator).
+const QUORUM_NUMERATOR: u64 = 2;
+const QUORUM_DENOMINATOR: u64 = 3;
+
+/// Maximum number of validator signatures accepted (DoS protection).
+const MAX_SIGNATURES: usize = 200;
+
+/// ECDSA signature length (r[32] + s[32] + v[1]).
+const SIGNATURE_LENGTH: usize = 65;
+
+/// Session record stored on-chain for registered attestations.
+#[derive(Debug, Clone, Default, Storable)]
+pub struct SessionRecord {
+    pub epoch: u64,
+    pub proof_hash: B256,
+    pub statement_hash: B256,
+    pub server_name_hash: B256,
+    pub submitter: Address,
+    pub timestamp: u64,
+}
+
+/// TLSNotary precompile: verifies and registers TLSNotary attestations
+/// where Tempo validators act as MPC participants in the TLSNotary protocol.
+///
+/// Validators run MPC-TLS off-chain and produce attestations (signed proof hashes).
+/// This precompile verifies validator quorum signatures and optionally stores
+/// session metadata on-chain for indexing and replay prevention.
+#[contract(addr = TLS_NOTARY_ADDRESS)]
+pub struct TLSNotary {
+    sessions: Mapping<B256, SessionRecord>,
+    registered_proofs: Mapping<B256, bool>,
+}
+
+impl TLSNotary {
+    /// Initialize the TLSNotary precompile.
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
+    }
+
+    /// Derive a deterministic session ID from epoch and proof hash.
+    pub fn derive_session_id(epoch: u64, proof_hash: B256) -> B256 {
+        let mut data = Vec::with_capacity(8 + 32);
+        data.extend_from_slice(&epoch.to_be_bytes());
+        data.extend_from_slice(proof_hash.as_slice());
+        keccak256(&data)
+    }
+
+    /// Compute the canonical attestation message that validators sign.
+    pub fn compute_attestation_message(
+        chain_id: u64,
+        epoch: u64,
+        proof_hash: B256,
+        statement_hash: B256,
+        server_name_hash: B256,
+    ) -> B256 {
+        let mut data = Vec::with_capacity(ATTESTATION_DOMAIN.len() + 8 + 8 + 32 + 32 + 32);
+        data.extend_from_slice(ATTESTATION_DOMAIN);
+        data.extend_from_slice(&chain_id.to_be_bytes());
+        data.extend_from_slice(&epoch.to_be_bytes());
+        data.extend_from_slice(proof_hash.as_slice());
+        data.extend_from_slice(statement_hash.as_slice());
+        data.extend_from_slice(server_name_hash.as_slice());
+        keccak256(&data)
+    }
+
+    /// Parse a bitmap to determine which validator indices have signed.
+    fn parse_bitmap(bitmap: &[u8], validator_count: usize) -> Vec<usize> {
+        let mut indices = Vec::new();
+        for (byte_idx, &byte) in bitmap.iter().enumerate() {
+            for bit_idx in 0..8 {
+                let global_idx = byte_idx * 8 + bit_idx;
+                if global_idx >= validator_count {
+                    break;
+                }
+                if byte & (1 << bit_idx) != 0 {
+                    indices.push(global_idx);
+                }
+            }
+        }
+        indices
+    }
+
+    /// Verify an attestation: check validator quorum signatures over the attestation message.
+    ///
+    /// This is a view function that does not modify state. It verifies:
+    /// 1. The attestation message format
+    /// 2. Each validator signature in the bitmap
+    /// 3. That the total signed voting power meets quorum (2/3)
+    pub fn verify_attestation(
+        &self,
+        call: ITLSNotary::verifyAttestationCall,
+    ) -> Result<ITLSNotary::verifyAttestationReturn> {
+        let attestation_data = &call.attestation;
+
+        if attestation_data.len() < 8 + 32 + 32 + 32 {
+            return Err(TLSNotaryError::invalid_attestation().into());
+        }
+
+        let mut offset = 0;
+
+        // Parse epoch (8 bytes)
+        let epoch = u64::from_be_bytes(
+            attestation_data[offset..offset + 8]
+                .try_into()
+                .map_err(|_| TLSNotaryError::invalid_attestation())?,
+        );
+        offset += 8;
+
+        // Parse proofHash (32 bytes)
+        let proof_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
+        offset += 32;
+
+        // Parse statementHash (32 bytes)
+        let statement_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
+        offset += 32;
+
+        // Parse serverNameHash (32 bytes)
+        let server_name_hash = B256::from_slice(&attestation_data[offset..offset + 32]);
+        offset += 32;
+
+        if attestation_data.len() < offset + 4 {
+            return Err(TLSNotaryError::invalid_attestation().into());
+        }
+
+        // Parse bitmap length (4 bytes) then bitmap
+        let bitmap_len = u32::from_be_bytes(
+            attestation_data[offset..offset + 4]
+                .try_into()
+                .map_err(|_| TLSNotaryError::invalid_attestation())?,
+        ) as usize;
+        offset += 4;
+
+        if attestation_data.len() < offset + bitmap_len {
+            return Err(TLSNotaryError::invalid_bitmap_length().into());
+        }
+
+        let bitmap = &attestation_data[offset..offset + bitmap_len];
+        offset += bitmap_len;
+
+        // Remaining bytes are signatures
+        let signatures_data = &attestation_data[offset..];
+
+        // Get validator count from ValidatorConfig precompile
+        let validator_count = self.get_validator_count()?;
+
+        // Parse bitmap to get signing validator indices
+        let signing_indices = Self::parse_bitmap(bitmap, validator_count as usize);
+
+        if signing_indices.len() > MAX_SIGNATURES {
+            return Err(TLSNotaryError::invalid_attestation().into());
+        }
+
+        // Verify signature count matches bitmap
+        if signatures_data.len() != signing_indices.len() * SIGNATURE_LENGTH {
+            return Err(TLSNotaryError::invalid_signature_length().into());
+        }
+
+        // Compute the message that should have been signed
+        let chain_id = StorageCtx.chain_id();
+        let attestation_message = Self::compute_attestation_message(
+            chain_id,
+            epoch,
+            proof_hash,
+            statement_hash,
+            server_name_hash,
+        );
+
+        // Verify each signature and sum voting power
+        // For simplicity, each active validator has equal voting power of 1
+        let mut signed_power = U256::ZERO;
+        let total_power = U256::from(validator_count);
+
+        for (i, &validator_idx) in signing_indices.iter().enumerate() {
+            let sig_start = i * SIGNATURE_LENGTH;
+            let sig_bytes = &signatures_data[sig_start..sig_start + SIGNATURE_LENGTH];
+
+            // Extract r, s, v from signature
+            let r = B256::from_slice(&sig_bytes[..32]);
+            let s = B256::from_slice(&sig_bytes[32..64]);
+            let v = sig_bytes[64];
+
+            // Recover signer address from signature
+            let recovered = Self::ecrecover(attestation_message, v, r, s);
+
+            match recovered {
+                Some(recovered_addr) => {
+                    // Get the validator address at this index
+                    let expected_addr = self.get_validator_address(validator_idx as u64)?;
+
+                    if recovered_addr != expected_addr {
+                        return Err(TLSNotaryError::signature_verification_failed(
+                            validator_idx as u64,
+                        )
+                        .into());
+                    }
+
+                    // Add voting power (1 per active validator)
+                    signed_power += U256::from(1);
+                }
+                None => {
+                    return Err(TLSNotaryError::signature_verification_failed(
+                        validator_idx as u64,
+                    )
+                    .into());
+                }
+            }
+        }
+
+        // Check quorum: signed_power * QUORUM_DENOMINATOR >= total_power * QUORUM_NUMERATOR
+        let quorum_met = signed_power * U256::from(QUORUM_DENOMINATOR)
+            >= total_power * U256::from(QUORUM_NUMERATOR);
+
+        Ok(ITLSNotary::verifyAttestationReturn {
+            ok: quorum_met,
+            epoch,
+            signedPower: signed_power,
+            totalPower: total_power,
+        })
+    }
+
+    /// Register an attestation on-chain after verifying the quorum.
+    pub fn register_attestation(
+        &mut self,
+        msg_sender: Address,
+        call: ITLSNotary::registerAttestationCall,
+    ) -> Result<B256> {
+        let epoch = call.epoch;
+        let proof_hash = call.proofHash;
+        let statement_hash = call.statementHash;
+        let server_name_hash = call.serverNameHash;
+        let signatures = &call.signatures;
+        let bitmap = &call.bitmap;
+
+        // Derive session ID
+        let session_id = Self::derive_session_id(epoch, proof_hash);
+
+        // Check if already registered
+        let already_registered = self.registered_proofs[proof_hash].read()?;
+        if already_registered {
+            return Err(TLSNotaryError::session_already_registered(session_id).into());
+        }
+
+        // Verify quorum by building attestation bytes and calling verify
+        let mut attestation_data = Vec::new();
+        attestation_data.extend_from_slice(&epoch.to_be_bytes());
+        attestation_data.extend_from_slice(proof_hash.as_slice());
+        attestation_data.extend_from_slice(statement_hash.as_slice());
+        attestation_data.extend_from_slice(server_name_hash.as_slice());
+        attestation_data.extend_from_slice(&(bitmap.len() as u32).to_be_bytes());
+        attestation_data.extend_from_slice(bitmap);
+        attestation_data.extend_from_slice(signatures);
+
+        let verify_result = self.verify_attestation(ITLSNotary::verifyAttestationCall {
+            attestation: attestation_data.into(),
+        })?;
+
+        if !verify_result.ok {
+            let required_power =
+                verify_result.totalPower * U256::from(QUORUM_NUMERATOR) / U256::from(QUORUM_DENOMINATOR);
+            return Err(
+                TLSNotaryError::insufficient_quorum(verify_result.signedPower, required_power)
+                    .into(),
+            );
+        }
+
+        // Get block timestamp
+        let timestamp = StorageCtx.timestamp();
+        let timestamp_u64 = timestamp.as_limbs()[0];
+
+        // Store session record
+        let session = SessionRecord {
+            epoch,
+            proof_hash,
+            statement_hash,
+            server_name_hash,
+            submitter: msg_sender,
+            timestamp: timestamp_u64,
+        };
+
+        self.sessions[session_id].write(session)?;
+        self.registered_proofs[proof_hash].write(true)?;
+
+        // Emit event
+        self.emit_event(TLSNotaryEvent::AttestationRegistered(
+            ITLSNotary::AttestationRegistered {
+                sessionId: session_id,
+                proofHash: proof_hash,
+                epoch,
+                statementHash: statement_hash,
+                serverNameHash: server_name_hash,
+                submitter: msg_sender,
+            },
+        ))?;
+
+        Ok(session_id)
+    }
+
+    /// Get a registered session by ID.
+    pub fn get_session(
+        &self,
+        call: ITLSNotary::getSessionCall,
+    ) -> Result<ITLSNotary::getSessionReturn> {
+        let session = self.sessions[call.sessionId].read()?;
+
+        // Check if session exists (proof_hash will be zero for non-existent sessions)
+        if session.proof_hash.is_zero() {
+            return Err(TLSNotaryError::session_not_found(call.sessionId).into());
+        }
+
+        Ok(ITLSNotary::getSessionReturn {
+            epoch: session.epoch,
+            proofHash: session.proof_hash,
+            statementHash: session.statement_hash,
+            serverNameHash: session.server_name_hash,
+            submitter: session.submitter,
+            timestamp: session.timestamp,
+        })
+    }
+
+    /// Check if a proof hash has been registered.
+    pub fn is_proof_registered(&self, call: ITLSNotary::isProofRegisteredCall) -> Result<bool> {
+        self.registered_proofs[call.proofHash].read()
+    }
+
+    /// Get the session ID for a given epoch and proof hash (pure computation).
+    pub fn get_session_id(
+        epoch: u64,
+        proof_hash: B256,
+    ) -> B256 {
+        Self::derive_session_id(epoch, proof_hash)
+    }
+
+    // --- Internal helpers ---
+
+    /// Get validator count by reading from the ValidatorConfig precompile's storage.
+    fn get_validator_count(&self) -> Result<u64> {
+        use tempo_contracts::precompiles::VALIDATOR_CONFIG_ADDRESS;
+
+        // ValidatorConfig layout: slot 0 = owner, slot 1 = validators_array length
+        // The array length is stored at the base slot for Vec fields
+        let count_slot = U256::from(1);
+        let count = StorageCtx.sload(VALIDATOR_CONFIG_ADDRESS, count_slot)?;
+        Ok(count.as_limbs()[0])
+    }
+
+    /// Get validator address at a specific index from ValidatorConfig storage.
+    fn get_validator_address(&self, index: u64) -> Result<Address> {
+        use tempo_contracts::precompiles::VALIDATOR_CONFIG_ADDRESS;
+
+        // ValidatorConfig: slot 1 = validators_array
+        // Array elements at keccak256(1) + index
+        let base_slot = U256::from(1);
+        let array_base = keccak256(B256::from(base_slot));
+        let element_slot = U256::from_be_bytes(*array_base) + U256::from(index);
+
+        let value = StorageCtx.sload(VALIDATOR_CONFIG_ADDRESS, element_slot)?;
+
+        // Address is stored in the lower 20 bytes
+        let bytes: [u8; 32] = value.to_be_bytes();
+        Ok(Address::from_slice(&bytes[12..32]))
+    }
+
+    /// Perform ECDSA recovery to get the signer address.
+    fn ecrecover(message: B256, v: u8, r: B256, s: B256) -> Option<Address> {
+        use alloy::primitives::Signature;
+
+        let v_normalized = if v >= 27 { v - 27 } else { v };
+        let sig = Signature::new(
+            U256::from_be_bytes(*r),
+            U256::from_be_bytes(*s),
+            v_normalized != 0,
+        );
+
+        sig.recover_address_from_prehash(&message).ok()
+    }
+}

--- a/scripts/tlsnotary-email-claim.sh
+++ b/scripts/tlsnotary-email-claim.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+set -e
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TLSNotary Email Ownership Proof — E2E Demo
+#
+# This script demonstrates proving email ownership on-chain using the
+# TLSNotary precompile. In production, the notary signature comes from
+# validators running MPC-TLS with the email provider. Here we simulate
+# the notary role using a dev key.
+#
+# Prerequisites:
+#   - A running Tempo localnet: `just localnet`
+#   - `cast` (Foundry) installed
+#
+# Usage:
+#   ./scripts/tlsnotary-email-claim.sh [email] [rpc_url]
+#
+# Example:
+#   ./scripts/tlsnotary-email-claim.sh zygimantas@tempo.xyz http://localhost:8545
+# ─────────────────────────────────────────────────────────────────────────────
+
+EMAIL="${1:-zygimantas@tempo.xyz}"
+ETH_RPC_URL="${2:-http://localhost:8545}"
+export ETH_RPC_URL
+
+TLS_NOTARY="0x714E000000000000000000000000000000000000"
+
+# Dev admin key (mnemonic index 0: "test test test test test test test test test test test junk")
+ADMIN_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+ADMIN_ADDR=$(cast wallet address $ADMIN_PK)
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  TLSNotary Email Ownership Proof"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+echo "  Email:    $EMAIL"
+echo "  RPC:      $ETH_RPC_URL"
+echo "  Admin:    $ADMIN_ADDR"
+echo ""
+
+# ── Step 1: Generate a notary key pair ────────────────────────────────────────
+echo "─── Step 1: Generate notary key pair ─────────────────────────"
+NOTARY_WALLET=$(cast wallet new --json)
+NOTARY_PK=$(echo "$NOTARY_WALLET" | jq -r '.[0].private_key')
+NOTARY_ADDR=$(echo "$NOTARY_WALLET" | jq -r '.[0].address')
+echo "  Notary address: $NOTARY_ADDR"
+
+# ── Step 2: Generate the claimant wallet ──────────────────────────────────────
+echo ""
+echo "─── Step 2: Generate claimant wallet ─────────────────────────"
+CLAIMANT_WALLET=$(cast wallet new --json)
+CLAIMANT_PK=$(echo "$CLAIMANT_WALLET" | jq -r '.[0].private_key')
+CLAIMANT_ADDR=$(echo "$CLAIMANT_WALLET" | jq -r '.[0].address')
+echo "  Claimant address: $CLAIMANT_ADDR"
+
+# Fund claimant
+echo "  Funding claimant..."
+cast rpc tempo_fundAddress $CLAIMANT_ADDR > /dev/null 2>&1
+sleep 2
+
+# ── Step 3: Register the notary on-chain ──────────────────────────────────────
+echo ""
+echo "─── Step 3: Register notary on-chain (admin tx) ──────────────"
+cast send $TLS_NOTARY \
+  "addNotary(address)" $NOTARY_ADDR \
+  --private-key $ADMIN_PK \
+  --json | jq -r '"  tx: \(.transactionHash) (status: \(.status))"'
+
+# Verify
+IS_NOTARY=$(cast call $TLS_NOTARY "isNotary(address)(bool)" $NOTARY_ADDR)
+echo "  isNotary($NOTARY_ADDR) = $IS_NOTARY"
+
+# ── Step 4: Build the attestation ─────────────────────────────────────────────
+echo ""
+echo "─── Step 4: Build TLSNotary attestation ──────────────────────"
+echo "  [Simulating MPC-TLS session with accounts.google.com]"
+echo "  In production, validators would jointly verify the TLS session"
+echo "  and see that Google's servers confirm $EMAIL ownership."
+
+# Compute hashes
+SERVER_NAME_HASH=$(cast keccak "accounts.google.com")
+PROOF_HASH=$(cast keccak "tlsnotary-proof:$EMAIL:$(date +%s)")
+CHAIN_ID=$(cast chain-id)
+
+# The statement encodes: "email:<email> owner:<claimant>"
+STATEMENT="email:$EMAIL owner:$CLAIMANT_ADDR"
+STATEMENT_HASH=$(cast keccak "$STATEMENT")
+
+echo "  Server:    accounts.google.com"
+echo "  Email:     $EMAIL"
+echo "  Statement: $STATEMENT"
+echo "  Chain ID:  $CHAIN_ID"
+
+# ── Step 5: Notary signs the attestation ──────────────────────────────────────
+echo ""
+echo "─── Step 5: Notary signs attestation ─────────────────────────"
+
+# Build the attestation message: TEMPO_TLSNOTARY_V1 || chain_id || proof_hash || statement_hash || server_name_hash
+DOMAIN_HEX=$(echo -n "TEMPO_TLSNOTARY_V1" | xxd -p | tr -d '\n')
+CHAIN_ID_HEX=$(printf '%016x' $CHAIN_ID)
+# Remove 0x prefix from hashes
+PROOF_HASH_HEX=${PROOF_HASH#0x}
+STATEMENT_HASH_HEX=${STATEMENT_HASH#0x}
+SERVER_NAME_HASH_HEX=${SERVER_NAME_HASH#0x}
+
+ATTESTATION_PREIMAGE="0x${DOMAIN_HEX}${CHAIN_ID_HEX}${PROOF_HASH_HEX}${STATEMENT_HASH_HEX}${SERVER_NAME_HASH_HEX}"
+ATTESTATION_MESSAGE=$(cast keccak $ATTESTATION_PREIMAGE)
+
+echo "  Attestation message: $ATTESTATION_MESSAGE"
+
+# Sign with notary key (produces 65-byte r||s||v signature)
+SIGNATURE=$(cast wallet sign --no-hash $ATTESTATION_MESSAGE --private-key $NOTARY_PK)
+echo "  Signature: ${SIGNATURE:0:20}..."
+
+# ── Step 6: Submit email claim on-chain ───────────────────────────────────────
+echo ""
+echo "─── Step 6: Submit email claim on-chain ──────────────────────"
+
+RESULT=$(cast send $TLS_NOTARY \
+  "claimEmail(string,bytes32,bytes32,bytes)(bytes32)" \
+  "$EMAIL" \
+  $SERVER_NAME_HASH \
+  $PROOF_HASH \
+  $SIGNATURE \
+  --private-key $CLAIMANT_PK \
+  --json)
+
+TX_HASH=$(echo "$RESULT" | jq -r '.transactionHash')
+TX_STATUS=$(echo "$RESULT" | jq -r '.status')
+echo "  tx: $TX_HASH (status: $TX_STATUS)"
+
+if [ "$TX_STATUS" != "0x1" ]; then
+  echo ""
+  echo "  ✗ Transaction reverted!"
+  echo "  Logs: $(echo "$RESULT" | jq -r '.logs')"
+  exit 1
+fi
+
+# ── Step 7: Verify email ownership on-chain ───────────────────────────────────
+echo ""
+echo "─── Step 7: Verify email ownership on-chain ──────────────────"
+
+EMAIL_HASH=$(cast keccak "$EMAIL")
+echo "  emailHash = $EMAIL_HASH"
+
+OWNER_RESULT=$(cast call $TLS_NOTARY \
+  "emailOwner(bytes32)(address,uint64)" \
+  $EMAIL_HASH)
+echo "  emailOwner($EMAIL_HASH) ="
+echo "    $OWNER_RESULT"
+
+PROOF_REGISTERED=$(cast call $TLS_NOTARY \
+  "isProofRegistered(bytes32)(bool)" \
+  $PROOF_HASH)
+echo "  isProofRegistered = $PROOF_REGISTERED"
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  ✓ Email ownership proven on-chain!"
+echo ""
+echo "  $CLAIMANT_ADDR owns $EMAIL"
+echo "  Verified via TLSNotary + accounts.google.com"
+echo "═══════════════════════════════════════════════════════════════"

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -56,6 +56,7 @@ use tempo_precompiles::{
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
+    tls_notary::TLSNotary,
     validator_config::ValidatorConfig,
 };
 
@@ -378,6 +379,9 @@ impl GenesisArgs {
 
         println!("Initializing account keychain");
         initialize_account_keychain(&mut evm)?;
+
+        println!("Initializing TLS notary");
+        initialize_tls_notary(pathusd_admin, &mut evm)?;
 
         if !self.no_pairwise_liquidity {
             if let (Some(alpha), Some(beta), Some(theta)) =
@@ -836,6 +840,23 @@ fn initialize_account_keychain(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Re
         &ctx.cfg,
         &ctx.tx,
         || AccountKeychain::new().initialize(),
+    )?;
+
+    Ok(())
+}
+
+/// Initializes the [`TLSNotary`] contract with the given admin as owner.
+fn initialize_tls_notary(
+    admin: Address,
+    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
+) -> eyre::Result<()> {
+    let ctx = evm.ctx_mut();
+    StorageCtx::enter_evm(
+        &mut ctx.journaled_state,
+        &ctx.block,
+        &ctx.cfg,
+        &ctx.tx,
+        || TLSNotary::new().initialize(admin),
     )?;
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds a new TLSNotary precompile that enables on-chain verification of TLSNotary attestations, where Tempo validators act as MPC participants in the TLSNotary protocol.

**Thread**: https://tempoxyz.slack.com/archives/C0A87C21805/p1770668109621179

## Motivation

[TLSNotary](https://tlsnotary.org/docs/intro) enables data provenance from any TLS-protected website using MPC. By having Tempo validators act as the Verifier/Notary in the MPC-TLS protocol, we can bring trustless web data attestation on-chain with the full security of the validator set.

The design follows TLSNotary's Notary model: validators run MPC-TLS off-chain and produce signed attestations. The precompile verifies these attestations on-chain, checking that 2/3+ of validators signed the proof hash.

## Changes

- `crates/contracts/src/precompiles/tls_notary.rs` — ABI interface (`ITLSNotary`) with `verifyAttestation`, `registerAttestation`, `getSession`, `isProofRegistered`, `getSessionId`
- `crates/precompiles/src/tls_notary/mod.rs` — Core logic: attestation message computation, bitmap parsing, ECDSA signature recovery, validator quorum checking (reads from ValidatorConfig storage), session registration
- `crates/precompiles/src/tls_notary/dispatch.rs` — Precompile dispatch following `TIP403Registry` pattern
- `crates/precompiles/src/lib.rs` — Registered at `0x714E000000000000000000000000000000000000`
- `crates/precompiles/src/error.rs` — Added `TLSNotaryError` variant to `TempoPrecompileError`

### Key design decisions

- **Proof verification, not live MPC**: Validators run MPC-TLS off-chain; precompile only verifies the resulting attestations on-chain. Avoids real-time coordination complexity.
- **Validator quorum via ECDSA**: Reuses validators' existing signing keys. Attestation includes a bitmap + concatenated signatures. Requires 2/3 quorum.
- **Domain-separated attestation messages**: `TEMPO_TLSNOTARY_V1 || chain_id || epoch || proof_hash || statement_hash || server_name_hash` — prevents cross-chain/cross-purpose replay.
- **Reads ValidatorConfig storage directly**: Gets validator count and addresses from the existing `ValidatorConfig` precompile storage slots.
- **DoS guardrails**: Max 200 signatures, gas charged per input word, signature/bitmap length validation.

## Testing

```
cargo check -p tempo-contracts -p tempo-precompiles  # passes
```