### PR TITLE
test(invariants): remove logging infrastructure from invariant tests

### DIFF
--- a/tips/ref-impls/test/invariants/AccountKeychain.t.sol
+++ b/tips/ref-impls/test/invariants/AccountKeychain.t.sol
@@ -54,8 +54,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
     uint256 private _totalKeysRevoked;
     uint256 private _totalLimitUpdates;
 
-    /// @dev Coverage log file path
-
     /*//////////////////////////////////////////////////////////////
                                SETUP
     //////////////////////////////////////////////////////////////*/
@@ -71,8 +69,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
 
         // Seed each actor with an initial key to ensure handlers have keys to work with
         _seedInitialKeys();
-
-        _initLogFile("account_keychain.log", "AccountKeychain Invariant Test Log");
     }
 
     /// @dev Seeds each actor with one initial key to bootstrap the fuzzer state
@@ -81,7 +77,7 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
             address account = _actors[a];
             // Use a deterministic key for each actor (offset by actor index)
             address keyId = _potentialKeyIds[a % _potentialKeyIds.length];
-            _createKeyInternal(account, keyId, false);
+            _createKeyInternal(account, keyId);
         }
     }
 
@@ -111,8 +107,7 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
     /// @dev Core key authorization with ghost state updates. Does NOT include assertions.
     /// @param account The account to authorize the key for
     /// @param keyId The key ID to authorize
-    /// @param isFallback Whether this is a fallback creation (for logging)
-    function _createKeyInternal(address account, address keyId, bool isFallback) internal {
+    function _createKeyInternal(address account, address keyId) internal {
         uint64 expiry = _generateExpiry(uint256(keccak256(abi.encode(account, keyId))));
         IAccountKeychain.TokenLimit[] memory limits = new IAccountKeychain.TokenLimit[](0);
 
@@ -131,17 +126,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
         if (!_keyUsed[account][keyId]) {
             _keyUsed[account][keyId] = true;
             _accountKeys[account].push(keyId);
-        }
-
-        if (isFallback && _loggingEnabled) {
-            _log(
-                string.concat(
-                    "AUTHORIZE_KEY[fallback]: account=",
-                    _getActorIndex(account),
-                    " keyId=",
-                    vm.toString(keyId)
-                )
-            );
         }
     }
 
@@ -208,7 +192,7 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
             address candidateKey = _potentialKeyIds[idx];
             // Can't reauthorize revoked keys (TEMPO-KEY4)
             if (!_ghostKeyRevoked[account][candidateKey]) {
-                _createKeyInternal(account, candidateKey, true);
+                _createKeyInternal(account, candidateKey);
                 return (account, candidateKey, false);
             }
         }
@@ -285,21 +269,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 uint8(info.signatureType), uint8(sigType), "TEMPO-KEY1: SignatureType should match"
             );
             assertFalse(info.isRevoked, "TEMPO-KEY1: Should not be revoked");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "AUTHORIZE_KEY: account=",
-                        _getActorIndex(account),
-                        " keyId=",
-                        vm.toString(keyId),
-                        " sigType=",
-                        vm.toString(uint8(sigType)),
-                        " enforceLimits=",
-                        enforceLimits ? "true" : "false"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownKeychainError(reason);
@@ -338,17 +307,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
             assertTrue(info.isRevoked, "TEMPO-KEY3: Key should be marked as revoked");
             assertEq(info.expiry, 0, "TEMPO-KEY3: Expiry should be cleared");
             assertEq(info.keyId, address(0), "TEMPO-KEY3: KeyId should return 0 for revoked");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "REVOKE_KEY: account=",
-                        _getActorIndex(account),
-                        " keyId=",
-                        vm.toString(keyId)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownKeychainError(reason);
@@ -404,7 +362,7 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 return;
             }
             // Create and immediately revoke the key
-            _createKeyInternal(account, keyId, false);
+            _createKeyInternal(account, keyId);
             vm.prank(account);
             keychain.revokeKey(keyId);
             _totalKeysRevoked++;
@@ -435,18 +393,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IAccountKeychain.KeyAlreadyRevoked.selector,
                 "TEMPO-KEY4: Should revert with KeyAlreadyRevoked"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_REAUTHORIZE_REVOKED: account=",
-                    _getActorIndex(account),
-                    " keyId=",
-                    vm.toString(keyId),
-                    " correctly rejected"
-                )
             );
         }
     }
@@ -495,22 +441,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
             // TEMPO-KEY6: Verify enforceLimits is now true
             IAccountKeychain.KeyInfo memory info = keychain.getKey(account, keyId);
             assertTrue(info.enforceLimits, "TEMPO-KEY6: EnforceLimits should be true after update");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "UPDATE_LIMIT: account=",
-                        _getActorIndex(account),
-                        " keyId=",
-                        vm.toString(keyId),
-                        " token=",
-                        vm.toString(token),
-                        " limit=",
-                        vm.toString(newLimit),
-                        hadLimitsBefore ? "" : " (enabled limits)"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownKeychainError(reason);
@@ -540,14 +470,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IAccountKeychain.ZeroPublicKey.selector,
                 "TEMPO-KEY7: Should revert with ZeroPublicKey"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_ZERO_KEY: account=", _getActorIndex(account), " correctly rejected"
-                )
             );
         }
     }
@@ -582,18 +504,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 "TEMPO-KEY8: Should revert with KeyAlreadyExists"
             );
         }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_DUPLICATE_KEY: account=",
-                    _getActorIndex(account),
-                    " keyId=",
-                    vm.toString(keyId),
-                    " correctly rejected"
-                )
-            );
-        }
     }
 
     /// @notice Handler for revoking non-existent key (should fail)
@@ -620,20 +530,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IAccountKeychain.KeyNotFound.selector,
                 "TEMPO-KEY9: Should revert with KeyNotFound"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    wasRevoked
-                        ? "TRY_REVOKE_ALREADY_REVOKED: account="
-                        : "TRY_REVOKE_NONEXISTENT: account=",
-                    _getActorIndex(account),
-                    " keyId=",
-                    vm.toString(keyId),
-                    " correctly rejected with KeyNotFound"
-                )
             );
         }
     }
