### PR TITLE
feat: update TIP-1004, add bytes signature permit overload

### DIFF
--- a/tips/tip-1004.md
+++ b/tips/tip-1004.md
@@ -24,6 +24,8 @@ EIP-2612 introduced the `permit()` function which allows approvals to be granted
 
 Since TIP-20 aims to be a superset of ERC-20 with additional functionality, adding EIP-2612 permit support ensures TIP-20 tokens work seamlessly with existing DeFi protocols and tooling that expect permit functionality.
 
+This TIP adds the EIP-2612 `permit()`, as well as an updated implementation that takes in `bytes signature` instead of the `v, r, s` components of the ECDSA signature. This allows accounts with variable length signatures such as smart accounts, P256, and webauthn accounts to use permit.
+
 ### Alternatives
 
 While Tempo transactions provide solutions for most of the common problems that are solved by account abstraction, they do not provide a way to transfer tokens from an address that has never sent a transaction onchain, which means it does not provide an easy way for a batched transaction to "sweep" tokens from many addresses.
@@ -64,6 +66,26 @@ interface ITIP20Permit {
         uint8 v,
         bytes32 r,
         bytes32 s
+    ) external;
+
+    /// @notice Approves `spender` to spend `value` tokens on behalf of `owner` via a signed permit
+    /// @param owner The address granting the approval
+    /// @param spender The address being approved to spend tokens
+    /// @param value The amount of tokens to approve
+    /// @param deadline Unix timestamp after which the permit is no longer valid
+    /// @param signature The signature in bytes form
+    /// @dev The permit is valid only if:
+    ///      - The current block timestamp is <= deadline
+    ///      - The signature is valid and was signed by `owner`
+    ///      - The nonce in the signature matches the current nonce for `owner`
+    ///      Upon successful execution, increments the nonce for `owner` by 1.
+    ///      Emits an {Approval} event.
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        bytes calldata signature
     ) external;
 
     /// @notice Returns the current nonce for an address
@@ -143,7 +165,7 @@ bytes32 digest = keccak256(abi.encodePacked(
 ));
 ```
 
-The signature `(v, r, s)` must be produced by signing `digest` with the private key of `owner`.
+The signature `(v, r, s)` must be produced by signing `digest` with the private key of `owner`. If using the `bytes signature` permit call, ECDSA signatures should have the form `abi.encodePacked(r, s, v)`.
 
 ## Behavior
 
@@ -173,11 +195,17 @@ The implementation must:
 2. Retrieve the current nonce for `owner` and use it to construct the `structHash` and `digest`
 3. Increment `nonces[owner]`
 4. Validate the signature:
-   - First, use `ecrecover` to recover a signer address from the digest
-   - If `ecrecover` returns a non-zero address that equals `owner`, the signature is valid (EOA case)
-   - Otherwise, if `owner` has code, call `owner.isValidSignature(digest, signature)` per [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
-   - If `isValidSignature` returns the magic value `0x1626ba7e`, the signature is valid (smart contract wallet case)
-   - Otherwise, revert with `InvalidSignature`
+   - `(v, r, s)` signature case:
+     - First, use `ecrecover` to recover a signer address from the digest
+     - If `ecrecover` returns a non-zero address that equals `owner`, the signature is valid (EOA case)
+     - Otherwise, if `owner` has code, call `owner.isValidSignature(digest, signature)` per [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
+     - If `isValidSignature` returns the magic value `0x1626ba7e`, the signature is valid (smart contract wallet case)
+     - Otherwise, revert with `InvalidSignature`
+   - `bytes signature` case:
+     - If the signature length is 65, continue with the `(v, r, s)` signature case
+     - Otherwise, call `owner.isValidSignature(digest, signature)` per [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
+     - If `isValidSignature` returns the magic value `0x1626ba7e`, the signature is valid (smart contract wallet case)
+     - Otherwise, revert with `InvalidSignature`
 5. Set `allowance[owner][spender] = value`
 6. Emit an `Approval(owner, spender, value)` event
 
@@ -255,3 +283,6 @@ The test suite must cover:
 13. **EIP-1271 smart contract wallet**: Permit works with smart contract wallet that implements `isValidSignature`
 14. **EIP-1271 rejection**: Reverts with `InvalidSignature` if smart contract wallet returns wrong magic value
 15. **EIP-1271 revert**: Reverts with `InvalidSignature` if `isValidSignature` call reverts
+16. **Bytes signature (ECDSA)**: Valid `bytes signature` permit with standard 65-byte ECDSA signature sets allowance correctly
+17. **Bytes signature (EIP-1271)**: Valid `bytes signature` permit with smart contract wallet signature sets allowance correctly
+18. **Bytes signature (invalid format)**: Reverts with `InvalidSignature` for non-65-byte signature on EOA owner


### PR DESCRIPTION
Adds a `bytes calldata signature` overload to TIP-1004 permit, enabling variable-length signatures (smart accounts, P256, WebAuthn).

Changes:
- New `permit(address,address,uint256,uint256,bytes)` overload in the interface
- Updated motivation section
- Added signature format guidance for the bytes overload
- Added test cases for the bytes signature path