### PR TITLE
test: add mutation-killing tests for alloy and chainspec crates

### DIFF
--- a/.changelog/neat-snails-shake.md
+++ b/.changelog/neat-snails-shake.md
@@ -1,0 +1,6 @@
+---
+tempo-alloy: patch
+tempo-chainspec: patch
+---
+
+Added comprehensive test coverage for transaction type detection, WebAuthn signature handling, hardfork gas parameters, and chainspec configuration methods.

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -557,4 +557,69 @@ mod tests {
         };
         assert_eq!(req.output_tx_type(), TempoTxType::AA);
     }
+
+    #[test]
+    fn test_setters_apply() {
+        let mut req = TempoTransactionRequest::default();
+
+        // set_input / input
+        TransactionBuilder::<TempoNetwork>::set_input(&mut req, Bytes::from(vec![0xab]));
+        assert_eq!(
+            TransactionBuilder::<TempoNetwork>::input(&req),
+            Some(&Bytes::from(vec![0xab]))
+        );
+
+        // set_from / from
+        req.set_from(Address::repeat_byte(0x01));
+        assert_eq!(
+            TransactionBuilder::<TempoNetwork>::from(&req),
+            Some(Address::repeat_byte(0x01))
+        );
+
+        // set_kind / kind
+        req.set_kind(TxKind::Create);
+        assert_eq!(req.kind(), Some(TxKind::Create));
+    }
+
+    #[test]
+    fn test_from_getter_none_and_some() {
+        let req = TempoTransactionRequest::default();
+        assert_eq!(TransactionBuilder::<TempoNetwork>::from(&req), None);
+
+        let mut req2 = TempoTransactionRequest::default();
+        req2.set_from(Address::repeat_byte(0xAA));
+        assert_eq!(
+            TransactionBuilder::<TempoNetwork>::from(&req2),
+            Some(Address::repeat_byte(0xAA))
+        );
+    }
+
+    #[test]
+    fn output_tx_type_nonce_key_is_aa() {
+        let req = TempoTransactionRequest {
+            nonce_key: Some(U256::from(1)),
+            ..Default::default()
+        };
+        assert_eq!(req.output_tx_type(), TempoTxType::AA);
+    }
+
+    #[test]
+    fn output_tx_type_fee_token_is_aa() {
+        let req = TempoTransactionRequest {
+            fee_token: Some(Address::repeat_byte(0x01)),
+            ..Default::default()
+        };
+        assert_eq!(req.output_tx_type(), TempoTxType::AA);
+    }
+
+    #[test]
+    fn test_into_wallet_returns_correct_address() {
+        let signer = PrivateKeySigner::random();
+        let expected_addr = signer.address();
+        let wallet: EthereumWallet = IntoWallet::<TempoNetwork>::into_wallet(signer);
+        assert_eq!(
+            NetworkWallet::<TempoNetwork>::default_signer_address(&wallet),
+            expected_addr
+        );
+    }
 }

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -575,5 +575,4 @@ mod tests {
         };
         assert_eq!(req.output_tx_type(), TempoTxType::AA);
     }
-
 }

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -559,42 +559,6 @@ mod tests {
     }
 
     #[test]
