### PR TITLE
tip: TIP-1011 Enhanced Access Key Permissions (call scoping + periodic limits)

### DIFF
--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -1,47 +1,56 @@
 ---
 id: TIP-1011
 title: Enhanced Access Key Permissions
-description: Extends Access Keys with periodic spending limits and destination address scoping for subscription-based and restricted access patterns.
-authors: Tanishk Goyal 
+description: Extends Access Keys with periodic spending limits, destination/function scoping, and limited calldata recipient scoping.
+authors: Tanishk Goyal
 status: Draft
-related: TIP-1000, AccountKeychain, IAccountKeychain.sol
-protocolVersion: TBD (requires hardfork)
+related: Tempo Transaction Spec
+protocolVersion: T3
 ---
 
 # TIP-1011: Enhanced Access Key Permissions
 
 ## Abstract
 
-This TIP extends Access Keys with two new permission features: (1) **periodic spending limits** that automatically reset after a configurable time period, enabling subscription-based access patterns, and (2) **destination address scoping** that restricts keys to only interact with specific contract addresses.
+This TIP extends Access Keys with three permission features:
+
+1. **Periodic spending limits** that reset on fixed intervals.
+2. **Call scoping** that limits what addresses a key can call and which selectors it can use.
+3. **Limited calldata recipient scoping** for token transfer/approval selectors.
+
 
 ## Motivation
 
-Currently, Access Keys support spending limits (per-TIP-20 token caps) and expiry timestamps. However, these primitives are insufficient for common real-world patterns:
+Current Access Keys support per-token limits and expiry, but miss two practical controls.
 
 ### Periodic Spending Limits
 
-The existing `TokenLimit` specifies a one-time spending cap that depletes permanently. This model doesn't support subscription-based patterns where:
-
-- A service needs recurring access to a fixed amount per billing cycle
-- Users want to authorize "up to X tokens per month" without re-authorizing
-- dApps implement subscription models (e.g., streaming services, SaaS payments)
+One-time limits cannot express recurring allowances.
 
 **Use cases:**
-1. **Subscription services**: Authorize a streaming service to charge 10 USDC/month
-2. **Recurring donations**: Allow an NPO to withdraw up to 5 USDC weekly
-3. **Payroll systems**: Enable payroll contracts to transfer salaries monthly
-4. **Rate-limited APIs**: Authorize API access keys with per-period token budgets
 
-### Destination Address Scoping
+1. Subscription billing (`10 USDC / month`).
+2. Payroll schedules (monthly budgeted payouts).
+3. Rate-limited agent/API budgets.
 
-Users have requested the ability to bind Access Keys to specific destinations (e.g., "only allow transactions to Uniswap"). This provides more granular permission scoping similar to Solana's delegate primitive.
+### Call Scoping (Target + Selector Set)
 
-**Use cases:**
-1. **DeFi integrations**: Allow a trading bot key to only interact with specific DEX contracts
-2. **Gaming**: Scope a session key to only interact with a game contract
-3. **Subscription services**: Allow a key to only call a specific payment contract
+Users need finer controls than "any call". They want keys like:
 
-**Current workaround**: Deploy a proxy contract that enforces destination restrictions, adding gas overhead and complexity.
+1. "Only call `swap()` and `exactInput()` on DEX X."
+2. "Only call gameplay methods on contract Y."
+3. "Only perform plain transfers, not token extension methods."
+4. "Only vote() on governance contracts."
+
+**Current workaround**: Deploy a proxy contract that enforces destination/function restrictions, adding gas overhead and complexity.
+
+### Recipient-Bound Token Calls
+
+Target + selector scoping still allows an access key to move funds to arbitrary recipients for token methods like `transfer` and `approve`.
+
+Users need a narrower policy: the key may call transfer/approve selectors, but only when the recipient/spender matches a configured address.
+
+This TIP intentionally adds a narrow calldata rule (first ABI `address` argument equality) instead of a generic calldata policy language.
 
 ---
 
