### PR TITLE
feat: add tracy feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,6 +4241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,6 +5667,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
 
 [[package]]
 name = "lru"
@@ -7889,10 +7917,12 @@ dependencies = [
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
+ "reth-tracing",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
  "tikv-jemallocator",
+ "tracy-client",
 ]
 
 [[package]]
@@ -10170,6 +10200,8 @@ dependencies = [
  "tracing-logfmt",
  "tracing-samply",
  "tracing-subscriber 0.3.22",
+ "tracing-tracy",
+ "tracy-client",
 ]
 
 [[package]]
@@ -13029,6 +13061,39 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+ "tracy-client",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f6fc3baeac5d86ab90c772e9e30620fc653bf1864295029921a15ef478e6a5"
+dependencies = [
+ "loom",
+ "once_cell",
+ "rustc-demangle",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
+dependencies = [
+ "cc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -103,6 +103,16 @@ jemalloc-prof = [
 	"reth-ethereum/jemalloc-prof",
 ]
 
+tracy = [
+	"reth-ethereum-cli/tracy",
+	"tempo-node/tracy",
+]
+tracy-allocator = [
+	"reth-cli-util/tracy-allocator",
+	"reth-ethereum-cli/tracy-allocator",
+	"tracy",
+]
+
 min-error-logs = [
 	"tracing/release_max_level_error",
 	"reth-ethereum-cli/min-error-logs",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -118,6 +118,8 @@ jemalloc-prof = [
 	"reth-node-metrics/jemalloc-prof",
 ]
 
+tracy = ["reth-node-core/tracy"]
+
 min-error-logs = ["reth-node-core/min-error-logs"]
 min-warn-logs = ["reth-node-core/min-warn-logs"]
 min-info-logs = ["reth-node-core/min-info-logs"]


### PR DESCRIPTION
## Summary
Add `tracy` and `tracy-allocator` feature flags to tempo that propagate to reth, matching the same pattern used in `bin/reth`.

## Changes
- `tempo-node`: add `tracy` feature → `reth-node-core/tracy`
- `bin/tempo`: add `tracy` feature → `reth-ethereum-cli/tracy` + `tempo-node/tracy`
- `bin/tempo`: add `tracy-allocator` feature → `reth-cli-util/tracy-allocator` + `reth-ethereum-cli/tracy-allocator` + `tracy`

Note: samply (`tracing-samply`) is always compiled in `reth-tracing` and requires no feature flag.

## Testing
```
cargo check -p tempo --features tracy
cargo check -p tempo --features tracy-allocator
```

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770675735110479