-    fn test_setters_apply() {
-        let mut req = TempoTransactionRequest::default();
-
-        // set_input / input
-        TransactionBuilder::<TempoNetwork>::set_input(&mut req, Bytes::from(vec![0xab]));
-        assert_eq!(
-            TransactionBuilder::<TempoNetwork>::input(&req),
-            Some(&Bytes::from(vec![0xab]))
-        );
-
-        // set_from / from
-        req.set_from(Address::repeat_byte(0x01));
-        assert_eq!(
-            TransactionBuilder::<TempoNetwork>::from(&req),
-            Some(Address::repeat_byte(0x01))
-        );
-
-        // set_kind / kind
-        req.set_kind(TxKind::Create);
-        assert_eq!(req.kind(), Some(TxKind::Create));
-    }
-
-    #[test]
-    fn test_from_getter_none_and_some() {
-        let req = TempoTransactionRequest::default();
-        assert_eq!(TransactionBuilder::<TempoNetwork>::from(&req), None);
-
-        let mut req2 = TempoTransactionRequest::default();
-        req2.set_from(Address::repeat_byte(0xAA));
-        assert_eq!(
-            TransactionBuilder::<TempoNetwork>::from(&req2),
-            Some(Address::repeat_byte(0xAA))
-        );
-    }
-
-    #[test]
     fn output_tx_type_nonce_key_is_aa() {
         let req = TempoTransactionRequest {
             nonce_key: Some(U256::from(1)),
@@ -612,14 +576,4 @@ mod tests {
         assert_eq!(req.output_tx_type(), TempoTxType::AA);
     }
 
-    #[test]
-    fn test_into_wallet_returns_correct_address() {
-        let signer = PrivateKeySigner::random();
-        let expected_addr = signer.address();
-        let wallet: EthereumWallet = IntoWallet::<TempoNetwork>::into_wallet(signer);
-        assert_eq!(
-            NetworkWallet::<TempoNetwork>::default_signer_address(&wallet),
-            expected_addr
-        );
-    }
 }

--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -460,53 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn test_mock_secp256k1_signature() {
-        let sig = create_mock_primitive_signature(&SignatureType::Secp256k1, None);
-        assert!(
-            matches!(sig, PrimitiveSignature::Secp256k1(_)),
-            "Expected Secp256k1 variant"
-        );
-    }
-
-    #[test]
-    fn test_mock_p256_signature() {
-        let sig = create_mock_primitive_signature(&SignatureType::P256, None);
-        assert!(
-            matches!(sig, PrimitiveSignature::P256(_)),
-            "Expected P256 variant"
-        );
-    }
-
-    #[test]
-    fn test_mock_keychain_wrapping() {
-        use tempo_primitives::transaction::tt_signature::TempoSignature;
-
-        let caller = Address::repeat_byte(0x01);
-        let sig = create_mock_tempo_signature(
-            &SignatureType::Secp256k1,
-            None,
-            Some(Address::ZERO),
-            caller,
-        );
-        assert!(
-            matches!(sig, TempoSignature::Keychain(_)),
-            "Expected Keychain variant when key_id is Some"
-        );
-    }
-
-    #[test]
-    fn test_mock_primitive_wrapping() {
-        use tempo_primitives::transaction::tt_signature::TempoSignature;
-
-        let caller = Address::repeat_byte(0x01);
-        let sig = create_mock_tempo_signature(&SignatureType::Secp256k1, None, None, caller);
-        assert!(
-            matches!(sig, TempoSignature::Primitive(_)),
-            "Expected Primitive variant when key_id is None"
-        );
-    }
-
-    #[test]
     fn test_webauthn_1byte_key_data() {
         let sig = create_mock_primitive_signature(
             &SignatureType::WebAuthn,

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -591,5 +591,4 @@ mod tests {
             "build_aa must preserve key_authorization from the request"
         );
     }
-
 }

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -591,4 +591,18 @@ mod tests {
             "build_aa must preserve key_authorization from the request"
         );
     }
+
+    #[test]
+    fn test_as_ref_returns_inner() {
+        let mut req = TempoTransactionRequest::default();
+        req.inner.nonce = Some(42);
+        assert_eq!(req.as_ref().nonce, Some(42));
+    }
+
+    #[test]
+    fn test_as_mut_modifies_inner() {
+        let mut req = TempoTransactionRequest::default();
+        req.as_mut().nonce = Some(99);
+        assert_eq!(req.inner.nonce, Some(99));
+    }
 }

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -592,17 +592,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_as_ref_returns_inner() {
-        let mut req = TempoTransactionRequest::default();
-        req.inner.nonce = Some(42);
-        assert_eq!(req.as_ref().nonce, Some(42));
-    }
-
-    #[test]
-    fn test_as_mut_modifies_inner() {
-        let mut req = TempoTransactionRequest::default();
-        req.as_mut().nonce = Some(99);
-        assert_eq!(req.inner.nonce, Some(99));
-    }
 }

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -249,4 +249,107 @@ mod tests {
         let deserialized: TempoHardfork = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, fork);
     }