@@ -49,9 +58,15 @@ Users have requested the ability to bind Access Keys to specific destinations (e
 
 ## Extended Data Structures
 
+Conventions used in this section:
+
+1. Protocol/RLP structs are written with Rust-like `Option<...>` notation.
+2. Solidity ABI structs are listed separately where ABI cannot directly represent protocol `Option` semantics.
+
 ### TokenLimit
 
 **Current:**
+
 ```solidity
 struct TokenLimit {
     address token;
@@ -60,254 +75,547 @@ struct TokenLimit {
 ```
 
 **Proposed:**
+
 ```solidity
 struct TokenLimit {
     address token;
-    uint256 limit;      // Per-period limit when period > 0, one-time limit otherwise
-    uint256 remainingInPeriod;  // Remaining allowance in current period
-    uint64 period;      // Period duration in seconds (0 = one-time limit)
-    uint64 periodEnd;   // Timestamp when current period expires
+    uint256 limit;  // One-time cap when period == 0, per-period cap when period > 0
+    uint64 period;  // Period duration in seconds (0 = one-time limit)
 }
 ```
 
+Design note: `period` is specified as an explicit field (instead of packed into `token`) to keep encoding/auditing straightforward and avoid migration risk for existing limit semantics.
+
+Runtime state is derived and stored by the precompile (not signed):
+
+```text
+TokenLimitState {
+    remainingInPeriod: uint256,
+    periodEnd: uint64,
+}
+```
+
+Initialization and persistence:
+
+1. `TokenLimitState` is initialized when the key is authorized (or a limit is created via root mutation), not lazily at first spend.
+2. `period == 0` initializes `remainingInPeriod = limit` and `periodEnd = 0`.
+3. `period > 0` initializes `remainingInPeriod = limit` and `periodEnd = authorize_time + period`.
+4. For a given `(account,key,token)`, there is exactly one active `TokenLimit`; duplicate token entries in a single authorization MUST be rejected.
+
+### CallScope
+
+Call scoping is defined with optional fields (protocol-level / RLP model):
+
+```text
+CallScope {
+    target: address,
+    selector_rules: Option<Vec<SelectorRule>>,   // None => any selector on this target
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct CallScope {
+    address target;
+    bool allowAllSelectors;
+    SelectorRule[] selectorRules;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `allowAllSelectors = true` maps to `selector_rules = None`; `selectorRules` input MUST be empty.
+2. `allowAllSelectors = false` maps to `selector_rules = Some(selectorRules)`.
+3. `allowAllSelectors = false` with `selectorRules = []` is explicit deny-all for this target.
+4. Any non-canonical combination MUST be rejected.
+
+`selector_rules` behavior intentionally mirrors `limits` tri-state semantics:
+
+1. `None`: allow any selector.
+2. `Some([])`: allow no selectors (matches nothing for that scope).
+3. `Some([r1, r2, ...])`: allow exactly the listed selector rules.
+
+`Some([])` exists as an explicit deny-all sentinel for deterministic root-key updates.
+
+### SelectorRule
+
+```text
+SelectorRule {
+    selector: bytes4,
+    recipients: Option<Vec<address>>, // None => any recipient, Some([a1, ...]) => only listed recipients
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct SelectorRule {
+    bytes4 selector;
+    bool allowAllRecipients;
+    address[] recipients;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `allowAllRecipients = true` maps to `recipients = None`; `recipients` input MUST be empty.
+2. `allowAllRecipients = false` maps to `recipients = Some(recipients)`; `recipients` input MUST be non-empty.
+3. Any non-canonical combination MUST be rejected.
+
+`SelectorRule.recipients` behavior:
+
+1. `None` => no calldata recipient checks for this selector.
+2. `Some([a1, a2, ...])` => enforce `arg0` recipient membership for this selector.
+3. `Some([])` MUST be rejected as invalid configuration.
+4. Selector rules MUST be unique per target (`selector` appears at most once).
+
+Supported constrained selectors in this TIP:
+
+1. `0xa9059cbb` => `transfer(address,uint256)`
+2. `0x095ea7b3` => `approve(address,uint256)`
+3. `0x95777d59` => `transferWithMemo(address,uint256,bytes32)`
+4. `0xc2da9aed` => `approveWithMemo(address,uint256,bytes32)`
+
+If a selector rule uses `recipients = Some([..])`, then:
+
+1. `target` MUST be a TIP-20 token address.
+2. `selector` MUST be one of the four constrained selectors above.
+3. Otherwise, key authorization MUST be rejected.
+
+For these selectors, the constrained field is ABI argument `0` (the first `address` argument).
+
+Selector width is fixed at 4 bytes.
+
+1. Each `SelectorRule.selector` MUST be exactly 4 bytes.
+2. Implementations MUST revert when decoding or accepting any selector whose length is not exactly 4 bytes.
+3. Selectorless calls (`calldata.length < 4`) and fallback/receive routing are not scope-matchable and MUST be rejected in scoped mode.
+4. Contracts with non-standard selector parsing are NOT supported.
+
+Examples:
+
+1. `{ target: 0x123, selector_rules: Some([{selector: 0xaabbccdd, recipients: None}, {selector: 0xeeff0011, recipients: None}]) }`: allow two selectors on one target.
+2. `{ target: 0x123, selector_rules: None }`: address-only scoping (any selector on `0x123`).
+3. `{ target: 0x123, selector_rules: Some([]) }`: matches no selector on `0x123`.
+4. `allowedCalls = None`: unrestricted key.
+5. `allowedCalls = Some([])`: key is authorized but cannot make scoped calls.
+6. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xReceiver])}]) }`: allow `transfer` only when `to == 0xReceiver`.
+7. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xA, 0xB])}]) }`: allow `transfer` only when `to` is in `{0xA, 0xB}`.
+8. Distinct target scopes are independent: allowing selector `s` on target `A` never allows selector `s` on target `B`.
+
 ### KeyAuthorization
 
-**Current fields retained:**
-- `spendingLimits`: `TokenLimit[]`
-- `expiry`: `uint64`
+Existing fields remain, with a trailing optional call-scope field:
 
