### PR TITLE
refactor(test): consolidate Set<T> unit tests to reduce SLOC

### DIFF
--- a/crates/precompiles/src/storage/types/set.rs
+++ b/crates/precompiles/src/storage/types/set.rs
@@ -719,7 +719,10 @@ mod tests {
                 handler.insert(U256::from(i))?;
             }
 
-            assert_eq!(handler.read_range(1, 4)?, vec![U256::from(1), U256::from(2), U256::from(3)]);
+            assert_eq!(
+                handler.read_range(1, 4)?,
+                vec![U256::from(1), U256::from(2), U256::from(3)]
+            );
             // end > len clamps
             assert_eq!(handler.read_range(0, 100)?.len(), 5);
             // start > end returns empty
@@ -738,7 +741,11 @@ mod tests {
 
             // Write to grow (1 → 3)
             handler.insert(U256::from(1))?;
-            handler.write(Set::from(vec![U256::from(10), U256::from(20), U256::from(30)]))?;
+            handler.write(Set::from(vec![
+                U256::from(10),
+                U256::from(20),
+                U256::from(30),
+            ]))?;
             assert_eq!(handler.len()?, 3);
             assert!(!handler.contains(&U256::from(1))?);
             assert!(handler.contains(&U256::from(10))?);


### PR DESCRIPTION
## Summary
Consolidate redundant Set<T> unit tests from 27 functions into 11 focused tests, cutting **290 lines** while preserving the same coverage.

## Changes
- Merge 3 empty-constructor tests into `test_set_constructors_and_edge_cases`
- Merge empty-state checks (contains, remove, at, read, read_range) into `test_handler_empty_state`
- Merge insert dup / remove single / insert-after-remove into `test_handler_insert_remove_basics`
- Merge 3 remove-swap tests into `test_handler_remove_swap_semantics`
- Merge at + Index<usize> into `test_handler_at_and_index`
- Merge 3 read_range tests into one
- Merge write grow/shrink/empty into one
- Merge delete + delete_clears_positions into one
- Merge base_slot + debug + clone into `test_handler_metadata`
- Remove redundant `contains_empty` (covered by `empty_state`)
- Remove duplicate negative-contains loop in cycles test (proptest covers this)

## Testing
```
cargo test -p tempo-precompiles -- storage::types::set::tests
# 22 passed; 0 failed
```

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770720526841399