+
+    use crate::spec::*;
+
+    #[test]
+    fn test_base_fee_values() {
+        assert_eq!(TempoHardfork::Genesis.base_fee(), TEMPO_T0_BASE_FEE);
+        assert_eq!(TempoHardfork::T0.base_fee(), TEMPO_T0_BASE_FEE);
+        assert_eq!(TempoHardfork::T1.base_fee(), TEMPO_T1_BASE_FEE);
+        assert_eq!(TempoHardfork::T2.base_fee(), TEMPO_T1_BASE_FEE);
+        // Ensure T0 and T1 base fees are distinct
+        assert_ne!(TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE);
+    }
+
+    #[test]
+    fn test_general_gas_limit() {
+        assert_eq!(TempoHardfork::Genesis.general_gas_limit(), None);
+        assert_eq!(TempoHardfork::T0.general_gas_limit(), None);
+        assert_eq!(
+            TempoHardfork::T1.general_gas_limit(),
+            Some(TEMPO_T1_GENERAL_GAS_LIMIT)
+        );
+        assert_eq!(
+            TempoHardfork::T2.general_gas_limit(),
+            Some(TEMPO_T1_GENERAL_GAS_LIMIT)
+        );
+        assert_ne!(TEMPO_T1_GENERAL_GAS_LIMIT, 0);
+        assert_ne!(TEMPO_T1_GENERAL_GAS_LIMIT, 1);
+    }
+
+    #[test]
+    fn test_tx_gas_limit_cap() {
+        assert_eq!(TempoHardfork::Genesis.tx_gas_limit_cap(), Some(u64::MAX));
+        assert_eq!(TempoHardfork::T0.tx_gas_limit_cap(), Some(u64::MAX));
+        assert_eq!(
+            TempoHardfork::T1.tx_gas_limit_cap(),
+            Some(TEMPO_T1_TX_GAS_LIMIT_CAP)
+        );
+        assert_eq!(
+            TempoHardfork::T2.tx_gas_limit_cap(),
+            Some(TEMPO_T1_TX_GAS_LIMIT_CAP)
+        );
+        assert_ne!(TEMPO_T1_TX_GAS_LIMIT_CAP, 0);
+        assert_ne!(TEMPO_T1_TX_GAS_LIMIT_CAP, 1);
+    }
+
+    #[test]
+    fn test_gas_existing_nonce_key() {
+        assert_eq!(
+            TempoHardfork::Genesis.gas_existing_nonce_key(),
+            TEMPO_T1_EXISTING_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T0.gas_existing_nonce_key(),
+            TEMPO_T1_EXISTING_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T1.gas_existing_nonce_key(),
+            TEMPO_T1_EXISTING_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T2.gas_existing_nonce_key(),
+            TEMPO_T2_EXISTING_NONCE_KEY_GAS
+        );
+        // T2 gas should differ from T1
+        assert_ne!(
+            TEMPO_T1_EXISTING_NONCE_KEY_GAS,
+            TEMPO_T2_EXISTING_NONCE_KEY_GAS
+        );
+        assert_ne!(TEMPO_T1_EXISTING_NONCE_KEY_GAS, 0);
+        assert_ne!(TEMPO_T1_EXISTING_NONCE_KEY_GAS, 1);
+    }
+
+    #[test]
+    fn test_gas_new_nonce_key() {
+        assert_eq!(
+            TempoHardfork::Genesis.gas_new_nonce_key(),
+            TEMPO_T1_NEW_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T0.gas_new_nonce_key(),
+            TEMPO_T1_NEW_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T1.gas_new_nonce_key(),
+            TEMPO_T1_NEW_NONCE_KEY_GAS
+        );
+        assert_eq!(
+            TempoHardfork::T2.gas_new_nonce_key(),
+            TEMPO_T2_NEW_NONCE_KEY_GAS
+        );
+        assert_ne!(TEMPO_T1_NEW_NONCE_KEY_GAS, TEMPO_T2_NEW_NONCE_KEY_GAS);
+        assert_ne!(TEMPO_T1_NEW_NONCE_KEY_GAS, 0);
+        assert_ne!(TEMPO_T1_NEW_NONCE_KEY_GAS, 1);
+    }
+
+    #[test]
+    fn test_hardfork_to_spec_id() {
+        use alloy_evm::revm::primitives::hardfork::SpecId;
+        assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
+        assert_eq!(SpecId::from(TempoHardfork::T0), SpecId::OSAKA);
+        assert_eq!(SpecId::from(TempoHardfork::T1), SpecId::OSAKA);
+        assert_eq!(SpecId::from(TempoHardfork::T2), SpecId::OSAKA);
+    }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -605,5 +605,4 @@ mod tests {
             "timestamp_millis_part should be timestamp % 1000"
         );
     }
-
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -516,4 +516,156 @@ mod tests {
         assert_eq!(chainspec.tempo_hardfork_at(1000), TempoHardfork::T2);
         assert_eq!(chainspec.tempo_hardfork_at(u64::MAX), TempoHardfork::T2);
     }
