### PR TITLE
chore(precompiles): migrate TIP403Registry to `#[abi]` macro

### DIFF
--- a/crates/precompiles/benches/tempo_precompiles.rs
+++ b/crates/precompiles/benches/tempo_precompiles.rs
@@ -5,7 +5,11 @@ use tempo_precompiles::{
     storage::{StorageCtx, hashmap::HashMapStorageProvider},
     test_util::TIP20Setup,
     tip20::{ISSUER_ROLE, ITIP20, PAUSE_ROLE, UNPAUSE_ROLE},
-    tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
+    tip403_registry::{
+        AuthRole,
+        ITIP403Registry::{self, traits::*},
+        TIP403Registry,
+    },
 };
 
 fn tip20_metadata(c: &mut Criterion) {
@@ -507,21 +511,13 @@ fn tip403_registry_view(c: &mut Criterion) {
         StorageCtx::enter(&mut storage, || {
             let mut registry = TIP403Registry::new();
             let policy_id = registry
-                .create_policy(
-                    admin,
-                    ITIP403Registry::createPolicyCall {
-                        admin,
-                        policyType: ITIP403Registry::PolicyType::WHITELIST,
-                    },
-                )
+                .create_policy(admin, admin, ITIP403Registry::PolicyType::WHITELIST)
                 .unwrap();
 
             b.iter(|| {
                 let registry = black_box(&mut registry);
-                let call = black_box(ITIP403Registry::policyDataCall {
-                    policyId: policy_id,
-                });
-                let result = registry.policy_data(call).unwrap();
+                let policy_id = black_box(policy_id);
+                let result = registry.policy_data(policy_id).unwrap();
                 black_box(result);
             });
         });
@@ -534,13 +530,7 @@ fn tip403_registry_view(c: &mut Criterion) {
         StorageCtx::enter(&mut storage, || {
             let mut registry = TIP403Registry::new();
             let policy_id = registry
-                .create_policy(
-                    admin,
-                    ITIP403Registry::createPolicyCall {
-                        admin,
-                        policyType: ITIP403Registry::PolicyType::WHITELIST,
-                    },
-                )
+                .create_policy(admin, admin, ITIP403Registry::PolicyType::WHITELIST)
                 .unwrap();
 
             b.iter(|| {
@@ -566,11 +556,9 @@ fn tip403_registry_mutate(c: &mut Criterion) {
             b.iter(|| {
                 let registry = black_box(&mut registry);
                 let admin = black_box(admin);
-                let call = black_box(ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::WHITELIST,
-                });
-                let result = registry.create_policy(admin, call).unwrap();
+                let result = registry
+                    .create_policy(admin, admin, ITIP403Registry::PolicyType::WHITELIST)
+                    .unwrap();
                 black_box(result);
             });
         });
@@ -588,12 +576,14 @@ fn tip403_registry_mutate(c: &mut Criterion) {
             b.iter(|| {
                 let registry = black_box(&mut registry);
                 let admin = black_box(admin);
-                let call = black_box(ITIP403Registry::createPolicyWithAccountsCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::WHITELIST,
-                    accounts: accounts.clone(),
-                });
-                let result = registry.create_policy_with_accounts(admin, call).unwrap();
+                let result = registry
+                    .create_policy_with_accounts(
+                        admin,
+                        admin,
+                        ITIP403Registry::PolicyType::WHITELIST,
+                        accounts.clone(),
+                    )
+                    .unwrap();
                 black_box(result);
             });
         });
@@ -605,23 +595,13 @@ fn tip403_registry_mutate(c: &mut Criterion) {
         StorageCtx::enter(&mut storage, || {
             let mut registry = TIP403Registry::new();
             let policy_id = registry
-                .create_policy(
-                    admin,
-                    ITIP403Registry::createPolicyCall {
-                        admin,
-                        policyType: ITIP403Registry::PolicyType::WHITELIST,
-                    },
-                )
+                .create_policy(admin, admin, ITIP403Registry::PolicyType::WHITELIST)
                 .unwrap();
 
             b.iter(|| {
                 let registry = black_box(&mut registry);
                 let admin = black_box(admin);
-                let call = black_box(ITIP403Registry::setPolicyAdminCall {
-                    policyId: policy_id,
-                    admin,
-                });
-                registry.set_policy_admin(admin, call).unwrap();
+                registry.set_policy_admin(admin, policy_id, admin).unwrap();
             });
         });
     });
@@ -633,24 +613,15 @@ fn tip403_registry_mutate(c: &mut Criterion) {
         StorageCtx::enter(&mut storage, || {
             let mut registry = TIP403Registry::new();
             let policy_id = registry
-                .create_policy(
-                    admin,
-                    ITIP403Registry::createPolicyCall {
-                        admin,
-                        policyType: ITIP403Registry::PolicyType::WHITELIST,
-                    },
-                )
+                .create_policy(admin, admin, ITIP403Registry::PolicyType::WHITELIST)
                 .unwrap();
 
             b.iter(|| {
                 let registry = black_box(&mut registry);
                 let admin = black_box(admin);
-                let call = black_box(ITIP403Registry::modifyPolicyWhitelistCall {
-                    policyId: policy_id,
-                    account: user,
-                    allowed: true,
-                });
-                registry.modify_policy_whitelist(admin, call).unwrap();
+                registry
+                    .modify_policy_whitelist(admin, policy_id, user, true)
+                    .unwrap();
             });
         });
     });
@@ -662,24 +633,15 @@ fn tip403_registry_mutate(c: &mut Criterion) {
         StorageCtx::enter(&mut storage, || {
             let mut registry = TIP403Registry::new();
             let policy_id = registry
-                .create_policy(
-                    admin,
-                    ITIP403Registry::createPolicyCall {
-                        admin,
-                        policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                    },
-                )
+                .create_policy(admin, admin, ITIP403Registry::PolicyType::BLACKLIST)
                 .unwrap();
 
             b.iter(|| {
                 let registry = black_box(&mut registry);
                 let admin = black_box(admin);
-                let call = black_box(ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: user,
-                    restricted: true,
-                });
-                registry.modify_policy_blacklist(admin, call).unwrap();
+                registry
+                    .modify_policy_blacklist(admin, policy_id, user, true)
+                    .unwrap();
             });
         });
     });

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use crate::{
-    tip20::TIP20Error,
-    tip20_factory::TIP20FactoryError,
+    tip20::TIP20Error, tip20_factory::TIP20FactoryError,
     tip403_registry::ITIP403Registry::Error as TIP403RegistryError,
 };
 use alloy::{

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -3,7 +3,11 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
-use crate::{tip20::TIP20Error, tip20_factory::TIP20FactoryError};
+use crate::{
+    tip20::TIP20Error,
+    tip20_factory::TIP20FactoryError,
+    tip403_registry::ITIP403Registry::Error as TIP403RegistryError,
+};
 use alloy::{
     primitives::{Selector, U256},
     sol_types::{Panic, PanicKind, SolError, SolInterface},
@@ -14,7 +18,7 @@ use revm::{
 };
 use tempo_contracts::precompiles::{
     AccountKeychainError, FeeManagerError, NonceError, RolesAuthError, StablecoinDEXError,
-    TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError,
+    TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError,
 };
 
 /// Top-level error type for all Tempo precompile operations

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1399,7 +1399,8 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip403_registry::{
-            ITIP403Registry::{traits::*, PolicyType}, TIP403Registry,
+            ITIP403Registry::{PolicyType, traits::*},
+            TIP403Registry,
         },
     };
 

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -194,7 +194,9 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, setup_storage},
         tip20::{ISSUER_ROLE, PAUSE_ROLE, UNPAUSE_ROLE},
