### PR TITLE
feat(txpool): add transferFrom and transferFromWithMemo to payment lane

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -25,13 +25,11 @@ const PAYMENT_CALLDATA: &[([u8; 4], usize)] = &[
 /// Returns `true` if `input` has a recognized TIP-20 payment selector and its length exactly
 /// matches the expected ABI-encoded size for that function.
 fn is_valid_payment_calldata(input: &[u8]) -> bool {
-    input
-        .first_chunk::<4>()
-        .is_some_and(|selector| {
-            PAYMENT_CALLDATA
-                .iter()
-                .any(|(sel, len)| selector == sel && input.len() == *len)
-        })
+    input.first_chunk::<4>().is_some_and(|selector| {
+        PAYMENT_CALLDATA
+            .iter()
+            .any(|(sel, len)| selector == sel && input.len() == *len)
+    })
 }
 
 /// Returns `true` if `to` has the TIP-20 payment prefix and `input` is valid payment calldata.
@@ -814,7 +812,10 @@ mod tests {
                 input: payment_calldata(i),
             };
             let envelope = create_aa_envelope(call);
-            assert!(envelope.is_payment(), "PAYMENT_CALLDATA[{i}] should be classified as payment");
+            assert!(
+                envelope.is_payment(),
+                "PAYMENT_CALLDATA[{i}] should be classified as payment"
+            );
         }
     }
 
@@ -851,7 +852,10 @@ mod tests {
                 input: payment_calldata(i),
             };
             let envelope = create_aa_envelope(call);
-            assert!(envelope.is_payment(), "PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix");
+            assert!(
+                envelope.is_payment(),
+                "PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
Adds `transferFrom` and `transferFromWithMemo` selectors to the payment lane, and refactors the selector/length validation into a single `PAYMENT_CALLDATA` table.

## Motivation
`transferFrom` and `transferFromWithMemo` are standard delegated value transfers (apps/relayers moving funds on behalf of users). They should get payment lane priority just like `transfer` and `transferWithMemo`.

## Changes
- Replaced individual `TRANSFER_SELECTOR`, `TRANSFER_WITH_MEMO_SELECTOR`, and length constants with a single `PAYMENT_CALLDATA: &[([u8; 4], usize)]` table containing all four selectors
- Simplified `is_valid_payment_calldata()` to a table-driven lookup
- Added test cases for `transferFrom` (100 bytes) and `transferFromWithMemo` (132 bytes)

## Testing
```
cargo test -p tempo-primitives -- test_payment          # 11 passed
cargo clippy -p tempo-primitives -p tempo-transaction-pool -- -D warnings  # clean
cargo fmt --all --check                                 # clean
```

Thread: https://tempoxyz.slack.com/archives/C09K7873V4N/p1770737474265259