### PR TITLE
ci: speed up test workflow with partitioning, e2e separation, and MSRV skipping

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,16 +86,35 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Download cargo test coverage
+      - name: Download cargo test coverage (partition 1)
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: test.yml
-          name: cargo-test-coverage
-          path: cargo-coverage
+          name: cargo-test-coverage-1
+          path: cargo-coverage-1
           if_no_artifact_found: warn
           search_artifacts: true
           commit: ${{ inputs.commit_sha }}
         continue-on-error: true
+      - name: Download cargo test coverage (partition 2)
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        with:
+          workflow: test.yml
+          name: cargo-test-coverage-2
+          path: cargo-coverage-2
+          if_no_artifact_found: warn
+          search_artifacts: true
+          commit: ${{ inputs.commit_sha }}
+        continue-on-error: true
+      - name: Merge cargo coverage partitions
+        run: |
+          mkdir -p cargo-coverage/precompiles-bin
+          for dir in cargo-coverage-1 cargo-coverage-2; do
+            if [[ -d "$dir" ]]; then
+              [[ -f "$dir/cargo-test.profdata" ]] && cp "$dir/cargo-test.profdata" "cargo-coverage/cargo-test-$(basename $dir).profdata"
+              [[ -d "$dir/precompiles-bin" ]] && cp -n "$dir/precompiles-bin/"* cargo-coverage/precompiles-bin/ 2>/dev/null || true
+            fi
+          done
 
       - name: Download forge test coverage
         uses: actions/download-artifact@v4
@@ -114,10 +133,12 @@ jobs:
 
           # Collect profdata files
           PROFDATA_FILES=""
-          if [[ -f cargo-coverage/cargo-test.profdata ]]; then
-            PROFDATA_FILES="$PROFDATA_FILES cargo-coverage/cargo-test.profdata"
-            echo "Found cargo test coverage"
-          fi
+          for f in cargo-coverage/cargo-test-*.profdata; do
+            if [[ -f "$f" ]]; then
+              PROFDATA_FILES="$PROFDATA_FILES $f"
+              echo "Found cargo test coverage: $f"
+            fi
+          done
           if [[ -f forge-coverage/coverage/forge-test.profdata ]]; then
             PROFDATA_FILES="$PROFDATA_FILES forge-coverage/coverage/forge-test.profdata"
             echo "Found forge test coverage"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,36 +19,6 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  check-precompiles:
