### PR TITLE
chore(precompiles): migrate ValidatorConfig to `#[abi]` macro

### DIFF
--- a/crates/commonware-node/src/dkg/manager/validators.rs
+++ b/crates/commonware-node/src/dkg/manager/validators.rs
@@ -14,7 +14,7 @@ use reth_provider::{
 use tempo_node::TempoFullNode;
 use tempo_precompiles::{
     storage::StorageCtx,
-    validator_config::{IValidatorConfig, ValidatorConfig},
+    validator_config::{IValidatorConfig, ValidatorConfig, traits::*},
 };
 
 use tracing::{Level, info, instrument, warn};
@@ -171,19 +171,19 @@ impl DecodedValidator {
     pub(super) fn decode_from_contract(
         IValidatorConfig::Validator {
             active,
-            publicKey,
+            public_key,
             index,
-            validatorAddress,
-            inboundAddress,
-            outboundAddress,
+            validator_address,
+            inbound_address,
+            outbound_address,
         }: IValidatorConfig::Validator,
     ) -> eyre::Result<Self> {
-        let public_key = PublicKey::decode(publicKey.as_ref())
+        let public_key = PublicKey::decode(public_key.as_ref())
             .wrap_err("failed decoding publicKey field as ed25519 public key")?;
-        let inbound = inboundAddress
+        let inbound = inbound_address
             .parse()
             .wrap_err("inboundAddress was not valid")?;
-        let outbound = outboundAddress
+        let outbound = outbound_address
             .parse()
             .wrap_err("outboundAddress was not valid")?;
         Ok(Self {
@@ -192,7 +192,7 @@ impl DecodedValidator {
             inbound,
             outbound,
             index,
-            address: validatorAddress,
+            address: validator_address,
         })
     }
 }

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -57,7 +57,7 @@ use tempo_node::{
 use tempo_precompiles::{
     VALIDATOR_CONFIG_ADDRESS,
     storage::StorageCtx,
-    validator_config::{IValidatorConfig, ValidatorConfig},
+    validator_config::{IValidatorConfig, ValidatorConfig, traits::*},
 };
 
 const ADMIN_INDEX: u32 = 0;
@@ -145,13 +145,11 @@ impl Builder {
                     validator_config
                         .add_validator(
                             admin(),
-                            IValidatorConfig::addValidatorCall {
-                                newValidatorAddress: *chain_addr,
-                                publicKey: peer.encode().as_ref().try_into().unwrap(),
-                                active: true,
-                                inboundAddress: net_addr.to_string(),
-                                outboundAddress: net_addr.to_string(),
-                            },
+                            *chain_addr,
+                            peer.encode().as_ref().try_into().unwrap(),
+                            true,
+                            net_addr.to_string(),
+                            net_addr.to_string(),
                         )
                         .unwrap();
                 }

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -10,6 +10,7 @@ use crate::{
     tip20::TIP20Error,
     tip20_factory::TIP20FactoryError,
     tip403_registry::ITIP403Registry::Error as TIP403RegistryError,
+    validator_config::IValidatorConfig::Error as ValidatorConfigError,
 };
 use alloy::{
     primitives::{Selector, U256},
@@ -19,9 +20,7 @@ use revm::{
     context::journaled_state::JournalLoadErasedError,
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
 };
-use tempo_contracts::precompiles::{
-    RolesAuthError, StablecoinDEXError, UnknownFunctionSelector, ValidatorConfigError,
-};
+use tempo_contracts::precompiles::{RolesAuthError, StablecoinDEXError, UnknownFunctionSelector};
 
 /// Top-level error type for all Tempo precompile operations
 #[derive(

--- a/crates/precompiles/src/validator_config/abi.rs
+++ b/crates/precompiles/src/validator_config/abi.rs
@@ -34,11 +34,22 @@ pub mod IValidatorConfig {
     }
 
     pub trait Interface {
+        /// Get the owner of the precompile.
+        #[getter]
         fn owner(&self) -> Result<Address>;
+        /// Get the complete set of validators.
         fn get_validators(&self) -> Result<Vec<Validator>>;
+        /// Get the epoch at which a fresh DKG ceremony will be triggered.
+        ///
+        /// The fresh DKG ceremony runs in epoch N, and epoch N+1 uses the new DKG polynomial.
+        #[getter = "next_dkg_ceremony"]
         fn get_next_full_dkg_ceremony(&self) -> Result<u64>;
+        /// Get validator address at a specific index in the validators array.
         fn validators_array(&self, index: U256) -> Result<Address>;
+        /// Get validator information by address.
+        #[getter]
         fn validators(&self, validator: Address) -> Result<Validator>;
+        /// Get the current validator count.
         fn validator_count(&self) -> Result<u64>;
 
         #[msg_sender]

--- a/crates/precompiles/src/validator_config/mod.rs
+++ b/crates/precompiles/src/validator_config/mod.rs
@@ -1,33 +1,22 @@
+pub mod abi;
 pub mod dispatch;
 
-use tempo_contracts::precompiles::VALIDATOR_CONFIG_ADDRESS;
-pub use tempo_contracts::precompiles::{IValidatorConfig, ValidatorConfigError};
-use tempo_precompiles_macros::{Storable, contract};
+pub use abi::{IValidatorConfig, IValidatorConfig::prelude::*};
+
+#[cfg(feature = "precompile")]
+pub use abi::IValidatorConfig::Interface;
 
 use crate::{
+    VALIDATOR_CONFIG_ADDRESS,
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, U256};
+use tempo_precompiles_macros::contract;
 use tracing::trace;
 
-/// Validator information
-#[derive(Debug, Storable)]
-struct Validator {
-    public_key: B256,
-    active: bool,
-    index: u64,
-    validator_address: Address,
-    /// Address where other validators can connect to this validator.
-    /// Format: `<hostname|ip>:<port>`
-    inbound_address: String,
-    /// IP address for firewall whitelisting by other validators.
-    /// Format: `<ip>:<port>` - must be an IP address, not a hostname.
-    outbound_address: String,
-}
-
 /// Validator Config precompile for managing consensus validators
-#[contract(addr = VALIDATOR_CONFIG_ADDRESS)]
+#[contract(addr = VALIDATOR_CONFIG_ADDRESS, abi = IValidatorConfig, dispatch)]
 pub struct ValidatorConfig {
     owner: Address,
     validators_array: Vec<Address>,
@@ -46,11 +35,6 @@ impl ValidatorConfig {
         self.owner.write(owner)
     }
 
-    /// Internal helper to get owner
-    pub fn owner(&self) -> Result<Address> {
-        self.owner.read()
-    }
-
     /// Check if caller is the owner
     pub fn check_owner(&self, caller: Address) -> Result<()> {
         if self.owner()? != caller {
@@ -60,23 +44,45 @@ impl ValidatorConfig {
         Ok(())
     }
 
-    /// Change the owner (owner only)
-    pub fn change_owner(
-        &mut self,
-        sender: Address,
-        call: IValidatorConfig::changeOwnerCall,
-    ) -> Result<()> {
-        self.check_owner(sender)?;
-        self.owner.write(call.newOwner)
+    /// Check if a validator exists by checking if their publicKey is non-zero
+    /// Since ed25519 keys cannot be zero, this is a reliable existence check
+    fn validator_exists(&self, validator: Address) -> Result<bool> {
+        let validator = self.validators[validator].read()?;
+        Ok(!validator.public_key.is_zero())
+    }
+}
+
+impl IValidatorConfig::Interface for ValidatorConfig {
+    /// Get the owner of the precompile
+    fn owner(&self) -> Result<Address> {
+        self.owner.read()
     }
 
-    /// Get the current validator count
-    pub fn validator_count(&self) -> Result<u64> {
-        self.validators_array.len().map(|c| c as u64)
+    /// Change owner (owner only)
+    fn change_owner(&mut self, msg_sender: Address, new_owner: Address) -> Result<()> {
+        self.check_owner(msg_sender)?;
+        self.owner.write(new_owner)
+    }
+
+    /// Get the complete set of validators (view function)
+    fn get_validators(&self) -> Result<Vec<Validator>> {
+        let count = self.validators_array.len()?;
+        let mut validators = Vec::with_capacity(count);
+
+        for i in 0..count {
+            // Read validator address from the array at index i
+            let validator_address = self.validators_array[i].read()?;
+            let mut val = self.validators[validator_address].read()?;
+            val.validator_address = validator_address;
+            validators.push(val);
+        }
+
+        Ok(validators)
     }
 
     /// Get validator address at a specific index in the validators array
-    pub fn validators_array(&self, index: u64) -> Result<Address> {
+    fn validators_array(&self, index: U256) -> Result<Address> {
+        let index = u64::try_from(index).map_err(|_| TempoPrecompileError::array_oob())?;
         match self.validators_array.at(index as usize)? {
             Some(elem) => elem.read(),
             None => Err(TempoPrecompileError::array_oob()),
@@ -84,88 +90,51 @@ impl ValidatorConfig {
     }
 
     /// Get validator information by address
-    pub fn validators(&self, validator: Address) -> Result<IValidatorConfig::Validator> {
-        let validator_info = self.validators[validator].read()?;
-        Ok(IValidatorConfig::Validator {
-            publicKey: validator_info.public_key,
-            active: validator_info.active,
-            index: validator_info.index,
-            validatorAddress: validator_info.validator_address,
-            inboundAddress: validator_info.inbound_address,
-            outboundAddress: validator_info.outbound_address,
-        })
+    fn validators(&self, validator: Address) -> Result<Validator> {
+        self.validators[validator].read()
     }
 
-    /// Check if a validator exists by checking if their publicKey is non-zero
-    /// Since ed25519 keys cannot be zero, this is a reliable existence check
-    fn validator_exists(&self, validator: Address) -> Result<bool> {
-        let validator = self.validators[validator].read()?;
-        Ok(!validator.public_key.is_zero())
-    }
-
-    /// Get all validators (view function)
-    pub fn get_validators(&self) -> Result<Vec<IValidatorConfig::Validator>> {
-        let count = self.validators_array.len()?;
-        let mut validators = Vec::with_capacity(count);
-
-        for i in 0..count {
-            // Read validator address from the array at index i
-            let validator_address = self.validators_array[i].read()?;
-
-            let Validator {
-                public_key,
-                active,
-                index,
-                validator_address: _,
-                inbound_address,
-                outbound_address,
-            } = self.validators[validator_address].read()?;
-
-            validators.push(IValidatorConfig::Validator {
-                publicKey: public_key,
-                active,
-                index,
-                validatorAddress: validator_address,
-                inboundAddress: inbound_address,
-                outboundAddress: outbound_address,
-            });
-        }
-
-        Ok(validators)
+    /// Get the current validator count
+    fn validator_count(&self) -> Result<u64> {
+        self.validators_array.len().map(|c| c as u64)
     }
 
     /// Add a new validator (owner only)
-    pub fn add_validator(
+    fn add_validator(
         &mut self,
-        sender: Address,
-        call: IValidatorConfig::addValidatorCall,
+        msg_sender: Address,
+        new_validator_address: Address,
+        public_key: B256,
+        active: bool,
+        inbound_address: String,
+        outbound_address: String,
     ) -> Result<()> {
         // Reject zero public key - zero is used as sentinel value for non-existence
-        if call.publicKey.is_zero() {
+        if public_key.is_zero() {
             return Err(ValidatorConfigError::invalid_public_key())?;
         }
 
         // Only owner can create validators
-        self.check_owner(sender)?;
+        self.check_owner(msg_sender)?;
 
         // Check if validator already exists
-        if self.validator_exists(call.newValidatorAddress)? {
+        if self.validator_exists(new_validator_address)? {
             return Err(ValidatorConfigError::validator_already_exists())?;
         }
 
         // Validate addresses
-        ensure_address_is_ip_port(&call.inboundAddress).map_err(|err| {
+        ensure_address_is_ip_port(&inbound_address).map_err(|err| {
             ValidatorConfigError::not_host_port(
                 "inboundAddress".to_string(),
-                call.inboundAddress.clone(),
+                inbound_address.clone(),
                 format!("{err:?}"),
             )
         })?;
 
-        ensure_address_is_ip_port(&call.outboundAddress).map_err(|err| {
+        ensure_address_is_ip_port(&outbound_address).map_err(|err| {
             ValidatorConfigError::not_ip_port(
                 "outboundAddress".to_string(),
-                call.outboundAddress.clone(),
+                outbound_address.clone(),
                 format!("{err:?}"),
             )
         })?;
@@ -173,17 +142,17 @@ impl ValidatorConfig {
         // Store the new validator in the validators mapping
         let count = self.validator_count()?;
         let validator = Validator {
-            public_key: call.publicKey,
-            active: call.active,
+            public_key,
+            active,
             index: count,
-            validator_address: call.newValidatorAddress,
-            inbound_address: call.inboundAddress,
-            outbound_address: call.outboundAddress,
+            validator_address: new_validator_address,
+            inbound_address,
+            outbound_address,
         };
-        self.validators[call.newValidatorAddress].write(validator)?;
+        self.validators[new_validator_address].write(validator)?;
 
         // Add the validator public key to the validators array
-        self.validators_array.push(call.newValidatorAddress)
+        self.validators_array.push(new_validator_address)
     }
 
     /// Update validator information (and optionally rotate to new address)
@@ -197,125 +166,121 @@ impl ValidatorConfig {
     /// the original key stored in the boundary header cannot be mapped to the modified registry).
     /// By setting validator addresses to non-user-controllable addresses in the genesis config,
     /// only the contract owner (admin) can effectively call this function.
-    pub fn update_validator(
+    fn update_validator(
         &mut self,
-        sender: Address,
-        call: IValidatorConfig::updateValidatorCall,
+        msg_sender: Address,
+        new_validator_address: Address,
+        public_key: B256,
+        inbound_address: String,
+        outbound_address: String,
     ) -> Result<()> {
         // Reject zero public key - zero is used as sentinel value for non-existence
-        if call.publicKey.is_zero() {
+        if public_key.is_zero() {
             return Err(ValidatorConfigError::invalid_public_key())?;
         }
 
         // Validator can update their own info
-        if !self.validator_exists(sender)? {
+        if !self.validator_exists(msg_sender)? {
             return Err(ValidatorConfigError::validator_not_found())?;
         }
 
         // Load the current validator info
-        let old_validator = self.validators[sender].read()?;
+        let old_validator = self.validators[msg_sender].read()?;
 
         // Check if rotating to a new address
-        if call.newValidatorAddress != sender {
-            if self.validator_exists(call.newValidatorAddress)? {
+        if new_validator_address != msg_sender {
+            if self.validator_exists(new_validator_address)? {
                 return Err(ValidatorConfigError::validator_already_exists())?;
             }
 
             // Update the validators array to point at the new validator address
-            self.validators_array[old_validator.index as usize].write(call.newValidatorAddress)?;
+            self.validators_array[old_validator.index as usize].write(new_validator_address)?;
 
             // Clear the old validator
-            self.validators[sender].delete()?;
+            self.validators[msg_sender].delete()?;
         }
 
-        ensure_address_is_ip_port(&call.inboundAddress).map_err(|err| {
+        ensure_address_is_ip_port(&inbound_address).map_err(|err| {
             ValidatorConfigError::not_host_port(
                 "inboundAddress".to_string(),
-                call.inboundAddress.clone(),
+                inbound_address.clone(),
                 format!("{err:?}"),
             )
         })?;
 
-        ensure_address_is_ip_port(&call.outboundAddress).map_err(|err| {
+        ensure_address_is_ip_port(&outbound_address).map_err(|err| {
             ValidatorConfigError::not_ip_port(
                 "outboundAddress".to_string(),
-                call.outboundAddress.clone(),
+                outbound_address.clone(),
                 format!("{err:?}"),
             )
         })?;
 
         let updated_validator = Validator {
-            public_key: call.publicKey,
+            public_key,
             active: old_validator.active,
             index: old_validator.index,
-            validator_address: call.newValidatorAddress,
-            inbound_address: call.inboundAddress,
-            outbound_address: call.outboundAddress,
+            validator_address: new_validator_address,
+            inbound_address,
+            outbound_address,
         };
 
-        self.validators[call.newValidatorAddress].write(updated_validator)
+        self.validators[new_validator_address].write(updated_validator)
     }
 
     /// Change validator active status (owner only) - by address
     /// Deprecated: Use change_validator_status_by_index to prevent front-running attacks
-    pub fn change_validator_status(
+    fn change_validator_status(
         &mut self,
-        sender: Address,
-        call: IValidatorConfig::changeValidatorStatusCall,
+        msg_sender: Address,
+        validator: Address,
+        active: bool,
     ) -> Result<()> {
-        self.check_owner(sender)?;
+        self.check_owner(msg_sender)?;
 
-        if !self.validator_exists(call.validator)? {
+        if !self.validator_exists(validator)? {
             return Err(ValidatorConfigError::validator_not_found())?;
         }
 
-        let mut validator = self.validators[call.validator].read()?;
-        validator.active = call.active;
-        self.validators[call.validator].write(validator)
+        let mut val = self.validators[validator].read()?;
+        val.active = active;
+        self.validators[validator].write(val)
     }
 
     /// Change validator active status by index (owner only) - T1+
     /// Added in T1 to prevent front-running attacks where a validator changes its address
-    pub fn change_validator_status_by_index(
+    fn change_validator_status_by_index(
         &mut self,
-        sender: Address,
-        call: IValidatorConfig::changeValidatorStatusByIndexCall,
+        msg_sender: Address,
+        index: u64,
+        active: bool,
     ) -> Result<()> {
-        self.check_owner(sender)?;
+        self.check_owner(msg_sender)?;
 
         // Look up validator address by index
-        let validator_address = match self.validators_array.at(call.index as usize)? {
+        let validator_address = match self.validators_array.at(index as usize)? {
             Some(elem) => elem.read()?,
             None => return Err(ValidatorConfigError::validator_not_found())?,
         };
 
         let mut validator = self.validators[validator_address].read()?;
-        validator.active = call.active;
+        validator.active = active;
         self.validators[validator_address].write(validator)
     }
 
     /// Get the epoch at which a fresh DKG ceremony will be triggered.
     ///
     /// The fresh DKG ceremony runs in epoch N, and epoch N+1 uses the new DKG polynomial.
-    pub fn get_next_full_dkg_ceremony(&self) -> Result<u64> {
-        self.next_dkg_ceremony.read()
-    }
-
-    /// Get the epoch at which a fresh DKG ceremony will be triggered (public getter)
-    pub fn next_dkg_ceremony(&self) -> Result<u64> {
+    fn get_next_full_dkg_ceremony(&self) -> Result<u64> {
         self.next_dkg_ceremony.read()
     }
 
     /// Set the epoch at which a fresh DKG ceremony will be triggered (owner only).
     ///
     /// Epoch N runs the ceremony, and epoch N+1 uses the new DKG polynomial.
-    pub fn set_next_full_dkg_ceremony(
-        &mut self,
-        sender: Address,
-        call: IValidatorConfig::setNextFullDkgCeremonyCall,
-    ) -> Result<()> {
-        self.check_owner(sender)?;
-        self.next_dkg_ceremony.write(call.epoch)
+    fn set_next_full_dkg_ceremony(&mut self, msg_sender: Address, epoch: u64) -> Result<()> {
+        self.check_owner(msg_sender)?;
+        self.next_dkg_ceremony.write(epoch)
     }
 }
 
@@ -358,10 +323,7 @@ mod tests {
             );
 
             // Change owner to owner2
-            validator_config.change_owner(
-                owner1,
-                IValidatorConfig::changeOwnerCall { newOwner: owner2 },
-            )?;
+            validator_config.change_owner(owner1, owner2)?;
 
             // Check that owner is now owner2
             let current_owner = validator_config.owner()?;
@@ -388,30 +350,22 @@ mod tests {
             let public_key = FixedBytes::<32>::from([0x44; 32]);
             validator_config.add_validator(
                 owner1,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: public_key,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator1,
+                public_key,
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             )?;
 
             // Verify validator was added
             let validators = validator_config.get_validators()?;
             assert_eq!(validators.len(), 1, "Should have 1 validator");
-            assert_eq!(validators[0].validatorAddress, validator1);
-            assert_eq!(validators[0].publicKey, public_key);
+            assert_eq!(validators[0].validator_address, validator1);
+            assert_eq!(validators[0].public_key, public_key);
             assert!(validators[0].active, "New validator should be active");
 
             // Owner1 changes validator status - should succeed
-            validator_config.change_validator_status(
-                owner1,
-                IValidatorConfig::changeValidatorStatusCall {
-                    validator: validator1,
-                    active: false,
-                },
-            )?;
+            validator_config.change_validator_status(owner1, validator1, false)?;
 
             // Verify status was changed
             let validators = validator_config.get_validators()?;
@@ -420,24 +374,16 @@ mod tests {
             // Owner2 (non-owner) tries to add validator - should fail
             let res = validator_config.add_validator(
                 owner2,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator2,
-                    publicKey: FixedBytes::<32>::from([0x66; 32]),
-                    inboundAddress: "192.168.1.2:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.2:9000".to_string(),
-                },
+                validator2,
+                FixedBytes::<32>::from([0x66; 32]),
+                true,
+                "192.168.1.2:8000".to_string(),
+                "192.168.1.2:9000".to_string(),
             );
             assert_eq!(res, Err(ValidatorConfigError::unauthorized().into()));
 
             // Owner2 (non-owner) tries to change validator status - should fail
-            let res = validator_config.change_validator_status(
-                owner2,
-                IValidatorConfig::changeValidatorStatusCall {
-                    validator: validator1,
-                    active: true,
-                },
-            );
+            let res = validator_config.change_validator_status(owner2, validator1, true);
             assert_eq!(res, Err(ValidatorConfigError::unauthorized().into()));
 
             Ok(())
@@ -459,25 +405,21 @@ mod tests {
             let outbound1 = "192.168.1.1:9000".to_string();
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: public_key1,
-                    inboundAddress: inbound1.clone(),
-                    active: true,
-                    outboundAddress: outbound1,
-                },
+                validator1,
+                public_key1,
+                true,
+                inbound1.clone(),
+                outbound1,
             )?;
 
             // Try adding duplicate validator - should fail
             let result = validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator1,
+                FixedBytes::<32>::from([0x22; 32]),
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             );
             assert_eq!(
                 result,
@@ -490,52 +432,44 @@ mod tests {
             let public_key2 = FixedBytes::<32>::from([0x22; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator2,
-                    publicKey: public_key2,
-                    inboundAddress: "192.168.1.2:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.2:9000".to_string(),
-                },
+                validator2,
+                public_key2,
+                true,
+                "192.168.1.2:8000".to_string(),
+                "192.168.1.2:9000".to_string(),
             )?;
 
             let validator3 = Address::from([0x13; 20]);
             let public_key3 = FixedBytes::<32>::from([0x23; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator3,
-                    publicKey: public_key3,
-                    inboundAddress: "192.168.1.3:8000".to_string(),
-                    active: false,
-                    outboundAddress: "192.168.1.3:9000".to_string(),
-                },
+                validator3,
+                public_key3,
+                false,
+                "192.168.1.3:8000".to_string(),
+                "192.168.1.3:9000".to_string(),
             )?;
 
             let validator4 = Address::from([0x14; 20]);
             let public_key4 = FixedBytes::<32>::from([0x24; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator4,
-                    publicKey: public_key4,
-                    inboundAddress: "192.168.1.4:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.4:9000".to_string(),
-                },
+                validator4,
+                public_key4,
+                true,
+                "192.168.1.4:8000".to_string(),
+                "192.168.1.4:9000".to_string(),
             )?;
 
             let validator5 = Address::from([0x15; 20]);
             let public_key5 = FixedBytes::<32>::from([0x25; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator5,
-                    publicKey: public_key5,
-                    inboundAddress: "192.168.1.5:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.5:9000".to_string(),
-                },
+                validator5,
+                public_key5,
+                true,
+                "192.168.1.5:8000".to_string(),
+                "192.168.1.5:9000".to_string(),
             )?;
 
             // Get all validators
@@ -545,32 +479,32 @@ mod tests {
             assert_eq!(validators.len(), 5, "Should have 5 validators");
 
             // Sort by validator address for consistent checking
-            validators.sort_by_key(|v| v.validatorAddress);
+            validators.sort_by_key(|v| v.validator_address);
 
             // Verify each validator
-            assert_eq!(validators[0].validatorAddress, validator1);
-            assert_eq!(validators[0].publicKey, public_key1);
-            assert_eq!(validators[0].inboundAddress, inbound1);
+            assert_eq!(validators[0].validator_address, validator1);
+            assert_eq!(validators[0].public_key, public_key1);
+            assert_eq!(validators[0].inbound_address, inbound1);
             assert!(validators[0].active);
 
-            assert_eq!(validators[1].validatorAddress, validator2);
-            assert_eq!(validators[1].publicKey, public_key2);
-            assert_eq!(validators[1].inboundAddress, "192.168.1.2:8000");
+            assert_eq!(validators[1].validator_address, validator2);
+            assert_eq!(validators[1].public_key, public_key2);
+            assert_eq!(validators[1].inbound_address, "192.168.1.2:8000");
             assert!(validators[1].active);
 
-            assert_eq!(validators[2].validatorAddress, validator3);
-            assert_eq!(validators[2].publicKey, public_key3);
-            assert_eq!(validators[2].inboundAddress, "192.168.1.3:8000");
+            assert_eq!(validators[2].validator_address, validator3);
+            assert_eq!(validators[2].public_key, public_key3);
+            assert_eq!(validators[2].inbound_address, "192.168.1.3:8000");
             assert!(!validators[2].active);
 
-            assert_eq!(validators[3].validatorAddress, validator4);
-            assert_eq!(validators[3].publicKey, public_key4);
-            assert_eq!(validators[3].inboundAddress, "192.168.1.4:8000");
+            assert_eq!(validators[3].validator_address, validator4);
+            assert_eq!(validators[3].public_key, public_key4);
+            assert_eq!(validators[3].inbound_address, "192.168.1.4:8000");
             assert!(validators[3].active);
 
-            assert_eq!(validators[4].validatorAddress, validator5);
-            assert_eq!(validators[4].publicKey, public_key5);
-            assert_eq!(validators[4].inboundAddress, "192.168.1.5:8000");
+            assert_eq!(validators[4].validator_address, validator5);
+            assert_eq!(validators[4].public_key, public_key5);
+            assert_eq!(validators[4].inbound_address, "192.168.1.5:8000");
             assert!(validators[4].active);
 
             // Validator1 updates from long to short address (tests update_string slot clearing)
@@ -579,24 +513,20 @@ mod tests {
             let short_outbound1 = "10.0.0.1:9000".to_string();
             validator_config.update_validator(
                 validator1,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: public_key1_new,
-                    inboundAddress: short_inbound1.clone(),
-                    outboundAddress: short_outbound1,
-                },
+                validator1,
+                public_key1_new,
+                short_inbound1.clone(),
+                short_outbound1,
             )?;
 
             // Validator2 rotates to new address, keeps IP and publicKey
             let validator2_new = Address::from([0x22; 20]);
             validator_config.update_validator(
                 validator2,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator2_new,
-                    publicKey: public_key2,
-                    inboundAddress: "192.168.1.2:8000".to_string(),
-                    outboundAddress: "192.168.1.2:9000".to_string(),
-                },
+                validator2_new,
+                public_key2,
+                "192.168.1.2:8000".to_string(),
+                "192.168.1.2:9000".to_string(),
             )?;
 
             // Validator3 rotates to new address with long host (tests delete_string on old slot)
@@ -605,12 +535,10 @@ mod tests {
             let long_outbound3 = "192.168.1.3:9000".to_string();
             validator_config.update_validator(
                 validator3,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator3_new,
-                    publicKey: public_key3,
-                    inboundAddress: long_inbound3.clone(),
-                    outboundAddress: long_outbound3,
-                },
+                validator3_new,
+                public_key3,
+                long_inbound3.clone(),
+                long_outbound3,
             )?;
 
             // Get all validators again
@@ -620,52 +548,52 @@ mod tests {
             assert_eq!(validators.len(), 5, "Should still have 5 validators");
 
             // Sort by validator address
-            validators.sort_by_key(|v| v.validatorAddress);
+            validators.sort_by_key(|v| v.validator_address);
 
             // Verify validator1 - updated from long to short address
-            assert_eq!(validators[0].validatorAddress, validator1);
+            assert_eq!(validators[0].validator_address, validator1);
             assert_eq!(
-                validators[0].publicKey, public_key1_new,
+                validators[0].public_key, public_key1_new,
                 "PublicKey should be updated"
             );
             assert_eq!(
-                validators[0].inboundAddress, short_inbound1,
+                validators[0].inbound_address, short_inbound1,
                 "Address should be updated to short"
             );
             assert!(validators[0].active);
 
             // Verify validator4 - unchanged
-            assert_eq!(validators[1].validatorAddress, validator4);
-            assert_eq!(validators[1].publicKey, public_key4);
-            assert_eq!(validators[1].inboundAddress, "192.168.1.4:8000");
+            assert_eq!(validators[1].validator_address, validator4);
+            assert_eq!(validators[1].public_key, public_key4);
+            assert_eq!(validators[1].inbound_address, "192.168.1.4:8000");
             assert!(validators[1].active);
 
             // Verify validator5 - unchanged
-            assert_eq!(validators[2].validatorAddress, validator5);
-            assert_eq!(validators[2].publicKey, public_key5);
-            assert_eq!(validators[2].inboundAddress, "192.168.1.5:8000");
+            assert_eq!(validators[2].validator_address, validator5);
+            assert_eq!(validators[2].public_key, public_key5);
+            assert_eq!(validators[2].inbound_address, "192.168.1.5:8000");
             assert!(validators[2].active);
 
             // Verify validator2_new - rotated address, kept IP and publicKey
-            assert_eq!(validators[3].validatorAddress, validator2_new);
+            assert_eq!(validators[3].validator_address, validator2_new);
             assert_eq!(
-                validators[3].publicKey, public_key2,
+                validators[3].public_key, public_key2,
                 "PublicKey should be same"
             );
             assert_eq!(
-                validators[3].inboundAddress, "192.168.1.2:8000",
+                validators[3].inbound_address, "192.168.1.2:8000",
                 "IP should be same"
             );
             assert!(validators[3].active);
 
             // Verify validator3_new - rotated address with long host, kept publicKey
-            assert_eq!(validators[4].validatorAddress, validator3_new);
+            assert_eq!(validators[4].validator_address, validator3_new);
             assert_eq!(
-                validators[4].publicKey, public_key3,
+                validators[4].public_key, public_key3,
                 "PublicKey should be same"
             );
             assert_eq!(
-                validators[4].inboundAddress, long_inbound3,
+                validators[4].inbound_address, long_inbound3,
                 "Address should be updated to long"
             );
             assert!(!validators[4].active);
@@ -687,24 +615,20 @@ mod tests {
             let public_key = FixedBytes::<32>::from([0x21; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator,
-                    publicKey: public_key,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator,
+                public_key,
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             )?;
 
             // Owner tries to update validator - should fail
             let result = validator_config.update_validator(
                 owner,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator,
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
-                    inboundAddress: "10.0.0.1:8000".to_string(),
-                    outboundAddress: "10.0.0.1:9000".to_string(),
-                },
+                validator,
+                FixedBytes::<32>::from([0x22; 32]),
+                "10.0.0.1:8000".to_string(),
+                "10.0.0.1:9000".to_string(),
             );
 
             assert_eq!(
@@ -734,24 +658,20 @@ mod tests {
 
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: public_key,
-                    inboundAddress: long_inbound,
-                    active: true,
-                    outboundAddress: long_outbound,
-                },
+                validator1,
+                public_key,
+                true,
+                long_inbound,
+                long_outbound,
             )?;
 
             // Rotate to new address with shorter addresses
             validator_config.update_validator(
                 validator1,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator2,
-                    publicKey: public_key,
-                    inboundAddress: "10.0.0.1:8000".to_string(),
-                    outboundAddress: "10.0.0.1:9000".to_string(),
-                },
+                validator2,
+                public_key,
+                "10.0.0.1:8000".to_string(),
+                "10.0.0.1:9000".to_string(),
             )?;
 
             // Verify old slots are cleared by checking storage directly
@@ -798,17 +718,11 @@ mod tests {
             assert_eq!(validator_config.get_next_full_dkg_ceremony()?, 0);
 
             // Owner can set the value
-            validator_config.set_next_full_dkg_ceremony(
-                owner,
-                IValidatorConfig::setNextFullDkgCeremonyCall { epoch: 42 },
-            )?;
+            validator_config.set_next_full_dkg_ceremony(owner, 42)?;
             assert_eq!(validator_config.get_next_full_dkg_ceremony()?, 42);
 
             // Non-owner cannot set the value
-            let result = validator_config.set_next_full_dkg_ceremony(
-                non_owner,
-                IValidatorConfig::setNextFullDkgCeremonyCall { epoch: 100 },
-            );
+            let result = validator_config.set_next_full_dkg_ceremony(non_owner, 100);
             assert_eq!(result, Err(ValidatorConfigError::unauthorized().into()));
 
             // Value unchanged after failed attempt
@@ -840,13 +754,11 @@ mod tests {
             let zero_public_key = FixedBytes::<32>::ZERO;
             let result = validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator,
-                    publicKey: zero_public_key,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator,
+                zero_public_key,
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             );
 
             assert_eq!(
@@ -875,24 +787,20 @@ mod tests {
             let original_public_key = FixedBytes::<32>::from([0x44; 32]);
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator,
-                    publicKey: original_public_key,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator,
+                original_public_key,
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             )?;
 
             let zero_public_key = FixedBytes::<32>::ZERO;
             let result = validator_config.update_validator(
                 validator,
-                IValidatorConfig::updateValidatorCall {
-                    newValidatorAddress: validator,
-                    publicKey: zero_public_key,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator,
+                zero_public_key,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             );
 
             assert_eq!(
@@ -905,7 +813,7 @@ mod tests {
             let validators = validator_config.get_validators()?;
             assert_eq!(validators.len(), 1, "Should still have 1 validator");
             assert_eq!(
-                validators[0].publicKey, original_public_key,
+                validators[0].public_key, original_public_key,
                 "Original public key should be preserved"
             );
 

--- a/crates/precompiles/src/validator_config/mod.rs
+++ b/crates/precompiles/src/validator_config/mod.rs
@@ -53,18 +53,12 @@ impl ValidatorConfig {
 }
 
 impl IValidatorConfig::Interface for ValidatorConfig {
-    /// Get the owner of the precompile
-    fn owner(&self) -> Result<Address> {
-        self.owner.read()
-    }
-
     /// Change owner (owner only)
     fn change_owner(&mut self, msg_sender: Address, new_owner: Address) -> Result<()> {
         self.check_owner(msg_sender)?;
         self.owner.write(new_owner)
     }
 
-    /// Get the complete set of validators (view function)
     fn get_validators(&self) -> Result<Vec<Validator>> {
         let count = self.validators_array.len()?;
         let mut validators = Vec::with_capacity(count);
@@ -80,7 +74,6 @@ impl IValidatorConfig::Interface for ValidatorConfig {
         Ok(validators)
     }
 
-    /// Get validator address at a specific index in the validators array
     fn validators_array(&self, index: U256) -> Result<Address> {
         let index = u64::try_from(index).map_err(|_| TempoPrecompileError::array_oob())?;
         match self.validators_array.at(index as usize)? {
@@ -89,12 +82,6 @@ impl IValidatorConfig::Interface for ValidatorConfig {
         }
     }
 
-    /// Get validator information by address
-    fn validators(&self, validator: Address) -> Result<Validator> {
-        self.validators[validator].read()
-    }
-
-    /// Get the current validator count
     fn validator_count(&self) -> Result<u64> {
         self.validators_array.len().map(|c| c as u64)
     }
@@ -266,13 +253,6 @@ impl IValidatorConfig::Interface for ValidatorConfig {
         let mut validator = self.validators[validator_address].read()?;
         validator.active = active;
         self.validators[validator_address].write(validator)
-    }
-
-    /// Get the epoch at which a fresh DKG ceremony will be triggered.
-    ///
-    /// The fresh DKG ceremony runs in epoch N, and epoch N+1 uses the new DKG polynomial.
-    fn get_next_full_dkg_ceremony(&self) -> Result<u64> {
-        self.next_dkg_ceremony.read()
     }
 
     /// Set the epoch at which a fresh DKG ceremony will be triggered (owner only).


### PR DESCRIPTION
## Summary

Migrates `ValidatorConfig` from `sol!`-based ABI definitions to the `#[abi]` macro.

### Changes

- **New**: `validator_config/abi.rs` — defines `IValidatorConfig` with:
  - `Validator` struct (`Storable` derive) containing network configuration fields
  - `Error` enum with structured variants (`NotIpPort`, `NotHostPort`)
  - `Interface` trait with `#[getter]` auto-impls (`owner`, `validators`), renamed getter (`get_next_full_dkg_ceremony` → `next_dkg_ceremony`), and `#[hardfork = TempoHardfork::T1]` gating on `change_validator_status_by_index`
- **Migrated**: `validator_config/mod.rs` — implements `IValidatorConfig::Interface` trait
- **Simplified**: `validator_config/dispatch.rs` — manual dispatch replaced
- Adjustments to `error.rs`, `xtask/genesis_args.rs`, `e2e/execution_runtime.rs`, and `commonware-node/dkg`

### Stack

> Part of the [`#[abi]` macro stack](https://github.com/tempoxyz/tempo/pull/2687) — PR 7 of 11.