-**New field:**
-```solidity
-struct KeyAuthorization {
-    TokenLimit[] spendingLimits;
-    uint64 expiry;
-    address[] allowedDestinations; // Empty array = unrestricted
+```text
+KeyAuthorization {
+    chain_id: u64,
+    key_type: SignatureType,
+    key_id: address,
+    expiry: Option<u64>,
+    limits: Option<Vec<TokenLimit>>,
+    allowed_calls: Option<Vec<CallScope>>,  // New trailing field
 }
 ```
 
 ## Interface Changes
 
+### Events
+
+```solidity
+/// @notice Emitted when an access key spends tokens against a spending limit
+/// @param account The account whose key was used
+/// @param publicKey The public key (address) that initiated the spend
+/// @param token The token address being spent
+/// @param amount The amount spent in this transaction
+/// @param remainingLimit The remaining spending limit after this spend
+event AccessKeySpend(
+    address indexed account,
+    address indexed publicKey,
+    address indexed token,
+    uint256 amount,
+    uint256 remainingLimit
+);
+```
+
+This event MUST be emitted whenever an access-key transaction deducts from a spending limit (one-time or periodic).
+
 ### IAccountKeychain.sol
 
 ```solidity
 /// @notice Authorizes a key with enhanced permissions
-/// @param key The public key to authorize
+/// @param keyId The key identifier (address derived from public key)
+/// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
 /// @param expiry Block timestamp when key expires
+/// @param enforceLimits Whether spending limits are enforced for this key
 /// @param spendingLimits Token spending limits (may include periodic limits)
-/// @param allowedDestinations Addresses the key may call (empty = unrestricted)
+/// @param allowedCalls Per-target call scopes for this key.
 function authorizeKey(
-    bytes calldata key,
+    address keyId,
+    SignatureType signatureType,
     uint64 expiry,
+    bool enforceLimits,
     TokenLimit[] calldata spendingLimits,
-    address[] calldata allowedDestinations
+    CallScope[] calldata allowedCalls
 ) external;
 
-/// @notice Returns the allowed destinations for a key
-/// @param key The public key to query
-/// @return destinations Array of allowed destination addresses (empty = unrestricted)
-function getAllowedDestinations(bytes calldata key) external view returns (address[] memory destinations);
+/// @notice Creates or replaces one target scope for a key
+/// @dev Root key only. If `target` does not exist, creates a new scope; otherwise replaces it atomically.
+/// @dev `allowAllSelectors = true` sets `selector_rules = None` semantics for this target.
+/// @dev `allowAllSelectors = false` and `selectorRules = []` disables this target scope (delete-equivalent).
+/// @dev If a selector rule has `recipients`, `target` MUST be TIP-20 and `selector` MUST be transfer/approve (+memo).
+/// @dev For each selector rule, `allowAllRecipients=true` requires empty `recipients`; `allowAllRecipients=false` requires non-empty `recipients`.
+function setAllowedCalls(
+    address keyId,
+    address target,
+    bool allowAllSelectors,
+    SelectorRule[] calldata selectorRules
+) external;
 