@@ -729,20 +625,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
 
         assertEq(limit1, 1000e6, "TEMPO-KEY10: Account1 limit should be 1000");
         assertEq(limit2, 2000e6, "TEMPO-KEY10: Account2 limit should be 2000");
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "ACCOUNT_ISOLATION: keyId=",
-                    vm.toString(keyId),
-                    " ",
-                    _getActorIndex(account1),
-                    " ",
-                    _getActorIndex(account2),
-                    " verified"
-                )
-            );
-        }
     }
 
     /// @notice Handler for checking getTransactionKey
@@ -831,16 +713,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                     "TEMPO-KEY17: Should revert with KeyExpired when timestamp == expiry"
                 );
             }
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "EXPIRY_BOUNDARY: account=",
-                        _getActorIndex(account),
-                        " key correctly expired at timestamp==expiry"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             // ExpiryInPast is acceptable if expiry <= block.timestamp at creation
@@ -892,18 +764,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 "TEMPO-KEY18: Should revert with KeyExpired"
             );
         }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "EXPIRED_KEY_OP: account=",
-                    _getActorIndex(account),
-                    " keyId=",
-                    vm.toString(keyId),
-                    " correctly rejected after expiry"
-                )
-            );
-        }
     }
 
     /// @notice Handler for testing invalid signature type
@@ -951,18 +811,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 bytes4(returnData),
                 IAccountKeychain.InvalidSignatureType.selector,
                 "TEMPO-KEY19: Should revert with InvalidSignatureType"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "INVALID_SIG_TYPE: account=",
-                    _getActorIndex(account),
-                    " badType=",
-                    vm.toString(badType),
-                    " correctly rejected"
-                )
             );
         }
     }
@@ -1038,38 +886,6 @@ contract AccountKeychainInvariantTest is InvariantBaseTest {
                 }
             }
         }
-    }
-
-    /// @notice Called after each invariant run to log final state
-    function afterInvariant() public {
-        if (!_loggingEnabled) return;
-
-        // Count total keys across all accounts
-        uint256 totalActiveKeys = 0;
-        uint256 totalRevokedKeys = 0;
-        for (uint256 a = 0; a < _actors.length; a++) {
-            address account = _actors[a];
-            address[] memory keys = _accountKeys[account];
-            for (uint256 k = 0; k < keys.length; k++) {
-                if (_ghostKeyRevoked[account][keys[k]]) {
-                    totalRevokedKeys++;
-                } else if (_ghostKeyExists[account][keys[k]]) {
-                    totalActiveKeys++;
-                }
-            }
-        }
-
-        _log("");
-        _log("--------------------------------------------------------------------------------");
-        _log("Final State Summary");
-        _log("--------------------------------------------------------------------------------");
-        _log(string.concat("Keys authorized: ", vm.toString(_totalKeysAuthorized)));
-        _log(string.concat("Keys revoked: ", vm.toString(_totalKeysRevoked)));
-        _log(string.concat("Limit updates: ", vm.toString(_totalLimitUpdates)));
-        _log(string.concat("Active keys (ghost): ", vm.toString(totalActiveKeys)));
-        _log(string.concat("Revoked keys (ghost): ", vm.toString(totalRevokedKeys)));
-        _log(string.concat("Final timestamp: ", vm.toString(block.timestamp)));
-        _log("--------------------------------------------------------------------------------");
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/tips/ref-impls/test/invariants/InvariantBaseTest.t.sol
+++ b/tips/ref-impls/test/invariants/InvariantBaseTest.t.sol
@@ -9,7 +9,7 @@ import { BaseTest } from "../BaseTest.t.sol";
 
 /// @title Invariant Base Test
 /// @notice Shared test infrastructure for invariant testing of Tempo precompiles
-/// @dev Provides common actor management, token selection, funding, and logging utilities
+/// @dev Provides common actor management, token selection, funding, and policy utilities
 abstract contract InvariantBaseTest is BaseTest {
 
     /*//////////////////////////////////////////////////////////////
@@ -31,12 +31,6 @@ abstract contract InvariantBaseTest is BaseTest {
     /// @dev Additional tokens (token3, token4) - token1/token2 from BaseTest
     TIP20 public token3;
     TIP20 public token4;
-
-    /// @dev Log file path - must be set by child contract
-    string internal _logFile;
-
-    /// @dev Whether logging is enabled (set once from INVARIANT_LOG env var)
-    bool internal _loggingEnabled;
 
     /// @dev All addresses that may hold token balances (for invariant checks)
     address[] internal _balanceHolders;
@@ -93,26 +87,6 @@ abstract contract InvariantBaseTest is BaseTest {
     /// @dev Registers an address as a potential balance holder
     function _registerBalanceHolder(address holder) internal {
         _balanceHolders.push(holder);
-    }
-
-    /// @notice Initialize log file with header
-    /// @param logFile The log file path
-    /// @param title The title for the log header
-    /// @dev Logging is only enabled if INVARIANT_LOG=true env var is set
-    function _initLogFile(string memory logFile, string memory title) internal {
-        // Read env var once during setup (default to false if not set)
-        _loggingEnabled = vm.envOr("INVARIANT_LOG", false);
-
-        if (!_loggingEnabled) return;
-
-        _logFile = logFile;
-        try vm.removeFile(_logFile) { } catch { }
-        _log("================================================================================");
-        _log(string.concat("                         ", title));
-        _log("================================================================================");
-        _log(string.concat("Actors: ", vm.toString(_actors.length), " | Tokens: T1, T2, T3, T4"));
-        _log("--------------------------------------------------------------------------------");
-        _log("");
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -256,21 +230,6 @@ abstract contract InvariantBaseTest is BaseTest {
         return authorized[bound(seed, 0, count - 1)];
     }
 
-    /// @dev Gets token symbol for logging
-    /// @param token Token address
-    /// @return Symbol string
-    function _getTokenSymbol(address token) internal view returns (string memory) {
-        if (token == address(pathUSD)) {
-            return "pathUSD";
-        }
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            if (address(_tokens[i]) == token) {
-                return _tokens[i].symbol();
-            }
-        }
-        return vm.toString(token);
-    }
-
     /*//////////////////////////////////////////////////////////////
                           FUNDING HELPERS
     //////////////////////////////////////////////////////////////*/
@@ -329,48 +288,6 @@ abstract contract InvariantBaseTest is BaseTest {
     /// @return True if authorized
     function _isAuthorized(address token, address actor) internal view returns (bool) {
         return registry.isAuthorized(_getPolicyId(token), actor);
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                              LOGGING
-    //////////////////////////////////////////////////////////////*/
-
-    /// @dev Logs a message to the log file (no-op if logging disabled)
-    function _log(string memory message) internal {
-        if (!_loggingEnabled) return;
-        vm.writeLine(_logFile, message);
-    }
-
-    /// @dev Gets actor index from address for logging
-    function _getActorIndex(address actor) internal view returns (string memory) {
-        for (uint256 i = 0; i < _actors.length; i++) {
-            if (_actors[i] == actor) {
-                return string.concat("Actor", vm.toString(i));
-            }
-        }
-        if (actor == admin) return "Admin";
-        if (actor == address(0)) return "ZERO";
-        return vm.toString(actor);
-    }
-
-    /// @dev Logs contract balances for all tokens (no-op if logging disabled)
-    /// @param contractAddr Contract address to check
-    /// @param contractName Name for logging
-    function _logContractBalances(address contractAddr, string memory contractName) internal {
-        if (!_loggingEnabled) return;
-        string memory balanceStr = string.concat(
-            contractName, " balances: pathUSD=", vm.toString(pathUSD.balanceOf(contractAddr))
-        );
-        for (uint256 t = 0; t < _tokens.length; t++) {
-            balanceStr = string.concat(
-                balanceStr,
-                ", ",
-                _tokens[t].symbol(),
-                "=",
-                vm.toString(_tokens[t].balanceOf(contractAddr))
-            );
-        }
-        _log(balanceStr);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/tips/ref-impls/test/invariants/Nonce.t.sol
+++ b/tips/ref-impls/test/invariants/Nonce.t.sol
@@ -85,8 +85,6 @@ contract NonceInvariantTest is InvariantBaseTest {
 
         _setupInvariantBase();
         _actors = _buildActors(10);
-
-        _initLogFile("nonce.log", "Nonce Invariant Test Log");
     }
 
     /// @dev Gets a valid nonce key (1 to MAX_NORMAL_NONCE_KEY)
@@ -198,21 +196,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         // TEMPO-NON3: New value should be readable
         uint64 actualAfter = nonce.getNonce(actor, nonceKey);
         assertEq(actualAfter, newNonce, "TEMPO-NON3: Stored nonce should match returned value");
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "INCREMENT: ",
-                    _getActorIndex(actor),
-                    " key=",
-                    vm.toString(nonceKey),
-                    " ",
-                    vm.toString(expectedBefore),
-                    " -> ",
-                    vm.toString(newNonce)
-                )
-            );
-        }
     }
 
     /// @notice Handler for reading nonces
@@ -247,12 +230,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         }
 
         _totalProtocolNonceRejections++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat("TRY_PROTOCOL_NONCE: ", _getActorIndex(actor), " correctly rejected")
