### PR TITLE
tip-1004: use TIP-1020 precompile for signature verification

### DIFF
--- a/tips/tip-1004.md
+++ b/tips/tip-1004.md
@@ -4,6 +4,7 @@ title: Permit for TIP-20
 description: Addition of EIP-2612 permit functionality to TIP-20 tokens, enabling gasless approvals via off-chain signatures.
 authors: Dan Robinson
 status: Approved
+related: TIP-1020
 ---
 
 # TIP-1004: Permit for TIP-20
@@ -165,7 +166,20 @@ bytes32 digest = keccak256(abi.encodePacked(
 ));
 ```
 
-The signature `(v, r, s)` must be produced by signing `digest` with the private key of `owner`. If using the `bytes signature` permit call, ECDSA signatures should have the form `abi.encodePacked(r, s, v)`.
+The signature must be produced by signing `digest` with the private key of `owner`.
+
+For the `(v, r, s)` overload, pass the ECDSA signature components directly.
+
+For the `bytes signature` overload, signatures must be encoded using the [TIP-1020 Signature Verification Precompile](./tip-1020.md) format:
+
+| Type | Format | Length |
+|------|--------|--------|
+| secp256k1 | `r \|\| s \|\| v` | 65 bytes |
+| P256 | `0x01 \|\| r \|\| s \|\| x \|\| y \|\| prehash` | 130 bytes |
+| WebAuthn | `0x02 \|\| webauthn_data \|\| r \|\| s \|\| x \|\| y` | 129–2049 bytes |
+| Keychain | `0x03 \|\| user_address \|\| inner_signature` | Variable |
+
+See [Tempo Transaction signatures](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#signature-types) for encoding details.
 
 ## Behavior
 
@@ -194,49 +208,44 @@ The implementation must:
 1. Verify that `block.timestamp <= deadline`, otherwise revert with `PermitExpired`
 2. Retrieve the current nonce for `owner` and use it to construct the `structHash` and `digest`
 3. Increment `nonces[owner]`
-4. Validate the signature:
+4. Validate the signature using the [TIP-1020 Signature Verification Precompile](./tip-1020.md):
    - `(v, r, s)` signature case:
-     - First, use `ecrecover` to recover a signer address from the digest
-     - If `ecrecover` returns a non-zero address that equals `owner`, the signature is valid (EOA case)
-     - Otherwise, if `owner` has code, call `owner.isValidSignature(digest, signature)` per [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
-     - If `isValidSignature` returns the magic value `0x1626ba7e`, the signature is valid (smart contract wallet case)
-     - Otherwise, revert with `InvalidSignature`
+     - Encode the signature as `abi.encodePacked(r, s, v)` (65 bytes)
+     - Call `ISignatureVerification(0x5165300000000000000000000000000000000000).verify(owner, digest, signature)`
+     - If the call reverts, revert with `InvalidSignature`
    - `bytes signature` case:
-     - If the signature length is 65, continue with the `(v, r, s)` signature case
-     - Otherwise, call `owner.isValidSignature(digest, signature)` per [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
-     - If `isValidSignature` returns the magic value `0x1626ba7e`, the signature is valid (smart contract wallet case)
-     - Otherwise, revert with `InvalidSignature`
+     - Call `ISignatureVerification(0x5165300000000000000000000000000000000000).verify(owner, digest, signature)`
+     - If the call reverts, revert with `InvalidSignature`
 5. Set `allowance[owner][spender] = value`
 6. Emit an `Approval(owner, spender, value)` event
 
-> **Note**: The nonce is included in the signed digest, so nonce verification is implicit in signature validation — if the wrong nonce was signed, `ecrecover` will return a different address. The nonce is incremented before signature validation (steps 3-4) rather than after. This ensures that if EIP-1271 validation involves an external call, reentrancy cannot replay the same signature.
+> **Note**: The nonce is included in the signed digest, so nonce verification is implicit in signature validation — if the wrong nonce was signed, the TIP-1020 precompile will recover a different address and revert with `SignerMismatch`. The nonce is incremented before signature validation (steps 3-4) rather than after, ensuring reentrancy cannot replay the same signature.
 
-### Smart Contract Wallet Support (EIP-1271)
+### TIP-1020 Integration
 
-TIP-1004 supports permits signed by smart contract wallets via [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). When the `owner` address has code deployed, the implementation calls:
+TIP-1004 delegates signature verification to the [TIP-1020 Signature Verification Precompile](./tip-1020.md) at address `0x5165300000000000000000000000000000000000`. This provides native support for all Tempo signature types:
+
+- **secp256k1**: Standard ECDSA signatures (EOAs)
+- **P256**: WebAuthn-compatible passkey signatures
+- **WebAuthn**: Full WebAuthn signatures with authenticator data
+- **Keychain**: Delegated signatures via Account Keychain access keys
 
 ```solidity
-bytes4 constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
+interface ISignatureVerification {
+    function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
+}
 
-// Pack signature for EIP-1271 call
-bytes memory signature = abi.encodePacked(r, s, v);
+address constant SIGNATURE_VERIFICATION = 0x5165300000000000000000000000000000000000;
 
