### PR TITLE
feat: enable tracy feature in profiling builds

### DIFF
--- a/docker-bake-profiling.hcl
+++ b/docker-bake-profiling.hcl
@@ -15,7 +15,7 @@ target "chef" {
   platforms = ["linux/amd64", "linux/arm64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp,tracy"
     EXTRA_RUSTFLAGS = "-C force-frame-pointers=yes"
   }
 }


### PR DESCRIPTION
Adds the `tracy` feature to profiling Docker builds, enabling Tracy instrumentation for performance analysis alongside samply profiling.

This works in conjunction with:
- https://github.com/tempoxyz/tempo/commit/bedc4d3a9a355a2f8c175bd53c214404e2adba26 (added tracy feature flags)