-            );
-        }
     }
 
     /// @notice Handler for verifying account independence
@@ -281,19 +258,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         assertEq(nonce2After, nonce2Before, "TEMPO-NON5: Other account nonce should be unchanged");
 
         _totalAccountIndependenceChecks++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "ACCOUNT_INDEPENDENCE: ",
-                    _getActorIndex(actor1),
-                    " incremented, ",
-                    _getActorIndex(actor2),
-                    " unchanged at ",
-                    vm.toString(nonce2After)
-                )
-            );
-        }
     }
 
     /// @notice Handler for verifying key independence
@@ -316,21 +280,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         assertEq(nonce2After, nonce2Before, "TEMPO-NON6: Other key nonce should be unchanged");
 
         _totalKeyIndependenceChecks++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "KEY_INDEPENDENCE: ",
-                    _getActorIndex(actor),
-                    " key=",
-                    vm.toString(key1),
-                    " incremented, key=",
-                    vm.toString(key2),
-                    " unchanged at ",
-                    vm.toString(nonce2After)
-                )
-            );
-        }
     }
 
     /// @notice Handler for testing max nonce key
@@ -354,17 +303,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         assertEq(afterIncrement, newNonce, "TEMPO-NON7: Large key should increment correctly");
 
         _totalLargeKeyTests++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "LARGE_KEY: ",
-                    _getActorIndex(actor),
-                    " key=MAX_UINT256-1 nonce=",
-                    vm.toString(newNonce)
-                )
-            );
-        }
     }
 
     /// @notice Handler for multiple sequential increments
@@ -394,23 +332,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         assertEq(endNonce, startNonce + uint64(count), "TEMPO-NON8: Total increment should match");
 
         _totalMultipleIncrements++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "MULTI_INCREMENT: ",
-                    _getActorIndex(actor),
-                    " key=",
-                    vm.toString(nonceKey),
-                    " count=",
-                    vm.toString(count),
-                    " ",
-                    vm.toString(startNonce),
-                    " -> ",
-                    vm.toString(endNonce)
-                )
-            );
-        }
     }
 
     /// @notice Handler for testing nonce overflow at u64::MAX
@@ -442,18 +363,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         this.externalIncrementNonceViaStorage(actor, nonceKey);
 
         _totalOverflowTests++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "NONCE_OVERFLOW: ",
-                    _getActorIndex(actor),
-                    " key=",
-                    vm.toString(nonceKey),
-                    " at u64::MAX - increment correctly reverted"
-                )
-            );
-        }
     }
 
     /// @notice Handler for testing invalid nonce key (key 0) increment rejection
@@ -469,14 +378,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         this.externalIncrementNonceViaStorage(actor, 0);
 
         _totalInvalidKeyRejections++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "INVALID_KEY_INCREMENT: ", _getActorIndex(actor), " key=0 correctly reverted"
-                )
-            );
-        }
     }
 
     /// @notice Handler for testing reserved TEMPO_EXPIRING_NONCE_KEY readability