-/// @notice Returns the remaining limit for a token, accounting for period resets
-/// @param key The public key to query
-/// @param token The token address
-/// @return remaining The remaining spending limit for the current period
-/// @return periodEnd The timestamp when the current period ends (0 if one-time limit)
-function getRemainingLimit(bytes calldata key, address token) external view returns (uint256 remaining, uint64 periodEnd);
+/// @notice Returns allowed call scopes for an account+key
+function getAllowedCalls(
+    address account,
+    address keyId
+) external view returns (CallScope[] memory calls);
+
+/// @notice Returns remaining limit for a token, accounting for period resets
+function getRemainingLimit(
+    address account,
+    address keyId,
+    address token
+) external view returns (uint256 remaining, uint64 periodEnd);
 ```
 
 ## Semantic Behavior
 
 ### Periodic Limit Reset Logic
 
-When a spending attempt occurs:
+On each spend attempt for `(account, key, token)`:
 
-```
-function verifyAndUpdateSpending(key, token, amount):
-    limit = getTokenLimit(key, token)
-    
-    if limit.period > 0:  // Periodic limit
-        if block.timestamp >= limit.periodEnd:
-            // Reset period
-            limit.periodEnd = block.timestamp + limit.period
-            limit.remainingInPeriod = limit.limit  // Reset to per-period allowance
-    
-    if amount > limit.remainingInPeriod:
-        revert SpendingLimitExceeded()
-    
-    limit.remainingInPeriod -= amount
-```
+1. Implementations MUST load the configured `TokenLimit` and runtime `TokenLimitState`.
+2. If `period == 0`, the limit is one-time and no period rollover is applied.
+3. If `period > 0` and `block.timestamp >= periodEnd`, implementations MUST reset `remainingInPeriod` to `limit` and advance `periodEnd` by whole multiples of `period` so that `periodEnd > block.timestamp`.
+4. If `amount > remainingInPeriod`, implementations MUST revert `SpendingLimitExceeded()`.
+5. Otherwise, implementations MUST decrement `remainingInPeriod` by `amount`.
 
-### Destination Validation Logic
+`updateSpendingLimit(account,key,token,newLimit)` semantics:
 
-When a transaction is submitted with an Access Key:
+1. MUST update the configured `limit` for that `(account,key,token)`.
+2. MUST set `remainingInPeriod = newLimit`.
+3. MUST NOT change `period`.
+4. MUST NOT change `periodEnd`.
+5. Therefore changing `period` requires re-authorizing the key (or removing and recreating that token limit entry).
 
-```
-function validateDestination(key, destination):
-    allowed = getAllowedDestinations(key)
-    
-    if allowed.length == 0:
-        return true  // Unrestricted
-    
-    for addr in allowed:
-        if addr == destination:
-            return true
-    
-    revert DestinationNotAllowed()
-```
+### Call Validation Logic
+
+Call-scope checks use map lookups keyed by `(account_key, target, selector)` plus optional selector-level recipient allowlists.
+
+
+#### Access-Key Contract Creation Ban
+
+If a transaction is signed with an access key (`key != Address::ZERO`), contract creation MUST be rejected in all configurations.
+
+This ban applies regardless of:
+
+1. Whether `allowed_calls` is `None` or `Some(...)`.
+2. Whether any target scope has `selector_rules = None` (allow-any-selector).
+3. Whether the creation call appears in a batch.
+
+Only the root key (`key == Address::ZERO`) may submit contract-creation calls; this is not a global create ban.
+
+#### Single Call Validation
+
+For each call:
+
+1. If the transaction uses an access key and the call is contract creation, implementations MUST revert `CallNotAllowed()`.
+2. If `allowed_calls = None`, implementations MUST allow the call (subject to the contract-creation ban).
+3. If `allowed_calls = Some(...)`, implementations MUST enforce target and selector matching.
+4. If no target scope exists for `destination`, implementations MUST revert `CallNotAllowed()`.
+5. If the target scope is `selector_rules = None`, implementations MUST allow the call.
+6. If calldata does not provide at least 4 selector bytes, implementations MUST revert `CallNotAllowed()` (and MUST NOT panic).
+7. If the target scope is `selector_rules = Some(list)`, there MUST be a rule for the selector; otherwise implementations MUST revert `CallNotAllowed()`.
+8. If the matched rule has `recipients = None`, implementations MUST allow the call.
+9. If the matched rule has `recipients = Some(list)`, implementations MUST decode ABI argument `0` as an `address` and require membership in `list`.
+10. For a selector rule with `recipients = Some(list)`, if calldata is shorter than `4 + 32` bytes, implementations MUST revert `CallNotAllowed()`.
+11. For a selector rule with `recipients = Some(list)`, implementations MUST enforce canonical ABI `address` encoding for argument `0` (upper 12 bytes zero) before membership check; otherwise implementations MUST revert `CallNotAllowed()`.
+
+#### Batch Validation
+
+For AA transactions with multiple calls, each call MUST be validated independently. If any call fails scope validation, the entire batch MUST revert.
+Gas charging for batch validation failure follows normal EVM execution semantics (charge for work performed up to the failure point; no precharge for calls that were not executed).
+
+### Root-Controlled Scope Updates
+
+`setAllowedCalls` MUST be root-key-only and MUST apply create-or-replace semantics per target.
+
+1. `allowAllSelectors = true` sets `selector_rules = None` semantics (any selector allowed on `target`) and `selectorRules` input MUST be ignored.
+2. `allowAllSelectors = false` with `selectorRules = []` disables that target scope.
+3. Implementations MUST enforce at most one scope per target for each `(account, key)`.
+4. If any rule has `recipients = Some([..])`, `allowAllSelectors` MUST be false.
+5. Selector rules MUST be unique by `selector` within a target scope.
+6. If any rule has `recipients = Some([..])`, `target` MUST be a TIP-20 token address.
+7. If any rule has `recipients = Some([..])`, its `selector` MUST be one of:
+   1. `0xa9059cbb` (`transfer(address,uint256)`)
+   2. `0x095ea7b3` (`approve(address,uint256)`)
+   3. `0x95777d59` (`transferWithMemo(address,uint256,bytes32)`)
+   4. `0xc2da9aed` (`approveWithMemo(address,uint256,bytes32)`)
+8. If any rule has `recipients = Some([..])`, each recipient in that list MUST be non-zero.
+9. If any rule has `recipients = Some([..])`, recipients in that list MUST be unique.
+10. If any rule has `recipients = Some([])`, implementations MUST reject the authorization (or revert `setAllowedCalls`).
+11. In the Solidity ABI path, `allowAllRecipients=true` with non-empty `recipients` MUST be rejected.
+12. In the Solidity ABI path, `allowAllRecipients=false` with empty `recipients` MUST be rejected.
+13. If any selector-rule validity rule is violated, implementations MUST reject the authorization (or revert `setAllowedCalls`).
+
+Rationale for rule 2 (`selectorRules = []` disable):
+
+1. This avoids unbounded gas from deletion-time slot iteration.
+2. Prior selector rows may remain in state, but the target mode deterministically disables matching.
 
 ### Interaction Rules
 
-1. **Mixed limits**: Keys can have a mix of one-time and periodic limits for different tokens
-2. **Destination + limits**: Both constraints are evaluated independently; both must pass
-3. **Period updates**: Calling `updateSpendingLimit()` updates the per-period amount and resets the current period
-4. **Empty destinations**: An empty `allowedDestinations` array means the key is unrestricted (can call any address)
+1. Keys may mix one-time and periodic token limits.
+2. Spending limits and call scopes are independent checks; both must pass.
+3. `updateSpendingLimit()` updates limit and `remainingInPeriod`, but does not change `period` or `periodEnd`.
+4. `allowed_calls = None` is unrestricted for non-create calls; `Some([])` is explicit deny-all.
+5. Every scope has an explicit target address, so there is no wildcard-target precedence ambiguity.
+6. Per-target updates are create-or-replace and duplicate target scopes are not allowed.
+7. Selector-level recipient allowlists are optional and only valid for TIP-20 targets and the four constrained selectors.
+8. Selector-level recipient allowlists are checked after selector match and before call execution.
+9. This TIP does not introduce generic calldata predicates, offset math, or wildcard argument matching.
 
-## Gas Costs
+Wallet UX recommendation (non-consensus):
 
-| Operation | Additional Gas |
-|-----------|----------------|
-| `authorizeKey` with N destinations | ~20,000 + 5,000 × N |
-| `authorizeKey` with periodic limit | ~3,000 per periodic token |
-| Destination check (per tx) | ~2,100 + 200 × N |
-| Period reset (when triggered) | ~5,000 |
+1. Wallets SHOULD default to scoped keys (`allowAllSelectors = false`) and require explicit user opt-in for unrestricted keys.
+
+## Gas And Complexity Bounds
+
+This TIP only specifies the additional intrinsic gas delta for call scopes in handler-side `key_authorization` charging.
+
+Existing key-authorization charging (signature verification, existing-key read, base key write, token-limit writes, and buffer) remains unchanged.
+
+Definitions:
+
+1. `SSTORE_SET = sstore_set_without_load_cost`.
+2. `S` = number of targets with configured call scope.
+3. `K` = total selector rules across all configured targets.
+4. `C` = total selector rules with `recipients = Some([..])`.
+5. `W` = total recipient entries across all constrained selector rules.
+6. `MAX_CALL_SCOPES = 8` target scopes per `(account, key)`.
+7. `MAX_SELECTOR_RULES_PER_SCOPE = 16` selector rules per target scope.
+8. `MAX_RECIPIENTS_PER_SELECTOR = 16` recipients per selector rule.
+   
+Assumed map rows (for gas accounting context):
+
+1. `allowed_calls_mode[account_key]` (restricted/unrestricted marker).
+2. `allowed_calls_target_mode[account_key][target]` (`0 = none`, `1 = any-selector`, `2 = explicit-selector-rules`).
+3. Per selector membership: `allowed_calls_selector_allowed[account_key][target][selector]` (`bool`).
+4. Per-selector recipient mode: `allowed_calls_selector_recipient_mode[account_key][target][selector]` (`0 = any`, `1 = constrained`).
+5. Per recipient membership: `allowed_calls_selector_recipient_allowed[account_key][target][selector][recipient]` (`bool`).
+
+Selectors are stored as `true` membership rows keyed by `(account_key, target, selector)`.
+
+```text
+gas_key_authorization_new = gas_key_authorization_existing
+                          + SSTORE_SET * scope_slots
+
+scope_slots = 0                    if allowed_calls is None
+            = 1                    if allowed_calls is Some([])   // explicit restricted-mode marker
+            = 1 + S + K + C + W    if allowed_calls is Some(scopes)
+```
+
+Justification for `1 + S + K + C + W`: `1` stores restricted mode, `S` stores one target mode per scoped target, `K` stores selector membership entries, `C` stores constrained-recipient mode per constrained selector, and `W` stores recipient membership entries.
+
+Bounds:
+
+1. Implementations MUST reject authorizations with `S > MAX_CALL_SCOPES`.
+2. Implementations MUST reject any target scope with selector-rule count greater than `MAX_SELECTOR_RULES_PER_SCOPE`.
+3. Implementations MUST reject any selector rule with recipient count greater than `MAX_RECIPIENTS_PER_SELECTOR`.
+4. Implementations MUST reject any selector rule with `recipients = Some([..])` whose `target` is not a TIP-20 token address.
+5. Implementations MUST reject any selector rule with `recipients = Some([..])` and selector outside the fixed constrained-selector set.
+6. Implementations MUST reject duplicate selector rules for the same `(target, selector)`.
+7. Implementations MUST reject duplicate recipients inside a selector rule.
+8. These bounds are consensus constants.
+
+Constant rationale:
+
+1. `MAX_CALL_SCOPES` and `MAX_SELECTOR_RULES_PER_SCOPE` cap authorization-time storage growth and per-call validation work.
+2. `MAX_RECIPIENTS_PER_SELECTOR` caps recipient membership checks and storage writes for constrained selectors.
+3. Any future change to these constants requires a new TIP / hardfork-gated update.
+
+No additional flat gas is specified here for precompile methods (`setAllowedCalls`, `getAllowedCalls`, etc.); those are charged by normal EVM metering at execution time.
 
 ## Encoding
 
-### Transaction Authorization
+### Signing Format
 
-The `KeyAuthorization` struct is RLP-encoded in the transaction's authorization field:
+Authorization digest format:
 
+```text
+key_auth_digest = keccak256(rlp([
+  chain_id,
+  key_type,
+  key_id,
+  expiry?,
+  limits?,
+  allowed_calls?
+]))
+
+limits = rlp([token, limit, period])
 ```
+
+RLP safety note:
+
+1. Implementations MUST use canonical RLP encoding for all fields.
+2. The signed payload is a typed RLP list; distinct field tuples produce distinct canonical encodings (no cross-field preimage ambiguity under canonical RLP).
+
+### Transaction Authorization RLP
+
+```text
 KeyAuthorization := RLP([
-    spendingLimits: [TokenLimit, ...],
-    expiry: uint64,
-    allowedDestinations: [address, ...]
+    chain_id: u64,
+    key_type: u8,
+    key_id: address,
+    expiry?: uint64,
+    limits?: [TokenLimit, ...],
+    allowed_calls?: [CallScope, ...]
 ])
 
 TokenLimit := RLP([
     token: address,
     limit: uint256,
-    remainingInPeriod: uint256,
-    period: uint64,
-    periodEnd: uint64
+    period: uint64
+])
+
+CallScope := RLP([
+    target: address,
+    selector_rules?: [SelectorRule, ...]
+])
+
+SelectorRule := RLP([
+    selector: bytes4,
+    recipients?: [address, ...]
 ])
 ```
 
+Optional encoding rules:
+
+1. Optional scalar fields (`expiry`) use `None => 0x80`.
+2. Optional list fields (`limits`, `allowed_calls`, `selector_rules`, `recipients`) use `None => 0x80`.
+3. `Some([])` list values encode as RLP empty list (`0xc0`).
+4. `Some([x, ...])` list values encode as normal lists.
+5. Each `SelectorRule.selector` MUST decode to exactly 4 bytes; otherwise the authorization MUST be rejected.
+6. `SelectorRule.recipients = Some([])` MUST be rejected.
+
 ---
-
-# Backward Compatibility
-
-This TIP requires a **hardfork** due to changes in transaction encoding and execution semantics.
-
-## RLP Encoding Changes
-
-### TokenLimit (2 fields → 5 fields)
-
-The current `TokenLimit` struct encodes as `[token, limit]`. This TIP extends it to `[token, limit, remainingInPeriod, period, periodEnd]`.
-
-**Breaking change**: Old nodes cannot decode new transactions with 5-field `TokenLimit`. New nodes must implement version-tolerant decoding:
-
-```
-On decode:
-  if list.len() == 2:
-    // V1 (legacy one-time limit)
-    remainingInPeriod = limit
-    period = 0
-    periodEnd = 0
-  else if list.len() == 5:
-    // V2 (periodic limit)
-    decode all fields
-  else:
-    error
-```
-
-Post-fork, all new `TokenLimit` encodings MUST use the 5-field format for consistency.
-
-### KeyAuthorization (trailing field addition)
-
-`KeyAuthorization` uses `#[rlp(trailing)]` which allows appending optional fields. Adding `allowedDestinations: Option<Vec<Address>>` as the last field is compatible with this pattern:
-
-- Old encodings (without `allowedDestinations`) decode as `allowedDestinations = None` (unrestricted)
-- New encodings with `allowedDestinations` will be rejected by old nodes
-
-## Compact/Database Encoding
-
-Although `TokenLimit` has `#[derive(reth_codecs::Compact)]`, it is **not used in production storage**. The storage path is:
-
-```
-TempoTransaction (derived Compact)
-  └─ key_authorization: Option<SignedKeyAuthorization>
-       └─ SignedKeyAuthorization (custom Compact impl → uses RLP internally)
-            └─ KeyAuthorization (RLP encoded)
-                 └─ limits: Option<Vec<TokenLimit>> (RLP encoded)
-```
-
-`SignedKeyAuthorization` implements a custom `Compact` that wraps RLP encoding. Therefore, `TokenLimit` is always serialized as RLP bytes in the database, not via its derived Compact layout.
-
-**Implication**: If we implement version-tolerant RLP decoding for `TokenLimit` (accept 2-field or 5-field lists), existing database entries will decode correctly. **No DB rebuild required** for this change.
 
 ## Precompile Storage Changes
 
