### PR TITLE
chore(precompiles): migrate NonceManager to `#[abi]` macro

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use crate::{
-    tip20::TIP20Error, tip20_factory::TIP20FactoryError,
+    nonce::INonce::Error as NonceError,
+    tip20::TIP20Error,
+    tip20_factory::TIP20FactoryError,
     tip403_registry::ITIP403Registry::Error as TIP403RegistryError,
 };
 use alloy::{
@@ -16,8 +18,8 @@ use revm::{
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
 };
 use tempo_contracts::precompiles::{
-    AccountKeychainError, FeeManagerError, NonceError, RolesAuthError, StablecoinDEXError,
-    TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError,
+    AccountKeychainError, FeeManagerError, RolesAuthError, StablecoinDEXError, TIPFeeAMMError,
+    UnknownFunctionSelector, ValidatorConfigError,
 };
 
 /// Top-level error type for all Tempo precompile operations

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -4,9 +4,7 @@ use std::{
 };
 
 use crate::{
-    nonce::INonce::Error as NonceError,
-    tip20::TIP20Error,
-    tip20_factory::TIP20FactoryError,
+    nonce::INonce::Error as NonceError, tip20::TIP20Error, tip20_factory::TIP20FactoryError,
     tip403_registry::ITIP403Registry::Error as TIP403RegistryError,
 };
 use alloy::{

--- a/crates/precompiles/src/nonce/abi.rs
+++ b/crates/precompiles/src/nonce/abi.rs
@@ -1,0 +1,29 @@
+use tempo_precompiles_macros::abi;
+
+#[rustfmt::skip]
+#[abi(no_reexport)]
+pub mod INonce {
+    #[cfg(feature = "precompile")]
+    use crate::error::Result;
+    use alloy::primitives::{Address, U256};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Error {
+        ProtocolNonceNotSupported,
+        InvalidNonceKey,
+        NonceOverflow,
+        ExpiringNonceReplay,
+        ExpiringNonceSetFull,
+        InvalidExpiringNonceExpiry,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Event {
+        NonceIncremented { #[indexed] account: Address, #[indexed] nonce_key: U256, new_nonce: u64 },
+    }
+
+    pub trait Interface {
+        /// Get the current nonce for a specific account and nonce key
+        fn get_nonce(&self, account: Address, nonce_key: U256) -> Result<u64>;
+    }
+}

--- a/crates/precompiles/src/nonce/dispatch.rs
+++ b/crates/precompiles/src/nonce/dispatch.rs
@@ -1,28 +1,10 @@
-use crate::{Precompile, dispatch_call, input_cost, nonce::NonceManager, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
-use revm::precompile::{PrecompileError, PrecompileResult};
-use tempo_contracts::precompiles::INonce::INonceCalls;
-
-impl Precompile for NonceManager {
-    fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
-        self.storage
-            .deduct_gas(input_cost(calldata.len()))
-            .map_err(|_| PrecompileError::OutOfGas)?;
-
-        dispatch_call(calldata, INonceCalls::abi_decode, |call| match call {
-            INonceCalls::getNonce(call) => view(call, |c| self.get_nonce(c)),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{
+        nonce::{NonceManager, abi::INonce::Calls},
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use tempo_contracts::precompiles::INonce::INonceCalls;
 
     #[test]
     fn test_nonce_selector_coverage() -> eyre::Result<()> {
@@ -32,9 +14,9 @@ mod tests {
 
             let unsupported = check_selector_coverage(
                 &mut nonce_manager,
-                INonceCalls::SELECTORS,
+                Calls::SELECTORS,
                 "INonce",
-                INonceCalls::name_by_selector,
+                Calls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -1,7 +1,8 @@
-pub mod dispatch;
+pub mod abi;
+mod dispatch;
 
-pub use tempo_contracts::precompiles::INonce;
-use tempo_contracts::precompiles::{NonceError, NonceEvent};
+use abi::INonce::{Error as NonceError, Event as NonceEvent};
+pub use abi::{INonce, INonce::Interface};
 use tempo_precompiles_macros::contract;
 
 use crate::{
@@ -24,7 +25,7 @@ pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 /// ```solidity
 /// contract Nonce {
 ///     mapping(address => mapping(uint256 => uint64)) public nonces;      // slot 0
-///     
+///
 ///     // Expiring nonce storage (for hash-based replay protection)
 ///     mapping(bytes32 => uint64) public expiringNonceSeen;               // slot 1: txHash => expiry
 ///     mapping(uint32 => bytes32) public expiringNonceRing;               // slot 2: circular buffer of tx hashes
@@ -39,7 +40,7 @@ pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 ///
 /// Note: Protocol nonce (key 0) is stored directly in account state, not here.
 /// Only user nonce keys (1-N) are managed by this precompile.
-#[contract(addr = NONCE_PRECOMPILE_ADDRESS)]
+#[contract(addr = NONCE_PRECOMPILE_ADDRESS, abi = INonce, dispatch)]
 pub struct NonceManager {
     nonces: Mapping<Address, Mapping<U256, u64>>,
     expiring_nonce_seen: Mapping<B256, u64>,
@@ -47,22 +48,23 @@ pub struct NonceManager {
     expiring_nonce_ring_ptr: u32,
 }
 
-impl NonceManager {
-    /// Initializes the nonce manager contract.
-    pub fn initialize(&mut self) -> Result<()> {
-        self.__initialize()
-    }
-
-    /// Get the nonce for a specific account and nonce key
-    pub fn get_nonce(&self, call: INonce::getNonceCall) -> Result<u64> {
+impl Interface for NonceManager {
+    fn get_nonce(&self, account: Address, nonce_key: U256) -> Result<u64> {
         // Protocol nonce (key 0) is stored in account state, not in this precompile
         // Users should query account nonce directly, not through this precompile
-        if call.nonceKey == 0 {
+        if nonce_key == 0 {
             return Err(NonceError::protocol_nonce_not_supported().into());
         }
 
         // For user nonce keys, read from precompile storage
-        self.nonces[call.account][call.nonceKey].read()
+        self.nonces[account][nonce_key].read()
+    }
+}
+
+impl NonceManager {
+    /// Initializes the nonce manager contract.
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
     }
 
     /// Internal: Increment nonce for a specific account and nonce key
@@ -79,11 +81,7 @@ impl NonceManager {
 
         self.nonces[account][nonce_key].write(new_nonce)?;
 
-        self.emit_event(NonceEvent::NonceIncremented(INonce::NonceIncremented {
-            account,
-            nonceKey: nonce_key,
-            newNonce: new_nonce,
-        }))?;
+        self.emit_event(NonceEvent::nonce_incremented(account, nonce_key, new_nonce))?;
 
         Ok(new_nonce)
     }
@@ -169,10 +167,7 @@ impl NonceManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        error::TempoPrecompileError,
-        storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
-    };
+    use crate::storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider};
 
     use super::*;
     use alloy::primitives::address;
@@ -184,10 +179,7 @@ mod tests {
             let mgr = NonceManager::new();
 
             let account = address!("0x1111111111111111111111111111111111111111");
-            let nonce = mgr.get_nonce(INonce::getNonceCall {
-                account,
-                nonceKey: U256::from(5),
-            })?;
+            let nonce = mgr.get_nonce(account, U256::from(5))?;
 
             assert_eq!(nonce, 0);
             Ok(())
@@ -201,14 +193,11 @@ mod tests {
             let mgr = NonceManager::new();
 
             let account = address!("0x1111111111111111111111111111111111111111");
-            let result = mgr.get_nonce(INonce::getNonceCall {
-                account,
-                nonceKey: U256::ZERO,
-            });
+            let result = mgr.get_nonce(account, U256::ZERO);
 
             assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::NonceError(NonceError::protocol_nonce_not_supported())
+                NonceError::protocol_nonce_not_supported().into()
             );
             Ok(())
         })
@@ -230,16 +219,8 @@ mod tests {
             let new_nonce = mgr.increment_nonce(account, nonce_key)?;
             assert_eq!(new_nonce, 2);
             mgr.assert_emitted_events(vec![
-                INonce::NonceIncremented {
-                    account,
-                    nonceKey: nonce_key,
-                    newNonce: 1,
-                },
-                INonce::NonceIncremented {
-                    account,
-                    nonceKey: nonce_key,
-                    newNonce: 2,
-                },
+                NonceEvent::nonce_incremented(account, nonce_key, 1),
+                NonceEvent::nonce_incremented(account, nonce_key, 2),
             ]);
 
             Ok(())
@@ -263,14 +244,8 @@ mod tests {
                 mgr.increment_nonce(account2, nonce_key)?;
             }
 
-            let nonce1 = mgr.get_nonce(INonce::getNonceCall {
-                account: account1,
-                nonceKey: nonce_key,
-            })?;
-            let nonce2 = mgr.get_nonce(INonce::getNonceCall {
-                account: account2,
-                nonceKey: nonce_key,
-            })?;
+            let nonce1 = mgr.get_nonce(account1, nonce_key)?;
+            let nonce2 = mgr.get_nonce(account2, nonce_key)?;
 
             assert_eq!(nonce1, 10);
             assert_eq!(nonce2, 20);
@@ -298,7 +273,7 @@ mod tests {
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, valid_before);
             assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::NonceError(NonceError::expiring_nonce_replay())
+                NonceError::expiring_nonce_replay().into()
             );
 
             Ok(())
@@ -319,21 +294,21 @@ mod tests {
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, now - 1);
             assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
+                NonceError::invalid_expiring_nonce_expiry().into()
             );
 
             // valid_before exactly at now should fail
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, now);
             assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
+                NonceError::invalid_expiring_nonce_expiry().into()
             );
 
             // valid_before too far in future should fail (uses EXPIRING_NONCE_MAX_EXPIRY_SECS = 30)
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 31);
             assert_eq!(
                 result.unwrap_err(),
-                TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
+                NonceError::invalid_expiring_nonce_expiry().into()
             );
 
             // valid_before at exactly max_skew should succeed

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -38,7 +38,7 @@ use tempo_contracts::precompiles::{
 use tempo_precompiles::{
     account_keychain::{AccountKeychain, TokenLimit, authorizeKeyCall},
     error::TempoPrecompileError,
-    nonce::{INonce::getNonceCall, NonceManager},
+    nonce::{Interface as NonceInterface, NonceManager},
     storage::{PrecompileStorageProvider, StorageCtx, evm::EvmPrecompileStorageProvider},
     tip_fee_manager::TipFeeManager,
     tip20::{ITIP20::InsufficientBalance, TIP20Error, TIP20Token, is_tip20_prefix},
@@ -699,10 +699,7 @@ where
                 if !cfg.is_nonce_check_disabled() {
                     let tx_nonce = tx.nonce();
                     let state = nonce_manager
-                        .get_nonce(getNonceCall {
-                            account: tx.caller(),
-                            nonceKey: nonce_key,
-                        })
+                        .get_nonce(tx.caller(), nonce_key)
                         .map_err(|err| match err {
                             TempoPrecompileError::Fatal(err) => EVMError::Custom(err),
                             err => {


### PR DESCRIPTION
## Summary

Migrates `NonceManager` from `sol!`-based ABI definitions to the `#[abi]` macro. The smallest migration in the stack.

### Changes

- **New**: `nonce/abi.rs` — defines `INonce` with `Error`, `Event`, and a single `Interface` method (`get_nonce`)
- **Migrated**: `nonce/mod.rs` — implements `INonce::Interface` trait
- **Simplified**: `nonce/dispatch.rs` — manual dispatch replaced with macro-generated routing
- Minor adjustments to `error.rs` and `revm/handler.rs`

### Stack

> Part of the [`#[abi]` macro stack](https://github.com/tempoxyz/tempo/pull/2687) — PR 4 of 11.