### PR TITLE
fix: pass RUST_FEATURES to Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ${CHEF_IMAGE} AS builder
 
 ARG TARGETARCH
 ARG RUST_PROFILE=profiling
+ARG RUST_FEATURES="asm-keccak,jemalloc,otlp"
 ARG VERGEN_GIT_SHA
 ARG VERGEN_GIT_SHA_SHORT
 ARG EXTRA_RUSTFLAGS=""
@@ -16,7 +17,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked,id=sccache-${TARGETARCH} \
     RUSTFLAGS="-C link-arg=-fuse-ld=mold ${EXTRA_RUSTFLAGS}" \
     cargo build --profile ${RUST_PROFILE} \
-        --bin tempo --features "asm-keccak,jemalloc,otlp" \
+        --bin tempo --features "${RUST_FEATURES}" \
         --bin tempo-bench \
         --bin tempo-sidecar \
         --bin tempo-xtask

--- a/docker-bake-profiling.hcl
+++ b/docker-bake-profiling.hcl
@@ -29,6 +29,7 @@ target "_common" {
   args = {
     CHEF_IMAGE = "chef"
     RUST_PROFILE = "profiling"
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp,tracy"
     EXTRA_RUSTFLAGS = "-C force-frame-pointers=yes"
     VERGEN_GIT_SHA = "${VERGEN_GIT_SHA}"
     VERGEN_GIT_SHA_SHORT = "${VERGEN_GIT_SHA_SHORT}"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,6 +32,7 @@ target "_common" {
   args = {
     CHEF_IMAGE = "chef"
     RUST_PROFILE = "profiling"
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
     VERGEN_GIT_SHA = "${VERGEN_GIT_SHA}"
     VERGEN_GIT_SHA_SHORT = "${VERGEN_GIT_SHA_SHORT}"
   }


### PR DESCRIPTION
## Summary
Fixes `--log.tracy` doing nothing in profiling builds.

## Motivation
The Dockerfile hardcoded `--features "asm-keccak,jemalloc,otlp"` in the `cargo build` step, ignoring the `RUST_FEATURES` arg set by the bake files. Profiling builds (`docker-bake-profiling.hcl`) correctly passed `tracy` to the chef stage for dependency pre-cooking, but the final binary was built without the `tracy` feature — so `#[cfg(feature = "tracy")]` code paths in `reth-node-core` were compiled out and `--log.tracy` silently did nothing.

## Changes
- `Dockerfile`: add `RUST_FEATURES` build arg (defaults to `asm-keccak,jemalloc,otlp`), use it in `cargo build`
- `docker-bake.hcl`: pass `RUST_FEATURES` in `_common` target args
- `docker-bake-profiling.hcl`: pass `RUST_FEATURES` (with `tracy`) in `_common` target args

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770760741629669