### PR TITLE
chore(consensus): update to commonware v2026.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,8 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa29e885815ceb4e9ac4e1cb840aa96fb5493ad0c3ea5ac401212385137736"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2460,8 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f6cacfdaad565ab6565b7c896cdf9d6d58a528e162150c2697d4d925a9938e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2474,8 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec7c97f3cb71e54a24a12af393d063d4daacf17ffcb69d79b9b519e5d19bafe"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2502,8 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea20d380b73eb74eb977c40b0ef3df88ad7a428a582c38ada2d64fd7a1ef909b"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2536,8 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241d65be9575e6de767236514985c9906e8ef0f6f6a5ce8faa6719886bf23270"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2545,8 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b7bdc304661c89e6d294c5581367db81a16cf161b27c036a9f855e317b21b8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2557,8 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c6de52eb60c386ad2376d44ff247c41e2e7b03a436041e7065a2054799e31e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2570,8 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3035f95ed50d7c440f0fbab6593409226bb42dfe105235975f6751e44051bf"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2595,8 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757b851e79eef082156ab7e33e354bda406ba9abbbc614fe3c92145d23a102fc"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2605,8 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247e2bca77b21f598178b0194b519560616136222f8b10d4aa8cf801a6de91eb"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2625,8 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f3c41066ea741c799381b31df729c572705cd27925601db577cd44f9cf0358"
 dependencies = [
  "async-lock",
  "axum",
@@ -2638,6 +2649,7 @@ dependencies = [
  "commonware-parallel",
  "commonware-utils",
  "criterion 0.7.0",
+ "crossbeam-queue",
  "futures",
  "getrandom 0.2.17",
  "governor",
@@ -2661,8 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31db25d40fcdf233e93dfec1749e0d7ee7b1dcdd9507f31f9f445fa98972ab8c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2684,8 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e6e61b311c4d65b16cfc70076e1d560fa1cf8975cc9afbe293501bf4814aad"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -2703,8 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.65"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=a1b60388c0bbc9126aa9934ec6ebade6ec344552#a1b60388c0bbc9126aa9934ec6ebade6ec344552"
+version = "2026.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d350ec4edcf243e8f746f8d6011956910c705325b295df3d686e77067b8b381b"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3034,6 +3049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4251,8 +4275,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -13093,7 +13117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,17 +189,17 @@ alloy-signer-local = "1.6.1"
 alloy-sol-types = "1.5.4"
 alloy-transport = "1.6.1"
 
-commonware-broadcast = "0.0.65"
-commonware-codec = "0.0.65"
-commonware-consensus = "0.0.65"
-commonware-cryptography = "0.0.65"
-commonware-macros = "0.0.65"
-commonware-math = "0.0.65"
-commonware-p2p = "0.0.65"
-commonware-parallel = "0.0.65"
-commonware-runtime = "0.0.65"
-commonware-storage = "0.0.65"
-commonware-utils = "0.0.65"
+commonware-broadcast = "2026.2.0"
+commonware-codec = "2026.2.0"
+commonware-consensus = "2026.2.0"
+commonware-cryptography = "2026.2.0"
+commonware-macros = "2026.2.0"
+commonware-math = "2026.2.0"
+commonware-p2p = "2026.2.0"
+commonware-parallel = "2026.2.0"
+commonware-runtime = "2026.2.0"
+commonware-storage = "2026.2.0"
+commonware-utils = "2026.2.0"
 
 arbitrary = { version = "1.4", features = ["derive"] }
 async-lock = "3.4.2"
@@ -326,16 +326,16 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 # reth-trie-sparse-parallel = { path = "../reth/crates/trie/sparse-parallel" }
 
-[patch.crates-io]
-# Commonware right after after PR #3018 was merged
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# [patch.crates-io]
+# # Commonware right after after PR #3018 was merged
+# commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }
+# commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "a1b60388c0bbc9126aa9934ec6ebade6ec344552" }

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -20,7 +20,7 @@ use commonware_cryptography::{
 };
 use commonware_math::algebra::Random as _;
 use commonware_p2p::{
-    Address, Receiver, Recipients, Sender,
+    AddressableManager, Receiver, Recipients, Sender,
     utils::mux::{self, MuxHandle},
 };
 use commonware_parallel::Sequential;
@@ -107,7 +107,7 @@ impl Read for Message {
 pub(crate) struct Actor<TContext, TPeerManager>
 where
     TContext: Clock + commonware_runtime::Metrics + commonware_runtime::Storage,
-    TPeerManager: commonware_p2p::Manager,
+    TPeerManager: AddressableManager,
 {
     /// The actor configuration passed in when constructing the actor.
     config: super::Config<TPeerManager>,
@@ -127,8 +127,7 @@ impl<TContext, TPeerManager> Actor<TContext, TPeerManager>
 where
     TContext:
         Clock + CryptoRngCore + commonware_runtime::Metrics + Spawner + commonware_runtime::Storage,
-    TPeerManager: commonware_p2p::Manager<PublicKey = PublicKey, Peers = ordered::Map<PublicKey, Address>>
-        + Sync,
+    TPeerManager: AddressableManager<PublicKey = PublicKey> + Sync,
 {
     pub(super) async fn new(
         config: super::Config<TPeerManager>,
@@ -241,7 +240,7 @@ where
         self.metrics.peers.set(all_peers.len() as i64);
         self.config
             .peer_manager
-            .update(state.epoch.get(), all_peers)
+            .track(state.epoch.get(), all_peers)
             .await;
 
         self.enter_epoch(&state)

--- a/crates/commonware-node/src/dkg/manager/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/mod.rs
@@ -3,9 +3,7 @@ use commonware_cryptography::{
     bls12381::primitives::group::Share,
     ed25519::{PrivateKey, PublicKey},
 };
-use commonware_p2p::Address;
 use commonware_runtime::{Clock, Metrics, Spawner, Storage};
-use commonware_utils::ordered;
 use eyre::WrapErr as _;
 use futures::channel::mpsc;
 use rand_core::CryptoRngCore;
@@ -28,8 +26,7 @@ pub(crate) async fn init<TContext, TPeerManager>(
 ) -> eyre::Result<(Actor<TContext, TPeerManager>, Mailbox)>
 where
     TContext: Clock + CryptoRngCore + Metrics + Spawner + Storage,
-    TPeerManager: commonware_p2p::Manager<PublicKey = PublicKey, Peers = ordered::Map<PublicKey, Address>>
-        + Sync,
+    TPeerManager: commonware_p2p::AddressableManager<PublicKey = PublicKey> + Sync,
 {
     let (tx, rx) = mpsc::unbounded();
 


### PR DESCRIPTION
Bumps commonware to their stable LTS release, v2026.2.0.

Updates the peer tracker to use the new `commonware_p2p::AddressableManager` API.