### PR TITLE
docs: TIP-1018 Credential Registry Precompile

### DIFF
--- a/tips/tip-1018.md
+++ b/tips/tip-1018.md
@@ -1,0 +1,212 @@
+---
+id: TIP-1018
+title: Credential Registry Precompile
+description: Append-only on-chain registry mapping WebAuthn credential IDs to public keys, providing chain-level availability for passkey authentication.
+authors: Georgios Konstantopoulos
+status: Draft
+related: AccountKeychain, TIP-1000
+protocolVersion: TBD
+---
+
+# TIP-1018: Credential Registry Precompile
+
+## Abstract
+
+This TIP introduces a new precompile that provides an append-only key-value store mapping WebAuthn credential IDs to their corresponding public keys. The registry is free to write (gas is charged but exempt from user cost via protocol subsidy) and provides the same availability guarantees as the chain itself. This eliminates the dependency on off-chain KV stores for passkey-based wallet authentication.
+
+## Motivation
+
+Tempo's wallet (keys.tempo.xyz) uses WebAuthn passkeys for user authentication. The authentication flow requires resolving a credential ID (opaque bytes assigned by the authenticator during passkey creation) to the user's public key. This mapping is critical: without it, the user's passkey becomes permanently unusable since the public key cannot be extracted at authentication time — only at registration time.
+
+Currently this mapping lives in an off-chain Cloudflare KV store. This has several problems:
+
+1. **Single point of failure**: If the KV store is deleted, corrupted, or experiences an outage, all users lose access to their wallets. This already happened — the `KEY_STORE` KV namespace was accidentally nuked, rendering all existing passkeys unusable.
+
+2. **Availability mismatch**: The credential registry must be at least as available as the chain itself (users can't transact if they can't authenticate), but an off-chain KV store has independent failure modes.
+
+3. **No replication guarantees**: Off-chain stores require explicit replication strategies. The chain provides replication across all validators for free.
+
+4. **Mutability risk**: Off-chain stores are mutable by operators. An append-only on-chain store prevents accidental or malicious deletion of credential mappings.
+
+Moving this to a precompile makes the credential registry as available and durable as the Tempo chain itself. It becomes append-only (credentials can never be deleted or overwritten), replicated across all validators, and queryable via any RPC node.
+
+---
+
+# Specification
+
+## Precompile Address
+
+```
+0xCCCC000000000000000000000000000000000000
+```
+
+The address follows the existing Tempo precompile convention using a distinctive prefix. The exact address is TBD pending allocation.
+
+## Interface
+
+```solidity
+interface ICredentialRegistry {
+    /// @notice Emitted when a new credential is registered
+    /// @param account The account that registered the credential
+    /// @param credentialId The WebAuthn credential ID
+    /// @param publicKeyX The X coordinate of the P256 public key
+    /// @param publicKeyY The Y coordinate of the P256 public key
+    event CredentialRegistered(
+        address indexed account,
+        bytes indexed credentialId,
+        uint256 publicKeyX,
+        uint256 publicKeyY
+    );
+
+    /// @notice Register a new credential ID → public key mapping
+    /// @param credentialId The WebAuthn credential ID (opaque bytes from the authenticator)
+    /// @param publicKeyX The X coordinate of the P256 public key
+    /// @param publicKeyY The Y coordinate of the P256 public key
+    /// @dev Reverts if the credential ID is already registered (append-only, no overwrites).
+    ///      Can only be called by the account that owns the credential (msg.sender).
+    function register(
+        bytes calldata credentialId,
+        uint256 publicKeyX,
+        uint256 publicKeyY
+    ) external;
+
+    /// @notice Look up the public key for a credential ID
+    /// @param credentialId The WebAuthn credential ID
+    /// @return account The account that registered this credential
+    /// @return publicKeyX The X coordinate of the P256 public key
+    /// @return publicKeyY The Y coordinate of the P256 public key
+    /// @dev Returns (address(0), 0, 0) if the credential ID is not registered.
+    function getPublicKey(bytes calldata credentialId)
+        external
+        view
+        returns (address account, uint256 publicKeyX, uint256 publicKeyY);
+
+    // Errors
+    error CredentialAlreadyRegistered();
+    error EmptyCredentialId();
+    error InvalidPublicKey();
+}
+```
+
+## Storage Layout
+
+The precompile uses a single mapping keyed by the keccak256 hash of the credential ID:
+
+```
+credentials[keccak256(credentialId)] -> { account, publicKeyX, publicKeyY }
+```
+
+Each entry occupies 3 storage slots:
+- Slot 0: `account` (address, 20 bytes)
+- Slot 1: `publicKeyX` (uint256, 32 bytes)
+- Slot 2: `publicKeyY` (uint256, 32 bytes)
+
+A credential is considered registered if `account != address(0)`.
+
+## Behavior
+
+### Registration
+
+1. Caller provides `credentialId`, `publicKeyX`, and `publicKeyY`
+2. Precompile validates:
+   - `credentialId` is non-empty (`EmptyCredentialId`)
+   - Public key is valid: neither `publicKeyX` nor `publicKeyY` is zero (`InvalidPublicKey`)
+   - Credential ID is not already registered (`CredentialAlreadyRegistered`)
+3. Stores the mapping: `keccak256(credentialId) → (msg.sender, publicKeyX, publicKeyY)`
+4. Emits `CredentialRegistered` event
+
+### Lookup
+
+1. Caller provides `credentialId`
+2. Precompile returns `(account, publicKeyX, publicKeyY)` or `(address(0), 0, 0)` if not found
+3. Pure read — no state changes
+
+### Append-Only Semantics
+
+Once a credential ID is registered, it **cannot** be overwritten, updated, or deleted. This is enforced at the protocol level by the precompile — there is no admin function, no migration path, and no escape hatch. If a user loses their passkey, they create a new passkey with a new credential ID.
+
+This is intentional: the credential registry is a permanent, tamper-proof record. The append-only property means:
+- No accidental deletion (the incident that motivated this TIP)
+- No admin key that could be compromised
+- No migration that could lose data
+- Replication is free (all validators have the full state)
+
+## Gas Costs
+
+### Registration
+
+Registration involves creating new storage slots. Under TIP-1000/TIP-1016 pricing:
+- 3 cold SSTOREs (zero → non-zero): 3 × 250,000 = 750,000 gas for storage
+- Calldata, hashing, validation: ~30,000 gas
+- Total: ~780,000 gas
+
+### Free-for-User Model
+
+Credential registration is **free for users**. The protocol subsidizes the gas cost:
+
+- The transaction is submitted with zero gas price (free transaction)
+- The precompile is whitelisted for free execution by the protocol
+- Validators absorb the state growth cost as a public good
+
+**Rationale**: Credential registration is a prerequisite to using the chain at all. Charging users to register their passkey before they have any funds creates a chicken-and-egg problem. The state growth per credential is bounded (~96 bytes) and the operation is rate-limited by the WebAuthn registration ceremony itself (requires user interaction with a hardware authenticator).
+
+### Lookup
+
+Lookup is a pure read operation and costs standard warm SLOAD gas (~2,100 gas for the hash computation + 3 × 100 gas for warm reads). In practice, lookups will be done via `eth_call` with no on-chain cost.
+
+## Integration with keys.tempo.xyz
+
+The wallet registration flow changes as follows:
+
+**Before (off-chain KV)**:
+1. User creates passkey → browser returns credential ID + public key
+2. App writes `credentialId → publicKey` to Cloudflare KV
+3. On login, app reads KV to resolve credential ID → public key
+4. App uses public key to verify WebAuthn assertion
+
+**After (on-chain precompile)**:
+1. User creates passkey → browser returns credential ID + public key
+2. App submits free transaction calling `CredentialRegistry.register(credentialId, pubKeyX, pubKeyY)`
+3. On login, app calls `CredentialRegistry.getPublicKey(credentialId)` via `eth_call`
+4. App uses public key to verify WebAuthn assertion
+
+The off-chain KV can optionally be retained as a cache/fallback, but the on-chain registry becomes the source of truth.
+
+## Interaction with AccountKeychain
+
+The Credential Registry is complementary to the AccountKeychain precompile (which manages authorized keys and spending limits). The flow is:
+
+1. **CredentialRegistry**: Maps `credentialId → publicKey` (WebAuthn-specific, needed because authenticators don't expose the public key at sign-in time)
+2. **AccountKeychain**: Maps `account → keyId → permissions` (general key management with expiry, spending limits, revocation)
+
+A typical passkey wallet setup:
+1. Register credential: `CredentialRegistry.register(credentialId, pubKeyX, pubKeyY)`
+2. Derive `keyId` from public key (e.g., `address(keccak256(pubKeyX, pubKeyY))`)
+3. Authorize key: `AccountKeychain.authorizeKey(keyId, SignatureType.WebAuthn, expiry, ...)`
+
+The Credential Registry handles the WebAuthn-specific credential ID → public key resolution that the AccountKeychain doesn't need to know about.
+
+---
+
+# Invariants
+
+1. **Append-only**: Once a credential ID is registered, its mapping MUST NOT be modifiable or deletable by any actor (including protocol upgrades, unless via hard fork governance)
+2. **Uniqueness**: A credential ID MUST map to exactly one public key. Re-registration of an existing credential ID MUST revert with `CredentialAlreadyRegistered`
+3. **Non-zero validation**: Registration MUST reject empty credential IDs and zero public keys
+4. **Consistency**: `getPublicKey(credentialId)` MUST return the exact values provided during `register()` for that credential ID, for all time
+5. **Free registration**: Credential registration MUST be executable as a free transaction (zero gas price) without reverting due to insufficient funds
+6. **Read availability**: `getPublicKey()` MUST be callable via `eth_call` without any on-chain transaction
+7. **Account binding**: The `account` field stored with each credential MUST equal `msg.sender` at registration time — no third party can register credentials on behalf of another account
+
+## Test Cases
+
+1. **Basic registration and lookup**: Register a credential, look it up, verify all fields match
+2. **Duplicate rejection**: Attempt to register the same credential ID twice, verify `CredentialAlreadyRegistered` revert
+3. **Empty credential ID**: Attempt to register with empty bytes, verify `EmptyCredentialId` revert
+4. **Invalid public key**: Attempt to register with zero X or Y coordinate, verify `InvalidPublicKey` revert
+5. **Unknown credential lookup**: Look up an unregistered credential ID, verify `(address(0), 0, 0)` return
+6. **Multiple credentials per account**: Register multiple credential IDs from the same account, verify each resolves independently
+7. **Cross-account isolation**: Register credentials from different accounts, verify no cross-contamination
+8. **Free transaction**: Register a credential with zero gas price, verify success
+9. **Event emission**: Verify `CredentialRegistered` event is emitted with correct parameters
+10. **Persistence across blocks**: Register in block N, verify lookup succeeds in block N+1

--- a/tips/tip-1018.md
+++ b/tips/tip-1018.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces a new precompile that provides an append-only key-value store mapping WebAuthn credential IDs to their corresponding public keys. The registry is free to write (gas is charged but exempt from user cost via protocol subsidy) and provides the same availability guarantees as the chain itself. This eliminates the dependency on off-chain KV stores for passkey-based wallet authentication.
+This TIP introduces a new precompile that provides an append-only key-value store mapping WebAuthn credential IDs to their corresponding public keys. The registry charges standard gas (priced via TIP-1000 storage costs to prevent state bloat), with the wallet app sponsoring registration via a relayer so users pay nothing. The precompile provides the same availability guarantees as the chain itself, eliminating the dependency on off-chain KV stores for passkey-based wallet authentication.
 
 ## Motivation
 
@@ -140,15 +140,18 @@ Registration involves creating new storage slots. Under TIP-1000/TIP-1016 pricin
 - Calldata, hashing, validation: ~30,000 gas
 - Total: ~780,000 gas
 
-### Free-for-User Model
+### Sponsored Registration (Free for Users, Not Free for Attackers)
 
-Credential registration is **free for users**. The protocol subsidizes the gas cost:
+The precompile charges **standard gas** — there is no protocol-level subsidy or whitelist. This is critical for state bloat protection: at ~780,000 gas per registration (~$0.015 at target base fee), an attacker would need ~$150M to fill 1TB of state, consistent with TIP-1000's economic guarantees.
 
-- The transaction is submitted with zero gas price (free transaction)
-- The precompile is whitelisted for free execution by the protocol
-- Validators absorb the state growth cost as a public good
+The "free for users" experience is achieved at the **application layer**:
 
-**Rationale**: Credential registration is a prerequisite to using the chain at all. Charging users to register their passkey before they have any funds creates a chicken-and-egg problem. The state growth per credential is bounded (~96 bytes) and the operation is rate-limited by the WebAuthn registration ceremony itself (requires user interaction with a hardware authenticator).
+- The wallet app operates a **relayer** that sponsors credential registration transactions on behalf of new users
+- The relayer submits the transaction and pays the gas cost
+- The relayer can enforce its own anti-abuse measures: rate limiting, CAPTCHA, WebAuthn attestation verification (checking the authenticator response before submitting), IP-based throttling, etc.
+- This is the same pattern used by other onboarding flows (e.g., faucets, gasless mints)
+
+**Rationale**: Making registration free at the protocol level would allow unchecked state growth. Delegating sponsorship to a relayer separates the UX concern (users shouldn't need funds to set up a passkey) from the protocol concern (state growth must be priced). The relayer absorbs a small cost per real user (~$0.015) while maintaining the ability to reject spam.
 
 ### Lookup
 
@@ -166,7 +169,7 @@ The wallet registration flow changes as follows:
 
 **After (on-chain precompile)**:
 1. User creates passkey → browser returns credential ID + public key
-2. App submits free transaction calling `CredentialRegistry.register(credentialId, pubKeyX, pubKeyY)`
+2. App submits sponsored transaction (via relayer) calling `CredentialRegistry.register(credentialId, pubKeyX, pubKeyY)`
 3. On login, app calls `CredentialRegistry.getPublicKey(credentialId)` via `eth_call`
 4. App uses public key to verify WebAuthn assertion
 
@@ -194,7 +197,7 @@ The Credential Registry handles the WebAuthn-specific credential ID → public k
 2. **Uniqueness**: A credential ID MUST map to exactly one public key. Re-registration of an existing credential ID MUST revert with `CredentialAlreadyRegistered`
 3. **Non-zero validation**: Registration MUST reject empty credential IDs and zero public keys
 4. **Consistency**: `getPublicKey(credentialId)` MUST return the exact values provided during `register()` for that credential ID, for all time
-5. **Free registration**: Credential registration MUST be executable as a free transaction (zero gas price) without reverting due to insufficient funds
+5. **Standard gas pricing**: Credential registration MUST charge standard TIP-1000 storage gas costs — no protocol-level subsidy
 6. **Read availability**: `getPublicKey()` MUST be callable via `eth_call` without any on-chain transaction
 7. **Account binding**: The `account` field stored with each credential MUST equal `msg.sender` at registration time — no third party can register credentials on behalf of another account
 
@@ -207,6 +210,6 @@ The Credential Registry handles the WebAuthn-specific credential ID → public k
 5. **Unknown credential lookup**: Look up an unregistered credential ID, verify `(address(0), 0, 0)` return
 6. **Multiple credentials per account**: Register multiple credential IDs from the same account, verify each resolves independently
 7. **Cross-account isolation**: Register credentials from different accounts, verify no cross-contamination
-8. **Free transaction**: Register a credential with zero gas price, verify success
+8. **Gas charging**: Register a credential, verify standard TIP-1000 storage gas is charged
 9. **Event emission**: Verify `CredentialRegistered` event is emitted with correct parameters
 10. **Persistence across blocks**: Register in block N, verify lookup succeeds in block N+1


### PR DESCRIPTION
## Summary

Append-only precompile that stores WebAuthn credential ID → public key mappings on-chain. Makes the credential registry as available as the chain itself.

## Motivation

Off-chain KV stores for credential mappings are a single point of failure with independent failure modes from the chain. Moving this on-chain eliminates the off-chain SPOF and gives us append-only semantics — credentials can never be accidentally or maliciously deleted.

## Key design decisions

- **Append-only**: No update, no delete, no admin key. Once registered, a credential mapping is permanent.
- **Standard gas, sponsored via relayer**: Charges TIP-1000 storage gas to prevent state bloat (~$0.015/registration). Wallet app sponsors real users via a relayer.
- **Simple KV**: Just `credentialId → (account, pubKeyX, pubKeyY)`. Complements AccountKeychain which handles permissions/spending limits.
- **P256 public key coordinates**: Stored as (X, Y) since WebAuthn uses P256/secp256r1.

Prompted by: georgios