### PR TITLE
test(chainspec,macros): strengthen chainspec and macro utils tests to kill mutation survivors

### DIFF
--- a/.changelog/fine-bees-draw.md
+++ b/.changelog/fine-bees-draw.md
@@ -1,0 +1,6 @@
+---
+tempo-chainspec: patch
+tempo-precompiles-macros: patch
+---
+
+Added comprehensive unit tests for hardfork gas parameter methods, chain spec accessors, bootnode configurations, and precompile macro utility functions.

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -400,12 +400,18 @@ mod tests {
         let cs = TempoChainSpec::from_genesis(genesis);
 
         // At T1 (timestamp >= 100), general_gas_limit_at returns the fixed value
-        assert_eq!(cs.general_gas_limit_at(100, 60_000_000, 10_000_000), 30_000_000);
+        assert_eq!(
+            cs.general_gas_limit_at(100, 60_000_000, 10_000_000),
+            30_000_000
+        );
         assert_eq!(cs.general_gas_limit_at(200, 100_000_000, 0), 30_000_000);
 
         // Pre-T1 (timestamp < 100), formula: (gas_limit - shared_gas_limit) / 2
         // (60_000_000 - 10_000_000) / 2 = 25_000_000
-        assert_eq!(cs.general_gas_limit_at(50, 60_000_000, 10_000_000), 25_000_000);
+        assert_eq!(
+            cs.general_gas_limit_at(50, 60_000_000, 10_000_000),
+            25_000_000
+        );
         // (100_000_000 - 0) / 2 = 50_000_000
         assert_eq!(cs.general_gas_limit_at(0, 100_000_000, 0), 50_000_000);
         // (1000 - 0) / 2 = 500 (detects / vs %, / vs *, - vs +, - vs /)

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -290,12 +290,14 @@ mod tests {
         assert_eq!(TempoHardfork::T0.base_fee(), 10_000_000_000);
         // T1+ variants use T1 base fee (20 billion)
         assert_eq!(TempoHardfork::T1.base_fee(), 20_000_000_000);
+        assert_eq!(TempoHardfork::T1A.base_fee(), 20_000_000_000);
         assert_eq!(TempoHardfork::T2.base_fee(), 20_000_000_000);
         // Ensure no variant returns 0 or 1
         for fork in [
             TempoHardfork::Genesis,
             TempoHardfork::T0,
             TempoHardfork::T1,
+            TempoHardfork::T1A,
             TempoHardfork::T2,
         ] {
             assert!(fork.base_fee() > 1, "base_fee must not be 0 or 1");
@@ -309,6 +311,7 @@ mod tests {
         assert_eq!(TempoHardfork::T0.general_gas_limit(), None);
         // T1+ returns Some(30_000_000)
         assert_eq!(TempoHardfork::T1.general_gas_limit(), Some(30_000_000));
+        assert_eq!(TempoHardfork::T1A.general_gas_limit(), Some(30_000_000));
         assert_eq!(TempoHardfork::T2.general_gas_limit(), Some(30_000_000));
         // Ensure T1+ values are not 0 or 1
         assert_ne!(TempoHardfork::T1.general_gas_limit(), Some(0));
@@ -317,17 +320,28 @@ mod tests {
 
     #[test]
     fn test_tx_gas_limit_cap_values() {
-        // Pre-T1 returns Some(u64::MAX)
-        assert_eq!(TempoHardfork::Genesis.tx_gas_limit_cap(), Some(u64::MAX));
-        assert_eq!(TempoHardfork::T0.tx_gas_limit_cap(), Some(u64::MAX));
-        // T1+ returns Some(30_000_000)
-        assert_eq!(TempoHardfork::T1.tx_gas_limit_cap(), Some(30_000_000));
+        // Pre-T1A returns EIP-7825 Osaka limit (16,777,216)
+        assert_eq!(
+            TempoHardfork::Genesis.tx_gas_limit_cap(),
+            Some(MAX_TX_GAS_LIMIT_OSAKA)
+        );
+        assert_eq!(
+            TempoHardfork::T0.tx_gas_limit_cap(),
+            Some(MAX_TX_GAS_LIMIT_OSAKA)
+        );
+        assert_eq!(
+            TempoHardfork::T1.tx_gas_limit_cap(),
+            Some(MAX_TX_GAS_LIMIT_OSAKA)
+        );
+        // T1A+ returns Some(30_000_000)
+        assert_eq!(TempoHardfork::T1A.tx_gas_limit_cap(), Some(30_000_000));
         assert_eq!(TempoHardfork::T2.tx_gas_limit_cap(), Some(30_000_000));
         // All variants return Some (never None)
         for fork in [
             TempoHardfork::Genesis,
             TempoHardfork::T0,
             TempoHardfork::T1,
+            TempoHardfork::T1A,
             TempoHardfork::T2,
         ] {
             assert!(fork.tx_gas_limit_cap().is_some());
@@ -342,6 +356,7 @@ mod tests {
         assert_eq!(TempoHardfork::Genesis.gas_existing_nonce_key(), 5000);
         assert_eq!(TempoHardfork::T0.gas_existing_nonce_key(), 5000);
         assert_eq!(TempoHardfork::T1.gas_existing_nonce_key(), 5000);
+        assert_eq!(TempoHardfork::T1A.gas_existing_nonce_key(), 5000);
         // T2: 5000 + 2*WARM_SLOAD(100) = 5200
         assert_eq!(TempoHardfork::T2.gas_existing_nonce_key(), 5200);
         // Ensure no variant returns 0 or 1
@@ -349,6 +364,7 @@ mod tests {
             TempoHardfork::Genesis,
             TempoHardfork::T0,
             TempoHardfork::T1,
+            TempoHardfork::T1A,
             TempoHardfork::T2,
         ] {
             assert!(fork.gas_existing_nonce_key() > 1);
@@ -361,6 +377,7 @@ mod tests {
         assert_eq!(TempoHardfork::Genesis.gas_new_nonce_key(), 22100);
         assert_eq!(TempoHardfork::T0.gas_new_nonce_key(), 22100);
         assert_eq!(TempoHardfork::T1.gas_new_nonce_key(), 22100);
+        assert_eq!(TempoHardfork::T1A.gas_new_nonce_key(), 22100);
         // T2: 22100 + 2*WARM_SLOAD(100) = 22300
         assert_eq!(TempoHardfork::T2.gas_new_nonce_key(), 22300);
         // Ensure no variant returns 0 or 1
@@ -368,6 +385,7 @@ mod tests {
             TempoHardfork::Genesis,
             TempoHardfork::T0,
             TempoHardfork::T1,
+            TempoHardfork::T1A,
             TempoHardfork::T2,
         ] {
             assert!(fork.gas_new_nonce_key() > 1);
@@ -380,6 +398,7 @@ mod tests {
         assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
         assert_eq!(SpecId::from(TempoHardfork::T0), SpecId::OSAKA);
         assert_eq!(SpecId::from(TempoHardfork::T1), SpecId::OSAKA);
+        assert_eq!(SpecId::from(TempoHardfork::T1A), SpecId::OSAKA);
         assert_eq!(SpecId::from(TempoHardfork::T2), SpecId::OSAKA);
         // Ensure it doesn't return default (which would be FRONTIER = 0)
         assert_ne!(SpecId::from(TempoHardfork::Genesis), SpecId::default());

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -607,8 +607,7 @@ mod tests {
         use reth_chainspec::EthChainSpec;
 
         // Load mainnet (presto, chain_id = 4217)
-        let cs = super::TempoChainSpecParser::parse("mainnet")
-            .expect("mainnet must load");
+        let cs = super::TempoChainSpecParser::parse("mainnet").expect("mainnet must load");
 
         // chain() returns the correct non-default chain
         let chain = cs.chain();
@@ -653,10 +652,8 @@ mod tests {
         assert!(deposit.is_some());
 
         // A custom chain without deposit contract should return None
-        let custom_genesis: alloy_genesis::Genesis = serde_json::from_str(
-            r#"{ "config": { "chainId": 77777 }, "alloc": {} }"#,
-        )
-        .unwrap();
+        let custom_genesis: alloy_genesis::Genesis =
+            serde_json::from_str(r#"{ "config": { "chainId": 77777 }, "alloc": {} }"#).unwrap();
         let custom = super::TempoChainSpec::from_genesis(custom_genesis);
         assert!(custom.deposit_contract_address().is_none());
     }
@@ -665,8 +662,7 @@ mod tests {
     fn test_bootnodes_moderato() {
         use reth_chainspec::EthChainSpec;
 
-        let cs = super::TempoChainSpecParser::parse("moderato")
-            .expect("moderato must load");
+        let cs = super::TempoChainSpecParser::parse("moderato").expect("moderato must load");
 
         let boots = cs.bootnodes();
         assert!(boots.is_some(), "moderato bootnodes must be Some");
@@ -692,10 +688,8 @@ mod tests {
         assert_eq!(boots.unwrap().len(), 4);
 
         // custom chain without matching id falls through
-        let genesis: alloy_genesis::Genesis = serde_json::from_str(
-            r#"{ "config": { "chainId": 99999 }, "alloc": {} }"#,
-        )
-        .unwrap();
+        let genesis: alloy_genesis::Genesis =
+            serde_json::from_str(r#"{ "config": { "chainId": 99999 }, "alloc": {} }"#).unwrap();
         let custom = super::TempoChainSpec::from_genesis(genesis);
         // inner chain spec has no bootnodes → returns None
         assert!(custom.bootnodes().is_none());


### PR DESCRIPTION
## Summary
Strengthen existing tests in `crates/chainspec/` and `crates/precompiles-macros/src/utils.rs` to eliminate 46 surviving mutants.

## Motivation
Mutation testing on c727e905 found 37 survivors in chainspec (hardfork gas values, chain spec accessors) and 9 in precompile macro utilities.

## Changes
- Added per-hardfork gas value assertions (base_fee, general_gas_limit, tx_gas_limit_cap, gas_existing/new_nonce_key)
- Added From<TempoHardfork> for SpecId test (OSAKA, not default)
- Added general_gas_limit_at arithmetic precision tests (detects / vs %, * and - vs +, /)
- Added EthChainSpec accessor tests (chain, genesis_hash, genesis_header, genesis, blob_params, final_paris_total_difficulty, next_block_base_fee, ethereum_fork_activation, deposit_contract_address)
- Added from_genesis timestamp modulo test (detects % vs / and +)
- Added bootnodes tests for all chain IDs (presto/andantino/moderato/custom)
- Added parse_slot_value tests for Int (decimal, hex) and Str literals
- Added to_snake_case edge cases (ABCdef, XMLParser, getHTTPResponse) to catch || vs && mutation
- Added extract_attributes tests with slot/base_slot/empty/unrelated attrs
- Added extract_storable_array_sizes tests (present with multiple sizes, absent, single)

## Testing
`cargo test -p tempo-chainspec` — 25 passed
`cargo test -p tempo-precompiles-macros` — 16 passed

Prompted by: zerosnacks