### PR TITLE
fix: install tempo to /usr/local/bin, warn if not in PATH

### DIFF
--- a/tempoup/install
+++ b/tempoup/install
@@ -2,10 +2,9 @@
 set -e
 
 # Tempoup bootstrap installer
-# Downloads tempoup script and sets up PATH
+# Downloads tempoup script and installs to /usr/local/bin
 
-INSTALL_DIR="${TEMPO_DIR:-$HOME/.tempo}"
-BIN_DIR="$INSTALL_DIR/bin"
+BIN_DIR="${TEMPO_BIN_DIR:-/usr/local/bin}"
 TEMPOUP_URL="https://raw.githubusercontent.com/tempoxyz/tempo/main/tempoup/tempoup"
 
 # Color output
@@ -21,72 +20,51 @@ warn() {
     echo -e "${YELLOW}warn${NC}: $1"
 }
 
-# Detect shell and config file
-get_shell_config() {
-    local shell_name=$(basename "$SHELL")
+# Install a file to BIN_DIR, using sudo if necessary
+install_bin() {
+    local src="$1"
+    local dst="$2"
 
-    case "$shell_name" in
-        zsh)
-            if [[ -n "$ZDOTDIR" ]]; then
-                echo "$ZDOTDIR/.zshenv"
-            else
-                echo "$HOME/.zshenv"
-            fi
-            ;;
-        bash)
-            echo "$HOME/.bashrc"
-            ;;
-        fish)
-            echo "$HOME/.config/fish/config.fish"
-            ;;
-        *)
-            echo "$HOME/.profile"
-            ;;
-    esac
+    if cp "$src" "$dst" 2>/dev/null; then
+        chmod +x "$dst"
+    elif sudo cp "$src" "$dst" 2>/dev/null; then
+        sudo chmod +x "$dst"
+    else
+        echo "error: failed to install to $dst"
+        echo "       try running with sudo"
+        exit 1
+    fi
 }
 
 main() {
     echo "Installing tempoup..."
     echo ""
 
-    # Create bin directory
-    mkdir -p "$BIN_DIR"
+    # Download tempoup script to a temp file
+    local tmp_file
+    tmp_file="$(mktemp 2>/dev/null || mktemp -t tempoup)"
+    trap "rm -f '$tmp_file'" EXIT
 
-    # Download tempoup script
     info "Downloading tempoup script..."
     if command -v curl >/dev/null 2>&1; then
-        curl -# -L "$TEMPOUP_URL" -o "$BIN_DIR/tempoup"
+        curl -# -L "$TEMPOUP_URL" -o "$tmp_file"
     elif command -v wget >/dev/null 2>&1; then
-        wget --show-progress -q -O "$BIN_DIR/tempoup" "$TEMPOUP_URL"
+        wget --show-progress -q -O "$tmp_file" "$TEMPOUP_URL"
     else
-        echo "Error: Neither curl nor wget found. Please install one of them."
+        echo "error: neither curl nor wget found"
         exit 1
     fi
 
-    chmod +x "$BIN_DIR/tempoup"
+    # Install tempoup to BIN_DIR
+    install_bin "$tmp_file" "$BIN_DIR/tempoup"
     info "Tempoup installed to $BIN_DIR/tempoup"
 
-    # Add to PATH if not already present
+    # Warn if BIN_DIR is not in PATH
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-        SHELL_CONFIG=$(get_shell_config)
-        SHELL_NAME=$(basename "$SHELL")
-
-        info "Adding $BIN_DIR to PATH in $SHELL_CONFIG"
-
-        mkdir -p "$(dirname "$SHELL_CONFIG")"
-
-        echo "" >> "$SHELL_CONFIG"
-        echo "# Added by tempoup installer" >> "$SHELL_CONFIG"
-
-        if [[ "$SHELL_NAME" == "fish" ]]; then
-            echo "fish_add_path -a \"$BIN_DIR\"" >> "$SHELL_CONFIG"
-        else
-            echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$SHELL_CONFIG"
-        fi
-
         echo ""
-        warn "Please restart your shell or run:"
-        echo "  source $SHELL_CONFIG"
+        warn "$BIN_DIR is not in your PATH"
+        echo "  Add it to your shell config:"
+        echo "    export PATH=\"$BIN_DIR:\$PATH\""
         echo ""
     fi
 
@@ -94,8 +72,7 @@ main() {
     info "Running tempoup to install tempo..."
     echo ""
 
-    export PATH="$BIN_DIR:$PATH"
-    "$BIN_DIR/tempoup"
+    TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup"
 }
 
 main

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,14 +6,13 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.4"
+TEMPOUP_INSTALLER_VERSION="0.0.5"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
 GPG_KEY_FINGERPRINT="EE3C5D41EA963E896F310EC3CBBFA54B20D33446"
 GPG_KEYSERVER="keyserver.ubuntu.com"
-INSTALL_DIR="${TEMPO_DIR:-$HOME/.tempo}"
-BIN_DIR="$INSTALL_DIR/bin"
+BIN_DIR="${TEMPO_BIN_DIR:-/usr/local/bin}"
 TEMPOUP_BIN_URL="https://raw.githubusercontent.com/tempoxyz/tempo/main/tempoup/tempoup"
 TEMPOUP_BIN_PATH="$BIN_DIR/tempoup"
 
@@ -156,9 +155,13 @@ update_tempoup() {
 
     # Replace current script with new version
     info "Updating from $TEMPOUP_INSTALLER_VERSION to $remote_version..."
-    mkdir -p "$BIN_DIR"
-    cp "$tmp_file" "$TEMPOUP_BIN_PATH"
-    chmod +x "$TEMPOUP_BIN_PATH"
+    if cp "$tmp_file" "$TEMPOUP_BIN_PATH" 2>/dev/null; then
+        chmod +x "$TEMPOUP_BIN_PATH"
+    elif sudo cp "$tmp_file" "$TEMPOUP_BIN_PATH" 2>/dev/null; then
+        sudo chmod +x "$TEMPOUP_BIN_PATH"
+    else
+        error "Failed to update tempoup at $TEMPOUP_BIN_PATH. Try running with sudo."
+    fi
 
     echo ""
     info "✓ Tempoup updated successfully to version $remote_version"
@@ -415,34 +418,26 @@ main() {
         BINARY_NAME="tempo.exe"
     fi
 
-    # Create installation directory
-    mkdir -p "$BIN_DIR"
-
     # Install binary
     info "Installing to $BIN_DIR/$BINARY_NAME..."
-    cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME"
-    chmod +x "$BIN_DIR/$BINARY_NAME"
+    if cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then
+        chmod +x "$BIN_DIR/$BINARY_NAME"
+    elif sudo cp "$BINARY_PATH" "$BIN_DIR/$BINARY_NAME" 2>/dev/null; then
+        sudo chmod +x "$BIN_DIR/$BINARY_NAME"
+    else
+        error "Failed to install to $BIN_DIR. Try running with sudo."
+    fi
 
     # Success message
     echo ""
     info "✓ Tempo $VERSION_TAG installed successfully!"
     echo ""
 
-    # Check if BIN_DIR is in PATH
+    # Warn only if BIN_DIR is not in PATH
     if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
-        warn "The installation directory is not in your PATH."
-        echo ""
-        echo "To use tempo, add the following to your shell configuration file:"
-        echo ""
-        echo "  export PATH=\"$BIN_DIR:\$PATH\""
-        echo ""
-
-        # Suggest appropriate config file based on shell
-        if [[ -n "$ZSH_VERSION" ]]; then
-            echo "For zsh, add it to: ~/.zshenv or ~/.zshrc"
-        elif [[ -n "$BASH_VERSION" ]]; then
-            echo "For bash, add it to: ~/.bashrc or ~/.bash_profile"
-        fi
+        warn "$BIN_DIR is not in your PATH"
+        echo "  Add it to your shell config:"
+        echo "    export PATH=\"$BIN_DIR:\$PATH\""
         echo ""
     else
         info "Run 'tempo --version' to verify installation"


### PR DESCRIPTION
## Summary

Fixes `curl -L https://tempo.xyz/install | bash` so `tempo --version` works immediately without restarting the shell.

Thread: https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770751416948799

## Changes

- Both `tempoup/install` (bootstrap) and `tempoup/tempoup` now install to `/usr/local/bin` (already in PATH)
- Use sudo fallback when direct write fails
- Only warn if `BIN_DIR` isn't in the user's PATH — no shell profile modification
- Removed shell auto-detection / profile editing code
- Bump tempoup version to 0.0.5

## Testing

```
bash -n tempoup/install   # syntax OK
bash -n tempoup/tempoup   # syntax OK
```