### PR TITLE
tip: TIP-1020 Signature Verification Precompile

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -110,6 +110,10 @@ This TIP does not modify `ecrecover` or any existing Ethereum precompile. `ecrec
 
 Solidity developers commonly use `ecrecover(hash, v, r, s)` to recover an address and then compare it to an expected signer. The Tempo signature verification precompile follows the same recover-and-return pattern but differs in one key way: `ecrecover` returns `address(0)` on invalid input or failed recovery, but the TIP-1020 precompile **reverts** on invalid signatures. Contracts that want non-reverting behavior SHOULD wrap calls using `try/catch` (high-level) or `staticcall` (low-level) and treat failure as "invalid signature".
 
+#### `v` Value Normalization
+
+For secp256k1 signatures, the precompile normalizes the recovery identifier `v`: both Ethereum-style values (`27`, `28`) and raw values (`0`, `1`) are accepted. This is intentional — `recover()` is designed to be as close to a drop-in replacement for `ecrecover` as possible, so it accepts the same `v` values. This differs from TIP-1004 (`permit()`), which requires `v ∈ {27, 28}` and reverts on `0` or `1`.
+
 #### Existing secp256k1 Signature Payloads
 
 For backwards compatibility, secp256k1 signatures are encoded as **65 bytes `r || s || v` with no type prefix**. Callers who already produce 65-byte secp256k1 signatures can reuse them directly as the `signature` argument to this precompile.


### PR DESCRIPTION
## Summary

Adds the TIP-1020 spec for a signature verification precompile at `0x5165300000000000000000000000000000000000`.

Enables contracts to verify Tempo signature types (secp256k1, P256, WebAuthn) onchain by reusing the existing audited verification logic from Tempo transaction processing.

Key design decisions:
- **Same gas schedule** as transaction signatures (3k secp256k1, 8k P256/WebAuthn)
- **Revert on invalid** rather than returning false (fail-fast)
- **No Keychain in precompile** — instead, the spec documents how contracts can verify Keychain signatures themselves by combining this precompile (inner signature verification) with the AccountKeychain precompile (access key validation)
- **No double-charge** for WebAuthn calldata gas (EVM already charges it)

Spec-only change — no code changes.

Implementation: https://github.com/tempoxyz/tempo/tree/tip/1020-impl