-The current storage layout:
-- `keys[account][keyId] → AuthorizedKey` (packed slot)
-- `spending_limits[key][token] → U256` (remaining amount)
+Current layout:
 
-This TIP requires additional per-token state for periodic limits. **Additive storage approach** (no migration required):
+1. `keys[account][keyId] -> AuthorizedKey`
+2. `spending_limits[(account,keyId)][token] -> U256`
+
+Additive periodic-limit layout:
 
 | Mapping | Type | Description |
 |---------|------|-------------|
-| `spending_limits[key][token]` | `U256` | Reinterpreted as `remainingInPeriod` |
-| `spending_limit_max[key][token]` | `U256` | Per-period cap (new) |
-| `spending_limit_period[key][token]` | `u64` | Period duration in seconds (new) |
-| `spending_limit_period_end[key][token]` | `u64` | Current period end timestamp (new) |
+| `spending_limits[account_key][token]` | `U256` | Reinterpreted as `remainingInPeriod` |
+| `spending_limit_max[account_key][token]` | `U256` | Per-period cap |
+| `spending_limit_period[account_key][token]` | `u64` | Period duration |
+| `spending_limit_period_end[account_key][token]` | `u64` | Current period end |
 
-For destination scoping:
+Call-scope storage MUST be account-scoped:
+
 | Mapping | Type | Description |
 |---------|------|-------------|