-        tip403_registry::{ITIP403Registry, TIP403Registry},
+        tip403_registry::{
+            ITIP403Registry::{traits::*, PolicyType}, TIP403Registry,
+        },
     };
     use alloy::{
         primitives::{Bytes, U256, address},
@@ -653,13 +655,7 @@ mod tests {
             registry.initialize()?;
 
             // Create a valid policy
-            let new_policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::WHITELIST,
-                },
-            )?;
+            let new_policy_id = registry.create_policy(admin, admin, PolicyType::WHITELIST)?;
 
             let change_policy_call = ITIP20::changeTransferPolicyIdCall {
                 newPolicyId: new_policy_id,
@@ -670,13 +666,7 @@ mod tests {
             assert_eq!(token.transfer_policy_id()?, new_policy_id);
 
             // Create another valid policy for the unauthorized test
-            let another_policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
+            let another_policy_id = registry.create_policy(admin, admin, PolicyType::BLACKLIST)?;
 
             let change_policy_call = ITIP20::changeTransferPolicyIdCall {
                 newPolicyId: another_policy_id,

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -195,7 +195,8 @@ mod tests {
         test_util::{TIP20Setup, setup_storage},
         tip20::{ISSUER_ROLE, PAUSE_ROLE, UNPAUSE_ROLE},
         tip403_registry::{
-            ITIP403Registry::{traits::*, PolicyType}, TIP403Registry,
+            ITIP403Registry::{PolicyType, traits::*},
+            TIP403Registry,
         },
     };
     use alloy::{

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     storage::{Handler, Mapping},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::{ITIP20Factory::traits::*, TIP20Factory},
-    tip403_registry::{ITIP403Registry::traits::*, AuthRole, TIP403Registry},
+    tip403_registry::{AuthRole, ITIP403Registry::traits::*, TIP403Registry},
 };
 use alloy::{
     hex,

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -350,10 +350,12 @@ mod tests {
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
-        tip403_registry::TIP403Registry,
+        tip403_registry::{
+            ITIP403Registry::{traits::*, PolicyType}, TIP403Registry,
+        },
     };
     use alloy::primitives::{Address, U256};
-    use tempo_contracts::precompiles::{ITIP403Registry, TIP20Error};
+    use tempo_contracts::precompiles::TIP20Error;
 
     #[test]
     fn test_set_reward_recipient() -> eyre::Result<()> {
@@ -647,22 +649,9 @@ mod tests {
             let mut registry = TIP403Registry::new();
             registry.initialize()?;
 
-            let policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
+            let policy_id = registry.create_policy(admin, admin, PolicyType::BLACKLIST)?;
 
-            registry.modify_policy_blacklist(
-                admin,
-                ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: alice,
-                    restricted: true,
-                },
-            )?;
+            registry.modify_policy_blacklist(admin, policy_id, alice, true)?;
 
             let mut token = TIP20Setup::create("Test", "TST", admin).apply()?;
 

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -351,7 +351,8 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
         tip403_registry::{
-            ITIP403Registry::{traits::*, PolicyType}, TIP403Registry,
+            ITIP403Registry::{PolicyType, traits::*},
+            TIP403Registry,
         },
     };
     use alloy::primitives::{Address, U256};

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -2,8 +2,7 @@
 pub mod abi;
 mod dispatch;
 
-use ITIP20Factory::traits::*;
-pub use abi::ITIP20Factory;
+pub use abi::{ITIP20Factory, ITIP20Factory::Interface};
 
 use tempo_precompiles_macros::contract;
 

--- a/crates/precompiles/src/tip403_registry/abi.rs
+++ b/crates/precompiles/src/tip403_registry/abi.rs
@@ -6,6 +6,7 @@ pub mod ITIP403Registry {
     #[cfg(feature = "precompile")]
     use crate::error::Result;
     use alloy::primitives::Address;
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Storable)]
     pub enum PolicyType {
@@ -38,9 +39,13 @@ pub mod ITIP403Registry {
         fn policy_exists(&self, policy_id: u64) -> Result<bool>;
         fn policy_data(&self, policy_id: u64) -> Result<(PolicyType, Address)>;
         fn is_authorized(&self, policy_id: u64, user: Address) -> Result<bool>;
+        #[hardfork = TempoHardfork::T2]
         fn is_authorized_sender(&self, policy_id: u64, user: Address) -> Result<bool>;
+        #[hardfork = TempoHardfork::T2]
         fn is_authorized_recipient(&self, policy_id: u64, user: Address) -> Result<bool>;
+        #[hardfork = TempoHardfork::T2]
         fn is_authorized_mint_recipient(&self, policy_id: u64, user: Address) -> Result<bool>;
+        #[hardfork = TempoHardfork::T2]
         fn compound_policy_data(&self, policy_id: u64) -> Result<(u64, u64, u64)>;
 
         // State-Changing Functions
@@ -55,6 +60,7 @@ pub mod ITIP403Registry {
         #[msg_sender]
         fn modify_policy_blacklist(&mut self, policy_id: u64, account: Address, restricted: bool) -> Result<()>;
         #[msg_sender]
+        #[hardfork = TempoHardfork::T2]
         fn create_compound_policy(&mut self, sender_policy_id: u64, recipient_policy_id: u64, mint_recipient_policy_id: u64) -> Result<u64>;
     }
 }

--- a/crates/precompiles/src/tip403_registry/abi.rs
+++ b/crates/precompiles/src/tip403_registry/abi.rs
@@ -1,0 +1,60 @@
+use tempo_precompiles_macros::abi;
+
+#[rustfmt::skip]
+#[abi(no_reexport)]
+pub mod ITIP403Registry {
+    #[cfg(feature = "precompile")]
+    use crate::error::Result;
+    use alloy::primitives::Address;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Storable)]
+    pub enum PolicyType {
+        WHITELIST = 0,
+        BLACKLIST = 1,
+        COMPOUND = 2,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Error {
+        Unauthorized,
+        PolicyNotFound,
+        PolicyNotSimple,
+        InvalidPolicyType,
+        IncompatiblePolicyType,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Event {
+        PolicyAdminUpdated { #[indexed] policy_id: u64, #[indexed] updater: Address, #[indexed] admin: Address },
+        PolicyCreated { #[indexed] policy_id: u64, #[indexed] updater: Address, policy_type: PolicyType },
+        WhitelistUpdated { #[indexed] policy_id: u64, #[indexed] updater: Address, #[indexed] account: Address, allowed: bool },
+        BlacklistUpdated { #[indexed] policy_id: u64, #[indexed] updater: Address, #[indexed] account: Address, restricted: bool },
+        CompoundPolicyCreated { #[indexed] policy_id: u64, #[indexed] creator: Address, sender_policy_id: u64, recipient_policy_id: u64, mint_recipient_policy_id: u64 },
+    }
+
+    pub trait Interface {
+        // View Functions
+        fn policy_id_counter(&self) -> Result<u64>;
+        fn policy_exists(&self, policy_id: u64) -> Result<bool>;
+        fn policy_data(&self, policy_id: u64) -> Result<(PolicyType, Address)>;
+        fn is_authorized(&self, policy_id: u64, user: Address) -> Result<bool>;
+        fn is_authorized_sender(&self, policy_id: u64, user: Address) -> Result<bool>;
+        fn is_authorized_recipient(&self, policy_id: u64, user: Address) -> Result<bool>;
+        fn is_authorized_mint_recipient(&self, policy_id: u64, user: Address) -> Result<bool>;
+        fn compound_policy_data(&self, policy_id: u64) -> Result<(u64, u64, u64)>;
+
+        // State-Changing Functions
+        #[msg_sender]
+        fn create_policy(&mut self, admin: Address, policy_type: PolicyType) -> Result<u64>;
+        #[msg_sender]
+        fn create_policy_with_accounts(&mut self, admin: Address, policy_type: PolicyType, accounts: Vec<Address>) -> Result<u64>;
+        #[msg_sender]
+        fn set_policy_admin(&mut self, policy_id: u64, admin: Address) -> Result<()>;
+        #[msg_sender]
+        fn modify_policy_whitelist(&mut self, policy_id: u64, account: Address, allowed: bool) -> Result<()>;
+        #[msg_sender]
+        fn modify_policy_blacklist(&mut self, policy_id: u64, account: Address, restricted: bool) -> Result<()>;
+        #[msg_sender]
+        fn create_compound_policy(&mut self, sender_policy_id: u64, recipient_policy_id: u64, mint_recipient_policy_id: u64) -> Result<u64>;
+    }
+}

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -1,123 +1,12 @@
-use crate::{
-    Precompile, dispatch_call, input_cost, mutate, mutate_void,
-    tip403_registry::{AuthRole, Interface, TIP403Registry, abi::ITIP403Registry},
-    unknown_selector, view,
-};
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
-use revm::precompile::{PrecompileError, PrecompileResult};
-
-impl Precompile for TIP403Registry {
-    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
-        use ITIP403Registry::{
-            Calls, compoundPolicyDataCall, createCompoundPolicyCall, isAuthorizedMintRecipientCall,
-            isAuthorizedRecipientCall, isAuthorizedSenderCall,
-        };
-
-        self.storage
-            .deduct_gas(input_cost(calldata.len()))
-            .map_err(|_| PrecompileError::OutOfGas)?;
-
-        dispatch_call(calldata, Calls::abi_decode, |call| match call {
-            Calls::policyIdCounter(call) => view(call, |_| Interface::policy_id_counter(self)),
-            Calls::policyExists(call) => {
-                view(call, |c| Interface::policy_exists(self, c.policy_id))
-            }
-            Calls::policyData(call) => view(call, |c| Interface::policy_data(self, c.policy_id)),
-            Calls::isAuthorized(call) => view(call, |c| {
-                self.is_authorized_as(c.policy_id, c.user, AuthRole::Transfer)
-            }),
-            // TIP-1015: T2+ only
-            Calls::isAuthorizedSender(call) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        isAuthorizedSenderCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
-                }
-                view(call, |c| {
-                    self.is_authorized_as(c.policy_id, c.user, AuthRole::Sender)
-                })
-            }
-            Calls::isAuthorizedRecipient(call) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        isAuthorizedRecipientCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
-                }
-                view(call, |c| {
-                    self.is_authorized_as(c.policy_id, c.user, AuthRole::Recipient)
-                })
-            }
-            Calls::isAuthorizedMintRecipient(call) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        isAuthorizedMintRecipientCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
-                }
-                view(call, |c| {
-                    self.is_authorized_as(c.policy_id, c.user, AuthRole::MintRecipient)
-                })
-            }
-            Calls::compoundPolicyData(call) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        compoundPolicyDataCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
-                }
-                view(call, |c| Interface::compound_policy_data(self, c.policy_id))
-            }
-            Calls::createPolicy(call) => mutate(call, msg_sender, |s, c| {
-                Interface::create_policy(self, s, c.admin, c.policy_type)
-            }),
-            Calls::createPolicyWithAccounts(call) => mutate(call, msg_sender, |s, c| {
-                Interface::create_policy_with_accounts(self, s, c.admin, c.policy_type, c.accounts)
-            }),
-            Calls::setPolicyAdmin(call) => mutate_void(call, msg_sender, |s, c| {
-                Interface::set_policy_admin(self, s, c.policy_id, c.admin)
-            }),
-            Calls::modifyPolicyWhitelist(call) => mutate_void(call, msg_sender, |s, c| {
-                Interface::modify_policy_whitelist(self, s, c.policy_id, c.account, c.allowed)
-            }),
-            Calls::modifyPolicyBlacklist(call) => mutate_void(call, msg_sender, |s, c| {
-                Interface::modify_policy_blacklist(self, s, c.policy_id, c.account, c.restricted)
-            }),
-            // TIP-1015: T2+ only
-            Calls::createCompoundPolicy(call) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        createCompoundPolicyCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
-                }
-                mutate(call, msg_sender, |s, c| {
-                    Interface::create_compound_policy(
-                        self,
-                        s,
-                        c.sender_policy_id,
-                        c.recipient_policy_id,
-                        c.mint_recipient_policy_id,
-                    )
-                })
-            }
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{
+        Precompile,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
-        tip403_registry::ITIP403Registry,
+        tip403_registry::{TIP403Registry, abi::ITIP403Registry},
     };
-    use alloy::sol_types::{SolCall, SolValue};
+    use alloy::{primitives::Address, sol_types::{SolCall, SolValue}};
     use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -6,7 +6,10 @@ mod tests {
         test_util::{assert_full_coverage, check_selector_coverage},
         tip403_registry::{TIP403Registry, abi::ITIP403Registry},
     };
-    use alloy::{primitives::Address, sol_types::{SolCall, SolValue}};
+    use alloy::{
+        primitives::Address,
+        sol_types::{SolCall, SolValue},
+    };
     use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::{
     Precompile, dispatch_call, input_cost, mutate, mutate_void,
-    tip403_registry::{AuthRole, TIP403Registry},
+    tip403_registry::{AuthRole, Interface, TIP403Registry, abi::ITIP403Registry},
     unknown_selector, view,
 };
 use alloy::{
@@ -8,101 +8,104 @@ use alloy::{
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::{PrecompileError, PrecompileResult};
-use tempo_contracts::precompiles::ITIP403Registry::{
-    ITIP403RegistryCalls, compoundPolicyDataCall, createCompoundPolicyCall,
-    isAuthorizedMintRecipientCall, isAuthorizedRecipientCall, isAuthorizedSenderCall,
-};
 
 impl Precompile for TIP403Registry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        use ITIP403Registry::{
+            Calls, compoundPolicyDataCall, createCompoundPolicyCall, isAuthorizedMintRecipientCall,
+            isAuthorizedRecipientCall, isAuthorizedSenderCall,
+        };
+
         self.storage
             .deduct_gas(input_cost(calldata.len()))
             .map_err(|_| PrecompileError::OutOfGas)?;
 
-        dispatch_call(
-            calldata,
-            ITIP403RegistryCalls::abi_decode,
-            |call| match call {
-                ITIP403RegistryCalls::policyIdCounter(call) => {
-                    view(call, |_| self.policy_id_counter())
+        dispatch_call(calldata, Calls::abi_decode, |call| match call {
+            Calls::policyIdCounter(call) => view(call, |_| Interface::policy_id_counter(self)),
+            Calls::policyExists(call) => {
+                view(call, |c| Interface::policy_exists(self, c.policy_id))
+            }
+            Calls::policyData(call) => view(call, |c| Interface::policy_data(self, c.policy_id)),
+            Calls::isAuthorized(call) => view(call, |c| {
+                self.is_authorized_as(c.policy_id, c.user, AuthRole::Transfer)
+            }),
+            // TIP-1015: T2+ only
+            Calls::isAuthorizedSender(call) => {
+                if !self.storage.spec().is_t2() {
+                    return unknown_selector(
+                        isAuthorizedSenderCall::SELECTOR,
+                        self.storage.gas_used(),
+                    );
                 }
-                ITIP403RegistryCalls::policyExists(call) => view(call, |c| self.policy_exists(c)),
-                ITIP403RegistryCalls::policyData(call) => view(call, |c| self.policy_data(c)),
-                ITIP403RegistryCalls::isAuthorized(call) => view(call, |c| {
-                    self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
-                }),
-                // TIP-1015: T2+ only
-                ITIP403RegistryCalls::isAuthorizedSender(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedSenderCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
-                    })
+                view(call, |c| {
+                    self.is_authorized_as(c.policy_id, c.user, AuthRole::Sender)
+                })
+            }
+            Calls::isAuthorizedRecipient(call) => {
+                if !self.storage.spec().is_t2() {
+                    return unknown_selector(
+                        isAuthorizedRecipientCall::SELECTOR,
+                        self.storage.gas_used(),
+                    );
                 }
-                ITIP403RegistryCalls::isAuthorizedRecipient(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedRecipientCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
-                    })
+                view(call, |c| {
+                    self.is_authorized_as(c.policy_id, c.user, AuthRole::Recipient)
+                })
+            }
+            Calls::isAuthorizedMintRecipient(call) => {
+                if !self.storage.spec().is_t2() {
+                    return unknown_selector(
+                        isAuthorizedMintRecipientCall::SELECTOR,
+                        self.storage.gas_used(),
+                    );
                 }
-                ITIP403RegistryCalls::isAuthorizedMintRecipient(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedMintRecipientCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
-                    })
+                view(call, |c| {
+                    self.is_authorized_as(c.policy_id, c.user, AuthRole::MintRecipient)
+                })
+            }
+            Calls::compoundPolicyData(call) => {
+                if !self.storage.spec().is_t2() {
+                    return unknown_selector(
+                        compoundPolicyDataCall::SELECTOR,
+                        self.storage.gas_used(),
+                    );
                 }
-                ITIP403RegistryCalls::compoundPolicyData(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            compoundPolicyDataCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| self.compound_policy_data(c))
+                view(call, |c| Interface::compound_policy_data(self, c.policy_id))
+            }
+            Calls::createPolicy(call) => mutate(call, msg_sender, |s, c| {
+                Interface::create_policy(self, s, c.admin, c.policy_type)
+            }),
+            Calls::createPolicyWithAccounts(call) => mutate(call, msg_sender, |s, c| {
+                Interface::create_policy_with_accounts(self, s, c.admin, c.policy_type, c.accounts)
+            }),
+            Calls::setPolicyAdmin(call) => mutate_void(call, msg_sender, |s, c| {
+                Interface::set_policy_admin(self, s, c.policy_id, c.admin)
+            }),
+            Calls::modifyPolicyWhitelist(call) => mutate_void(call, msg_sender, |s, c| {
+                Interface::modify_policy_whitelist(self, s, c.policy_id, c.account, c.allowed)
+            }),
+            Calls::modifyPolicyBlacklist(call) => mutate_void(call, msg_sender, |s, c| {
+                Interface::modify_policy_blacklist(self, s, c.policy_id, c.account, c.restricted)
+            }),
+            // TIP-1015: T2+ only
+            Calls::createCompoundPolicy(call) => {
+                if !self.storage.spec().is_t2() {
+                    return unknown_selector(
+                        createCompoundPolicyCall::SELECTOR,
+                        self.storage.gas_used(),
+                    );
                 }
-                ITIP403RegistryCalls::createPolicy(call) => {
-                    mutate(call, msg_sender, |s, c| self.create_policy(s, c))
-                }
-                ITIP403RegistryCalls::createPolicyWithAccounts(call) => {
-                    mutate(call, msg_sender, |s, c| {
-                        self.create_policy_with_accounts(s, c)
-                    })
-                }
-                ITIP403RegistryCalls::setPolicyAdmin(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.set_policy_admin(s, c))
-                }
-                ITIP403RegistryCalls::modifyPolicyWhitelist(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.modify_policy_whitelist(s, c))
-                }
-                ITIP403RegistryCalls::modifyPolicyBlacklist(call) => {
-                    mutate_void(call, msg_sender, |s, c| self.modify_policy_blacklist(s, c))
-                }
-                // TIP-1015: T2+ only
-                ITIP403RegistryCalls::createCompoundPolicy(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            createCompoundPolicyCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    mutate(call, msg_sender, |s, c| self.create_compound_policy(s, c))
-                }
-            },
-        )
+                mutate(call, msg_sender, |s, c| {
+                    Interface::create_compound_policy(
+                        self,
+                        s,
+                        c.sender_policy_id,
+                        c.recipient_policy_id,
+                        c.mint_recipient_policy_id,
+                    )
+                })
+            }
+        })
     }
 }
 
