### PR TITLE
feat(revm): add token pair to InsufficientAmmLiquidity error

### DIFF
--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -249,10 +249,14 @@ pub enum FeePaymentError {
     ///
     /// This indicates the user's fee token cannot be swapped for the native token
     /// because there's insufficient liquidity in the AMM pool.
-    #[error("insufficient liquidity in FeeAMM pool to swap fee tokens (required: {fee})")]
+    #[error("insufficient liquidity in FeeAMM pool to swap fee tokens (required: {fee}, user_token: {user_token}, validator_token: {validator_token})")]
     InsufficientAmmLiquidity {
         /// The required fee amount that couldn't be swapped.
         fee: U256,
+        /// The user's fee token address.
+        user_token: Address,
+        /// The validator's preferred token address.
+        validator_token: Address,
     },
 
     /// Insufficient fee token balance to pay for transaction fees.
@@ -317,6 +321,8 @@ mod tests {
 
         let err = FeePaymentError::InsufficientAmmLiquidity {
             fee: U256::from(1000),
+            user_token: Address::ZERO,
+            validator_token: Address::ZERO,
         };
         assert!(
             err.to_string()
@@ -358,6 +364,8 @@ mod tests {
     fn test_fee_payment_error() {
         let _: EVMError<(), TempoInvalidTransaction> = FeePaymentError::InsufficientAmmLiquidity {
             fee: U256::from(1000),
+            user_token: Address::ZERO,
+            validator_token: Address::ZERO,
         }
         .into();
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1036,8 +1036,15 @@ where
             // in FeeAMM pool for fee swaps)
             Err(match err {
                 TempoPrecompileError::TIPFeeAMMError(TIPFeeAMMError::InsufficientLiquidity(_)) => {
+                    let validator_token = StorageCtx::enter_evm(journal, &block, cfg, tx, || {
+                        TipFeeManager::new().get_validator_token(block.beneficiary())
+                    })
+                    .unwrap_or(Address::ZERO);
+
                     FeePaymentError::InsufficientAmmLiquidity {
                         fee: gas_balance_spending,
+                        user_token: self.fee_token,
+                        validator_token,
                     }
                     .into()
                 }


### PR DESCRIPTION
## Summary
Adds user_token and validator_token addresses to the `FeePaymentError::InsufficientAmmLiquidity` error message.

## Motivation
A partner hit this error deploying on mainnet and the error only showed the required fee amount — no way to tell which FeeAMM pool was underfunded. Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1771001223885919

## Changes
- Added `user_token` and `validator_token` fields to `InsufficientAmmLiquidity` variant in `crates/revm/src/error.rs`
- Resolve validator token via `get_validator_token` in the handler error path (`crates/revm/src/handler.rs`)
- Updated tests

Error now reads:
```
insufficient liquidity in FeeAMM pool to swap fee tokens (required: 600001, user_token: 0x..., validator_token: 0x...)
```

## Testing
`cargo clippy -p tempo-revm -- -D warnings` — clean
`cargo test -p tempo-revm -- error::tests` — 4/4 pass

Prompted by: zygis