-| `allowed_destinations_len[key]` | `u64` | Number of allowed destinations |
-| `allowed_destinations[key][index]` | `Address` | Allowed destination at index |
+| `allowed_calls_mode[account_key]` | `u8` | Unrestricted/restricted marker |
+| `allowed_calls_target_mode[account_key][target]` | `u8` | `0 = none`, `1 = any-selector`, `2 = explicit-selector-rules` |
+| `allowed_calls_selector_allowed[account_key][target][selector]` | `bool` | Explicit selector membership |
+| `allowed_calls_selector_recipient_mode[account_key][target][selector]` | `u8` | `0 = any`, `1 = constrained` |
+| `allowed_calls_selector_recipient_allowed[account_key][target][selector][recipient]` | `bool` | Selector-level recipient membership |
 
-Legacy keys (pre-fork) have `period = 0`, `max = 0`, and behave as one-time limits.
+`account_key = keccak256(account || key_id)` to avoid cross-account collisions for shared key IDs.
+
+Implementations MAY maintain additional internal indexes.
 
 ## Hardfork-Gated Features
 
-The following MUST be gated behind the hardfork activation:
+The following MUST be fork-gated:
 
-1. **RLP decoding**: Accept 5-field `TokenLimit` and `allowedDestinations` in `KeyAuthorization`
-2. **Periodic limit reset logic**: Check `periodEnd` and reset `remainingInPeriod` on spend
-3. **Destination scoping enforcement**: Validate transaction `to` against `allowedDestinations`
-4. **New precompile storage writes**: Write to new storage slots for period/destination data
-5. **New precompile interface methods**: `getAllowedDestinations()`, updated `getRemainingLimit()` return type
+1. New `TokenLimit` decode/encode behavior.
+2. `allowed_calls` decode/encode behavior.
+3. `selector_rules` decode/encode behavior.
+4. Periodic reset logic.
+5. Call-scope validation logic.
+6. Selector-rule recipient-allowlist calldata validation logic.
+7. New precompile storage writes/reads for periodic + call-scope data.
+8. New precompile storage writes/reads for selector-level recipient allowlists.
+9. Updated precompile read APIs (`getAllowedCalls(account,key)`, richer `getRemainingLimit`).
+10. New mutator function `setAllowedCalls`, which can only be called by root key.
+11. Global ban on contract creation when using access keys.
+12. Selector-width enforcement (`selector length == 4` only).
+13. Scope/selector bound enforcement (`MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`).
+14. Constrained-selector allowlist and argument-0 canonical address checks.
+15. TIP-20 target verification for selector rules with recipient allowlists.
+16. Recipient count bound enforcement (`MAX_RECIPIENTS_PER_SELECTOR`).
 
