### PR TITLE
fix(config): trim whitespace from signing key and share hex inputs

### DIFF
--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -27,11 +27,11 @@ impl SigningKey {
 
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, SigningKeyError> {
         let hex = std::fs::read_to_string(path).map_err(SigningKeyErrorKind::Read)?;
-        Self::try_from_hex(&hex)
+        Self::try_from_hex(hex.trim())
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningKeyError> {
-        let bytes = const_hex::decode(hex).map_err(SigningKeyErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex.trim()).map_err(SigningKeyErrorKind::Hex)?;
         let inner = PrivateKey::decode(&bytes[..]).map_err(SigningKeyErrorKind::Parse)?;
         Ok(Self { inner })
     }
@@ -92,11 +92,11 @@ impl SigningShare {
 
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, SigningShareError> {
         let hex = std::fs::read_to_string(path).map_err(SigningShareErrorKind::Read)?;
-        Self::try_from_hex(&hex)
+        Self::try_from_hex(hex.trim())
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningShareError> {
-        let bytes = const_hex::decode(hex).map_err(SigningShareErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex.trim()).map_err(SigningShareErrorKind::Hex)?;
         let inner = Share::decode(&bytes[..]).map_err(SigningShareErrorKind::Parse)?;
         Ok(Self { inner })
     }

--- a/crates/commonware-node-config/src/tests.rs
+++ b/crates/commonware-node-config/src/tests.rs
@@ -33,6 +33,25 @@ fn signing_share_snapshot() {
 }
 
 #[test]
+fn signing_key_trailing_newline() {
+    let hex_with_newline = format!("{SIGNING_KEY}\n");
+    let key = SigningKey::try_from_hex(&hex_with_newline).unwrap();
+    assert_eq!(
+        key.public_key(),
+        SigningKey::try_from_hex(SIGNING_KEY).unwrap().public_key(),
+    );
+}
+
+#[test]
+fn signing_share_trailing_newline() {
+    let hex_with_newline = format!("{SIGNING_SHARE}\n");
+    assert_eq!(
+        SigningShare::try_from_hex(&hex_with_newline).unwrap(),
+        SigningShare::try_from_hex(SIGNING_SHARE).unwrap(),
+    );
+}
+
+#[test]
 fn signing_share_roundtrip() {
     let mut rng = rand_08::rngs::StdRng::seed_from_u64(42);
 


### PR DESCRIPTION
## Summary
Trims trailing newlines/whitespace from hex strings when reading signing key and signing share files, preventing confusing "odd number of bytes" hex decode errors.

## Changes
- `SigningKey::read_from_file` and `try_from_hex` now trim input before hex-decoding
- `SigningShare::read_from_file` and `try_from_hex` now trim input before hex-decoding
- Added tests for trailing newline handling on both types

## Testing
`cargo test -p tempo-commonware-node-config` — all 6 tests pass.

Prompted by: sds