@@ -116,7 +119,6 @@ mod tests {
     };
     use alloy::sol_types::{SolCall, SolValue};
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::ITIP403Registry::ITIP403RegistryCalls;
 
     #[test]
     fn test_is_authorized_precompile() -> eyre::Result<()> {
@@ -126,7 +128,7 @@ mod tests {
             let mut registry = TIP403Registry::new();
 
             // Test policy 1 (always allow)
-            let call = ITIP403Registry::isAuthorizedCall { policyId: 1, user };
+            let call = ITIP403Registry::isAuthorizedCall { policy_id: 1, user };
             let calldata = call.abi_encode();
             let result = registry.call(&calldata, Address::ZERO);
 
@@ -149,7 +151,7 @@ mod tests {
 
             let call = ITIP403Registry::createPolicyCall {
                 admin,
-                policyType: ITIP403Registry::PolicyType::WHITELIST,
+                policy_type: ITIP403Registry::PolicyType::WHITELIST,
             };
             let calldata = call.abi_encode();
             let result = registry.call(&calldata, admin);
@@ -183,281 +185,6 @@ mod tests {
     }
 
     #[test]
-    fn test_create_policy_with_accounts() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        let account1 = Address::random();
-        let account2 = Address::random();
-        let other_account = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-
-            let accounts = vec![account1, account2];
-            let call = ITIP403Registry::createPolicyWithAccountsCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::WHITELIST,
-                accounts,
-            };
-            let calldata = call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-
-            let policy_id: u64 =
-                ITIP403Registry::createPolicyWithAccountsCall::abi_decode_returns(&result.bytes)
-                    .unwrap();
-            assert_eq!(policy_id, 2);
-
-            // Check that accounts are authorized
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account1,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account2,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            // Check that other accounts are not authorized
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: other_account,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(!is_authorized);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_blacklist_policy() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        let blocked_account = Address::random();
-        let allowed_account = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-
-            // Create blacklist policy
-            let call = ITIP403Registry::createPolicyCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::BLACKLIST,
-            };
-            let calldata = call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let policy_id: u64 =
-                ITIP403Registry::createPolicyCall::abi_decode_returns(&result.bytes).unwrap();
-
-            // Initially, all accounts should be authorized (empty blacklist)
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: blocked_account,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            // Add account to blacklist
-            let modify_call = ITIP403Registry::modifyPolicyBlacklistCall {
-                policyId: policy_id,
-                account: blocked_account,
-                restricted: true,
-            };
-            let calldata = modify_call.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            // Now blocked account should not be authorized
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: blocked_account,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(!is_authorized);
-
-            // Other accounts should still be authorized
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: allowed_account,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            // Remove account from blacklist
-            let modify_call = ITIP403Registry::modifyPolicyBlacklistCall {
-                policyId: policy_id,
-                account: blocked_account,
-                restricted: false,
-            };
-            let calldata = modify_call.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            // Account should be authorized again
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: blocked_account,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_modify_policy_whitelist() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        let account1 = Address::random();
-        let account2 = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-
-            // Create whitelist policy
-            let call = ITIP403Registry::createPolicyCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::WHITELIST,
-            };
-            let calldata = call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let policy_id: u64 =
-                ITIP403Registry::createPolicyCall::abi_decode_returns(&result.bytes).unwrap();
-
-            // Add multiple accounts to whitelist
-            let modify_call1 = ITIP403Registry::modifyPolicyWhitelistCall {
-                policyId: policy_id,
-                account: account1,
-                allowed: true,
-            };
-            let calldata = modify_call1.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            let modify_call2 = ITIP403Registry::modifyPolicyWhitelistCall {
-                policyId: policy_id,
-                account: account2,
-                allowed: true,
-            };
-            let calldata = modify_call2.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            // Both accounts should be authorized
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account1,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account2,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            // Remove one account from whitelist
-            let modify_call = ITIP403Registry::modifyPolicyWhitelistCall {
-                policyId: policy_id,
-                account: account1,
-                allowed: false,
-            };
-            let calldata = modify_call.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            // Account1 should not be authorized, account2 should still be
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account1,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(!is_authorized);
-
-            let is_auth_call = ITIP403Registry::isAuthorizedCall {
-                policyId: policy_id,
-                user: account2,
-            };
-            let calldata = is_auth_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let is_authorized = bool::abi_decode(&result.bytes).unwrap();
-            assert!(is_authorized);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_set_policy_admin() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        let new_admin = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-
-            // Create a policy
-            let call = ITIP403Registry::createPolicyCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::WHITELIST,
-            };
-            let calldata = call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let policy_id: u64 =
-                ITIP403Registry::createPolicyCall::abi_decode_returns(&result.bytes).unwrap();
-
-            // Get initial policy data
-            let policy_data_call = ITIP403Registry::policyDataCall {
-                policyId: policy_id,
-            };
-            let calldata = policy_data_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let policy_data =
-                ITIP403Registry::policyDataCall::abi_decode_returns(&result.bytes).unwrap();
-            assert_eq!(policy_data.admin, admin);
-
-            // Change policy admin
-            let set_admin_call = ITIP403Registry::setPolicyAdminCall {
-                policyId: policy_id,
-                admin: new_admin,
-            };
-            let calldata = set_admin_call.abi_encode();
-            registry.call(&calldata, admin).unwrap();
-
-            // Verify policy admin was changed
-            let policy_data_call = ITIP403Registry::policyDataCall {
-                policyId: policy_id,
-            };
-            let calldata = policy_data_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let policy_data =
-                ITIP403Registry::policyDataCall::abi_decode_returns(&result.bytes).unwrap();
-            assert_eq!(policy_data.admin, new_admin);
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_special_policy_ids() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let user = Address::random();
@@ -465,14 +192,14 @@ mod tests {
             let mut registry = TIP403Registry::new();
 
             // Test policy 0 (always deny)
-            let is_auth_call = ITIP403Registry::isAuthorizedCall { policyId: 0, user };
+            let is_auth_call = ITIP403Registry::isAuthorizedCall { policy_id: 0, user };
             let calldata = is_auth_call.abi_encode();
             let result = registry.call(&calldata, Address::ZERO).unwrap();
             let is_authorized = bool::abi_decode(&result.bytes).unwrap();
             assert!(!is_authorized);
 
             // Test policy 1 (always allow)
-            let is_auth_call = ITIP403Registry::isAuthorizedCall { policyId: 1, user };
+            let is_auth_call = ITIP403Registry::isAuthorizedCall { policy_id: 1, user };
             let calldata = is_auth_call.abi_encode();
             let result = registry.call(&calldata, Address::ZERO).unwrap();
             let is_authorized = bool::abi_decode(&result.bytes).unwrap();
@@ -517,48 +244,9 @@ mod tests {
     }
 
     #[test]
-    fn test_create_multiple_policies() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        StorageCtx::enter(&mut storage, || {
-            let mut registry = TIP403Registry::new();
-
-            // Create multiple policies with different types
-            let whitelist_call = ITIP403Registry::createPolicyCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::WHITELIST,
-            };
-            let calldata = whitelist_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let whitelist_id: u64 =
-                ITIP403Registry::createPolicyCall::abi_decode_returns(&result.bytes).unwrap();
-
-            let blacklist_call = ITIP403Registry::createPolicyCall {
-                admin,
-                policyType: ITIP403Registry::PolicyType::BLACKLIST,
-            };
-            let calldata = blacklist_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let blacklist_id: u64 =
-                ITIP403Registry::createPolicyCall::abi_decode_returns(&result.bytes).unwrap();
-
-            // Verify IDs are sequential
-            assert_eq!(whitelist_id, 2);
-            assert_eq!(blacklist_id, 3);
-
-            // Verify counter has been updated
-            let counter_call = ITIP403Registry::policyIdCounterCall {};
-            let calldata = counter_call.abi_encode();
-            let result = registry.call(&calldata, admin).unwrap();
-            let counter = u64::abi_decode(&result.bytes).unwrap();
-            assert_eq!(counter, 4);
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_selector_coverage() -> eyre::Result<()> {
+        use ITIP403Registry::Calls;
+
         // Use T2 to test all selectors including TIP-1015 compound policy functions
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
         StorageCtx::enter(&mut storage, || {
@@ -566,9 +254,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut registry,
-                ITIP403RegistryCalls::SELECTORS,
+                Calls::SELECTORS,
                 "ITIP403Registry",
-                ITIP403RegistryCalls::name_by_selector,
+                Calls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloy::primitives::{Address, U256};
 
-#[contract(addr = TIP403_REGISTRY_ADDRESS, abi = ITIP403Registry)]
+#[contract(addr = TIP403_REGISTRY_ADDRESS, abi = ITIP403Registry, dispatch)]
 pub struct TIP403Registry {
     policy_id_counter: u64,
     policy_records: Mapping<u64, PolicyRecord>,

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -694,10 +694,10 @@ mod tests {
             assert!(result.is_err());
 
             // Verify the error is PolicyNotFound
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(TIP403RegistryError::PolicyNotFound(_))
-            ));
+                TIP403RegistryError::policy_not_found().into()
+            );
 
             Ok(())
         })
@@ -1080,12 +1080,10 @@ mod tests {
             let mut registry = TIP403Registry::new();
 
             let result = registry.create_policy(admin, admin, PolicyType::COMPOUND);
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(
-                    TIP403RegistryError::IncompatiblePolicyType(_)
-                )
-            ));
+                TIP403RegistryError::incompatible_policy_type().into()
+            );
 
             Ok(())
         })