-Pre-fork blocks MUST be replayed with old semantics to preserve state root consistency.
+Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 
 ---
 
 # Invariants
 
-1. **Period monotonicity**: `periodEnd` MUST only increase; it cannot be set to a past timestamp.
-
-2. **Limit conservation**: For periodic limits, `remainingInPeriod` MUST NOT exceed `limit` after any reset.
-
-3. **Destination enforcement**: If `allowedDestinations` is non-empty, transactions to addresses not in the list MUST revert.
-
-4. **Backward compatibility**: Keys authorized without the new fields MUST behave as unrestricted (`allowedDestinations = []`) with one-time limits (`period = 0`).
-
-5. **Expiry precedence**: Key expiry MUST be checked before spending limits or destination restrictions.
+1. `periodEnd` is monotonic and never set to the past.
+2. `remainingInPeriod <= limit` after any operation.
+3. Expiry check runs before spending and call-scope checks.
+4. If `key != Address::ZERO`, any contract-creation call MUST revert regardless of `allowed_calls`.
+5. `allowed_calls = None` allows all non-create calls; `allowed_calls = Some(...)` requires target+selector-rule match and reverts otherwise.
+6. In scoped mode, calldata must contain at least 4 selector bytes.
+7. For each `(account, key)`, target scopes are unique, selector rules are unique per target, and recipients are unique per selector rule.
+8. `setAllowedCalls(..., allowAllSelectors = true, ...)` ignores `selectorRules`; `allowAllSelectors = false` with `selectorRules = []` disables that target scope.
+9. Selector rules with recipient allowlists are valid only for TIP-20 targets and only for the fixed constrained selector set.
+10. For recipient-allowlisted rules, calldata argument `0` must be a canonically encoded ABI address and must be in the configured recipient set.
+11. Solidity ABI selector-rule encoding is canonical: `allowAllRecipients = true` iff `recipients` is empty.
+12. Authorizations exceeding `MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`, or `MAX_RECIPIENTS_PER_SELECTOR` MUST be rejected.
 
 ## Test Cases
 
