### PR TITLE
fix(e2e): fix flaky sync tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,1 @@
 [profile.default]
-
-[[profile.default.overrides]]
-filter = "test(sync::can_restart_after_joining_from_snapshot)"
-slow-timeout = { period = "60s", terminate-after = 4, on-timeout = "pass" }
-success-output = "final"


### PR DESCRIPTION
Fixes the flaky sync tests by connecting the execution nodes. The reason for the flakiness was that when restarting the node took too long, that the network advanced too far into the future.

When this happens, the consensus layer starts skipping epochs by setting marshal actor's sync floor, relying on the execution layer to provide the missing blocks. But if the execution layer has no connection to any of its peers, then this sync mechanism does not work, preventing the node from advancing.