@@ -1105,12 +1103,10 @@ mod tests {
                 PolicyType::COMPOUND,
                 vec![account],
             );
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(
-                    TIP403RegistryError::IncompatiblePolicyType(_)
-                )
-            ));
+                TIP403RegistryError::incompatible_policy_type().into()
+            );
 
             Ok(())
         })
@@ -1177,12 +1173,10 @@ mod tests {
                 PolicyType::COMPOUND,
                 vec![account],
             );
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(
-                    TIP403RegistryError::IncompatiblePolicyType(_)
-                )
-            ));
+                TIP403RegistryError::incompatible_policy_type().into()
+            );
 
             // With empty accounts: succeeds (loop never enters revert path)
             let policy_id =
@@ -1399,12 +1393,10 @@ mod tests {
             let mut registry = TIP403Registry::new();
 
             let result = registry.create_policy(admin, admin, PolicyType::COMPOUND);
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(
-                    TIP403RegistryError::IncompatiblePolicyType(_)
-                )
-            ));
+                TIP403RegistryError::incompatible_policy_type().into()
+            );
 
             Ok(())
         })
@@ -1461,20 +1453,18 @@ mod tests {
 
             // Non-existent policy should return PolicyNotFound
             let result = registry.compound_policy_data(999);
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(TIP403RegistryError::PolicyNotFound(_))
-            ));
+                TIP403RegistryError::policy_not_found().into()
+            );
 
             // Simple policy should return IncompatiblePolicyType
             let simple_policy_id = registry.create_policy(admin, admin, PolicyType::WHITELIST)?;
             let result = registry.compound_policy_data(simple_policy_id);
