### PR TITLE
fix: download command respects --chain flag for snapshot URL

### DIFF
--- a/.changelog/fix-download-chain-url.md
+++ b/.changelog/fix-download-chain-url.md
@@ -1,0 +1,5 @@
+---
+tempo: patch
+---
+
+Fixed `tempo download --chain moderato` (and `--chain testnet`) downloading the mainnet snapshot instead of the chain-specific one.


### PR DESCRIPTION
## Summary

Fixes `tempo download --chain moderato` (and `--chain testnet`) downloading the mainnet snapshot instead of the chain-specific one.

## Problem

`DownloadDefaults` (from reth) uses a global `OnceLock` with a single `default_base_url` that was always set to mainnet (`https://snapshots.tempoxyz.dev/4217`). The download command's `execute()` ignores the chain spec when resolving the snapshot URL, so `--chain moderato` produced the same download as `--chain mainnet`.

Reported: https://tempoxyz.slack.com/archives/C09UECB49QQ/p1770865117785499

## Fix

Pre-parses `--chain` / `-c` from `std::env::args()` before clap runs, then sets `default_base_url` to the correct chain-specific snapshot URL:

| Chain | URL |
|-------|-----|
| mainnet (default) | `https://snapshots.tempoxyz.dev/4217` |
| moderato | `https://snapshots.tempoxyz.dev/42431` |
| testnet/andantino | `https://snapshots.tempoxyz.dev/42429` |

This workaround is necessary because reth's `DownloadDefaults` is a global `OnceLock` initialized before CLI parsing, and the upstream `DownloadCommand::execute()` doesn't use the chain spec for URL selection.

## Testing

```
cargo test -p tempo -- defaults
```

6 unit tests covering: default (mainnet), explicit mainnet, moderato, testnet, `--chain=moderato` syntax, and `-c` short flag.

## Note on PR #2645

This PR supersedes #2645 (which only added logging but didn't fix the URL). Once merged, #2645 can be closed.