### PR TITLE
ci(docker): add raw version tag on tag pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
@@ -73,6 +74,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
@@ -93,6 +95,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
@@ -113,6 +116,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main


### PR DESCRIPTION
## Summary
Adds a raw `{{version}}` tag to all Docker images, enabled only when `github.ref_type == 'tag'`.

This produces a clean version tag (e.g. `1.2.3`) alongside the existing semver tags on release pushes.

## Changes
- Added `type=raw,value={{version}},enable=${{ github.ref_type == 'tag' }}` to all four metadata steps (tempo, tempo-bench, tempo-sidecar, tempo-xtask)

Thread: https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770694650306739