### PR TITLE
feat(precompiles): TLSEmailOwnership - on-chain email verification via TLSNotary

### DIFF
--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -6,6 +6,7 @@ pub mod tip20;
 pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
+pub mod tls_email_ownership;
 pub mod validator_config;
 
 pub use account_keychain::*;
@@ -17,6 +18,7 @@ pub use tip_fee_manager::*;
 pub use tip20::*;
 pub use tip20_factory::*;
 pub use tip403_registry::*;
+pub use tls_email_ownership::*;
 pub use validator_config::*;
 
 pub const TIP_FEE_MANAGER_ADDRESS: Address = address!("0xfeec000000000000000000000000000000000000");
@@ -31,3 +33,5 @@ pub const VALIDATOR_CONFIG_ADDRESS: Address =
     address!("0xCCCCCCCC00000000000000000000000000000000");
 pub const ACCOUNT_KEYCHAIN_ADDRESS: Address =
     address!("0xAAAAAAAA00000000000000000000000000000000");
+pub const TLS_EMAIL_OWNERSHIP_ADDRESS: Address =
+    address!("0x714E000000000000000000000000000000000000");

--- a/crates/contracts/src/precompiles/tls_email_ownership.rs
+++ b/crates/contracts/src/precompiles/tls_email_ownership.rs
@@ -1,0 +1,143 @@
+pub use ITLSEmailOwnership::ITLSEmailOwnershipErrors as TLSEmailOwnershipError;
+
+crate::sol! {
+    /// TLS Email Ownership verification interface.
+    ///
+    /// Verifies email ownership using TLSNotary attestations signed by trusted Notaries.
+    /// Users submit a Notary-signed attestation of their Google userinfo response,
+    /// and the precompile verifies the signature, extracts the email, and stores the claim.
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    interface ITLSEmailOwnership {
+        /// A verified email claim stored on-chain.
+        struct EmailClaim {
+            string email;
+            bytes32 emailHash;
+            uint64 verifiedAt;
+            bytes32 notaryKeyId;
+        }
+
+        /// Verify a Google userinfo email attestation and store the claim.
+        ///
+        /// The attestation must be signed by a trusted Notary over the digest:
+        ///   keccak256(abi.encodePacked(
+        ///     "TempoEmailAttestationV1",
+        ///     subject,
+        ///     serverName,
+        ///     endpoint,
+        ///     responseBodyHash,
+        ///     emailHash,
+        ///     notaryKeyId
+        ///   ))
+        ///
+        /// The signature uses secp256k1 ECDSA (same as Ethereum's ecrecover).
+        ///
+        /// @param notaryKeyId Key ID selecting which trusted Notary to verify against
+        /// @param subject Must equal msg.sender
+        /// @param serverName Must be "www.googleapis.com"
+        /// @param endpoint Must be "/oauth2/v3/userinfo"
+        /// @param responseBody The disclosed HTTP response body (JSON containing "email" field)
+        /// @param v ECDSA recovery id
+        /// @param r ECDSA r value
+        /// @param s ECDSA s value
+        /// @return email The verified email address
+        function verifyEmail(
+            bytes32 notaryKeyId,
+            address subject,
+            string calldata serverName,
+            string calldata endpoint,
+            bytes calldata responseBody,
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        ) external returns (string memory email);
+
+        /// Get the verified email claim for an address.
+        /// @param user The address to look up
+        /// @return claim The email claim (empty if not verified)
+        function getVerifiedEmail(address user) external view returns (EmailClaim memory claim);
+
+        /// Check if an address has a verified email.
+        /// @param user The address to check
+        /// @return Whether the address has a verified email claim
+        function isVerified(address user) external view returns (bool);
+
+        /// Get the owner of the precompile.
+        function owner() external view returns (address);
+
+        /// Change the owner (owner only).
+        /// @param newOwner The new owner address
+        function changeOwner(address newOwner) external;
+
+        /// Register a trusted Notary public key (owner only).
+        /// @param notaryKeyId Unique identifier for this Notary key
+        /// @param notaryAddress The Ethereum address of the Notary (derived from its secp256k1 pubkey)
+        function setNotaryKey(bytes32 notaryKeyId, address notaryAddress) external;
+
+        /// Remove a trusted Notary key (owner only).
+        /// @param notaryKeyId The key to remove
+        function removeNotaryKey(bytes32 notaryKeyId) external;
+
+        /// Get a Notary's address by key ID.
+        /// @param notaryKeyId The key ID to look up
+        /// @return notaryAddress The Notary's Ethereum address (zero if not set)
+        function getNotaryKey(bytes32 notaryKeyId) external view returns (address notaryAddress);
+
+        /// Revoke your own email claim.
+        function revokeMyEmail() external;
+
+        // Errors
+        error Unauthorized();
+        error InvalidSubject();
+        error InvalidServerName();
+        error InvalidEndpoint();
+        error ResponseBodyMismatch();
+        error EmailNotFound();
+        error InvalidSignature();
+        error NotaryKeyNotFound();
+        error AlreadyVerified();
+        error NotVerified();
+    }
+}
+
+impl TLSEmailOwnershipError {
+    pub const fn unauthorized() -> Self {
+        Self::Unauthorized(ITLSEmailOwnership::Unauthorized {})
+    }
+
+    pub const fn invalid_subject() -> Self {
+        Self::InvalidSubject(ITLSEmailOwnership::InvalidSubject {})
+    }
+
+    pub const fn invalid_server_name() -> Self {
+        Self::InvalidServerName(ITLSEmailOwnership::InvalidServerName {})
+    }
+
+    pub const fn invalid_endpoint() -> Self {
+        Self::InvalidEndpoint(ITLSEmailOwnership::InvalidEndpoint {})
+    }
+
+    pub const fn response_body_mismatch() -> Self {
+        Self::ResponseBodyMismatch(ITLSEmailOwnership::ResponseBodyMismatch {})
+    }
+
+    pub const fn email_not_found() -> Self {
+        Self::EmailNotFound(ITLSEmailOwnership::EmailNotFound {})
+    }
+
+    pub const fn invalid_signature() -> Self {
+        Self::InvalidSignature(ITLSEmailOwnership::InvalidSignature {})
+    }
+
+    pub const fn notary_key_not_found() -> Self {
+        Self::NotaryKeyNotFound(ITLSEmailOwnership::NotaryKeyNotFound {})
+    }
+
+    pub const fn already_verified() -> Self {
+        Self::AlreadyVerified(ITLSEmailOwnership::AlreadyVerified {})
+    }
+
+    pub const fn not_verified() -> Self {
+        Self::NotVerified(ITLSEmailOwnership::NotVerified {})
+    }
+}

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -14,8 +14,8 @@ use revm::{
 };
 use tempo_contracts::precompiles::{
     AccountKeychainError, FeeManagerError, NonceError, RolesAuthError, StablecoinDEXError,
-    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector,
-    ValidatorConfigError,
+    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, TLSEmailOwnershipError,
+    UnknownFunctionSelector, ValidatorConfigError,
 };
 
 /// Top-level error type for all Tempo precompile operations
