### PR TITLE
docs(tip-1016): add subcall gas propagation and intrinsic gas sections

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -152,7 +152,7 @@ At 500M payment lane regular gas limit:
 
 Two runtime counters track gas:
 
-- **`gas_remaining`**: ordinary EVM gas (regular + storage creation), initialized to `tx.gas_limit`.
+- **`gas_remaining`**: total EVM gas (regular + storage creation), initialized to `tx.gas_limit`.
 - **`regular_gas_remaining`**: regular gas only, initialized to `max(tx.gas_limit, max_transaction_gas_limit)`. Global counter — always propagated to subcalls, always returned to parent, never reverted.
 
 Subcall outcomes:


### PR DESCRIPTION
## Summary
- Adds **Subcall Gas Propagation** section: explains `regular_gas_remaining` as a global counter with behavior on success/revert/halt
- Adds **Intrinsic Gas** section: explains how intrinsic gas splits between regular and storage creation components
- Depends on #2585 (rename execution gas → regular gas)

## Test plan
- [x] Verify new sections are inserted before "Changes from TIP-1000"
- [ ] Review technical accuracy of subcall propagation semantics
- [ ] Review intrinsic gas split description