### PR TITLE
fix: log chain id when downloading snapshot

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -140,6 +140,11 @@ fn main() -> eyre::Result<()> {
         tempo_cmd::TempoSubcommand,
     >::parse();
 
+    if let Commands::Download(ref cmd) = cli.command {
+        let chain_id = cmd.chain_spec().map(|cs| cs.chain().id()).unwrap_or(4217);
+        info!(chain_id, url = %defaults::DEFAULT_DOWNLOAD_URL, "downloading snapshot");
+    }
+
     // If telemetry is enabled, set logs OTLP (conflicts_with in TelemetryArgs prevents both being set)
     let mut telemetry_config = None;
     if let Commands::Node(node_cmd) = &cli.command


### PR DESCRIPTION
## Summary

Adds an info log line when running `tempo download` that shows the chain ID and snapshot base URL being used.

## Changes

- Log `chain_id` and `url` before snapshot download starts in `main.rs`

## Testing

`cargo check -p tempo` passes.

Thread: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1770722789479339

Prompted by: zygis