@@ -65,6 +65,10 @@ pub enum TempoPrecompileError {
     /// Error from account keychain precompile
     #[error("Account keychain error: {0:?}")]
     AccountKeychainError(AccountKeychainError),
+
+    /// Error from TLS email ownership precompile
+    #[error("TLS email ownership error: {0:?}")]
+    TLSEmailOwnershipError(TLSEmailOwnershipError),
 
     #[error("Gas limit exceeded")]
     OutOfGas,
@@ -117,6 +121,7 @@ impl TempoPrecompileError {
             }
             Self::ValidatorConfigError(e) => e.abi_encode().into(),
             Self::AccountKeychainError(e) => e.abi_encode().into(),
+            Self::TLSEmailOwnershipError(e) => e.abi_encode().into(),
             Self::OutOfGas => {
                 return Err(PrecompileError::OutOfGas);
             }
@@ -179,6 +184,7 @@ pub fn error_decoder_registry() -> TempoPrecompileErrorRegistry {
     add_errors_to_registry(&mut registry, TempoPrecompileError::NonceError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ValidatorConfigError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::AccountKeychainError);
+    add_errors_to_registry(&mut registry, TempoPrecompileError::TLSEmailOwnershipError);
 
     registry
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -14,6 +14,7 @@ pub mod tip20;
 pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
+pub mod tls_email_ownership;
 pub mod validator_config;
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -28,6 +29,7 @@ use crate::{
     tip20::{TIP20Token, is_tip20_prefix},
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
+    tls_email_ownership::TLSEmailOwnership,
     validator_config::ValidatorConfig,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -48,7 +50,7 @@ use revm::{
 pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
     STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
-    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, TLS_EMAIL_OWNERSHIP_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -90,6 +92,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(ValidatorConfigPrecompile::create(&cfg))
         } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
             Some(AccountKeychainPrecompile::create(&cfg))
+        } else if *address == TLS_EMAIL_OWNERSHIP_ADDRESS {
+            Some(TLSEmailOwnershipPrecompile::create(&cfg))
         } else {
             None
         }
@@ -181,6 +185,13 @@ pub struct ValidatorConfigPrecompile;
 impl ValidatorConfigPrecompile {
     pub fn create(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
         tempo_precompile!("ValidatorConfig", cfg, |input| { ValidatorConfig::new() })
+    }
+}
+
+pub struct TLSEmailOwnershipPrecompile;
+impl TLSEmailOwnershipPrecompile {
+    pub fn create(cfg: &CfgEnv<TempoHardfork>) -> DynPrecompile {
+        tempo_precompile!("TLSEmailOwnership", cfg, |input| { TLSEmailOwnership::new() })
     }
 }
 

--- a/crates/precompiles/src/tls_email_ownership/README.md
+++ b/crates/precompiles/src/tls_email_ownership/README.md
@@ -1,0 +1,144 @@
+# TLS Email Ownership Precompile
+
+Proves email ownership on-chain using TLSNotary attestations.
+
+**Address:** `0x714E000000000000000000000000000000000000`
+
+## How It Works
+
+1. **Off-chain:** User runs a TLSNotary session against Google's userinfo API (`https://www.googleapis.com/oauth2/v3/userinfo`), which returns their email
+2. **Notary attestation:** A trusted Notary verifies the TLS proof and signs a compact attestation binding the email to the user's Ethereum address
+3. **On-chain:** User submits the attestation + response body to this precompile, which verifies the Notary's secp256k1 signature and stores the email claim
+
+## Attestation Digest
+
+The Notary signs `keccak256(abi.encodePacked(...))` over:
+
+```
+"TempoEmailAttestationV1"     // domain separator
+subject                       // user's Ethereum address (20 bytes)
+keccak256(serverName)          // "www.googleapis.com"
+keccak256(endpoint)            // "/oauth2/v3/userinfo"
+responseBodyHash               // keccak256(responseBody)
+emailHash                      // keccak256(email)
+notaryKeyId                    // 32 bytes
+```
+
+## E2E Flow (localnet)
+
+### 1. Start localnet
+
+```bash
+just localnet
+export ETH_RPC_URL="http://localhost:8545"
+```
+
+### 2. Fund a wallet
+
+```bash
+WALLET=$(cast wallet new --json)
+PK=$(echo "$WALLET" | jq -r '.[0].private_key')
+ADDR=$(echo "$WALLET" | jq -r '.[0].address')
+cast rpc tempo_fundAddress $ADDR
+sleep 2
+```
+
+### 3. Initialize the precompile (genesis does this, but for manual testing)
+
+The precompile is initialized during genesis with the chain owner. The owner can then register trusted Notary keys.
+
+### 4. Register a Notary key (owner only)
+
+```bash
+# Generate a Notary key (for testing only)
+NOTARY_WALLET=$(cast wallet new --json)
+NOTARY_PK=$(echo "$NOTARY_WALLET" | jq -r '.[0].private_key')
+NOTARY_ADDR=$(echo "$NOTARY_WALLET" | jq -r '.[0].address')
+NOTARY_KEY_ID="0x0000000000000000000000000000000000000000000000000000000000000001"
+
+# Owner registers the Notary (replace OWNER_PK with actual owner private key)
+PRECOMPILE="0x714E000000000000000000000000000000000000"
+cast send $PRECOMPILE "setNotaryKey(bytes32,address)" \
+    $NOTARY_KEY_ID $NOTARY_ADDR \
+    --private-key $OWNER_PK
+```
+
+### 5. Create and sign the attestation (off-chain)
+
+The Notary creates the attestation after verifying the TLSNotary proof:
+
+```bash
+# The Google userinfo response body (from TLSNotary session)
+RESPONSE_BODY='{"sub":"1234567890","email":"zygimantas@tempo.xyz","email_verified":true}'
+RESPONSE_HASH=$(cast keccak "$RESPONSE_BODY")
+EMAIL_HASH=$(cast keccak "zygimantas@tempo.xyz")
+SERVER_NAME_HASH=$(cast keccak "www.googleapis.com")
+ENDPOINT_HASH=$(cast keccak "/oauth2/v3/userinfo")
+
+# Compute attestation digest
+DIGEST=$(cast keccak $(cast abi-encode-packed \
+    "string,address,bytes32,bytes32,bytes32,bytes32,bytes32" \
+    "TempoEmailAttestationV1" \
+    $ADDR \
+    $SERVER_NAME_HASH \
+    $ENDPOINT_HASH \
+    $RESPONSE_HASH \
+    $EMAIL_HASH \
+    $NOTARY_KEY_ID))
+
+# Notary signs the digest
+SIG=$(cast wallet sign --private-key $NOTARY_PK $DIGEST)
+```
+
+### 6. Submit the attestation on-chain
+
+```bash
+# Parse signature components
+R=$(echo $SIG | cut -c1-66)
+S="0x$(echo $SIG | cut -c67-130)"
+V=$(echo $SIG | cut -c131-132)
+
+# Call verifyEmail
+cast send $PRECOMPILE \
+    "verifyEmail(bytes32,address,string,string,bytes,uint8,bytes32,bytes32)" \
+    $NOTARY_KEY_ID \
+    $ADDR \
+    "www.googleapis.com" \
+    "/oauth2/v3/userinfo" \
+    $(cast --from-utf8 "$RESPONSE_BODY") \
+    $V $R $S \
+    --private-key $PK
+```
+
+### 7. Query the verified email
+
+```bash
+# Check if verified
+cast call $PRECOMPILE "isVerified(address)(bool)" $ADDR
+
+# Get the full claim
+cast call $PRECOMPILE "getVerifiedEmail(address)((string,bytes32,uint64,bytes32))" $ADDR
+```
+
+## Interface
+
+```solidity
+interface ITLSEmailOwnership {
+    // Verify email ownership
+    function verifyEmail(bytes32 notaryKeyId, address subject, string serverName,
+        string endpoint, bytes responseBody, uint8 v, bytes32 r, bytes32 s)
+        external returns (string email);
+
+    // Query verified emails
+    function getVerifiedEmail(address user) external view returns (EmailClaim);
+    function isVerified(address user) external view returns (bool);
+
+    // Admin: Notary key management
+    function setNotaryKey(bytes32 notaryKeyId, address notaryAddress) external;
+    function removeNotaryKey(bytes32 notaryKeyId) external;
+    function getNotaryKey(bytes32 notaryKeyId) external view returns (address);
+
+    // User: revoke
+    function revokeMyEmail() external;
+}
+```

--- a/crates/precompiles/src/tls_email_ownership/README.md
+++ b/crates/precompiles/src/tls_email_ownership/README.md
@@ -6,139 +6,78 @@ Proves email ownership on-chain using TLSNotary attestations.
 
 ## How It Works
 
-1. **Off-chain:** User runs a TLSNotary session against Google's userinfo API (`https://www.googleapis.com/oauth2/v3/userinfo`), which returns their email
-2. **Notary attestation:** A trusted Notary verifies the TLS proof and signs a compact attestation binding the email to the user's Ethereum address
-3. **On-chain:** User submits the attestation + response body to this precompile, which verifies the Notary's secp256k1 signature and stores the email claim
+1. User authenticates with Google and gets an OAuth access token
+2. The Notary fetches `https://www.googleapis.com/oauth2/v3/userinfo` using TLSNotary MPC, verifying the TLS session
+3. The Notary signs a compact attestation binding the user's email to their Ethereum address
+4. The user submits the attestation + response body on-chain
+5. The precompile verifies the Notary's secp256k1 signature, extracts the email from the JSON, and stores the claim
+6. Anyone can query `isVerified(address)` to check
+
+## Quick Start
+
+```bash
+# Get a Google OAuth token
+TOKEN=$(gcloud auth print-access-token --scopes=email)
+
+# Run the full E2E (starts localnet, calls Google, submits on-chain)
+./scripts/verify-email.sh "$TOKEN"
+```
+
+The script:
+- Fetches your real email from Google's userinfo API
+- Builds and starts a Tempo localnet (or reuses one already running)
+- Creates a Notary-signed attestation over the response
+- Submits it to the precompile on-chain
+- Queries `isVerified()` and prints the result
 
 ## Attestation Digest
 
 The Notary signs `keccak256(abi.encodePacked(...))` over:
 
-```
-"TempoEmailAttestationV1"     // domain separator
-subject                       // user's Ethereum address (20 bytes)
-keccak256(serverName)          // "www.googleapis.com"
-keccak256(endpoint)            // "/oauth2/v3/userinfo"
-responseBodyHash               // keccak256(responseBody)
-emailHash                      // keccak256(email)
-notaryKeyId                    // 32 bytes
-```
-
-## E2E Flow (localnet)
-
-### 1. Start localnet
-
-```bash
-just localnet
-export ETH_RPC_URL="http://localhost:8545"
-```
-
-### 2. Fund a wallet
-
-```bash
-WALLET=$(cast wallet new --json)
-PK=$(echo "$WALLET" | jq -r '.[0].private_key')
-ADDR=$(echo "$WALLET" | jq -r '.[0].address')
-cast rpc tempo_fundAddress $ADDR
-sleep 2
-```
-
-### 3. Initialize the precompile (genesis does this, but for manual testing)
-
-The precompile is initialized during genesis with the chain owner. The owner can then register trusted Notary keys.
-
-### 4. Register a Notary key (owner only)
-
-```bash
-# Generate a Notary key (for testing only)
-NOTARY_WALLET=$(cast wallet new --json)
-NOTARY_PK=$(echo "$NOTARY_WALLET" | jq -r '.[0].private_key')
-NOTARY_ADDR=$(echo "$NOTARY_WALLET" | jq -r '.[0].address')
-NOTARY_KEY_ID="0x0000000000000000000000000000000000000000000000000000000000000001"
-
-# Owner registers the Notary (replace OWNER_PK with actual owner private key)
-PRECOMPILE="0x714E000000000000000000000000000000000000"
-cast send $PRECOMPILE "setNotaryKey(bytes32,address)" \
-    $NOTARY_KEY_ID $NOTARY_ADDR \
-    --private-key $OWNER_PK
-```
-
-### 5. Create and sign the attestation (off-chain)
-
-The Notary creates the attestation after verifying the TLSNotary proof:
-
-```bash
-# The Google userinfo response body (from TLSNotary session)
-RESPONSE_BODY='{"sub":"1234567890","email":"zygimantas@tempo.xyz","email_verified":true}'
-RESPONSE_HASH=$(cast keccak "$RESPONSE_BODY")
-EMAIL_HASH=$(cast keccak "zygimantas@tempo.xyz")
-SERVER_NAME_HASH=$(cast keccak "www.googleapis.com")
-ENDPOINT_HASH=$(cast keccak "/oauth2/v3/userinfo")
-
-# Compute attestation digest
-DIGEST=$(cast keccak $(cast abi-encode-packed \
-    "string,address,bytes32,bytes32,bytes32,bytes32,bytes32" \
-    "TempoEmailAttestationV1" \
-    $ADDR \
-    $SERVER_NAME_HASH \
-    $ENDPOINT_HASH \
-    $RESPONSE_HASH \
-    $EMAIL_HASH \
-    $NOTARY_KEY_ID))
-
-# Notary signs the digest
-SIG=$(cast wallet sign --private-key $NOTARY_PK $DIGEST)
-```
-
-### 6. Submit the attestation on-chain
-
-```bash
-# Parse signature components
-R=$(echo $SIG | cut -c1-66)
-S="0x$(echo $SIG | cut -c67-130)"
-V=$(echo $SIG | cut -c131-132)
-
-# Call verifyEmail
-cast send $PRECOMPILE \
-    "verifyEmail(bytes32,address,string,string,bytes,uint8,bytes32,bytes32)" \
-    $NOTARY_KEY_ID \
-    $ADDR \
-    "www.googleapis.com" \
-    "/oauth2/v3/userinfo" \
-    $(cast --from-utf8 "$RESPONSE_BODY") \
-    $V $R $S \
-    --private-key $PK
-```
-
-### 7. Query the verified email
-
-```bash
-# Check if verified
-cast call $PRECOMPILE "isVerified(address)(bool)" $ADDR
-
-# Get the full claim
-cast call $PRECOMPILE "getVerifiedEmail(address)((string,bytes32,uint64,bytes32))" $ADDR
-```
+| Field | Description |
+|-------|-------------|
+| `"TempoEmailAttestationV1"` | Domain separator |
+| `subject` | User's Ethereum address (20 bytes) |
+| `keccak256(serverName)` | `"www.googleapis.com"` |
+| `keccak256(endpoint)` | `"/oauth2/v3/userinfo"` |
+| `responseBodyHash` | `keccak256(responseBody)` |
+| `emailHash` | `keccak256(email)` |
+| `notaryKeyId` | 32 bytes identifying the Notary |
 
 ## Interface
 
 ```solidity
 interface ITLSEmailOwnership {
-    // Verify email ownership
-    function verifyEmail(bytes32 notaryKeyId, address subject, string serverName,
-        string endpoint, bytes responseBody, uint8 v, bytes32 r, bytes32 s)
-        external returns (string email);
+    function verifyEmail(
+        bytes32 notaryKeyId,
+        address subject,
+        string serverName,
+        string endpoint,
+        bytes responseBody,
+        uint8 v, bytes32 r, bytes32 s
+    ) external returns (string email);
 
-    // Query verified emails
     function getVerifiedEmail(address user) external view returns (EmailClaim);
     function isVerified(address user) external view returns (bool);
+    function revokeMyEmail() external;
 
-    // Admin: Notary key management
+    // Admin (owner only)
     function setNotaryKey(bytes32 notaryKeyId, address notaryAddress) external;
     function removeNotaryKey(bytes32 notaryKeyId) external;
     function getNotaryKey(bytes32 notaryKeyId) external view returns (address);
-
-    // User: revoke
-    function revokeMyEmail() external;
+    function changeOwner(address newOwner) external;
 }
 ```
+
+## Trust Model
+
+The precompile uses a **trusted Notary** model:
+- The chain owner registers Notary public keys (Ethereum addresses)
+- Notaries verify TLSNotary proofs off-chain and sign attestations
+- The precompile verifies Notary signatures on-chain using `ecrecover`
+- Users can revoke their own claims at any time
+- The owner can add/remove Notary keys
+
+For the dev Notary (localnet), the well-known Hardhat account #0 is used:
+- Address: `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
+- Key ID: `0x0101...0101`

--- a/crates/precompiles/src/tls_email_ownership/dispatch.rs
+++ b/crates/precompiles/src/tls_email_ownership/dispatch.rs
@@ -1,0 +1,148 @@
+use super::TLSEmailOwnership;
+use crate::{Precompile, dispatch_call, input_cost, mutate, mutate_void, view};
+use alloy::{
+    primitives::Address,
+    sol_types::SolInterface,
+};
+use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_contracts::precompiles::ITLSEmailOwnership::ITLSEmailOwnershipCalls;
+
+impl Precompile for TLSEmailOwnership {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        self.storage
+            .deduct_gas(input_cost(calldata.len()))
+            .map_err(|_| PrecompileError::OutOfGas)?;
+
+        dispatch_call(
+            calldata,
+            ITLSEmailOwnershipCalls::abi_decode,
+            |call| match call {
+                // View functions
+                ITLSEmailOwnershipCalls::owner(call) => view(call, |_| self.owner()),
+                ITLSEmailOwnershipCalls::getVerifiedEmail(call) => {
+                    view(call, |c| self.get_verified_email(c))
+                }
+                ITLSEmailOwnershipCalls::isVerified(call) => {
+                    view(call, |c| self.is_verified(c))
+                }
+                ITLSEmailOwnershipCalls::getNotaryKey(call) => {
+                    view(call, |c| self.get_notary_key(c))
+                }
+
+                // Mutate functions
+                ITLSEmailOwnershipCalls::verifyEmail(call) => {
+                    mutate(call, msg_sender, |s, c| self.verify_email(s, c))
+                }
+                ITLSEmailOwnershipCalls::changeOwner(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.change_owner(s, c))
+                }
+                ITLSEmailOwnershipCalls::setNotaryKey(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_notary_key(s, c))
+                }
+                ITLSEmailOwnershipCalls::removeNotaryKey(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.remove_notary_key(s, c))
+                }
+                ITLSEmailOwnershipCalls::revokeMyEmail(call) => {
+                    mutate_void(call, msg_sender, |s, _c| self.revoke_my_email(s))
+                }
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        expect_precompile_revert,
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::{assert_full_coverage, check_selector_coverage},
+    };
+    use alloy::{
+        primitives::{Address, FixedBytes},
+        sol_types::{SolCall, SolValue},
+    };
+    use tempo_contracts::precompiles::{
+        ITLSEmailOwnership, ITLSEmailOwnership::ITLSEmailOwnershipCalls, TLSEmailOwnershipError,
+    };
+
+    #[test]
+    fn test_function_selector_dispatch() -> eyre::Result<()> {
+        let sender = Address::random();
+        let owner = Address::random();
+
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let result = tls.call(&[0x12, 0x34, 0x56, 0x78], sender)?;
+            assert!(result.reverted);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_owner_view_dispatch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let sender = Address::random();
+        let owner = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let owner_call = ITLSEmailOwnership::ownerCall {};
+            let calldata = owner_call.abi_encode();
+
+            let result = tls.call(&calldata, sender)?;
+            assert_eq!(result.gas_used, 0);
+
+            let decoded = Address::abi_decode(&result.bytes)?;
+            assert_eq!(decoded, owner);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_unauthorized_set_notary_key_dispatch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let non_owner = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let call = ITLSEmailOwnership::setNotaryKeyCall {
+                notaryKeyId: FixedBytes::<32>::from([0x01; 32]),
+                notaryAddress: Address::random(),
+            };
+            let calldata = call.abi_encode();
+
+            let result = tls.call(&calldata, non_owner);
+            expect_precompile_revert(&result, TLSEmailOwnershipError::unauthorized());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_selector_coverage() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+
+            let unsupported = check_selector_coverage(
+                &mut tls,
+                ITLSEmailOwnershipCalls::SELECTORS,
+                "ITLSEmailOwnership",
+                ITLSEmailOwnershipCalls::name_by_selector,
+            );
+
+            assert_full_coverage([unsupported]);
+
+            Ok(())
+        })
+    }
+}

--- a/crates/precompiles/src/tls_email_ownership/mod.rs
+++ b/crates/precompiles/src/tls_email_ownership/mod.rs
@@ -1,0 +1,548 @@
+pub mod dispatch;
+
+use tempo_contracts::precompiles::TLS_EMAIL_OWNERSHIP_ADDRESS;
+pub use tempo_contracts::precompiles::{ITLSEmailOwnership, TLSEmailOwnershipError};
+use tempo_precompiles_macros::{Storable, contract};
+
+use crate::{
+    error::{Result, TempoPrecompileError},
+    storage::{Handler, Mapping},
+};
+use alloy::primitives::{Address, B256, keccak256};
+
+const ALLOWED_SERVER_NAME: &str = "www.googleapis.com";
+const ALLOWED_ENDPOINT: &str = "/oauth2/v3/userinfo";
+
+#[derive(Debug, Storable)]
+struct NotaryKey {
+    notary_address: Address,
+    active: bool,
+}
+
+#[derive(Debug, Storable)]
+struct EmailClaim {
+    email: String,
+    email_hash: B256,
+    verified_at: u64,
+    notary_key_id: B256,
+}
+
+#[contract(addr = TLS_EMAIL_OWNERSHIP_ADDRESS)]
+pub struct TLSEmailOwnership {
+    owner: Address,
+    notary_keys: Mapping<B256, NotaryKey>,
+    claims: Mapping<Address, EmailClaim>,
+}
+
+impl TLSEmailOwnership {
+    pub fn initialize(&mut self, owner: Address) -> Result<()> {
+        self.__initialize()?;
+        self.owner.write(owner)
+    }
+
+    pub fn owner(&self) -> Result<Address> {
+        self.owner.read()
+    }
+
+    fn check_owner(&self, caller: Address) -> Result<()> {
+        if self.owner()? != caller {
+            return Err(TLSEmailOwnershipError::unauthorized())?;
+        }
+        Ok(())
+    }
+
+    pub fn change_owner(
+        &mut self,
+        sender: Address,
+        call: ITLSEmailOwnership::changeOwnerCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+        self.owner.write(call.newOwner)
+    }
+
+    pub fn set_notary_key(
+        &mut self,
+        sender: Address,
+        call: ITLSEmailOwnership::setNotaryKeyCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+        let key = NotaryKey {
+            notary_address: call.notaryAddress,
+            active: true,
+        };
+        self.notary_keys[call.notaryKeyId].write(key)
+    }
+
+    pub fn remove_notary_key(
+        &mut self,
+        sender: Address,
+        call: ITLSEmailOwnership::removeNotaryKeyCall,
+    ) -> Result<()> {
+        self.check_owner(sender)?;
+        self.notary_keys[call.notaryKeyId].delete()
+    }
+
+    pub fn get_notary_key(
+        &self,
+        call: ITLSEmailOwnership::getNotaryKeyCall,
+    ) -> Result<Address> {
+        let key = self.notary_keys[call.notaryKeyId].read()?;
+        if !key.active {
+            return Ok(Address::ZERO);
+        }
+        Ok(key.notary_address)
+    }
+
+    pub fn verify_email(
+        &mut self,
+        sender: Address,
+        call: ITLSEmailOwnership::verifyEmailCall,
+    ) -> Result<String> {
+        if call.subject != sender {
+            return Err(TLSEmailOwnershipError::invalid_subject())?;
+        }
+
+        if call.serverName != ALLOWED_SERVER_NAME {
+            return Err(TLSEmailOwnershipError::invalid_server_name())?;
+        }
+
+        if call.endpoint != ALLOWED_ENDPOINT {
+            return Err(TLSEmailOwnershipError::invalid_endpoint())?;
+        }
+
+        let notary_key = self.notary_keys[call.notaryKeyId].read()?;
+        if !notary_key.active || notary_key.notary_address.is_zero() {
+            return Err(TLSEmailOwnershipError::notary_key_not_found())?;
+        }
+
+        let email = extract_email_from_json(&call.responseBody)
+            .ok_or(TempoPrecompileError::from(TLSEmailOwnershipError::email_not_found()))?;
+
+        let response_body_hash = keccak256(&call.responseBody);
+        let email_hash = keccak256(email.as_bytes());
+
+        let digest = compute_attestation_digest(
+            call.subject,
+            &call.serverName,
+            &call.endpoint,
+            response_body_hash,
+            email_hash,
+            call.notaryKeyId,
+        );
+
+        let sig = alloy::primitives::Signature::from_scalars_and_parity(
+            call.r,
+            call.s,
+            call.v != 0,
+        );
+
+        let recovered = sig
+            .recover_address_from_prehash(&digest)
+            .map_err(|_| TempoPrecompileError::from(TLSEmailOwnershipError::invalid_signature()))?;
+
+        if recovered != notary_key.notary_address {
+            return Err(TLSEmailOwnershipError::invalid_signature())?;
+        }
+
+        let claim = EmailClaim {
+            email: email.clone(),
+            email_hash,
+            verified_at: 0,
+            notary_key_id: call.notaryKeyId,
+        };
+        self.claims[sender].write(claim)?;
+
+        Ok(email)
+    }
+
+    pub fn get_verified_email(
+        &self,
+        call: ITLSEmailOwnership::getVerifiedEmailCall,
+    ) -> Result<ITLSEmailOwnership::EmailClaim> {
+        let claim = self.claims[call.user].read()?;
+        Ok(ITLSEmailOwnership::EmailClaim {
+            email: claim.email,
+            emailHash: claim.email_hash,
+            verifiedAt: claim.verified_at,
+            notaryKeyId: claim.notary_key_id,
+        })
+    }
+
+    pub fn is_verified(
+        &self,
+        call: ITLSEmailOwnership::isVerifiedCall,
+    ) -> Result<bool> {
+        let claim = self.claims[call.user].read()?;
+        Ok(!claim.email_hash.is_zero())
+    }
+
+    pub fn revoke_my_email(&mut self, sender: Address) -> Result<()> {
+        let claim = self.claims[sender].read()?;
+        if claim.email_hash.is_zero() {
+            return Err(TLSEmailOwnershipError::not_verified())?;
+        }
+        self.claims[sender].delete()
+    }
+}
+
+fn compute_attestation_digest(
+    subject: Address,
+    server_name: &str,
+    endpoint: &str,
+    response_body_hash: B256,
+    email_hash: B256,
+    notary_key_id: B256,
+) -> B256 {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"TempoEmailAttestationV1");
+    buf.extend_from_slice(subject.as_slice());
+    buf.extend_from_slice(keccak256(server_name.as_bytes()).as_slice());
+    buf.extend_from_slice(keccak256(endpoint.as_bytes()).as_slice());
+    buf.extend_from_slice(response_body_hash.as_slice());
+    buf.extend_from_slice(email_hash.as_slice());
+    buf.extend_from_slice(notary_key_id.as_slice());
+    keccak256(&buf)
+}
+
+fn extract_email_from_json(body: &[u8]) -> Option<String> {
+    let s = std::str::from_utf8(body).ok()?;
+
+    let email_key = "\"email\"";
+    let pos = s.find(email_key)?;
+    let after_key = &s[pos + email_key.len()..];
+
+    let after_colon = after_key.trim_start();
+    if !after_colon.starts_with(':') {
+        return None;
+    }
+    let after_colon = after_colon[1..].trim_start();
+
+    if !after_colon.starts_with('"') {
+        return None;
+    }
+    let value_start = 1;
+    let value_end = after_colon[value_start..].find('"')?;
+    let email = &after_colon[value_start..value_start + value_end];
+
+    if email.is_empty() || !email.contains('@') {
+        return None;
+    }
+
+    Some(email.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+    use alloy::primitives::{Address, FixedBytes};
+
+    #[test]
+    fn test_extract_email_from_json() {
+        let body = br#"{"sub":"123","email":"zygimantas@tempo.xyz","email_verified":true}"#;
+        assert_eq!(
+            extract_email_from_json(body),
+            Some("zygimantas@tempo.xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_email_from_json_missing() {
+        let body = br#"{"sub":"123","name":"test"}"#;
+        assert_eq!(extract_email_from_json(body), None);
+    }
+
+    #[test]
+    fn test_extract_email_from_json_no_at() {
+        let body = br#"{"email":"notanemail"}"#;
+        assert_eq!(extract_email_from_json(body), None);
+    }
+
+    #[test]
+    fn test_extract_email_from_json_empty() {
+        let body = br#"{"email":""}"#;
+        assert_eq!(extract_email_from_json(body), None);
+    }
+
+    #[test]
+    fn test_initialize_and_owner() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+            assert_eq!(tls.owner()?, owner);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_set_and_get_notary_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let notary_addr = Address::random();
+        let key_id = FixedBytes::<32>::from([0x01; 32]);
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            tls.set_notary_key(
+                owner,
+                ITLSEmailOwnership::setNotaryKeyCall {
+                    notaryKeyId: key_id,
+                    notaryAddress: notary_addr,
+                },
+            )?;
+
+            let result = tls.get_notary_key(ITLSEmailOwnership::getNotaryKeyCall {
+                notaryKeyId: key_id,
+            })?;
+            assert_eq!(result, notary_addr);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_unauthorized_set_notary_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let non_owner = Address::random();
+        let key_id = FixedBytes::<32>::from([0x01; 32]);
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let result = tls.set_notary_key(
+                non_owner,
+                ITLSEmailOwnership::setNotaryKeyCall {
+                    notaryKeyId: key_id,
+                    notaryAddress: Address::random(),
+                },
+            );
+            assert_eq!(
+                result,
+                Err(TLSEmailOwnershipError::unauthorized().into())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_email_invalid_subject() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let sender = Address::random();
+        let wrong_subject = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let result = tls.verify_email(
+                sender,
+                ITLSEmailOwnership::verifyEmailCall {
+                    notaryKeyId: FixedBytes::<32>::ZERO,
+                    subject: wrong_subject,
+                    serverName: ALLOWED_SERVER_NAME.to_string(),
+                    endpoint: ALLOWED_ENDPOINT.to_string(),
+                    responseBody: vec![].into(),
+                    v: 0,
+                    r: FixedBytes::<32>::ZERO,
+                    s: FixedBytes::<32>::ZERO,
+                },
+            );
+            assert_eq!(
+                result,
+                Err(TLSEmailOwnershipError::invalid_subject().into())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_email_invalid_server() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let sender = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let result = tls.verify_email(
+                sender,
+                ITLSEmailOwnership::verifyEmailCall {
+                    notaryKeyId: FixedBytes::<32>::ZERO,
+                    subject: sender,
+                    serverName: "evil.example.com".to_string(),
+                    endpoint: ALLOWED_ENDPOINT.to_string(),
+                    responseBody: vec![].into(),
+                    v: 0,
+                    r: FixedBytes::<32>::ZERO,
+                    s: FixedBytes::<32>::ZERO,
+                },
+            );
+            assert_eq!(
+                result,
+                Err(TLSEmailOwnershipError::invalid_server_name().into())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_verify_email_end_to_end() -> eyre::Result<()> {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let user = Address::random();
+
+        let notary_signer = PrivateKeySigner::random();
+        let notary_address = notary_signer.address();
+        let notary_key_id = FixedBytes::<32>::from([0x42; 32]);
+
+        let response_body =
+            br#"{"sub":"1234567890","email":"zygimantas@tempo.xyz","email_verified":true}"#;
+        let response_body_hash = keccak256(response_body);
+        let email_hash = keccak256(b"zygimantas@tempo.xyz");
+
+        let digest = compute_attestation_digest(
+            user,
+            ALLOWED_SERVER_NAME,
+            ALLOWED_ENDPOINT,
+            response_body_hash,
+            email_hash,
+            notary_key_id,
+        );
+
+        let sig = notary_signer.sign_hash_sync(&digest)?;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            tls.set_notary_key(
+                owner,
+                ITLSEmailOwnership::setNotaryKeyCall {
+                    notaryKeyId: notary_key_id,
+                    notaryAddress: notary_address,
+                },
+            )?;
+
+            let email = tls.verify_email(
+                user,
+                ITLSEmailOwnership::verifyEmailCall {
+                    notaryKeyId: notary_key_id,
+                    subject: user,
+                    serverName: ALLOWED_SERVER_NAME.to_string(),
+                    endpoint: ALLOWED_ENDPOINT.to_string(),
+                    responseBody: response_body.to_vec().into(),
+                    v: sig.v() as u8,
+                    r: FixedBytes::<32>::from(sig.r().to_be_bytes::<32>()),
+                    s: FixedBytes::<32>::from(sig.s().to_be_bytes::<32>()),
+                },
+            )?;
+
+            assert_eq!(email, "zygimantas@tempo.xyz");
+
+            let claim = tls.get_verified_email(ITLSEmailOwnership::getVerifiedEmailCall {
+                user,
+            })?;
+            assert_eq!(claim.email, "zygimantas@tempo.xyz");
+            assert_eq!(claim.emailHash, email_hash);
+
+            let verified = tls.is_verified(ITLSEmailOwnership::isVerifiedCall { user })?;
+            assert!(verified);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_revoke_email() -> eyre::Result<()> {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let user = Address::random();
+
+        let notary_signer = PrivateKeySigner::random();
+        let notary_address = notary_signer.address();
+        let notary_key_id = FixedBytes::<32>::from([0x42; 32]);
+
+        let response_body =
+            br#"{"sub":"1234567890","email":"zygimantas@tempo.xyz","email_verified":true}"#;
+        let response_body_hash = keccak256(response_body);
+        let email_hash = keccak256(b"zygimantas@tempo.xyz");
+
+        let digest = compute_attestation_digest(
+            user,
+            ALLOWED_SERVER_NAME,
+            ALLOWED_ENDPOINT,
+            response_body_hash,
+            email_hash,
+            notary_key_id,
+        );
+
+        let sig = notary_signer.sign_hash_sync(&digest)?;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            tls.set_notary_key(
+                owner,
+                ITLSEmailOwnership::setNotaryKeyCall {
+                    notaryKeyId: notary_key_id,
+                    notaryAddress: notary_address,
+                },
+            )?;
+
+            tls.verify_email(
+                user,
+                ITLSEmailOwnership::verifyEmailCall {
+                    notaryKeyId: notary_key_id,
+                    subject: user,
+                    serverName: ALLOWED_SERVER_NAME.to_string(),
+                    endpoint: ALLOWED_ENDPOINT.to_string(),
+                    responseBody: response_body.to_vec().into(),
+                    v: sig.v() as u8,
+                    r: FixedBytes::<32>::from(sig.r().to_be_bytes::<32>()),
+                    s: FixedBytes::<32>::from(sig.s().to_be_bytes::<32>()),
+                },
+            )?;
+
+            assert!(tls.is_verified(ITLSEmailOwnership::isVerifiedCall { user })?);
+
+            tls.revoke_my_email(user)?;
+
+            assert!(!tls.is_verified(ITLSEmailOwnership::isVerifiedCall { user })?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_revoke_not_verified() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let user = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut tls = TLSEmailOwnership::new();
+            tls.initialize(owner)?;
+
+            let result = tls.revoke_my_email(user);
+            assert_eq!(
+                result,
+                Err(TLSEmailOwnershipError::not_verified().into())
+            );
+
+            Ok(())
+        })
+    }
+}

--- a/scripts/verify-email.sh
+++ b/scripts/verify-email.sh
@@ -1,113 +1,286 @@
 #!/bin/bash
 #
-# E2E script to verify email ownership on Tempo localnet.
+# E2E email ownership verification on Tempo.
+#
+# Proves on-chain that you own an email address by:
+#   1. Starting a Tempo localnet (builds node + generates genesis)
+#   2. Fetching your email from Google's userinfo API (real HTTPS call)
+#   3. Computing a Notary-signed attestation over the response
+#   4. Submitting the attestation on-chain to the TLSEmailOwnership precompile
+#   5. Querying the precompile to confirm verification
 #
 # Usage:
-#   ./scripts/verify-email.sh <email> [user_private_key]
+#   ./scripts/verify-email.sh <google_access_token>
+#
+# Getting a Google access token:
+#   Option A (gcloud CLI):
+#     gcloud auth login
+#     gcloud auth print-access-token --scopes=email
+#
+#   Option B (OAuth playground):
+#     https://developers.google.com/oauthplayground
+#     Select "Google OAuth2 API v2 > email" scope, authorize, get access token.
 #
 # Prerequisites:
-#   - Tempo localnet running: just localnet
-#   - cast (from foundry) installed
-#   - The genesis must include TLSEmailOwnership precompile initialization
-#
-# Example:
-#   ./scripts/verify-email.sh zygimantas@tempo.xyz
+#   - cast (foundry) installed
+#   - curl installed
+#   - jq installed
+#   - cargo installed (to build the node)
 #
 set -euo pipefail
 
-EMAIL="${1:?Usage: $0 <email> [user_private_key]}"
-
-ETH_RPC_URL="${ETH_RPC_URL:-http://localhost:8545}"
+# --- Configuration ---
+RPC_URL="http://localhost:8545"
+RPC_PORT=8545
 PRECOMPILE="0x714E000000000000000000000000000000000000"
+GOOGLE_USERINFO_URL="https://www.googleapis.com/oauth2/v3/userinfo"
+BUILD_PROFILE="${BUILD_PROFILE:-dev}"
+NODE_LOG="./localnet/logs/node.log"
 
-# Dev Notary private key (Hardhat account #0 — registered in genesis)
+# Dev Notary key (Hardhat account #0 — pre-registered in genesis)
 NOTARY_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 NOTARY_KEY_ID="0x0101010101010101010101010101010101010101010101010101010101010101"
 
-# User wallet — generate a fresh one or use provided
-if [ -n "${2:-}" ]; then
-    USER_PK="$2"
-    USER_ADDR=$(cast wallet address "$USER_PK")
-else
-    echo "==> Generating a fresh user wallet..."
-    WALLET_JSON=$(cast wallet new --json)
-    USER_PK=$(echo "$WALLET_JSON" | jq -r '.[0].private_key')
-    USER_ADDR=$(echo "$WALLET_JSON" | jq -r '.[0].address')
+# --- Input ---
+GOOGLE_TOKEN="${1:-}"
+if [ -z "$GOOGLE_TOKEN" ]; then
+    echo "Usage: $0 <google_access_token>"
+    echo ""
+    echo "Get a token via:  gcloud auth print-access-token --scopes=email"
+    echo "Or:               https://developers.google.com/oauthplayground"
+    exit 1
 fi
 
+# --- Dependency checks ---
+for cmd in cast curl jq cargo; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' is not installed."
+        exit 1
+    fi
+done
+
+# --- Cleanup handler ---
+NODE_PID=""
+cleanup() {
+    if [ -n "$NODE_PID" ] && kill -0 "$NODE_PID" 2>/dev/null; then
+        echo ""
+        echo "==> Shutting down localnet (PID $NODE_PID)..."
+        kill "$NODE_PID" 2>/dev/null || true
+        wait "$NODE_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# --- Helper: wait for RPC ---
+wait_for_rpc() {
+    local timeout=120
+    local elapsed=0
+    echo "    Waiting for RPC at $RPC_URL (timeout ${timeout}s)..."
+    while [ $elapsed -lt $timeout ]; do
+        if curl -s -X POST "$RPC_URL" \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' 2>/dev/null | jq -e '.result' &>/dev/null; then
+            echo "    RPC is up."
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "    ERROR: RPC did not become available within ${timeout}s"
+    echo "    Check logs: $NODE_LOG"
+    exit 1
+}
+
+# --- Helper: wait for blocks ---
+wait_for_blocks() {
+    local count=${1:-2}
+    echo "    Waiting for $count blocks..."
+    local start_block
+    start_block=$(curl -s -X POST "$RPC_URL" \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq -r '.result' | xargs printf "%d\n")
+    local target=$((start_block + count))
+    local timeout=30
+    local elapsed=0
+    while [ $elapsed -lt $timeout ]; do
+        local current
+        current=$(curl -s -X POST "$RPC_URL" \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq -r '.result' | xargs printf "%d\n")
+        if [ "$current" -ge "$target" ]; then
+            echo "    Block $current reached."
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "    WARNING: timeout waiting for blocks"
+}
+
 echo ""
-echo "=========================================="
-echo " TLS Email Ownership Verification"
-echo "=========================================="
-echo " Email:      $EMAIL"
-echo " User:       $USER_ADDR"
-echo " RPC:        $ETH_RPC_URL"
-echo " Precompile: $PRECOMPILE"
-echo "=========================================="
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║           Tempo Email Ownership Verification                ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 
-# Step 1: Fund the user wallet
-echo "==> Step 1: Funding user wallet..."
-cast rpc tempo_fundAddress "$USER_ADDR" --rpc-url "$ETH_RPC_URL" > /dev/null 2>&1
-sleep 2
-BALANCE=$(cast balance "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
-echo "    Balance: $BALANCE wei"
+# =========================================================================
+# STEP 1: Fetch email from Google
+# =========================================================================
+echo "==> Step 1: Fetching email from Google userinfo API..."
 
-# Step 2: Create the Google userinfo response body (simulated TLSNotary session)
+RESPONSE_BODY=$(curl -sf -H "Authorization: Bearer $GOOGLE_TOKEN" "$GOOGLE_USERINFO_URL") || {
+    echo "    ERROR: Failed to fetch Google userinfo. Is your token valid?"
+    echo "    Get a new one: gcloud auth print-access-token --scopes=email"
+    exit 1
+}
+
+EMAIL=$(echo "$RESPONSE_BODY" | jq -r '.email // empty')
+EMAIL_VERIFIED=$(echo "$RESPONSE_BODY" | jq -r '.email_verified // "false"')
+
+if [ -z "$EMAIL" ]; then
+    echo "    ERROR: No email found in Google response."
+    echo "    Response: $RESPONSE_BODY"
+    exit 1
+fi
+
+if [ "$EMAIL_VERIFIED" != "true" ]; then
+    echo "    WARNING: Google reports email is not verified."
+fi
+
+echo "    Email:    $EMAIL"
+echo "    Verified: $EMAIL_VERIFIED"
+echo "    Response: $(echo "$RESPONSE_BODY" | jq -c .)"
+
+# =========================================================================
+# STEP 2: Start localnet
+# =========================================================================
 echo ""
-echo "==> Step 2: Creating Google userinfo response (simulated TLSNotary session)..."
-RESPONSE_BODY="{\"sub\":\"1234567890\",\"email\":\"${EMAIL}\",\"email_verified\":true,\"name\":\"Zygimantas\",\"picture\":\"https://example.com/photo.jpg\"}"
-echo "    Response: $RESPONSE_BODY"
+echo "==> Step 2: Building and starting Tempo localnet..."
 
-# Step 3: Compute attestation digest
+# Check if port is already in use
+if curl -s -X POST "$RPC_URL" -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' 2>/dev/null | jq -e '.result' &>/dev/null; then
+    echo "    Localnet already running at $RPC_URL, reusing."
+else
+    # Clean slate
+    rm -rf ./localnet/ 2>/dev/null || true
+    mkdir -p ./localnet/logs
+
+    echo "    Generating genesis..."
+    cargo run -p tempo-xtask --profile "$BUILD_PROFILE" -- \
+        generate-genesis --output ./localnet -a 100 --no-dkg-in-genesis 2>&1 | tail -5
+
+    echo "    Starting node..."
+    cargo run --bin tempo --profile "$BUILD_PROFILE" -- \
+        node \
+        --chain ./localnet/genesis.json \
+        --dev \
+        --dev.block-time 1sec \
+        --datadir ./localnet/reth \
+        --http \
+        --http.addr 0.0.0.0 \
+        --http.port "$RPC_PORT" \
+        --http.api all \
+        --engine.disable-precompile-cache \
+        --engine.legacy-state-root \
+        --builder.gaslimit 3000000000 \
+        --builder.max-tasks 8 \
+        --builder.deadline 3 \
+        --log.file.directory ./localnet/logs \
+        --faucet.enabled \
+        --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+        --faucet.amount 1000000000000 \
+        --faucet.address 0x20c0000000000000000000000000000000000001 \
+        > "$NODE_LOG" 2>&1 &
+    NODE_PID=$!
+    echo "    Node PID: $NODE_PID"
+
+    wait_for_rpc
+    wait_for_blocks 2
+fi
+
+# =========================================================================
+# STEP 3: Create user wallet and fund it
+# =========================================================================
 echo ""
-echo "==> Step 3: Computing attestation digest..."
+echo "==> Step 3: Creating and funding user wallet..."
 
-RESPONSE_BODY_HEX=$(cast --from-utf8 "$RESPONSE_BODY")
-RESPONSE_HASH=$(cast keccak "$RESPONSE_BODY_HEX")
-EMAIL_HASH=$(cast keccak "$(cast --from-utf8 "$EMAIL")")
+WALLET_JSON=$(cast wallet new --json)
+USER_PK=$(echo "$WALLET_JSON" | jq -r '.[0].private_key')
+USER_ADDR=$(echo "$WALLET_JSON" | jq -r '.[0].address')
+
+echo "    Address: $USER_ADDR"
+
+cast rpc tempo_fundAddress "$USER_ADDR" --rpc-url "$RPC_URL" > /dev/null 2>&1
+wait_for_blocks 2
+
+# =========================================================================
+# STEP 4: Compute attestation digest and sign
+# =========================================================================
+echo ""
+echo "==> Step 4: Creating Notary attestation..."
+
 SERVER_NAME="www.googleapis.com"
 ENDPOINT="/oauth2/v3/userinfo"
-SERVER_NAME_HASH=$(cast keccak "$(cast --from-utf8 "$SERVER_NAME")")
-ENDPOINT_HASH=$(cast keccak "$(cast --from-utf8 "$ENDPOINT")")
 
-# abi.encodePacked("TempoEmailAttestationV1", subject, serverNameHash, endpointHash, responseBodyHash, emailHash, notaryKeyId)
-DOMAIN_HEX=$(cast --from-utf8 "TempoEmailAttestationV1")
-SUBJECT_HEX=$(echo "$USER_ADDR" | sed 's/0x//')
+# Convert to hex for hashing
+RESPONSE_BODY_HEX=$(cast --from-utf8 "$RESPONSE_BODY")
+EMAIL_HEX=$(cast --from-utf8 "$EMAIL")
+SERVER_NAME_HEX=$(cast --from-utf8 "$SERVER_NAME")
+ENDPOINT_HEX=$(cast --from-utf8 "$ENDPOINT")
 
-# Remove 0x prefix for concatenation
+# Compute hashes
+RESPONSE_HASH=$(cast keccak "$RESPONSE_BODY_HEX")
+EMAIL_HASH=$(cast keccak "$EMAIL_HEX")
+SERVER_NAME_HASH=$(cast keccak "$SERVER_NAME_HEX")
+ENDPOINT_HASH=$(cast keccak "$ENDPOINT_HEX")
+
+echo "    responseBodyHash: $RESPONSE_HASH"
+echo "    emailHash:        $EMAIL_HASH"
+
+# Build the attestation digest:
+#   keccak256(abi.encodePacked(
+#     "TempoEmailAttestationV1",
+#     subject,
+#     keccak256(serverName),
+#     keccak256(endpoint),
+#     responseBodyHash,
+#     emailHash,
+#     notaryKeyId
+#   ))
+DOMAIN_HEX=$(cast --from-utf8 "TempoEmailAttestationV1" | sed 's/0x//')
+SUBJECT_RAW=$(echo "$USER_ADDR" | sed 's/0x//')
 SERVER_NAME_HASH_RAW=$(echo "$SERVER_NAME_HASH" | sed 's/0x//')
 ENDPOINT_HASH_RAW=$(echo "$ENDPOINT_HASH" | sed 's/0x//')
 RESPONSE_HASH_RAW=$(echo "$RESPONSE_HASH" | sed 's/0x//')
 EMAIL_HASH_RAW=$(echo "$EMAIL_HASH" | sed 's/0x//')
 NOTARY_KEY_ID_RAW=$(echo "$NOTARY_KEY_ID" | sed 's/0x//')
-DOMAIN_HEX_RAW=$(echo "$DOMAIN_HEX" | sed 's/0x//')
 
-PACKED="0x${DOMAIN_HEX_RAW}${SUBJECT_HEX}${SERVER_NAME_HASH_RAW}${ENDPOINT_HASH_RAW}${RESPONSE_HASH_RAW}${EMAIL_HASH_RAW}${NOTARY_KEY_ID_RAW}"
+PACKED="0x${DOMAIN_HEX}${SUBJECT_RAW}${SERVER_NAME_HASH_RAW}${ENDPOINT_HASH_RAW}${RESPONSE_HASH_RAW}${EMAIL_HASH_RAW}${NOTARY_KEY_ID_RAW}"
 DIGEST=$(cast keccak "$PACKED")
 
-echo "    Digest: $DIGEST"
+echo "    digest:           $DIGEST"
 
-# Step 4: Notary signs the attestation
-echo ""
-echo "==> Step 4: Notary signing attestation..."
+# Sign with Notary key (--no-hash because digest is already a hash)
 SIG=$(cast wallet sign --no-hash "$DIGEST" --private-key "$NOTARY_PK")
-echo "    Signature: ${SIG:0:20}..."
 
-# Parse signature into r, s, v
-R="0x$(echo "$SIG" | sed 's/0x//' | cut -c1-64)"
-S="0x$(echo "$SIG" | sed 's/0x//' | cut -c65-128)"
-V_HEX=$(echo "$SIG" | sed 's/0x//' | cut -c129-130)
+# Parse r, s, v from the 65-byte signature
+SIG_RAW=$(echo "$SIG" | sed 's/0x//')
+R="0x${SIG_RAW:0:64}"
+S="0x${SIG_RAW:64:64}"
+V_HEX="${SIG_RAW:128:2}"
 V=$((16#$V_HEX))
 
-echo "    r: $R"
-echo "    s: $S"
-echo "    v: $V"
+echo "    signature:        0x${SIG_RAW:0:16}..."
+echo "    v=$V"
 
-# Step 5: Submit the attestation on-chain
+# =========================================================================
+# STEP 5: Submit attestation on-chain
+# =========================================================================
 echo ""
-echo "==> Step 5: Submitting attestation on-chain..."
-TX_HASH=$(cast send "$PRECOMPILE" \
+echo "==> Step 5: Submitting attestation to precompile..."
+
+TX_RESULT=$(cast send "$PRECOMPILE" \
     "verifyEmail(bytes32,address,string,string,bytes,uint8,bytes32,bytes32)" \
     "$NOTARY_KEY_ID" \
     "$USER_ADDR" \
@@ -118,27 +291,66 @@ TX_HASH=$(cast send "$PRECOMPILE" \
     "$R" \
     "$S" \
     --private-key "$USER_PK" \
-    --rpc-url "$ETH_RPC_URL" \
-    --json 2>&1 | jq -r '.transactionHash')
-echo "    TX: $TX_HASH"
+    --rpc-url "$RPC_URL" \
+    --json 2>&1)
 
-sleep 2
+TX_HASH=$(echo "$TX_RESULT" | jq -r '.transactionHash // empty')
+TX_STATUS=$(echo "$TX_RESULT" | jq -r '.status // empty')
 
-# Step 6: Verify on-chain
+if [ -z "$TX_HASH" ]; then
+    echo "    ERROR: Transaction failed to send."
+    echo "    $TX_RESULT"
+    exit 1
+fi
+
+echo "    TX hash:  $TX_HASH"
+echo "    Status:   $TX_STATUS"
+
+if [ "$TX_STATUS" = "0x0" ]; then
+    echo "    ERROR: Transaction reverted."
+    echo "    Debug: cast run $TX_HASH --rpc-url $RPC_URL"
+    exit 1
+fi
+
+wait_for_blocks 1
+
+# =========================================================================
+# STEP 6: Query on-chain state
+# =========================================================================
 echo ""
 echo "==> Step 6: Querying on-chain verification..."
 
-IS_VERIFIED=$(cast call "$PRECOMPILE" "isVerified(address)(bool)" "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
-echo "    isVerified($USER_ADDR) = $IS_VERIFIED"
+IS_VERIFIED=$(cast call "$PRECOMPILE" \
+    "isVerified(address)(bool)" "$USER_ADDR" \
+    --rpc-url "$RPC_URL")
 
-CLAIM=$(cast call "$PRECOMPILE" "getVerifiedEmail(address)((string,bytes32,uint64,bytes32))" "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
-echo "    getVerifiedEmail($USER_ADDR) = $CLAIM"
+CLAIM_RAW=$(cast call "$PRECOMPILE" \
+    "getVerifiedEmail(address)((string,bytes32,uint64,bytes32))" "$USER_ADDR" \
+    --rpc-url "$RPC_URL")
 
+ONCHAIN_EMAIL=$(echo "$CLAIM_RAW" | head -1 | xargs)
+
+echo "    isVerified:  $IS_VERIFIED"
+echo "    onchainEmail: $ONCHAIN_EMAIL"
+
+# =========================================================================
+# RESULT
+# =========================================================================
 echo ""
-echo "=========================================="
+echo "╔══════════════════════════════════════════════════════════════╗"
 if [ "$IS_VERIFIED" = "true" ]; then
-    echo " ✅ SUCCESS: $EMAIL is verified on-chain for $USER_ADDR"
+    echo "║  ✅  $EMAIL"
+    printf "║      is verified on-chain for %-28s ║\n" "$USER_ADDR"
+    echo "║                                                              ║"
+    echo "║  Precompile: $PRECOMPILE  ║"
+    echo "║  TX:         $TX_HASH  ║"
 else
-    echo " ❌ FAILED: verification did not succeed"
+    echo "║  ❌  Verification FAILED                                     ║"
+    echo "║      Check transaction: cast run $TX_HASH"
 fi
-echo "=========================================="
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+if [ "$IS_VERIFIED" != "true" ]; then
+    exit 1
+fi

--- a/scripts/verify-email.sh
+++ b/scripts/verify-email.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# E2E script to verify email ownership on Tempo localnet.
+#
+# Usage:
+#   ./scripts/verify-email.sh <email> [user_private_key]
+#
+# Prerequisites:
+#   - Tempo localnet running: just localnet
+#   - cast (from foundry) installed
+#   - The genesis must include TLSEmailOwnership precompile initialization
+#
+# Example:
+#   ./scripts/verify-email.sh zygimantas@tempo.xyz
+#
+set -euo pipefail
+
+EMAIL="${1:?Usage: $0 <email> [user_private_key]}"
+
+ETH_RPC_URL="${ETH_RPC_URL:-http://localhost:8545}"
+PRECOMPILE="0x714E000000000000000000000000000000000000"
+
+# Dev Notary private key (Hardhat account #0 — registered in genesis)
+NOTARY_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+NOTARY_KEY_ID="0x0101010101010101010101010101010101010101010101010101010101010101"
+
+# User wallet — generate a fresh one or use provided
+if [ -n "${2:-}" ]; then
+    USER_PK="$2"
+    USER_ADDR=$(cast wallet address "$USER_PK")
+else
+    echo "==> Generating a fresh user wallet..."
+    WALLET_JSON=$(cast wallet new --json)
+    USER_PK=$(echo "$WALLET_JSON" | jq -r '.[0].private_key')
+    USER_ADDR=$(echo "$WALLET_JSON" | jq -r '.[0].address')
+fi
+
+echo ""
+echo "=========================================="
+echo " TLS Email Ownership Verification"
+echo "=========================================="
+echo " Email:      $EMAIL"
+echo " User:       $USER_ADDR"
+echo " RPC:        $ETH_RPC_URL"
+echo " Precompile: $PRECOMPILE"
+echo "=========================================="
+echo ""
+
+# Step 1: Fund the user wallet
+echo "==> Step 1: Funding user wallet..."
+cast rpc tempo_fundAddress "$USER_ADDR" --rpc-url "$ETH_RPC_URL" > /dev/null 2>&1
+sleep 2
+BALANCE=$(cast balance "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
+echo "    Balance: $BALANCE wei"
+
+# Step 2: Create the Google userinfo response body (simulated TLSNotary session)
+echo ""
+echo "==> Step 2: Creating Google userinfo response (simulated TLSNotary session)..."
+RESPONSE_BODY="{\"sub\":\"1234567890\",\"email\":\"${EMAIL}\",\"email_verified\":true,\"name\":\"Zygimantas\",\"picture\":\"https://example.com/photo.jpg\"}"
+echo "    Response: $RESPONSE_BODY"
+
+# Step 3: Compute attestation digest
+echo ""
+echo "==> Step 3: Computing attestation digest..."
+
+RESPONSE_BODY_HEX=$(cast --from-utf8 "$RESPONSE_BODY")
+RESPONSE_HASH=$(cast keccak "$RESPONSE_BODY_HEX")
+EMAIL_HASH=$(cast keccak "$(cast --from-utf8 "$EMAIL")")
+SERVER_NAME="www.googleapis.com"
+ENDPOINT="/oauth2/v3/userinfo"
+SERVER_NAME_HASH=$(cast keccak "$(cast --from-utf8 "$SERVER_NAME")")
+ENDPOINT_HASH=$(cast keccak "$(cast --from-utf8 "$ENDPOINT")")
+
+# abi.encodePacked("TempoEmailAttestationV1", subject, serverNameHash, endpointHash, responseBodyHash, emailHash, notaryKeyId)
+DOMAIN_HEX=$(cast --from-utf8 "TempoEmailAttestationV1")
+SUBJECT_HEX=$(echo "$USER_ADDR" | sed 's/0x//')
+
+# Remove 0x prefix for concatenation
+SERVER_NAME_HASH_RAW=$(echo "$SERVER_NAME_HASH" | sed 's/0x//')
+ENDPOINT_HASH_RAW=$(echo "$ENDPOINT_HASH" | sed 's/0x//')
+RESPONSE_HASH_RAW=$(echo "$RESPONSE_HASH" | sed 's/0x//')
+EMAIL_HASH_RAW=$(echo "$EMAIL_HASH" | sed 's/0x//')
+NOTARY_KEY_ID_RAW=$(echo "$NOTARY_KEY_ID" | sed 's/0x//')
+DOMAIN_HEX_RAW=$(echo "$DOMAIN_HEX" | sed 's/0x//')
+
+PACKED="0x${DOMAIN_HEX_RAW}${SUBJECT_HEX}${SERVER_NAME_HASH_RAW}${ENDPOINT_HASH_RAW}${RESPONSE_HASH_RAW}${EMAIL_HASH_RAW}${NOTARY_KEY_ID_RAW}"
+DIGEST=$(cast keccak "$PACKED")
+
+echo "    Digest: $DIGEST"
+
+# Step 4: Notary signs the attestation
+echo ""
+echo "==> Step 4: Notary signing attestation..."
+SIG=$(cast wallet sign --no-hash "$DIGEST" --private-key "$NOTARY_PK")
+echo "    Signature: ${SIG:0:20}..."
+
+# Parse signature into r, s, v
+R="0x$(echo "$SIG" | sed 's/0x//' | cut -c1-64)"
+S="0x$(echo "$SIG" | sed 's/0x//' | cut -c65-128)"
+V_HEX=$(echo "$SIG" | sed 's/0x//' | cut -c129-130)
+V=$((16#$V_HEX))
+
+echo "    r: $R"
+echo "    s: $S"
+echo "    v: $V"
+
+# Step 5: Submit the attestation on-chain
+echo ""
+echo "==> Step 5: Submitting attestation on-chain..."
+TX_HASH=$(cast send "$PRECOMPILE" \
+    "verifyEmail(bytes32,address,string,string,bytes,uint8,bytes32,bytes32)" \
+    "$NOTARY_KEY_ID" \
+    "$USER_ADDR" \
+    "$SERVER_NAME" \
+    "$ENDPOINT" \
+    "$RESPONSE_BODY_HEX" \
+    "$V" \
+    "$R" \
+    "$S" \
+    --private-key "$USER_PK" \
+    --rpc-url "$ETH_RPC_URL" \
+    --json 2>&1 | jq -r '.transactionHash')
+echo "    TX: $TX_HASH"
+
+sleep 2
+
+# Step 6: Verify on-chain
+echo ""
+echo "==> Step 6: Querying on-chain verification..."
+
+IS_VERIFIED=$(cast call "$PRECOMPILE" "isVerified(address)(bool)" "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
+echo "    isVerified($USER_ADDR) = $IS_VERIFIED"
+
+CLAIM=$(cast call "$PRECOMPILE" "getVerifiedEmail(address)((string,bytes32,uint64,bytes32))" "$USER_ADDR" --rpc-url "$ETH_RPC_URL")
+echo "    getVerifiedEmail($USER_ADDR) = $CLAIM"
+
+echo ""
+echo "=========================================="
+if [ "$IS_VERIFIED" = "true" ]; then
+    echo " ✅ SUCCESS: $EMAIL is verified on-chain for $USER_ADDR"
+else
+    echo " ❌ FAILED: verification did not succeed"
+fi
+echo "=========================================="


### PR DESCRIPTION
## Summary
On-chain email ownership verification using TLSNotary attestations.

## Motivation
Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770668109621179

Enables users to prove they own an email address (e.g. `zygimantas@tempo.xyz`) by running a TLSNotary session against Google's userinfo API, having a trusted Notary sign a compact attestation, and submitting it on-chain.

## Changes
- `crates/contracts/src/precompiles/tls_email_ownership.rs` — ABI: `ITLSEmailOwnership` interface with 9 functions + 10 error types
- `crates/precompiles/src/tls_email_ownership/mod.rs` — Core logic: attestation verification, JSON email extraction, notary key management, claim storage
- `crates/precompiles/src/tls_email_ownership/dispatch.rs` — Call dispatch routing
- `crates/precompiles/src/lib.rs` — Registration at `0x714E000000000000000000000000000000000000`
- `crates/precompiles/src/error.rs` — Error variant + registry entry
- `crates/contracts/src/precompiles/mod.rs` — Module export + address constant

## Design
- Compact Notary-signed attestation (not full TLSNotary proof on-chain)
- secp256k1 ECDSA signature verification via `ecrecover`
- Owner-managed Notary key registry
- Digest binds: domain separator + subject + server + endpoint + response hash + email hash + key ID
- Allowlisted to `www.googleapis.com` + `/oauth2/v3/userinfo`

## Testing
```
cargo check -p tempo-precompiles  # ✅
cargo test -p tempo-precompiles --lib tls_email_ownership  # 16/16 tests pass
```

Includes E2E test with real secp256k1 signing (`test_verify_email_end_to_end`).