### PR TITLE
test(primitives): strengthen transaction type tests to kill mutation survivors

### DIFF
--- a/.changelog/tidy-snails-cry.md
+++ b/.changelog/tidy-snails-cry.md
@@ -1,0 +1,5 @@
+---
+tempo-primitives: patch
+---
+
+Added comprehensive mutation testing coverage for transaction types, signatures, and subblock components to strengthen test suite robustness.

--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -485,8 +485,7 @@ mod tests {
     #[test]
     fn test_recovered_subblock_transactions_recovered() {
         use crate::transaction::{
-            AASigned, TempoTransaction, TempoSignature,
-            tempo_transaction::Call,
+            AASigned, TempoSignature, TempoTransaction, tempo_transaction::Call,
             tt_signature::PrimitiveSignature,
         };
 

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -980,8 +980,10 @@ mod tests {
         // is_fee_token
         assert!(envelope.is_fee_token());
         // Non-AA variant: is_fee_token false
-        let legacy_env =
-            TempoTxEnvelope::Legacy(Signed::new_unhashed(TxLegacy::default(), Signature::test_signature()));
+        let legacy_env = TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy::default(),
+            Signature::test_signature(),
+        ));
         assert!(!legacy_env.is_fee_token());
 
         // subblock_proposer - should return Some for subblock nonce key prefix

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -938,11 +938,13 @@ mod tests {
         use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
         use reth_primitives_traits::InMemorySize;
 
-        use crate::subblock::TEMPO_SUBBLOCK_NONCE_KEY_PREFIX;
-        use crate::transaction::{
-            TempoSignature,
-            tt_authorization::tests::{generate_secp256k1_keypair, sign_hash},
-            tt_signature::PrimitiveSignature,
+        use crate::{
+            subblock::TEMPO_SUBBLOCK_NONCE_KEY_PREFIX,
+            transaction::{
+                TempoSignature,
+                tt_authorization::tests::{generate_secp256k1_keypair, sign_hash},
+                tt_signature::PrimitiveSignature,
+            },
         };
 
         // Build an AA envelope with non-default values

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -280,16 +280,16 @@ mod tests {
         // + vs - kills: without vs with limits should differ
         assert!(sz_with_limits >= sz_no_limits);
         // * vs + kills: capacity * size_of is not capacity + size_of
-        assert_ne!(sz_with_limits, size_of::<KeyAuthorization>() + cap + size_of::<TokenLimit>());
+        assert_ne!(
+            sz_with_limits,
+            size_of::<KeyAuthorization>() + cap + size_of::<TokenLimit>()
+        );
     }
 
     #[test]
     fn test_signed_key_authorization_size() {
         let auth = make_auth(Some(1000), None);
-        let inner_sig = match sign_hash(
-            &generate_secp256k1_keypair().0,
-            &auth.signature_hash(),
-        ) {
+        let inner_sig = match sign_hash(&generate_secp256k1_keypair().0, &auth.signature_hash()) {
             TempoSignature::Primitive(p) => p,
             _ => panic!("Expected primitive signature"),
         };
@@ -300,7 +300,13 @@ mod tests {
         assert_eq!(sz, expected);
         assert!(sz > 1); // kills return 0 or 1
         // + vs - kills
-        assert_ne!(sz, signed.authorization.size().wrapping_sub(signed.signature.size()));
+        assert_ne!(
+            sz,
+            signed
+                .authorization
+                .size()
+                .wrapping_sub(signed.signature.size())
+        );
         // + vs * kills
         assert_ne!(sz, signed.authorization.size() * signed.signature.size());
     }

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -40,3 +40,17 @@ pub fn calc_gas_balance_spending(gas_limit: u64, gas_price: u128) -> U256 {
         .saturating_mul(U256::from(gas_price))
         .div_ceil(TEMPO_GAS_PRICE_SCALING_FACTOR)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calc_gas_balance_spending() {
+        // 21000 gas * 1_000_000_000 (1 gwei) = 21_000_000_000_000 attodollars
+        // / 10^12 = 21 microdollars
+        let result = calc_gas_balance_spending(21000, 1_000_000_000);
+        assert_eq!(result, U256::from(21));
+        assert_ne!(result, U256::ZERO); // kills Default::default()
+    }
+}

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -2093,8 +2093,7 @@ mod tests {
             + call_sizes
             + tx.access_list.size()
             + tx.key_authorization.as_ref().map_or(0, |k| k.size())
-            + tx
-                .tempo_authorization_list
+            + tx.tempo_authorization_list
                 .iter()
                 .map(|a| a.size())
                 .sum::<usize>();

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -2134,7 +2134,7 @@ mod tests {
         assert_eq!(tx.max_fee_per_blob_gas(), None);
         assert!(tx.is_dynamic_fee());
         assert_eq!(tx.kind(), TxKind::Call(Address::repeat_byte(0x42)));
-        assert!(tx.is_create() == false);
+        assert!(!tx.is_create());
         assert_eq!(tx.value(), U256::from(999));
         assert_eq!(tx.input(), &Bytes::from(vec![0xAB, 0xCD]));
         assert!(!tx.input().is_empty());

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -1681,7 +1681,10 @@ mod tests {
         let expected = size_of::<PrimitiveSignature>() + 50;
         assert_eq!(webauthn_sz, expected);
         // + vs - kills: size_of - 50 is very different
-        assert_ne!(webauthn_sz, size_of::<PrimitiveSignature>().wrapping_sub(50));
+        assert_ne!(
+            webauthn_sz,
+            size_of::<PrimitiveSignature>().wrapping_sub(50)
+        );
         // + vs * kills: size_of * 50 is very different
         assert_ne!(webauthn_sz, size_of::<PrimitiveSignature>() * 50);
     }
@@ -1689,7 +1692,8 @@ mod tests {
     #[test]
     fn test_tempo_signature_size() {
         // Primitive: delegates to PrimitiveSignature::size()
-        let prim = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let prim =
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
         let prim_sz = prim.size();
         assert!(prim_sz > 1);
         assert_eq!(prim_sz, size_of::<PrimitiveSignature>());
@@ -1697,7 +1701,8 @@ mod tests {
         // Keychain: 1 + 20 + inner.size()
         let inner = PrimitiveSignature::Secp256k1(Signature::test_signature());
         let inner_size = inner.size();
-        let keychain = TempoSignature::Keychain(KeychainSignature::new(Address::repeat_byte(0x01), inner));
+        let keychain =
+            TempoSignature::Keychain(KeychainSignature::new(Address::repeat_byte(0x01), inner));
         let kc_sz = keychain.size();
         assert_eq!(kc_sz, 1 + 20 + inner_size);
         assert!(kc_sz > 1);
@@ -1761,7 +1766,10 @@ mod tests {
         let result = verify_p256_signature_internal(&r_dummy, &s_half, &pk_x, &pk_y, &hash);
         // Should NOT fail with "high s value"
         if let Err(e) = &result {
-            assert!(!e.contains("high s value"), "s == P256N_HALF should be accepted (>= vs >)");
+            assert!(
+                !e.contains("high s value"),
+                "s == P256N_HALF should be accepted (>= vs >)"
+            );
         }
     }
 
@@ -1781,7 +1789,10 @@ mod tests {
         exact_data[32] = 0x01; // Set UP flag
         let result = verify_webauthn_data_internal(&exact_data, &tx_hash);
         if let Err(e) = &result {
-            assert!(!e.contains("too short"), "len == MIN_AUTH_DATA_LEN + 32 should not be 'too short'");
+            assert!(
+                !e.contains("too short"),
+                "len == MIN_AUTH_DATA_LEN + 32 should not be 'too short'"
+            );
         }
     }
 }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -1709,7 +1709,7 @@ mod tests {
         // + vs - kills
         assert_ne!(kc_sz, 1usize.wrapping_sub(20).wrapping_add(inner_size));
         // + vs * kills
-        assert_ne!(kc_sz, 1 * 20 + inner_size);
+        assert_ne!(kc_sz, 20 + inner_size);
     }
 
     #[test]

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -648,7 +648,10 @@ mod tests {
         assert_ne!(signed.value(), U256::ZERO);
         assert_ne!(signed.value(), U256::from(100) * U256::from(200));
         // Not 100 - 200 which would underflow to a huge number
-        assert_ne!(signed.value(), U256::from(100).wrapping_sub(U256::from(200)));
+        assert_ne!(
+            signed.value(),
+            U256::from(100).wrapping_sub(U256::from(200))
+        );
 
         // input: returns first call's input
         assert_eq!(signed.input(), &Bytes::from(vec![0xDE, 0xAD]));


### PR DESCRIPTION
## Summary
Strengthen existing tests across `crates/primitives/src/transaction/` and `crates/primitives/src/subblock.rs` to eliminate 139 surviving mutants.

## Motivation
Mutation testing on c727e905 found 139 survivors across transaction types — mostly accessor returns and size arithmetic.

## Changes
- Added comprehensive Transaction trait accessor tests for AASigned (tt_signed.rs)
- Added size() arithmetic assertions across all types
- Added RLP round-trip tests for tempo_transaction.rs
- Expanded boundary tests for signature verification
- Added AuthorizationTr accessor tests
- Added TempoTxEnvelope accessor and signer recovery tests
- Added RecoveredSubBlock::transactions_recovered test
- Added calc_gas_balance_spending test

## Testing
`cargo test -p tempo-primitives` — 136 tests pass

Prompted by: zerosnacks