-1. **Periodic reset**: Verify that a periodic limit resets correctly after the period elapses
-2. **Partial period usage**: Verify that unused periodic allowance does not roll over
-3. **Destination allow**: Verify that transactions to allowed destinations succeed
-4. **Destination deny**: Verify that transactions to non-allowed destinations revert
-5. **Empty destinations**: Verify that empty `allowedDestinations` allows any destination
-6. **Mixed limits**: Verify that a key can have both one-time and periodic limits for different tokens
-7. **Upgrade path**: Verify that existing keys continue to function after upgrade
+1. Periodic reset after elapsed period.
+2. No rollover of unused periodic allowance.
+3. Address + multi-selector scope allow.
+4. Address-only allow (`selector_rules=None`).
+5. Deny when no scope matches.
+6. `allowed_calls=None` allows all non-create calls.
+7. `allowed_calls=Some([])` denies all calls.
+8. Mixed one-time and periodic token limits.
+9. Existing keys continue to function after the fork.
+10. Batch validation reverts entire batch on one invalid call.
+11. Shared key IDs across accounts cannot overwrite each other’s scopes.
+12. Reject `allowed_calls` entries with `S > MAX_CALL_SCOPES`.
+13. Reject any target scope with selector-rule count `> MAX_SELECTOR_RULES_PER_SCOPE`.
+14. Reject calls that do not provide at least 4 selector bytes when `allowed_calls = Some(...)`.
+15. `setAllowedCalls(..., allowAllSelectors = true, selectorRules = [x, ...])` ignores selectorRules input and allows any selector on that target.
+16. `setAllowedCalls` create-or-replace semantics are enforced.
+17. `setAllowedCalls(..., allowAllSelectors = true, selectorRules = [])` allows any selector on that target.
+18. `setAllowedCalls(..., allowAllSelectors = false, selectorRules = [])` blocks all calls to that target (unless unrestricted mode is active).
+19. Access-key transactions with CREATE as first call are rejected.
+20. Access-key transactions with any CREATE in a batch are rejected.
+21. For constrained TIP-20 selectors (`transfer`, `approve`, `transferWithMemo`, `approveWithMemo`), calls succeed iff calldata argument `0` is in the configured recipient set.
+22. Single-recipient and multi-recipient selector rules both enforce the same membership rule.
+23. Selector rule with recipient allowlist call and calldata shorter than `4 + 32` bytes reverts.
+24. Selector rule with recipient allowlist call and non-canonical ABI address encoding in argument `0` reverts.
+25. Reject selector rules with recipient allowlists when `allowAllSelectors = true`.
+26. Reject selector rules with recipient allowlists for selectors outside the fixed constrained-selector set.
+27. Reject duplicate selector rules for the same `(target, selector)`.
+28. Reject duplicate recipients within a selector rule.
+29. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
+30. Reject `allowAllRecipients=true` with non-empty `recipients` in `setAllowedCalls`.
+31. Reject `allowAllRecipients=false` with empty `recipients` in `setAllowedCalls`.
 
 ## References
 
 - [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
+- [Tempo Transactions](https://docs.tempo.xyz/guide/tempo-transaction)
 - [IAccountKeychain.sol](tips/ref-impls/src/interfaces/IAccountKeychain.sol)
 - [GitHub Issue #1865](https://github.com/tempoxyz/tempo/issues/1865) - Periodic spending limits
 - [GitHub Issue #1491](https://github.com/tempoxyz/tempo/issues/1491) - Destination address scoping

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -21,7 +21,7 @@ This TIP extends Access Keys with three permission features:
 
 ## Motivation
 
-Current Access Keys support per-token limits and expiry, but miss two practical controls.
+Currently Access Keys support per-token limits and expiry, but miss two practical controls.
 
 ### Periodic Spending Limits
 


### PR DESCRIPTION
## Summary

Closes #2299

This updates TIP-1011 to the current spec model for enhanced access-key permissions.

- Defines call scoping with `CallScope { target, selectors? }`, including `None` / `Some([])` / `Some([...])` semantics.
- Clarifies selector rules: selector entries are exactly 4 bytes, and call validation rejects calls that do not provide exactly 4 selector bytes when scoped selector matching is required.
- Specifies map-based call-scope validation model and per-target create-or-replace behavior for `setAllowedCalls`.
- Documents intrinsic gas delta for call scopes with explicit bounds: `MAX_SCOPES = 8`, `MAX_SELECTORS_PER_SCOPE = 16`.
- Tightens invariants/test cases for bounds, `allowAnySelector` precedence, create-or-replace behavior, and contract-creation rejection under access keys.
- Fixes/updates references (Tempo Transactions docs + local `IAccountKeychain.sol` path).
- Adds explicit batch-validation gas charging statement (normal EVM semantics up to failure).

Spec-only PR; no runtime code changes.