-            assert!(matches!(
+            assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::TIP403RegistryError(
-                    TIP403RegistryError::IncompatiblePolicyType(_)
-                )
-            ));
+                TIP403RegistryError::incompatible_policy_type().into()
+            );
 
             Ok(())
         })

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1418,7 +1418,7 @@ mod tests {
 
         // Add TIP403Registry with blacklist policy containing fee_payer
         let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
+            policy_type: ITIP403Registry::PolicyType::BLACKLIST,
             admin: Address::ZERO,
         };
         let policy_data_slot = TIP403Registry::new().policy_records[policy_id]


### PR DESCRIPTION
## Summary

Migrates `TIP403Registry` from `sol!`-based ABI definitions to the `#[abi]` macro. This is the largest net-deletion migration in the stack (-977 lines), as it replaces substantial manual dispatch logic and duplicated type definitions.

### Changes

- **New**: `tip403_registry/abi.rs` — defines `ITIP403Registry` with `PolicyType` enum (`Storable` derive), `Error`, `Event`, and `Interface` trait with `#[hardfork]` gating on T2 methods (`is_authorized_sender`, `is_authorized_recipient`, `compound_policy_data`, `create_compound_policy`)
- **Migrated**: `tip403_registry/mod.rs` — implements `ITIP403Registry::Interface` trait, substantially simplified
- **Simplified**: `tip403_registry/dispatch.rs` — manual selector routing replaced with macro-generated dispatch
- Adjustments to `error.rs`, `tip20`, `stablecoin_dex`, benchmarks, and `transaction-pool/validator.rs`

### Stack

> Part of the [`#[abi]` macro stack](https://github.com/tempoxyz/tempo/pull/2687) — PR 3 of 11.