@@ -496,17 +397,6 @@ contract NonceInvariantTest is InvariantBaseTest {
         assertEq(result, 0, "TEMPO-NON11: Reserved key should return 0 for uninitialized");
 
         _totalReservedKeyTests++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "RESERVED_EXPIRING_KEY: ",
-                    _getActorIndex(actor),
-                    " key=MAX_UINT256 readable, value=",
-                    vm.toString(result)
-                )
-            );
-        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -535,59 +425,6 @@ contract NonceInvariantTest is InvariantBaseTest {
                 assertGe(actual, lastSeen, "TEMPO-NON1: Nonce decreased from last seen value");
             }
         }
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                          AFTER INVARIANT
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Logs final state summary after invariant run
-    function afterInvariant() public {
-        if (!_loggingEnabled) return;
-
-        _log("");
-        _log("--------------------------------------------------------------------------------");
-        _log("                              Final State Summary");
-        _log("--------------------------------------------------------------------------------");
-        _log(string.concat("Total increments: ", vm.toString(_totalIncrements)));
-        _log(string.concat("Total reads: ", vm.toString(_totalReads)));
-        _log(
-            string.concat(
-                "Protocol nonce rejections (NON4): ", vm.toString(_totalProtocolNonceRejections)
-            )
-        );
-        _log(
-            string.concat(
-                "Account independence checks (NON5): ", vm.toString(_totalAccountIndependenceChecks)
-            )
-        );
-        _log(
-            string.concat(
-                "Key independence checks (NON6): ", vm.toString(_totalKeyIndependenceChecks)
-            )
-        );
-        _log(string.concat("Large key tests (NON7): ", vm.toString(_totalLargeKeyTests)));
-        _log(
-            string.concat(
-                "Multiple increment operations (NON8): ", vm.toString(_totalMultipleIncrements)
-            )
-        );
-        _log(string.concat("Overflow tests (NON9): ", vm.toString(_totalOverflowTests)));
-        _log(
-            string.concat(
-                "Invalid key rejections (NON10): ", vm.toString(_totalInvalidKeyRejections)
-            )
-        );
-        _log(string.concat("Reserved key tests (NON11): ", vm.toString(_totalReservedKeyTests)));
-        _log("--------------------------------------------------------------------------------");
-
-        // Count total unique nonce keys tracked
-        uint256 totalTrackedKeys = 0;
-        for (uint256 a = 0; a < _actors.length; a++) {
-            totalTrackedKeys += _accountNonceKeys[_actors[a]].length;
-        }
-        _log(string.concat("Total tracked nonce keys: ", vm.toString(totalTrackedKeys)));
-        _log("--------------------------------------------------------------------------------");
     }
 
 }

--- a/tips/ref-impls/test/invariants/TIP1015.t.sol
+++ b/tips/ref-impls/test/invariants/TIP1015.t.sol
@@ -33,8 +33,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
                               STATE
     //////////////////////////////////////////////////////////////*/
 
-    string private constant LOG_FILE = "tip1015.log";
-
     uint64[] private _simplePolicies;
     uint64[] private _compoundPolicies;
 
@@ -133,8 +131,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
             _dexApproved[_actors[i]][address(initialToken)] = true;
             _dexApproved[_actors[i]][address(pathUSD)] = true;
         }
-
-        _initLogFile(LOG_FILE, "TIP-1015 Compound Policy Invariant Test Log");
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -155,19 +151,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
         _simplePolicies.push(pid);
         _policyTypes[pid] = ptype;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "CREATE_SIMPLE_POLICY: ",
-                    _getActorIndex(actor),
-                    " created policy ",
-                    vm.toString(pid),
-                    " type=",
-                    isWhitelist ? "WHITELIST" : "BLACKLIST"
-                )
-            );
-        }
     }
 
     function createCompoundPolicy(
@@ -209,21 +192,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
             assertEq(storedS, sPid, "Sender policy mismatch");
             assertEq(storedR, rPid, "Recipient policy mismatch");
             assertEq(storedM, mPid, "MintRecipient policy mismatch");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CREATE_COMPOUND_POLICY: compound=",
-                        vm.toString(compoundPid),
-                        " sender=",
-                        vm.toString(sPid),
-                        " recipient=",
-                        vm.toString(rPid),
-                        " mint=",
-                        vm.toString(mPid)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownRegistryRevert(reason);
@@ -250,21 +218,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
         _compoundRecipientPolicy[compoundPid] = rPid;
         _compoundMintPolicy[compoundPid] = mPid;
         _totalCompoundPoliciesCreated++;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "CREATE_COMPOUND_WITH_BUILTINS: compound=",
-                    vm.toString(compoundPid),
-                    " sender=",
-                    vm.toString(sPid),
-                    " recipient=",
-                    vm.toString(rPid),
-                    " mint=",
-                    vm.toString(mPid)
-                )
-            );
-        }
     }
 
     function tryCreateCompoundWithCompound(uint256 seed) external {
@@ -310,18 +263,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
         assertEq(
             errorSelector, ITIP403Registry.PolicyNotSimple.selector, "TEMPO-1015-1: Wrong error"
         );
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_CREATE_COMPOUND_WITH_COMPOUND: position=",
-                    vm.toString(position),
-                    " compoundRef=",
-                    vm.toString(compoundRef),
-                    " (correctly reverted)"
-                )
-            );
-        }
     }
 
     function tryCreateCompoundWithNonExistent(uint256 seed) external {
@@ -368,18 +309,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
             ITIP403Registry.PolicyNotFound.selector,
             "TEMPO-1015-3: Wrong error selector"
         );
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_CREATE_COMPOUND_WITH_NONEXISTENT: position=",
-                    vm.toString(position),
-                    " nonExistent=",
-                    vm.toString(nonExistent),
-                    " (correctly reverted)"
-                )
-            );
-        }
     }
 
     function modifySimplePolicy(uint256 policySeed, uint256 accountSeed, bool add) external {
@@ -404,19 +333,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
         if (!_policyAccountTracked[pid][account]) {
             _policyAccountTracked[pid][account] = true;
             _policyAccounts[pid].push(account);
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "MODIFY_SIMPLE_POLICY: policy=",
-                    vm.toString(pid),
-                    " account=",
-                    _getActorIndex(account),
-                    " add=",
-                    add ? "true" : "false"
-                )
-            );
         }
     }
 
