### PR TITLE
fix: default snapshot download URL to mainnet (4217)

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -118,7 +118,7 @@ pub(crate) struct TelemetryConfig {
 fn init_download_urls() {
     let download_defaults = DownloadDefaults {
         available_snapshots: vec![
-            Cow::Borrowed("https://snapshots.tempoxyz.dev/4217 (mainnet)"),
+            Cow::Owned(format!("{DEFAULT_DOWNLOAD_URL} (mainnet)")),
             Cow::Borrowed("https://snapshots.tempoxyz.dev/42431 (moderato)"),
             Cow::Borrowed("https://snapshots.tempoxyz.dev/42429 (andantino)"),
         ],


### PR DESCRIPTION
`tempo download --chain mainnet` was downloading the moderato (42431) snapshot instead of mainnet (4217).

