### PR TITLE
fix: use chmod 755 for installed tempoup binary

### DIFF
--- a/tempoup/install
+++ b/tempoup/install
@@ -63,7 +63,7 @@ main() {
         exit 1
     fi
 
-    chmod +x "$BIN_DIR/tempoup"
+    chmod 755 "$BIN_DIR/tempoup"
     info "Tempoup installed to $BIN_DIR/tempoup"
 
     # Add to PATH if not already present


### PR DESCRIPTION
## Summary

Sets 755 permissions on the installed tempoup binary so all users can execute it.

Thread: https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1770751416948799

## Changes

- Changed `chmod +x` to `chmod 755` in `tempoup/install`