### PR TITLE
ci(docker): publish tempo image to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,9 @@ jobs:
         id: meta-tempo
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ${{ env.REGISTRY }}/tempo
+          images: |
+            ${{ env.REGISTRY }}/tempo
+            docker.io/tempoxyz/tempo
           bake-target: tempo
           tags: |
             type=schedule,pattern=nightly
@@ -117,6 +119,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - id: shortsha
         run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Publish the `tempo` Docker image to Docker Hub (`docker.io/tempoxyz/tempo`) in addition to GHCR.

## Changes
- Added `docker.io/tempoxyz/tempo` as a second image in the `meta-tempo` metadata step so all tags get applied to both registries
- Added a Docker Hub login step using `vars.DOCKER_HUB_USER` and `secrets.DOCKER_HUB_TOKEN`

Only the `tempo` image is published to Docker Hub; `tempo-bench`, `tempo-sidecar`, and `tempo-xtask` remain GHCR-only.

Thread: https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770681714419049