@@ -445,14 +361,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
         assertTrue(
             blacklistReverted, "TEMPO-1015-2: modifyPolicyBlacklist should revert for compound"
         );
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_MODIFY_COMPOUND_POLICY: policy=", vm.toString(pid), " (correctly reverted)"
-                )
-            );
-        }
     }
 
     function checkSimplePolicyEquivalence(uint256 policySeed, uint256 accountSeed) external view {
@@ -539,17 +447,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
         _compoundTokens.push(token);
         _tokenPolicy[address(token)] = pid;
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "CREATE_TOKEN_WITH_COMPOUND: token=",
-                    vm.toString(address(token)),
-                    " policy=",
-                    vm.toString(pid)
-                )
-            );
-        }
     }
 
     /// @notice Opt an actor into rewards - critical for testing reward distribution/claim flows
@@ -600,17 +497,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
         if (authorized) {
             token.mint(recipient, amount);
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "MINT: recipient=",
-                        _getActorIndex(recipient),
-                        " amount=",
-                        vm.toString(amount),
-                        " (authorized)"
-                    )
-                );
-            }
         } else {
             bool reverted;
             bytes4 errorSelector;
@@ -624,16 +510,6 @@ contract TIP1015InvariantTest is InvariantBaseTest {
             assertEq(
                 errorSelector, ITIP20.PolicyForbids.selector, "Wrong error for unauthorized mint"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "MINT: recipient=",
-                        _getActorIndex(recipient),
-                        " (unauthorized, correctly reverted)"
-                    )
-                );
-            }
         }
 
         vm.stopPrank();
@@ -796,41 +672,15 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
         vm.prank(sender);
         if (senderAuth && contractRecipientAuth) {
-            try token.distributeReward(amount) {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "DISTRIBUTE_REWARD: sender=",
-                            _getActorIndex(sender),
-                            " amount=",
-                            vm.toString(amount),
-                            " (authorized)"
-                        )
-                    );
-                }
-            } catch {
+            try token.distributeReward(amount) { }
+                catch {
                 // Can fail for other reasons (e.g., zero optedInSupply race)
             }
         } else {
             try token.distributeReward(amount) {
                 revert("TEMPO-1015-7: distributeReward should revert for unauthorized");
-            } catch (bytes memory reason) {
-                // May revert for other reasons too, only check if it's PolicyForbids
-                if (bytes4(reason) == ITIP20.PolicyForbids.selector) {
-                    if (_loggingEnabled) {
-                        _log(
-                            string.concat(
-                                "DISTRIBUTE_REWARD: sender=",
-                                _getActorIndex(sender),
-                                " senderAuth=",
-                                senderAuth ? "true" : "false",
-                                " contractRecipientAuth=",
-                                contractRecipientAuth ? "true" : "false",
-                                " (correctly reverted)"
-                            )
-                        );
-                    }
-                }
+            } catch {
+                // May revert for PolicyForbids or other reasons - both acceptable
             }
         }
 
@@ -902,37 +752,15 @@ contract TIP1015InvariantTest is InvariantBaseTest {
 
         vm.prank(claimer);
         if (contractSenderAuth && claimerRecipientAuth) {
-            try token.claimRewards() {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "CLAIM_REWARDS: claimer=", _getActorIndex(claimer), " (authorized)"
-                        )
-                    );
-                }
-            } catch {
+            try token.claimRewards() { }
+                catch {
                 // Can fail for other reasons
             }
         } else {
             try token.claimRewards() {
                 revert("TEMPO-1015-8: claimRewards should revert for unauthorized");
-            } catch (bytes memory reason) {
-                // May revert for other reasons too, only check if it's PolicyForbids
-                if (bytes4(reason) == ITIP20.PolicyForbids.selector) {
-                    if (_loggingEnabled) {
-                        _log(
-                            string.concat(
-                                "CLAIM_REWARDS: claimer=",
-                                _getActorIndex(claimer),
-                                " contractSenderAuth=",
-                                contractSenderAuth ? "true" : "false",
-                                " claimerRecipientAuth=",
-                                claimerRecipientAuth ? "true" : "false",
-                                " (correctly reverted)"
-                            )
-                        );
-                    }
-                }
+            } catch {
+                // May revert for PolicyForbids or other reasons - both acceptable
             }
         }
 

--- a/tips/ref-impls/test/invariants/TIP20.t.sol
+++ b/tips/ref-impls/test/invariants/TIP20.t.sol
@@ -10,9 +10,6 @@ import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
 /// @dev Tests invariants TEMPO-TIP1 through TEMPO-TIP29
 contract TIP20InvariantTest is InvariantBaseTest {
 
-    /// @dev Log file path for recording actions
-    string private constant LOG_FILE = "tip20.log";
-
     /// @dev Ghost variables for reward distribution tracking
     uint256 private _totalRewardsDistributed;
     uint256 private _totalRewardsClaimed;
@@ -79,8 +76,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             _registerHolder(tokenAddr, charlie);
             _registerHolder(tokenAddr, pathUSDAdmin);
         }
-
-        _initLogFile(LOG_FILE, "TIP20 Invariant Test Log");
 
         // One-time constant checks (immutable after deployment)
         for (uint256 i = 0; i < _tokens.length; i++) {
@@ -155,21 +150,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 totalSupplyBefore,
                 "TEMPO-TIP2: Total supply changed during transfer"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TRANSFER: ",
-                        _getActorIndex(actor),
-                        " -> ",
-                        _getActorIndex(recipient),
-                        " ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -216,19 +196,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertEq(
                 token.totalSupply(), totalSupplyBefore, "Total supply changed on zero transfer"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TRANSFER_ZERO: ",
-                        _getActorIndex(actor),
-                        " -> ",
-                        _getActorIndex(recipient),
-                        " 0 ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -296,23 +263,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 recipientBalanceBefore + amount,
                 "TEMPO-TIP3: Recipient balance not increased"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TRANSFER_FROM: ",
-                        _getActorIndex(owner),
-                        " -> ",
-                        _getActorIndex(recipient),
-                        " via ",
-                        _getActorIndex(spender),
-                        " ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -343,21 +293,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertEq(
                 token.allowance(actor, spender), amount, "TEMPO-TIP5: Allowance not set correctly"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "APPROVE: ",
-                        _getActorIndex(actor),
-                        " approved ",
-                        _getActorIndex(spender),
-                        " for ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -402,19 +337,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 recipientBalanceBefore + amount,
                 "TEMPO-TIP6: Recipient balance not increased"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "MINT: ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol(),
-                        " to ",
-                        _getActorIndex(recipient)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -451,10 +373,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 adminBalance - amount,
                 "TEMPO-TIP8: Admin balance not decreased"
             );