-    name: Check precompiles changes
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      coverage: ${{ steps.check.outputs.coverage }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check for precompiles changes
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Only run coverage on pull_request events when precompiles/contracts changed
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            echo "coverage=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping coverage: not a pull_request event (event: $EVENT_NAME)"
-          elif git diff --name-only origin/"$BASE_REF"...HEAD | grep -qE '^(crates/(precompiles|contracts)/|tips/ref-impls/)'; then
-            echo "coverage=true" >> "$GITHUB_OUTPUT"
-            echo "Running coverage: precompiles/contracts changed"
-          else
-            echo "coverage=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping coverage: no precompiles/contracts changes"
-          fi
-
   genesis:
     name: Genesis generation
     runs-on: depot-ubuntu-latest-4
@@ -82,7 +52,6 @@ jobs:
 
   test:
     name: test
-    needs: check-precompiles
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:
@@ -90,10 +59,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - name: Check for precompiles changes
+        id: check-precompiles
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "coverage=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping coverage: not a pull_request event (event: $EVENT_NAME)"
+          elif git diff --name-only origin/"$BASE_REF"...HEAD | grep -qE '^(crates/(precompiles|contracts)/|tips/ref-impls/)'; then
+            echo "coverage=true" >> "$GITHUB_OUTPUT"
+            echo "Running coverage: precompiles/contracts changed"
+          else
+            echo "coverage=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping coverage: no precompiles/contracts changes"
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ needs.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
+          components: ${{ steps.check-precompiles.outputs.coverage == 'true' && 'llvm-tools-preview' || '' }}
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19
@@ -101,12 +87,12 @@ jobs:
           tool: nextest@0.9.124
       # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.check-precompiles.outputs.coverage == 'true'
         run: cargo nextest run --profile ci --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.check-precompiles.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
           cargo nextest run --profile ci 
@@ -115,13 +101,13 @@ jobs:
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
       # Build and run tests WITHOUT coverage (when precompiles not changed)
       - name: Build and compile tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: steps.check-precompiles.outputs.coverage != 'true'
         run: cargo nextest run --profile ci --no-run
       - name: Run tests
-        if: needs.check-precompiles.outputs.coverage != 'true'
+        if: steps.check-precompiles.outputs.coverage != 'true'
         run: cargo nextest run  --profile ci
       - name: Generate precompiles coverage profdata
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.check-precompiles.outputs.coverage == 'true'
         run: |
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           "$LLVM_BIN/llvm-profdata" merge -sparse coverage/*.profraw -o coverage/cargo-test.profdata
@@ -130,7 +116,7 @@ jobs:
           find target/debug/deps -name 'tempo_precompiles-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
           find target/debug/deps -name 'tempo_contracts-*' -type f -executable ! -name '*.d' -exec cp {} coverage/precompiles-bin/ \;
       - name: Upload precompiles coverage artifacts
-        if: needs.check-precompiles.outputs.coverage == 'true'
+        if: steps.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cargo-test-coverage
@@ -183,7 +169,6 @@ jobs:
     if: always()
     permissions: {}
     needs:
-      - check-precompiles
       - test
       - cli
       - msrv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,16 @@ jobs:
             echo "Generated genesis matches test-genesis.json"
           fi
 
-  test:
-    name: test
+  unit-test:
+    name: unit test (${{ matrix.partition }}/2)
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -88,24 +92,24 @@ jobs:
       # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
         if: steps.check-precompiles.outputs.coverage == 'true'
-        run: cargo nextest run --profile ci --no-run
+        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
         if: steps.check-precompiles.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
-          cargo nextest run --profile ci 
+          cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
       # Build and run tests WITHOUT coverage (when precompiles not changed)
       - name: Build and compile tests
         if: steps.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run --profile ci --no-run
+        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2 --no-run
       - name: Run tests
         if: steps.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run  --profile ci
+        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2
       - name: Generate precompiles coverage profdata
         if: steps.check-precompiles.outputs.coverage == 'true'
         run: |
@@ -119,11 +123,32 @@ jobs:
         if: steps.check-precompiles.outputs.coverage == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: cargo-test-coverage
+          name: cargo-test-coverage-${{ matrix.partition }}
           path: |
             coverage/cargo-test.profdata
             coverage/precompiles-bin/
           retention-days: 1
+
+  e2e-test:
+    name: e2e test
+    runs-on: depot-ubuntu-latest-16
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19
+        with:
+          tool: nextest@0.9.124
+      - name: Build e2e tests
+        run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --no-run
+      - name: Run e2e tests
+        run: cargo nextest run --profile ci -E 'package(tempo-e2e)'
 
   cli:
     name: CLI smoke tests
@@ -143,8 +168,39 @@ jobs:
       - name: Run CLI tests
         run: ./scripts/test-cli.sh
 
+  check-msrv:
+    name: Check MSRV changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for dependency changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Running MSRV: not a pull_request event"
+          elif git diff --name-only origin/"$BASE_REF"...HEAD | grep -qE '(^Cargo\.(toml|lock)$|/Cargo\.toml$|rust-toolchain)'; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Running MSRV: dependency/toolchain files changed"
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping MSRV: no dependency/toolchain changes"
+          fi
+
   msrv:
     name: MSRV
+    needs: check-msrv
+    if: needs.check-msrv.outputs.should-run == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -169,8 +225,10 @@ jobs:
     if: always()
     permissions: {}
     needs:
-      - test
+      - unit-test
+      - e2e-test
       - cli
+      - check-msrv
       - msrv
       - genesis
     timeout-minutes: 30
@@ -178,4 +236,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: msrv
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Speed up the Test CI workflow by restructuring jobs for better parallelism.

### Changes

**1. Inline precompiles check** — The `test` job previously blocked on a separate `check-precompiles` job. The change detection now runs as a step inside the test job itself, so all jobs start immediately in parallel.

**2. Partition unit tests** — Split the single `test` job into `unit-test` with 2 partitions using nextest `--partition`. Each partition runs roughly half the tests on its own runner.

**3. Separate e2e tests** — The 32 heavy `tempo-e2e` tests (`threads-required = 2`) now run in a dedicated `e2e-test` job, avoiding resource contention with unit tests.

**4. Skip MSRV on non-dependency PRs** — MSRV check (~3 min compile) is skipped on PRs that don't touch `Cargo.toml`, `Cargo.lock`, or `rust-toolchain`. Still runs on every push to `main`.

**5. Update coverage workflow** — Downloads artifacts from both unit-test partitions and merges profdata correctly.

### Expected impact

| Job | Before | After |
|---|---|---|
| unit-test (1/2) | ~5:45 (single job) | ~3:15 (compile + half tests) |
| unit-test (2/2) | — | ~3:15 (parallel) |
| e2e-test | bundled above | dedicated, no contention |
| MSRV | always ~3:00 | skipped for most PRs |

Critical path should drop from ~5:45 to ~3:15.