+
+    #[test]
+    fn test_general_gas_limit_at_pre_t1() {
+        // testnet has no T0/T1 activation — should use fallback formula
+        let chainspec = super::TempoChainSpecParser::parse("testnet")
+            .expect("the testnet chainspec must always be well formed");
+
+        // (100 - 20) / 2 = 40
+        assert_eq!(chainspec.general_gas_limit_at(0, 100, 20), 40);
+        // (60_000_000 - 0) / 2 = 30_000_000
+        assert_eq!(chainspec.general_gas_limit_at(0, 60_000_000, 0), 30_000_000);
+        // Verify it's actually division not modulo/multiplication
+        assert_eq!(chainspec.general_gas_limit_at(0, 200, 0), 100);
+        // Verify subtraction, not addition
+        assert_eq!(chainspec.general_gas_limit_at(0, 100, 0), 50);
+    }
+
+    #[test]
+    fn test_general_gas_limit_at_t1() {
+        // dev has all hardforks active at 0
+        let chainspec = super::TempoChainSpecParser::parse("dev")
+            .expect("the dev chainspec must always be well formed");
+
+        // Should return fixed TEMPO_T1_GENERAL_GAS_LIMIT regardless of inputs
+        assert_eq!(
+            chainspec.general_gas_limit_at(0, 999, 999),
+            super::TEMPO_T1_GENERAL_GAS_LIMIT
+        );
+        assert_eq!(
+            chainspec.general_gas_limit_at(0, 0, 0),
+            super::TEMPO_T1_GENERAL_GAS_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_eth_chain_spec_delegation() {
+        use alloy_primitives::B256;
+        use reth_chainspec::EthChainSpec;
+
+        let spec = super::DEV.clone();
+
+        // chain() should not return default
+        let chain = spec.chain();
+        assert_ne!(chain, reth_chainspec::Chain::default());
+
+        // genesis_hash() should not return default
+        assert_ne!(spec.genesis_hash(), B256::default());
+
+        // genesis_header() — verify it returns a valid reference
+        let hdr = spec.genesis_header();
+        assert_eq!(hdr.inner.number, 0);
+
+        // genesis() should have alloc entries
+        assert!(!spec.genesis().alloc.is_empty());
+
+        // next_block_base_fee should return the hardfork-appropriate base fee
+        // Dev has T2 active at 0, which uses T1 base fee
+        assert_eq!(
+            spec.next_block_base_fee(spec.genesis_header(), 0),
+            Some(super::TEMPO_T1_BASE_FEE)
+        );
+
+        // deposit_contract_address delegation works
+        use alloy_evm::eth::spec::EthExecutorSpec;
+        let _ = spec.deposit_contract_address();
+    }
+
+    #[test]
+    fn test_bootnodes_per_chain() {
+        use reth_chainspec::EthChainSpec;
+
+        let presto = super::PRESTO.clone();
+        let andantino = super::ANDANTINO.clone();
+        let moderato = super::MODERATO.clone();
+
+        assert!(presto.bootnodes().is_some(), "presto should have bootnodes");
+        assert!(
+            andantino.bootnodes().is_some(),
+            "andantino should have bootnodes"
+        );
+        assert!(
+            moderato.bootnodes().is_some(),
+            "moderato should have bootnodes"
+        );
+
+        assert!(
+            !presto.bootnodes().unwrap().is_empty(),
+            "presto bootnodes should not be empty"
+        );
+        assert!(
+            !andantino.bootnodes().unwrap().is_empty(),
+            "andantino bootnodes should not be empty"
+        );
+        assert!(
+            !moderato.bootnodes().unwrap().is_empty(),
+            "moderato bootnodes should not be empty"
+        );
+    }
+
+    #[test]
+    fn test_from_genesis_timestamp_millis_part() {
+        use alloy_genesis::Genesis;
+
+        // timestamp 1234567890 => 1234567890 % 1000 = 890
+        let genesis: Genesis = serde_json::from_str(
+            r#"{
+                "config": {
+                    "chainId": 9999
+                },
+                "timestamp": "0x499602D2",
+                "alloc": {}
+            }"#,
+        )
+        .unwrap();
+
+        let chainspec = super::TempoChainSpec::from_genesis(genesis);
+        assert_eq!(
+            chainspec.inner.genesis_header().timestamp_millis_part,
+            890,
+            "timestamp_millis_part should be timestamp % 1000"
+        );
+    }
+
+    #[test]
+    fn test_final_paris_total_difficulty() {
+        use reth_chainspec::EthChainSpec;
+
+        let spec = super::DEV.clone();
+        // Tempo doesn't use Paris total difficulty in a meaningful way,
+        // but the delegation should work correctly
+        let _td = spec.final_paris_total_difficulty();
+    }
+
+    #[test]
+    fn test_blob_params_at_timestamp() {
+        use reth_chainspec::EthChainSpec;
+
+        let spec = super::DEV.clone();
+        // Verify delegation works (Tempo doesn't use blobs)
+        let _params = spec.blob_params_at_timestamp(0);
+    }
+
+    #[test]
+    fn test_ethereum_fork_activation() {
+        use reth_chainspec::{EthereumHardfork, EthereumHardforks};
+
+        let spec = super::DEV.clone();
+        // Should not panic and should return a valid ForkCondition
+        let activation = spec.ethereum_fork_activation(EthereumHardfork::Cancun);
+        // Just verify it doesn't return default — the exact value depends on genesis
+        let _ = activation;
+    }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -551,39 +551,6 @@ mod tests {
     }
 
     #[test]
-    fn test_eth_chain_spec_delegation() {
-        use alloy_primitives::B256;
-        use reth_chainspec::EthChainSpec;
-
-        let spec = super::DEV.clone();
-
-        // chain() should not return default
-        let chain = spec.chain();
-        assert_ne!(chain, reth_chainspec::Chain::default());
-
-        // genesis_hash() should not return default
-        assert_ne!(spec.genesis_hash(), B256::default());
-
-        // genesis_header() — verify it returns a valid reference
-        let hdr = spec.genesis_header();
-        assert_eq!(hdr.inner.number, 0);
-
-        // genesis() should have alloc entries
-        assert!(!spec.genesis().alloc.is_empty());
-
-        // next_block_base_fee should return the hardfork-appropriate base fee
-        // Dev has T2 active at 0, which uses T1 base fee
-        assert_eq!(
-            spec.next_block_base_fee(spec.genesis_header(), 0),
-            Some(super::TEMPO_T1_BASE_FEE)
-        );
-
-        // deposit_contract_address delegation works
-        use alloy_evm::eth::spec::EthExecutorSpec;
-        let _ = spec.deposit_contract_address();
-    }
-
-    #[test]
     fn test_bootnodes_per_chain() {
         use reth_chainspec::EthChainSpec;
 
@@ -639,33 +606,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_final_paris_total_difficulty() {
-        use reth_chainspec::EthChainSpec;
-
-        let spec = super::DEV.clone();
-        // Tempo doesn't use Paris total difficulty in a meaningful way,
-        // but the delegation should work correctly
-        let _td = spec.final_paris_total_difficulty();
-    }
-
-    #[test]
-    fn test_blob_params_at_timestamp() {
-        use reth_chainspec::EthChainSpec;
-
-        let spec = super::DEV.clone();
-        // Verify delegation works (Tempo doesn't use blobs)
-        let _params = spec.blob_params_at_timestamp(0);
-    }
-
-    #[test]
-    fn test_ethereum_fork_activation() {
-        use reth_chainspec::{EthereumHardfork, EthereumHardforks};
-
-        let spec = super::DEV.clone();
-        // Should not panic and should return a valid ForkCondition
-        let activation = spec.ethereum_fork_activation(EthereumHardfork::Cancun);
-        // Just verify it doesn't return default — the exact value depends on genesis
-        let _ = activation;
-    }
 }


### PR DESCRIPTION
## Summary

Adds 16 tests targeting surviving mutants from the latest mutation testing run (52% score, 76 survivors). Only covers tests for real logic — branching, arithmetic, match arm selection — not trivial delegation.

## Motivation

[Mutation test results](https://tempoxyz.slack.com/archives/C0A6PD3BQ3F/p1770984633363199) showed 76 survivors across `tempo-alloy` and `tempo-chainspec`.

## Changes

### `crates/alloy` (7 tests)
- **`network.rs`** — `output_tx_type` OR-chain coverage for `nonce_key` and `fee_token` fields
- **`rpc/compat.rs`** — WebAuthn key_data parsing (1-byte, 2-byte), `try_into_tx_env` with isolated fields (`tempo_authorization_list` only, `key_id` only), non-AA signing path

### `crates/chainspec` (9 tests)
- **`hardfork.rs`** — `base_fee()`, `general_gas_limit()`, `tx_gas_limit_cap()`, `gas_existing_nonce_key()`, `gas_new_nonce_key()` across all variants, `TempoHardfork -> SpecId` conversion
- **`spec.rs`** — `general_gas_limit_at` fallback arithmetic (pre-T1 vs T1), bootnodes per chain (presto/andantino/moderato), `timestamp_millis_part` modulo

## Testing

```
cargo test -p tempo-alloy --lib --features tempo-compat  # 37 passed
cargo test -p tempo-chainspec --lib --features cli        # 24 passed
```

Prompted by: zerosnacks