-
-            if (_loggingEnabled) {
-                _log(string.concat("BURN: ", vm.toString(amount), " ", token.symbol()));
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -504,21 +422,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 "TEMPO-TIP9: Recipient balance not increased"
             );
             assertEq(token.totalSupply(), totalSupplyBefore, "TEMPO-TIP9: Total supply changed");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TRANSFER_WITH_MEMO: ",
-                        _getActorIndex(actor),
-                        " -> ",
-                        _getActorIndex(recipient),
-                        " ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -590,23 +493,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                     "TEMPO-TIP3: Allowance not decreased correctly"
                 );
             }
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TRANSFER_FROM_MEMO: ",
-                        _getActorIndex(owner),
-                        " -> ",
-                        _getActorIndex(recipient),
-                        " via ",
-                        _getActorIndex(spender),
-                        " ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -646,7 +532,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
         (address currentRecipient,,) = token.userRewardInfo(actor);
         uint256 actorBalance = token.balanceOf(actor);
         uint128 optedInSupplyBefore = token.optedInSupply();
-        bool isDelegation = newRecipient != address(0) && newRecipient != actor;
 
         vm.startPrank(actor);
         try token.setRewardRecipient(newRecipient) {
@@ -675,34 +560,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                     optedInSupplyBefore - uint128(actorBalance),
                     "Opted-in supply not decreased"
                 );
-            }
-
-            if (isDelegation) {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "DELEGATE_REWARDS: ",
-                            _getActorIndex(actor),
-                            " delegated to ",
-                            _getActorIndex(newRecipient),
-                            " on ",
-                            token.symbol()
-                        )
-                    );
-                }
-            } else {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "SET_REWARD_RECIPIENT: ",
-                            _getActorIndex(actor),
-                            " -> ",
-                            newRecipient != address(0) ? _getActorIndex(newRecipient) : "NONE",
-                            " on ",
-                            token.symbol()
-                        )
-                    );
-                }
             }
         } catch (bytes memory reason) {
             vm.stopPrank();
@@ -761,19 +618,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 tokenBalanceBefore + amount,
                 "TEMPO-TIP13: Tokens not transferred to contract"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "DISTRIBUTE_REWARD: ",
-                        _getActorIndex(actor),
-                        " distributed ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -822,18 +666,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 globalRPTBefore,
                 "TEMPO-TIP12: Zero-delta distribution should not change globalRewardPerToken"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "DISTRIBUTE_REWARD_TINY: ",
-                        _getActorIndex(actor),
-                        " distributed 1 ",
-                        token.symbol(),
-                        " (delta=0)"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -866,17 +698,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 ITIP20.NoOptedInSupply.selector,
                 "TEMPO-TIP12: Should revert with NoOptedInSupply when optedInSupply == 0"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "DISTRIBUTE_REWARD_ZERO_OPTED: ",
-                    _getActorIndex(actor),
-                    " correctly rejected on ",
-                    token.symbol()
-                )
             );
         }
     }
@@ -924,21 +745,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertLe(
                 claimed, contractBalanceBefore, "TEMPO-TIP15: Claimed more than contract balance"
             );
-
-            if (claimed > 0) {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "CLAIM_REWARDS: ",
-                            _getActorIndex(actor),
-                            " claimed ",
-                            vm.toString(claimed),
-                            " ",
-                            token.symbol()
-                        )
-                    );
-                }
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -994,23 +800,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 contractBalance - claimed,
                 "TEMPO-TIP14: Contract balance not decreased correctly"
             );
-
-            if (claimed > 0) {
-                if (_loggingEnabled) {
-                    _log(
-                        string.concat(
-                            "CLAIM_VERIFIED: ",
-                            _getActorIndex(actor),
-                            " claimed ",
-                            vm.toString(claimed),
-                            "/",
-                            vm.toString(pendingRewards),
-                            " ",
-                            token.symbol()
-                        )
-                    );
-                }
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -1055,19 +844,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 totalSupplyBefore - amount,
                 "TEMPO-TIP23: Total supply not decreased"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "BURN_BLOCKED: ",
-                        vm.toString(amount),
-                        " ",
-                        token.symbol(),
-                        " from ",
-                        _getActorIndex(target)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -1221,26 +997,11 @@ contract TIP20InvariantTest is InvariantBaseTest {
             newPolicyId = uint64(policySeed % 10) + 2;
         }
 
-        uint64 currentPolicyId = token.transferPolicyId();
-
         vm.startPrank(admin);
         try token.changeTransferPolicyId(newPolicyId) {
             vm.stopPrank();
 
             assertEq(token.transferPolicyId(), newPolicyId, "Transfer policy ID not updated");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CHANGE_POLICY: ",
-                        token.symbol(),
-                        " policy ",
-                        vm.toString(currentPolicyId),
-                        " -> ",
-                        vm.toString(newPolicyId)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             // Expected if policy doesn't exist
@@ -1301,10 +1062,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
                 assertEq(
                     address(token.quoteToken()), address(newQuoteToken), "Quote token not updated"
                 );
-
-                if (_loggingEnabled) {
-                    _log(string.concat("UPDATE_QUOTE_TOKEN: ", token.symbol(), " quote changed"));
-                }
             } catch (bytes memory reason) {
                 vm.stopPrank();
                 // Cycle detection may reject
@@ -1345,7 +1102,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
         TIP20 token = _selectBaseToken(tokenSeed);
 
         uint256 currentSupply = token.totalSupply();
-        uint256 currentCap = token.supplyCap();
 
         // Bound new cap between current supply and max uint128
         newCap = bound(newCap, currentSupply, type(uint128).max);
@@ -1361,19 +1117,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertGe(
                 token.supplyCap(), token.totalSupply(), "TEMPO-TIP22: Supply cap below total supply"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "SET_SUPPLY_CAP: ",
-                        token.symbol(),
-                        " cap ",
-                        vm.toString(currentCap),
-                        " -> ",
-                        vm.toString(newCap)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -1459,19 +1202,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertEq(
                 afterAuthorized, !blacklist, "TEMPO-TIP16: Blacklist status not updated correctly"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "TOGGLE_BLACKLIST: ",
-                        _getActorIndex(actor),
-                        " ",
-                        blacklist ? "BLACKLISTED" : "UNBLACKLISTED",
-                        " on ",
-                        token.symbol()
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
@@ -1495,12 +1225,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
             assertFalse(token.paused(), "TEMPO-TIP17: Token should be unpaused");
         }
         vm.stopPrank();
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat("TOGGLE_PAUSE: ", token.symbol(), " ", pause ? "PAUSED" : "UNPAUSED")
-            );
-        }
     }
 
     /// @notice Handler that verifies paused tokens reject transfers with ContractPaused
