### PR TITLE
chore(precompiles): migrate StableDEX to `#[abi]` macro

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -6,6 +6,7 @@ use std::{
 use crate::{
     account_keychain::IAccountKeychain::Error as AccountKeychainError,
     nonce::INonce::Error as NonceError,
+    stablecoin_dex::IStablecoinDEX::Error as StablecoinDEXError,
     tip_fee_manager::{IFeeAMM, IFeeManager},
     tip20::TIP20Error,
     tip20_factory::TIP20FactoryError,
@@ -20,7 +21,7 @@ use revm::{
     context::journaled_state::JournalLoadErasedError,
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
 };
-use tempo_contracts::precompiles::{RolesAuthError, StablecoinDEXError, UnknownFunctionSelector};
+use tempo_contracts::precompiles::{RolesAuthError, UnknownFunctionSelector};
 
 /// Top-level error type for all Tempo precompile operations
 #[derive(
@@ -256,7 +257,6 @@ impl<T> IntoPrecompileResult<T> for TempoPrecompileError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempo_contracts::precompiles::StablecoinDEXError;
 
     #[test]
     fn test_add_errors_to_registry_populates_registry() {
@@ -300,10 +300,10 @@ mod tests {
         );
 
         let decoded = result.unwrap();
-        assert!(matches!(
+        assert_eq!(
             decoded.error,
-            TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderDoesNotExist(_))
-        ));
+            StablecoinDEXError::order_does_not_exist().into()
+        );
     }
 
     #[test]

--- a/crates/precompiles/src/stablecoin_dex/abi.rs
+++ b/crates/precompiles/src/stablecoin_dex/abi.rs
@@ -1,0 +1,146 @@
+use tempo_precompiles_macros::abi;
+
+#[rustfmt::skip]
+#[abi(no_reexport)]
+#[allow(non_snake_case)]
+pub mod IStablecoinDEX {
+    #[cfg(feature = "precompile")]
+    use crate::error::Result;
+    use alloy::primitives::{Address, B256};
+
+    // Constants from Solidity implementation
+    pub const TICK_SPACING: i16 = 10;
+    pub const MIN_TICK: i16 = -2000;
+    pub const MAX_TICK: i16 = 2000;
+    pub const PRICE_SCALE: u32 = 100_000;
+    // PRICE_SCALE + MIN_TICK = 100_000 - 2000
+    pub const MIN_PRICE: u32 = 98_000;
+    // PRICE_SCALE + MAX_TICK = 100_000 + 2000
+    pub const MAX_PRICE: u32 = 102_000;
+    /// Minimum order size of $100 USD
+    pub const MIN_ORDER_AMOUNT: u128 = 100_000_000;
+
+    /// Represents an order in the stablecoin DEX orderbook.
+    ///
+    /// This struct matches the Solidity reference implementation in StablecoinDEX.sol.
+    ///
+    /// # Order Types
+    /// - **Regular orders**: Orders with `is_flip = false`
+    /// - **Flip orders**: Orders with `is_flip = true` that automatically create
+    ///   a new order on the opposite side when fully filled
+    ///
+    /// # Order Lifecycle
+    /// 1. Order is placed via `place()` or `placeFlip()` and immediately added to the orderbook
+    /// 2. Orders can be filled (fully or partially) by swaps
+    /// 3. Flip orders automatically create a new order on the opposite side when fully filled
+    /// 4. Orders can be cancelled, removing them from the book and refunding escrow
+    ///
+    /// # Price-Time Priority
+    /// Orders are sorted by price (tick), then by insertion time.
+    /// The doubly linked list maintains insertion order - orders are added at the tail,
+    /// so traversing from head to tail gives price-time priority.
+    ///
+    /// # Onchain Storage
+    /// Orders are stored onchain in doubly linked lists organized by tick.
+    /// Each tick maintains a FIFO queue of orders using `prev` and `next` pointers.
+    #[derive(Debug, Clone, PartialEq, Eq, Storable)]
+    pub struct Order {
+        /// Unique identifier for this order
+        pub order_id: u128,
+        /// Address of the user who placed this order
+        pub maker: Address,
+        /// Orderbook key (identifies the trading pair)
+        pub book_key: B256,
+        /// Whether this is a bid (true) or ask (false) order
+        pub is_bid: bool,
+        /// Price tick
+        pub tick: i16,
+        /// Original order amount
+        pub amount: u128,
+        /// Remaining amount to be filled
+        pub remaining: u128,
+        /// Previous order ID in the doubly linked list (0 if head)
+        pub prev: u128,
+        /// Next order ID in the doubly linked list (0 if tail)
+        pub next: u128,
+        /// Whether this is a flip order
+        pub is_flip: bool,
+        /// Tick to flip to when fully filled (for flip orders, 0 for regular orders)
+        /// For bid flips: flip_tick must be > tick
+        /// For ask flips: flip_tick must be < tick
+        pub flip_tick: i16,
+    }
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
+    pub struct Orderbook {
+        /// Base token address
+        pub base: Address,
+        /// Quote token address
+        pub quote: Address,
+        /// Best bid tick for highest bid price
+        pub best_bid_tick: i16,
+        /// Best ask tick for lowest ask price
+        pub best_ask_tick: i16,
+    }
+
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Error {
+        Unauthorized,
+        PairDoesNotExist,
+        PairAlreadyExists,
+        OrderDoesNotExist,
+        IdenticalTokens,
+        InvalidToken,
+        TickOutOfBounds { tick: i16 },
+        InvalidTick,
+        InvalidFlipTick,
+        InsufficientBalance,
+        InsufficientLiquidity,
+        InsufficientOutput,
+        MaxInputExceeded,
+        BelowMinimumOrderSize { amount: u128 },
+        InvalidBaseToken,
+        OrderNotStale,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Event {
+        PairCreated { #[indexed] key: B256, #[indexed] base: Address, #[indexed] quote: Address },
+        OrderPlaced { #[indexed] order_id: u128, #[indexed] maker: Address, #[indexed] token: Address, amount: u128, is_bid: bool, tick: i16, is_flip_order: bool, flip_tick: i16 },
+        OrderFilled { #[indexed] order_id: u128, #[indexed] maker: Address, #[indexed] taker: Address, amount_filled: u128, partial_fill: bool },
+        OrderCancelled { #[indexed] order_id: u128 },
+    }
+
+    pub trait Interface {
+        // View/pure functions
+        /// Get user's balance for a specific token.
+        #[getter = "balances"]
+        fn balance_of(&self, user: Address, token: Address) -> Result<u128>;
+        fn get_order(&self, order_id: u128) -> Result<Order>;
+        fn get_tick_level(&self, base: Address, tick: i16, is_bid: bool) -> Result<(u128, u128, u128)>;
+        fn pair_key(&self, token_a: Address, token_b: Address) -> Result<B256>;
+        fn next_order_id(&self) -> Result<u128>;
+        fn books(&self, pair_key: B256) -> Result<Orderbook>;
+        fn tick_to_price(&self, tick: i16) -> Result<u32>;
+        fn price_to_tick(&self, price: u32) -> Result<i16>;
+        fn quote_swap_exact_amount_in(&self, token_in: Address, token_out: Address, amount_in: u128) -> Result<u128>;
+        fn quote_swap_exact_amount_out(&self, token_in: Address, token_out: Address, amount_out: u128) -> Result<u128>;
+
+        // Mutating functions
+        fn create_pair(&mut self, base: Address) -> Result<B256>;
+        #[msg_sender]
+        fn place(&mut self, token: Address, amount: u128, is_bid: bool, tick: i16) -> Result<u128>;
+        #[msg_sender]
+        fn place_flip(&mut self, token: Address, amount: u128, is_bid: bool, tick: i16, flip_tick: i16) -> Result<u128>;
+        #[msg_sender]
+        fn cancel(&mut self, order_id: u128) -> Result<()>;
+        fn cancel_stale_order(&mut self, order_id: u128) -> Result<()>;
+        #[msg_sender]
+        fn swap_exact_amount_in(&mut self, token_in: Address, token_out: Address, amount_in: u128, min_amount_out: u128) -> Result<u128>;
+        #[msg_sender]
+        fn swap_exact_amount_out(&mut self, token_in: Address, token_out: Address, amount_out: u128, max_amount_in: u128) -> Result<u128>;
+        #[msg_sender]
+        fn withdraw(&mut self, token: Address, amount: u128) -> Result<()>;
+    }
+}

--- a/crates/precompiles/src/validator_config/mod.rs
+++ b/crates/precompiles/src/validator_config/mod.rs
@@ -817,33 +817,32 @@ mod tests {
             // Add validators
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator1,
-                    publicKey: public_key1,
-                    inboundAddress: "192.168.1.1:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.1:9000".to_string(),
-                },
+                validator1,
+                public_key1,
+                true,
+                "192.168.1.1:8000".to_string(),
+                "192.168.1.1:9000".to_string(),
             )?;
 
             validator_config.add_validator(
                 owner,
-                IValidatorConfig::addValidatorCall {
-                    newValidatorAddress: validator2,
-                    publicKey: public_key2,
-                    inboundAddress: "192.168.1.2:8000".to_string(),
-                    active: true,
-                    outboundAddress: "192.168.1.2:9000".to_string(),
-                },
+                validator2,
+                public_key2,
+                true,
+                "192.168.1.2:8000".to_string(),
+                "192.168.1.2:9000".to_string(),
             )?;
 
             // validators_array should return the actual addresses, not default
-            assert_eq!(validator_config.validators_array(0)?, validator1);
-            assert_eq!(validator_config.validators_array(1)?, validator2);
+            assert_eq!(validator_config.validators_array(U256::ZERO)?, validator1);
+            assert_eq!(validator_config.validators_array(U256::ONE)?, validator2);
 
             // Verify they're not default
-            assert_ne!(validator_config.validators_array(0)?, Address::ZERO);
-            assert_ne!(validator_config.validators_array(1)?, Address::ZERO);
+            assert_ne!(
+                validator_config.validators_array(U256::ZERO)?,
+                Address::ZERO
+            );
+            assert_ne!(validator_config.validators_array(U256::ONE)?, Address::ZERO);
 
             Ok(())
         })
@@ -861,10 +860,7 @@ mod tests {
             assert_eq!(validator_config.get_next_full_dkg_ceremony()?, 0);
 
             // Set to a specific value
-            validator_config.set_next_full_dkg_ceremony(
-                owner,
-                IValidatorConfig::setNextFullDkgCeremonyCall { epoch: 100 },
-            )?;
+            validator_config.set_next_full_dkg_ceremony(owner, 100)?;
 
             // Should return the set value, not 0 or 1
             let result = validator_config.get_next_full_dkg_ceremony()?;

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -89,7 +89,7 @@ fn test_fee_manager_layout() {
 #[test]
 fn test_stablecoin_dex_layout() {
     use tempo_precompiles::stablecoin_dex::{
-        order::__packing_order::*, orderbook::__packing_orderbook::*, slots,
+        IStablecoinDEX::__packing_order::*, orderbook::__packing_orderbook::*, slots,
     };
 
     let sol_path = testdata("stablecoin_dex.sol");
@@ -284,7 +284,7 @@ fn export_all_storage_constants() {
     // Stablecoin DEX
     {
         use tempo_precompiles::stablecoin_dex::{
-            order::__packing_order::*, orderbook::__packing_orderbook::*, slots,
+            IStablecoinDEX::__packing_order::*, orderbook::__packing_orderbook::*, slots,
         };
 
         let fields = layout_fields!(books, orders, balances, next_order_id, book_keys);

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -9,12 +9,11 @@ use revm::{
     state::{AccountInfo, Bytecode},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_contracts::precompiles::{
-    DEFAULT_FEE_TOKEN, IFeeManager, IStablecoinDEX, STABLECOIN_DEX_ADDRESS,
-};
+use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IFeeManager, STABLECOIN_DEX_ADDRESS};
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     error::{Result as TempoResult, TempoPrecompileError},
+    stablecoin_dex::IStablecoinDEX,
     storage::{Handler, PrecompileStorageProvider, StorageCtx},
     tip_fee_manager::TipFeeManager,
     tip20::{ITIP20, TIP20Token, is_tip20_prefix},
@@ -180,13 +179,13 @@ pub trait TempoStateAccess<M = ()> {
             && (!tx.is_aa() || calls.next().is_none())
         {
             if let Ok(call) = IStablecoinDEX::swapExactAmountInCall::abi_decode(input)
-                && self.is_valid_fee_token(spec, call.tokenIn)?
+                && self.is_valid_fee_token(spec, call.token_in)?
             {
-                return Ok(call.tokenIn);
+                return Ok(call.token_in);
             } else if let Ok(call) = IStablecoinDEX::swapExactAmountOutCall::abi_decode(input)
-                && self.is_valid_fee_token(spec, call.tokenIn)?
+                && self.is_valid_fee_token(spec, call.token_in)?
             {
-                return Ok(call.tokenIn);
+                return Ok(call.token_in);
             }
         }
 
@@ -550,10 +549,10 @@ mod tests {
 
         // Test swapExactAmountIn
         let call = IStablecoinDEX::swapExactAmountInCall {
-            tokenIn: token_in,
-            tokenOut: token_out,
-            amountIn: 1000,
-            minAmountOut: 900,
+            token_in,
+            token_out,
+            amount_in: 1000,
+            min_amount_out: 900,
         };
 
         let tx_env = TxEnv {
@@ -573,10 +572,10 @@ mod tests {
 
         // Test swapExactAmountOut
         let call = IStablecoinDEX::swapExactAmountOutCall {
-            tokenIn: token_in,
-            tokenOut: token_out,
-            amountOut: 900,
-            maxAmountIn: 1000,
+            token_in,
+            token_out,
+            amount_out: 900,
+            max_amount_in: 1000,
         };
 
         let tx_env = TxEnv {


### PR DESCRIPTION
## Summary

Migrates `StablecoinDEX` from `sol!`-based ABI definitions to the `#[abi]` macro.

### Changes

- **New**: `stablecoin_dex/abi.rs` — defines `IStablecoinDEX` with:
  - 8 constants (`TICK_SPACING`, `MIN_TICK`, `MAX_TICK`, `PRICE_SCALE`, `MIN_PRICE`, `MAX_PRICE`, `MIN_ORDER_AMOUNT`)
  - `Order` struct (`Storable` derive) — 12-field orderbook order with linked-list pointers
  - `Orderbook` struct
  - `Error` enum with structured variants (`TickOutOfBounds`, `BelowMinimumOrderSize`)
  - `Event` enum
  - `Interface` trait with `#[getter]` auto-impls (`balances` → `balance_of`) and view/mutate methods
- **Migrated**: `stablecoin_dex/mod.rs`, `order.rs`, `orderbook.rs` — implement `IStablecoinDEX::Interface` trait
- **Simplified**: `stablecoin_dex/dispatch.rs` — manual dispatch replaced
- Adjustments to `error.rs`, `validator_config/mod.rs`, `revm/common.rs`, storage tests, and `node/tests`

### Stack

> Part of the [`#[abi]` macro stack](https://github.com/tempoxyz/tempo/pull/2687) — PR 8 of 11.