### PR TITLE
chore(precompiles): migrate AccountKeychain to `#[abi]` macro

### DIFF
--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -51,11 +51,10 @@ use reth_primitives_traits::transaction::TxHashRef;
 use reth_transaction_pool::TransactionPool;
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
-use tempo_contracts::precompiles::{
-    DEFAULT_FEE_TOKEN, account_keychain::IAccountKeychain::revokeKeyCall,
-};
+use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
+    account_keychain::IAccountKeychain::revokeKeyCall,
     tip20::ITIP20::{self, transferCall},
 };
 
@@ -4316,7 +4315,9 @@ async fn test_aa_access_key() -> eyre::Result<()> {
 
     use alloy::sol_types::SolCall;
     use alloy_primitives::address;
-    use tempo_precompiles::account_keychain::{getKeyCall, getRemainingLimitCall};
+    use tempo_precompiles::account_keychain::IAccountKeychain::{
+        getKeyCall, getRemainingLimitCall,
+    };
     const ACCOUNT_KEYCHAIN_ADDRESS: Address =
         address!("0xAAAAAAAA00000000000000000000000000000000");
 
@@ -4328,7 +4329,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
     // Query the precompile for the key info using eth_call
     let get_key_call = getKeyCall {
         account: root_key_addr,
-        keyId: access_key_addr,
+        key_id: access_key_addr,
     };
     let call_data = get_key_call.abi_encode();
 
@@ -4339,7 +4340,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
     // Query remaining spending limit
     let get_remaining_call = getRemainingLimitCall {
         account: root_key_addr,
-        keyId: access_key_addr,
+        key_id: access_key_addr,
         token: DEFAULT_FEE_TOKEN,
     };
     let call_data = get_remaining_call.abi_encode();
@@ -4367,7 +4368,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
 /// Tests: zero public key, duplicate key, unauthorized authorize
 #[tokio::test]
 async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
-    use tempo_precompiles::account_keychain::{SignatureType, authorizeKeyCall};
+    use tempo_precompiles::account_keychain::{IAccountKeychain::authorizeKeyCall, SignatureType};
     use tempo_primitives::transaction::TokenLimit;
 
     reth_tracing::init_test_tracing();
@@ -4391,10 +4392,10 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
     // Test 1: Try to authorize with zero public key (should fail)
     println!("Test 1: Zero public key");
     let authorize_call = authorizeKeyCall {
-        keyId: Address::ZERO,
-        signatureType: SignatureType::P256,
+        key_id: Address::ZERO,
+        signature_type: SignatureType::P256,
         expiry: u64::MAX,
-        enforceLimits: true,
+        enforce_limits: true,
         limits: vec![],
     };
     let mut tx = create_basic_aa_tx(
@@ -4619,7 +4620,7 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
 async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Result<()> {
     use alloy::sol_types::SolCall;
     use tempo_contracts::precompiles::ITIP20::{balanceOfCall, transferCall};
-    use tempo_precompiles::account_keychain::updateSpendingLimitCall;
+    use tempo_precompiles::account_keychain::IAccountKeychain::updateSpendingLimitCall;
     use tempo_primitives::transaction::TokenLimit;
 
     reth_tracing::init_test_tracing();
@@ -4709,9 +4710,9 @@ async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Resul
             to: ACCOUNT_KEYCHAIN_ADDRESS.into(),
             value: U256::ZERO,
             input: updateSpendingLimitCall {
-                keyId: access_key_addr,
+                key_id: access_key_addr,
                 token: DEFAULT_FEE_TOKEN,
-                newLimit: U256::from(20u64) * U256::from(10).pow(U256::from(18)),
+                new_limit: U256::from(20u64) * U256::from(10).pow(U256::from(18)),
             }
             .abi_encode()
             .into(),
@@ -6311,7 +6312,7 @@ async fn test_aa_keychain_revocation_toctou_dos() -> eyre::Result<()> {
     println!("\n=== STEP 3: Revoke the access key ===");
 
     let revoke_call = revokeKeyCall {
-        keyId: access_key_addr,
+        key_id: access_key_addr,
     };
 
     // Use a 2D nonce (different nonce_key) so this tx can be mined independently
@@ -6764,7 +6765,7 @@ async fn test_aa_expiring_nonce_independent_from_protocol_nonce() -> eyre::Resul
 /// 4. Transactions should be evicted from the mempool
 #[tokio::test]
 async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
-    use tempo_precompiles::account_keychain::updateSpendingLimitCall;
+    use tempo_precompiles::account_keychain::IAccountKeychain::updateSpendingLimitCall;
 
     reth_tracing::init_test_tracing();
 
@@ -6897,9 +6898,9 @@ async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
     println!("\n=== STEP 3: Reduce spending limit to 0 ===");
 
     let update_limit_call = updateSpendingLimitCall {
-        keyId: access_key_addr,
+        key_id: access_key_addr,
         token: DEFAULT_FEE_TOKEN,
-        newLimit: U256::ZERO, // Set to 0, making all pending transfers fail
+        new_limit: U256::ZERO, // Set to 0, making all pending transfers fail
     };
 
     // Use a 2D nonce (different nonce_key) so this tx can be mined independently

--- a/crates/precompiles/src/account_keychain/abi.rs
+++ b/crates/precompiles/src/account_keychain/abi.rs
@@ -1,0 +1,93 @@
+use tempo_precompiles_macros::abi;
+
+#[rustfmt::skip]
+#[abi(no_reexport)]
+#[allow(non_snake_case)]
+pub mod IAccountKeychain {
+    #[cfg(feature = "precompile")]
+    use crate::error::Result;
+    use alloy::primitives::{Address, U256};
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Storable)]
+    pub enum SignatureType {
+        Secp256k1 = 0,
+        P256      = 1,
+        WebAuthn  = 2,
+    }
+
+    impl SignatureType {
+        #[cfg(feature = "precompile")]
+        pub fn validate(self) -> Result<()> {
+            if matches!(self, Self::__Invalid) {
+                return Err(crate::account_keychain::AccountKeychainError::invalid_signature_type().into());
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
+    pub struct TokenLimit {
+        pub token: Address,
+        pub amount: U256,
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
+    pub struct KeyInfo {
+        pub signature_type: SignatureType,
+        pub key_id: Address,
+        pub expiry: u64,
+        pub enforce_limits: bool,
+        pub is_revoked: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Error {
+        UnauthorizedCaller,
+        KeyAlreadyExists,
+        KeyNotFound,
+        KeyExpired,
+        SpendingLimitExceeded,
+        InvalidSignatureType,
+        ZeroPublicKey,
+        ExpiryInPast,
+        KeyAlreadyRevoked,
+        SignatureTypeMismatch { expected: SignatureType, actual: SignatureType },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Event {
+        KeyAuthorized { #[indexed] account: Address, #[indexed] publicKey: Address, signatureType: SignatureType, expiry: u64 },
+        KeyRevoked { #[indexed] account: Address, #[indexed] publicKey: Address },
+        SpendingLimitUpdated { #[indexed] account: Address, #[indexed] publicKey: Address, #[indexed] token: Address, newLimit: U256 },
+    }
+
+    pub trait Interface {
+        /// Authorize a new key for the caller's account
+        #[msg_sender]
+        fn authorize_key(
+            &mut self,
+            key_id: Address,
+            signature_type: SignatureType,
+            expiry: u64,
+            enforce_limits: bool,
+            limits: Vec<TokenLimit>,
+        ) -> Result<()>;
+
+        /// Revoke an authorized key
+        #[msg_sender]
+        fn revoke_key(&mut self, key_id: Address) -> Result<()>;
+
+        /// Update spending limit for a key-token pair
+        #[msg_sender]
+        fn update_spending_limit(&mut self, key_id: Address, token: Address, new_limit: U256) -> Result<()>;
+
+        /// Get key information
+        fn get_key(&self, account: Address, key_id: Address) -> Result<KeyInfo>;
+
+        /// Get remaining spending limit
+        fn get_remaining_limit(&self, account: Address, key_id: Address, token: Address) -> Result<U256>;
+
+        /// Get the key used in the current transaction
+        fn get_transaction_key(&self) -> Result<Address>;
+    }
+}

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,46 +1,7 @@
-use super::AccountKeychain;
-use crate::{Precompile, dispatch_call, input_cost, mutate_void, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
-use revm::precompile::{PrecompileError, PrecompileResult};
-use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;
-
-impl Precompile for AccountKeychain {
-    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
-        self.storage
-            .deduct_gas(input_cost(calldata.len()))
-            .map_err(|_| PrecompileError::OutOfGas)?;
-
-        dispatch_call(
-            calldata,
-            IAccountKeychainCalls::abi_decode,
-            |call| match call {
-                IAccountKeychainCalls::authorizeKey(call) => {
-                    mutate_void(call, msg_sender, |sender, c| self.authorize_key(sender, c))
-                }
-                IAccountKeychainCalls::revokeKey(call) => {
-                    mutate_void(call, msg_sender, |sender, c| self.revoke_key(sender, c))
-                }
-                IAccountKeychainCalls::updateSpendingLimit(call) => {
-                    mutate_void(call, msg_sender, |sender, c| {
-                        self.update_spending_limit(sender, c)
-                    })
-                }
-                IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
-                IAccountKeychainCalls::getRemainingLimit(call) => {
-                    view(call, |c| self.get_remaining_limit(c))
-                }
-                IAccountKeychainCalls::getTransactionKey(call) => {
-                    view(call, |c| self.get_transaction_key(c, msg_sender))
-                }
-            },
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{
+        account_keychain::{AccountKeychain, abi::IAccountKeychain::Calls},
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
@@ -49,13 +10,13 @@ mod tests {
     fn test_account_keychain_selector_coverage() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
-            let mut fee_manager = AccountKeychain::new();
+            let mut keychain = AccountKeychain::new();
 
             let unsupported = check_selector_coverage(
-                &mut fee_manager,
-                IAccountKeychainCalls::SELECTORS,
+                &mut keychain,
+                Calls::SELECTORS,
                 "IAccountKeychain",
-                IAccountKeychainCalls::name_by_selector,
+                Calls::name_by_selector,
             );
 
             assert_full_coverage([unsupported]);

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::{
+    account_keychain::IAccountKeychain::Error as AccountKeychainError,
     nonce::INonce::Error as NonceError,
     tip_fee_manager::{IFeeAMM, IFeeManager},
     tip20::TIP20Error,
@@ -19,8 +20,7 @@ use revm::{
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
 };
 use tempo_contracts::precompiles::{
-    AccountKeychainError, RolesAuthError, StablecoinDEXError, UnknownFunctionSelector,
-    ValidatorConfigError,
+    RolesAuthError, StablecoinDEXError, UnknownFunctionSelector, ValidatorConfigError,
 };
 
 /// Top-level error type for all Tempo precompile operations

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -32,9 +32,12 @@ use revm::{
         interpreter::EthInterpreter,
     },
 };
-use tempo_contracts::precompiles::IAccountKeychain::SignatureType as PrecompileSignatureType;
 use tempo_precompiles::{
-    account_keychain::{AccountKeychain, TokenLimit, authorizeKeyCall},
+    account_keychain::{
+        AccountKeychain,
+        IAccountKeychain::{SignatureType as PrecompileSigType, TokenLimit},
+        Interface as KeychainInterface,
+    },
     error::TempoPrecompileError,
     nonce::{Interface as NonceInterface, NonceManager},
     storage::{PrecompileStorageProvider, StorageCtx, evm::EvmPrecompileStorageProvider},
@@ -850,9 +853,9 @@ where
                 // Convert signature type to precompile SignatureType enum
                 // Use the key_type field which specifies the type of key being authorized
                 let signature_type = match key_auth.key_type {
-                    SignatureType::Secp256k1 => PrecompileSignatureType::Secp256k1,
-                    SignatureType::P256 => PrecompileSignatureType::P256,
-                    SignatureType::WebAuthn => PrecompileSignatureType::WebAuthn,
+                    SignatureType::Secp256k1 => PrecompileSigType::Secp256k1,
+                    SignatureType::P256 => PrecompileSigType::P256,
+                    SignatureType::WebAuthn => PrecompileSigType::WebAuthn,
                 };
 
                 // Handle expiry: None means never expires (store as u64::MAX)
@@ -887,16 +890,15 @@ where
                     .unwrap_or_default();
 
                 // Create the authorize key call
-                let authorize_call = authorizeKeyCall {
-                    keyId: access_key_addr,
-                    signatureType: signature_type,
-                    expiry,
-                    enforceLimits: enforce_limits,
-                    limits: precompile_limits,
-                };
-
                 // Call precompile to authorize the key (same phase as nonce increment)
-                match keychain.authorize_key(*root_account, authorize_call) {
+                match keychain.authorize_key(
+                    *root_account,
+                    access_key_addr,
+                    signature_type,
+                    expiry,
+                    enforce_limits,
+                    precompile_limits,
+                ) {
                     // all is good, we can do execution.
                     Ok(_) => Ok(false),
                     // on out of gas we are skipping execution but not invalidating the transaction.
@@ -979,9 +981,12 @@ where
                         // type to authenticate as a key registered with a different type.
                         // Only validate signature type on T1+ to maintain backward compatibility
                         // with historical blocks during re-execution.
-                        let sig_type = spec
-                            .is_t1()
-                            .then_some(keychain_sig.signature.signature_type().into());
+                        let sig_type = spec.is_t1().then_some(
+                            PrecompileSigType::try_from(u8::from(
+                                keychain_sig.signature.signature_type(),
+                            ))
+                            .expect("valid signature type"),
+                        );
 
                         keychain
                             .validate_keychain_authorization(

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1045,6 +1045,7 @@ mod tests {
     use tempo_chainspec::spec::{MODERATO, TEMPO_T1_TX_GAS_LIMIT_CAP};
     use tempo_precompiles::{
         PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
+        account_keychain::SignatureType as PrecompileSigType,
         tip20::{TIP20Token, slots as tip20_slots},
         tip403_registry::{ITIP403Registry, PolicyData, TIP403Registry},
     };
@@ -2301,8 +2302,8 @@ mod tests {
 
             // Setup storage with a valid authorized key (expiry > 0, not revoked)
             let slot_value = AuthorizedKey {
-                signature_type: 0, // secp256k1
-                expiry: u64::MAX,  // never expires
+                signature_type: PrecompileSigType::Secp256k1,
+                expiry: u64::MAX, // never expires
                 enforce_limits: false,
                 is_revoked: false,
             }
@@ -2334,7 +2335,7 @@ mod tests {
 
             // Setup storage with a revoked key
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: 0, // revoked keys have expiry=0
                 enforce_limits: false,
                 is_revoked: true,
@@ -2371,7 +2372,7 @@ mod tests {
 
             // Setup storage with expiry = 0 (key doesn't exist)
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: 0, // expiry = 0 means key doesn't exist
                 enforce_limits: false,
                 is_revoked: false,
@@ -2716,7 +2717,7 @@ mod tests {
 
             // Setup with valid key for the actual sender
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: u64::MAX,
                 enforce_limits: false,
                 is_revoked: false,
@@ -2809,7 +2810,7 @@ mod tests {
 
             // Setup storage with an expired key (expiry in the past)
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: current_time - 1, // Expired (in the past)
                 enforce_limits: false,
                 is_revoked: false,
@@ -2847,7 +2848,7 @@ mod tests {
 
             // Setup storage with expiry == current_time (edge case: expired)
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: current_time, // Expiry at exactly current time should be rejected
                 enforce_limits: false,
                 is_revoked: false,
@@ -2884,7 +2885,7 @@ mod tests {
 
             // Setup storage with a future expiry
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: current_time + 100, // Valid (in the future)
                 enforce_limits: false,
                 is_revoked: false,
@@ -3163,7 +3164,7 @@ mod tests {
 
             // Setup AccountKeychain storage with AuthorizedKey
             let slot_value = AuthorizedKey {
-                signature_type: 0,
+                signature_type: PrecompileSigType::Secp256k1,
                 expiry: u64::MAX,
                 enforce_limits,
                 is_revoked: false,


### PR DESCRIPTION
## Summary

Migrates `AccountKeychain` from `sol!`-based ABI definitions to the `#[abi]` macro.

### Changes

- **New**: `account_keychain/abi.rs` — defines `IAccountKeychain` with:
  - `SignatureType` enum (`Storable` derive) with a custom `validate()` method
  - `TokenLimit` and `KeyInfo` structs
  - `Error` enum including a variant with `SignatureType` fields
  - `Event` enum
  - `Interface` trait with `#[msg_sender]` on key management methods
- **Migrated**: `account_keychain/mod.rs` — implements `IAccountKeychain::Interface` trait
- **Simplified**: `account_keychain/dispatch.rs` — manual dispatch replaced
- Adjustments to `error.rs`, `revm/handler.rs`, `transaction-pool/validator.rs`, and `node/tests`

### Stack

> Part of the [`#[abi]` macro stack](https://github.com/tempoxyz/tempo/pull/2687) — PR 6 of 11.