@@ -1529,17 +1253,6 @@ contract TIP20InvariantTest is InvariantBaseTest {
         } catch (bytes memory reason) {
             vm.stopPrank();
             assertTrue(_isKnownTIP20Error(bytes4(reason)), "Unknown error encountered");
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_TRANSFER_PAUSED: ",
-                    _getActorIndex(actor),
-                    " blocked on paused ",
-                    token.symbol()
-                )
-            );
         }
     }
 

--- a/tips/ref-impls/test/invariants/TIP403Registry.t.sol
+++ b/tips/ref-impls/test/invariants/TIP403Registry.t.sol
@@ -9,9 +9,6 @@ import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
 /// @dev Tests invariants TEMPO-REG1 through TEMPO-REG19 as documented in README.md
 contract TIP403RegistryInvariantTest is InvariantBaseTest {
 
-    /// @dev Log file path for recording actions
-    string private constant LOG_FILE = "tip403_registry.log";
-
     /// @dev Ghost variable for tracking total policies created in handlers
     uint256 private _totalPoliciesCreated;
 
@@ -44,12 +41,10 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
     /// @dev Core policy creation with ghost state updates. Does NOT include assertions.
     /// @param actor The address that will be the admin of the new policy
     /// @param policyType The type of policy to create
-    /// @param isFallback Whether this is a fallback creation (for logging)
     /// @return policyId The ID of the newly created policy
     function _createPolicyInternal(
         address actor,
-        ITIP403Registry.PolicyType policyType,
-        bool isFallback
+        ITIP403Registry.PolicyType policyType
     )
         internal
         returns (uint64 policyId)
@@ -61,23 +56,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
         _totalPoliciesCreated++;
         _createdPolicies.push(policyId);
         _policyTypes[policyId] = policyType;
-
-        if (isFallback) {
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CREATE_POLICY[fallback]: ",
-                        _getActorIndex(actor),
-                        " created policy ",
-                        vm.toString(policyId),
-                        " type=",
-                        policyType == ITIP403Registry.PolicyType.WHITELIST
-                            ? "WHITELIST"
-                            : "BLACKLIST"
-                    )
-                );
-            }
-        }
     }
 
     /// @dev Find an existing policy of the specified type
@@ -129,7 +107,7 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
                 return (policyId, admin);
             }
             // No policies exist, create a whitelist
-            policyId = _createPolicyInternal(actor, ITIP403Registry.PolicyType.WHITELIST, true);
+            policyId = _createPolicyInternal(actor, ITIP403Registry.PolicyType.WHITELIST);
             return (policyId, actor);
         }
 
@@ -144,7 +122,7 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
         }
 
         // Not found, create one as fallback
-        policyId = _createPolicyInternal(actor, requestedType, true);
+        policyId = _createPolicyInternal(actor, requestedType);
         return (policyId, actor);
     }
 
@@ -159,8 +137,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
         _basePoliciesCreated = registry.policyIdCounter() - counterBefore;
 
         _actors = _buildActors(10);
-
-        _initLogFile(LOG_FILE, "TIP403Registry Invariant Test Log");
 
         // One-time constant checks (immutable after deployment)
         // TEMPO-REG13: Special policies 0 and 1 always exist
@@ -182,7 +158,7 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
 
         uint64 counterBefore = registry.policyIdCounter();
 
-        uint64 policyId = _createPolicyInternal(actor, policyType, false);
+        uint64 policyId = _createPolicyInternal(actor, policyType);
 
         // TEMPO-REG1: Policy ID should equal counter before creation
         assertEq(
@@ -203,19 +179,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
         (ITIP403Registry.PolicyType storedType, address storedAdmin) = registry.policyData(policyId);
         assertEq(uint256(storedType), uint256(policyType), "TEMPO-REG4: Policy type mismatch");
         assertEq(storedAdmin, actor, "TEMPO-REG4: Policy admin mismatch");
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "CREATE_POLICY: ",
-                    _getActorIndex(actor),
-                    " created policy ",
-                    vm.toString(policyId),
-                    " type=",
-                    isWhitelist ? "WHITELIST" : "BLACKLIST"
-                )
-            );
-        }
     }
 
     /// @notice Handler for creating policies with initial accounts
@@ -270,20 +233,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
                     );
                 }
             }
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CREATE_POLICY_WITH_ACCOUNTS: ",
-                        _getActorIndex(actor),
-                        " created policy ",
-                        vm.toString(policyId),
-                        " with ",
-                        vm.toString(numAccounts),
-                        " accounts"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
@@ -304,19 +253,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
             // TEMPO-REG6: Admin should be updated
             (, address storedAdmin) = registry.policyData(policyId);
             assertEq(storedAdmin, newAdmin, "TEMPO-REG6: Admin not updated correctly");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "SET_ADMIN: policy ",
-                        vm.toString(policyId),
-                        " admin changed from ",
-                        _getActorIndex(currentAdmin),
-                        " to ",
-                        _getActorIndex(newAdmin)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
@@ -366,19 +302,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
             // TEMPO-REG8: Authorization should reflect whitelist status
             bool authAfter = registry.isAuthorized(policyId, account);
             assertEq(authAfter, allowed, "TEMPO-REG8: Whitelist authorization mismatch");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "MODIFY_WHITELIST: policy ",
-                        vm.toString(policyId),
-                        " ",
-                        _getActorIndex(account),
-                        " set to ",
-                        allowed ? "ALLOWED" : "DISALLOWED"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
@@ -407,19 +330,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
             // TEMPO-REG9: Authorization should be opposite of blacklist status
             bool authAfter = registry.isAuthorized(policyId, account);
             assertEq(authAfter, !restricted, "TEMPO-REG9: Blacklist authorization mismatch");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "MODIFY_BLACKLIST: policy ",
