### PR TITLE
feat(net): bump reth for disconnect metrics direction label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,7 +4748,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7707,7 +7707,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7763,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7887,7 +7887,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7976,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8058,7 +8058,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8088,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8128,7 +8128,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8211,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8269,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8297,7 +8297,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8345,7 +8345,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "futures",
  "pin-project",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8453,7 +8453,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8468,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8484,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8607,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "clap",
  "eyre",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8645,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8705,7 +8705,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8735,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8759,7 +8759,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-evm 0.27.2",
  "alloy-primitives",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8812,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "serde",
  "serde_json",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "bytes",
  "futures",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "bindgen",
  "cc",
@@ -8947,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "futures",
  "metrics",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9039,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9102,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9343,7 +9343,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "bytes",
  "eyre",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9521,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9700,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9771,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.27.2",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9914,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9944,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9994,7 +9994,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10035,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10129,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "clap",
  "eyre",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "clap",
  "eyre",
@@ -10190,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10368,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.2"
-source = "git+https://github.com/paradigmxyz/reth?branch=mattsse%2Fsplit-disconnect-metrics-direction#10f6fb8a4be650c8bde870963789c66b3a8ca847"
+source = "git+https://github.com/paradigmxyz/reth?branch=feat%2Fbacked-off-peers-reason-label#23ef36a2496064c651a87b2c0b921b3d7e50c105"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,51 +119,51 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 # reth v1.10.1
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "mattsse/split-disconnect-metrics-direction", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "feat/backed-off-peers-reason-label", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
## Summary
Bumps reth to include direction labels on disconnect and backed_off_peers metrics.

## Motivation
Needed to debug peering issues — can't currently distinguish whether our nodes are rejecting peers or being rejected.

Upstream PR: https://github.com/paradigmxyz/reth/pull/22002

## Changes
- Bumps all reth deps to `mattsse/split-disconnect-metrics-direction` branch

## TODO
- [ ] Wait for reth PR to merge
- [ ] Update rev to merged commit SHA
- [ ] Fix any breaking changes from reth bump

Thread: https://tempoxyz.slack.com/archives/C09FQDW2ZRP/p1770669485004379