-// Call isValidSignature on the owner contract
-(bool success, bytes memory result) = owner.staticcall(
-    abi.encodeWithSelector(
-        IERC1271.isValidSignature.selector,
-        digest,
-        signature
-    )
-);
-
-// Signature is valid if call succeeds and returns magic value
-bool isValid = success 
-    && result.length == 32 
-    && abi.decode(result, (bytes4)) == EIP1271_MAGIC_VALUE;
+// Verify the permit signature
+try ISignatureVerification(SIGNATURE_VERIFICATION).verify(owner, digest, signature) returns (bool) {
+    // Signature is valid
+} catch {
+    revert InvalidSignature();
+}
 ```
 
-This enables multisigs, smart contract wallets (e.g., Safe, Argent), and account abstraction wallets to use gasless permits.
+This enables P256 and WebAuthn accounts to use permits natively, without requiring smart contract wallet wrappers or EIP-1271.
 
 ## New errors
 
@@ -268,21 +277,21 @@ None. Successful permit execution emits the existing `Approval` event from TIP-2
 
 The test suite must cover:
 
-1. **Happy path**: Valid permit sets allowance correctly
+1. **Happy path (secp256k1)**: Valid permit with ECDSA signature sets allowance correctly
 2. **Expired permit**: Reverts with `PermitExpired` when `deadline < block.timestamp`
 3. **Invalid signature**: Reverts with `InvalidSignature` for malformed signatures
 4. **Wrong signer**: Reverts with `InvalidSignature` when signature is valid but signer ≠ owner
 5. **Replay protection**: Second use of same signature reverts (nonce already incremented)
 6. **Nonce tracking**: Verify nonce increments correctly after each permit
-7. **Zero address recovery**: Reverts with `InvalidSignature` if ecrecover returns zero address
-8. **Pause state**: Permit works when token is paused
-9. **Domain separator**: Verify correct EIP-712 domain separator computation
-10. **Domain separator chain ID**: Verify domain separator changes if chain ID changes
-11. **Max allowance**: Permit with `type(uint256).max` value works correctly
-12. **Allowance override**: Permit can override existing allowance (including to zero)
-13. **EIP-1271 smart contract wallet**: Permit works with smart contract wallet that implements `isValidSignature`
-14. **EIP-1271 rejection**: Reverts with `InvalidSignature` if smart contract wallet returns wrong magic value
-15. **EIP-1271 revert**: Reverts with `InvalidSignature` if `isValidSignature` call reverts
-16. **Bytes signature (ECDSA)**: Valid `bytes signature` permit with standard 65-byte ECDSA signature sets allowance correctly
-17. **Bytes signature (EIP-1271)**: Valid `bytes signature` permit with smart contract wallet signature sets allowance correctly
-18. **Bytes signature (invalid format)**: Reverts with `InvalidSignature` for non-65-byte signature on EOA owner
+7. **Pause state**: Permit works when token is paused
+8. **Domain separator**: Verify correct EIP-712 domain separator computation
+9. **Domain separator chain ID**: Verify domain separator changes if chain ID changes
+10. **Max allowance**: Permit with `type(uint256).max` value works correctly
+11. **Allowance override**: Permit can override existing allowance (including to zero)
+12. **Bytes signature (secp256k1)**: Valid `bytes signature` permit with 65-byte ECDSA signature sets allowance correctly
+13. **Bytes signature (P256)**: Valid `bytes signature` permit with P256 signature sets allowance correctly
+14. **Bytes signature (WebAuthn)**: Valid `bytes signature` permit with WebAuthn signature sets allowance correctly
+15. **Bytes signature (Keychain)**: Valid `bytes signature` permit with Keychain signature sets allowance correctly
+16. **Keychain unauthorized**: Reverts with `InvalidSignature` when keychain access key is not authorized
+17. **Keychain expired**: Reverts with `InvalidSignature` when keychain access key has expired
+18. **Bytes signature (invalid format)**: Reverts with `InvalidSignature` for unparseable signature bytes


### PR DESCRIPTION
## Summary

Replace `ecrecover` + EIP-1271 fallback with the [TIP-1020 Signature Verification Precompile](./tips/tip-1020.md). This provides native support for all Tempo signature types.

## Changes

- Updated signature validation to use `ISignatureVerification.verify()` at `0x5165300000000000000000000000000000000000`
- Documented TIP-1020 signature encoding formats (secp256k1, P256, WebAuthn, Keychain)
- Updated test cases to cover all signature types
- Added `related: TIP-1020` to frontmatter

## Supported Signature Types

| Type | Description |
|------|-------------|
| secp256k1 | Standard ECDSA signatures (EOAs) |
| P256 | WebAuthn-compatible passkey signatures |
| WebAuthn | Full WebAuthn signatures with authenticator data |
| Keychain | Delegated signatures via Account Keychain access keys |

## Benefits

- **Native P256/WebAuthn support**: Passkey accounts can use permits without EIP-1271 wrappers
- **Keychain support**: Access keys can sign permits on behalf of root accounts
- **Simplified implementation**: Single precompile call instead of ecrecover + EIP-1271 fallback
- **Consistent gas costs**: Uses same gas schedule as Tempo transaction signatures

Depends on #2438 (TIP-1020)