-                        vm.toString(policyId),
-                        " ",
-                        _getActorIndex(account),
-                        " set to ",
-                        restricted ? "RESTRICTED" : "UNRESTRICTED"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
@@ -553,17 +463,6 @@ contract TIP403RegistryInvariantTest is InvariantBaseTest {
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownError(reason);
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_MODIFY_SPECIAL_POLICY: ",
-                    _getActorIndex(actor),
-                    " blocked on policy ",
-                    vm.toString(policyId)
-                )
-            );
         }
     }
 

--- a/tips/ref-impls/test/invariants/ValidatorConfig.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfig.t.sol
@@ -45,8 +45,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
         _actors = _buildActors(10);
         _potentialValidators = _buildAddressPool(20, VALIDATOR_POOL_OFFSET);
         _ghostOwner = admin;
-
-        _initLogFile("validator_config.log", "ValidatorConfig Invariant Test Log");
     }
 
     /// @dev Selects a potential validator address based on seed
@@ -112,19 +110,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 countBefore,
                 "TEMPO-VAL2: New validator index should be previous count"
             );
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "ADD_VALIDATOR: ",
-                        vm.toString(validatorAddr),
-                        " index=",
-                        vm.toString(countBefore),
-                        " active=",
-                        active ? "true" : "false"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownValidatorError(reason);
@@ -154,17 +139,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IValidatorConfig.Unauthorized.selector,
                 "TEMPO-VAL1: Should revert with Unauthorized"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_ADD_UNAUTHORIZED: ",
-                    vm.toString(caller),
-                    " blocked from adding ",
-                    vm.toString(validatorAddr)
-                )
             );
         }
     }
@@ -204,14 +178,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 }
             }
             assertTrue(found, "TEMPO-VAL3: Updated validator should exist");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "UPDATE_VALIDATOR: ", vm.toString(validatorAddr), " updated public key"
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownValidatorError(reason);
@@ -244,14 +210,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 "TEMPO-VAL4: Should revert with ValidatorNotFound"
             );
         }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_OWNER_UPDATE: Owner blocked from updating ", vm.toString(validatorAddr)
-                )
-            );
-        }
     }
 
     /// @notice Handler for changing validator status (owner only)
@@ -277,17 +235,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                     );
                     break;
                 }
-            }
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CHANGE_STATUS: ",
-                        vm.toString(validatorAddr),
-                        " -> ",
-                        newStatus ? "ACTIVE" : "INACTIVE"
-                    )
-                );
             }
         } catch (bytes memory reason) {
             vm.stopPrank();
@@ -317,16 +264,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 "TEMPO-VAL5: Should revert with Unauthorized"
             );
         }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_SELF_STATUS_CHANGE: ",
-                    vm.toString(validatorAddr),
-                    " blocked from self-change"
-                )
-            );
-        }
     }
 
     /// @notice Handler for changing owner
@@ -343,14 +280,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
 
             // TEMPO-VAL7: Verify owner changed
             assertEq(validatorConfig.owner(), newOwner, "TEMPO-VAL7: Owner should be updated");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "CHANGE_OWNER: ", vm.toString(oldOwner), " -> ", vm.toString(newOwner)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownValidatorError(reason);
@@ -378,16 +307,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 "TEMPO-VAL8: Should revert with Unauthorized"
             );
         }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_CHANGE_OWNER_UNAUTHORIZED: ",
-                    vm.toString(caller),
-                    " blocked from ownership"
-                )
-            );
-        }
     }
 
     /// @notice Handler for adding duplicate validator
@@ -410,14 +329,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IValidatorConfig.ValidatorAlreadyExists.selector,
                 "TEMPO-VAL9: Should revert with ValidatorAlreadyExists"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_ADD_DUPLICATE: ", vm.toString(existingValidator), " correctly rejected"
-                )
             );
         }
     }
@@ -444,14 +355,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IValidatorConfig.InvalidPublicKey.selector,
                 "TEMPO-VAL10: Should revert with InvalidPublicKey"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_ZERO_PUBKEY: ", vm.toString(validatorAddr), " zero pubkey rejected"
-                )
             );
         }
     }
@@ -510,14 +413,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 }
             }
             assertTrue(found, "TEMPO-VAL11: Rotated validator should exist");
-
-            if (_loggingEnabled) {
-                _log(
-                    string.concat(
-                        "ROTATE_VALIDATOR: ", vm.toString(oldAddr), " -> ", vm.toString(newAddr)
-                    )
-                );
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownValidatorError(reason);
@@ -539,10 +434,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 epoch,
                 "TEMPO-VAL12: DKG epoch should be set"
             );
-
-            if (_loggingEnabled) {
-                _log(string.concat("SET_DKG_CEREMONY: epoch=", vm.toString(epoch)));
-            }
         } catch (bytes memory reason) {
             vm.stopPrank();
             _assertKnownValidatorError(reason);
@@ -567,14 +458,6 @@ contract ValidatorConfigInvariantTest is InvariantBaseTest {
                 bytes4(reason),
                 IValidatorConfig.Unauthorized.selector,
                 "TEMPO-VAL13: Should revert with Unauthorized"
-            );
-        }
-
-        if (_loggingEnabled) {
-            _log(
-                string.concat(
-                    "TRY_SET_DKG_UNAUTHORIZED: ", vm.toString(caller), " blocked from setting DKG"
-                )
             );
         }
     }


### PR DESCRIPTION
Towards CHAIN-618

Remove logging infrastructure from invariant tests.

The invariant tests carried a logging layer (`_log`, `_initLogFile`, `_logContractBalances`, `afterInvariant` summaries, etc.) originally added for instrumenting fuzz runs. It is no longer needed, so this PR strips it entirely from all 10 test files.

Removed across all invariant test files:
- `_log()` calls, `_initLogFile`, `_loggingEnabled` checks
- `_logContractBalances`, `_getActorIndex`, `_getTokenSymbol` helpers
- `LOG_FILE` constants, `afterInvariant` summary functions
- `console` imports, `vm.writeLine` / `vm.removeFile` usage

No functional changes to invariant logic or assertions.