### PR TITLE
test(alloy): strengthen RPC/network tests to kill mutation survivors

### DIFF
--- a/.changelog/dark-sheep-dance.md
+++ b/.changelog/dark-sheep-dance.md
@@ -1,0 +1,5 @@
+---
+tempo-alloy: patch
+---
+
+Added comprehensive unit tests for Tempo network transaction handling, signature types, and RPC compatibility layer.

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -171,8 +171,7 @@ mod tests {
     use crate::{TempoNetwork, fillers::Random2DNonceFiller, rpc::TempoTransactionRequest};
     use alloy_network::TransactionBuilder;
     use alloy_primitives::ruint::aliases::U256;
-    use alloy_provider::fillers::TxFiller;
-    use alloy_provider::{ProviderBuilder, SendableTx, mock::Asserter};
+    use alloy_provider::{ProviderBuilder, SendableTx, fillers::TxFiller, mock::Asserter};
     use eyre;
 
     #[tokio::test]

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -171,8 +171,8 @@ mod tests {
     use crate::{TempoNetwork, fillers::Random2DNonceFiller, rpc::TempoTransactionRequest};
     use alloy_network::TransactionBuilder;
     use alloy_primitives::ruint::aliases::U256;
-    use alloy_provider::{ProviderBuilder, SendableTx, mock::Asserter};
     use alloy_provider::fillers::TxFiller;
+    use alloy_provider::{ProviderBuilder, SendableTx, mock::Asserter};
     use eyre;
 
     #[tokio::test]

--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -431,8 +431,8 @@ mod tests {
             ..Default::default()
         };
 
-        let envelope = TryIntoSimTx::<TempoTxEnvelope>::try_into_sim_tx(req)
-            .expect("should produce sim tx");
+        let envelope =
+            TryIntoSimTx::<TempoTxEnvelope>::try_into_sim_tx(req).expect("should produce sim tx");
         // The envelope must be AA variant (mutant returns Ok(Default::default()))
         assert!(matches!(envelope, TempoTxEnvelope::AA(_)));
     }
@@ -603,12 +603,7 @@ mod tests {
 
     #[test]
     fn test_create_mock_tempo_signature_without_key_id() {
-        let sig = create_mock_tempo_signature(
-            &SignatureType::Secp256k1,
-            None,
-            None,
-            Address::ZERO,
-        );
+        let sig = create_mock_tempo_signature(&SignatureType::Secp256k1, None, None, Address::ZERO);
         match sig {
             TempoSignature::Primitive(_) => {}
             _ => panic!("Expected Primitive variant when key_id is None"),
@@ -619,12 +614,7 @@ mod tests {
     fn test_create_mock_tempo_signature_with_key_id() {
         let caller = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let key_id = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let sig = create_mock_tempo_signature(
-            &SignatureType::P256,
-            None,
-            Some(key_id),
-            caller,
-        );
+        let sig = create_mock_tempo_signature(&SignatureType::P256, None, Some(key_id), caller);
         match sig {
             TempoSignature::Keychain(ks) => {
                 assert_eq!(ks.user_address, caller);

--- a/crates/alloy/src/rpc/header.rs
+++ b/crates/alloy/src/rpc/header.rs
@@ -117,3 +117,31 @@ impl AsRef<TempoHeader> for TempoHeaderResponse {
         &self.inner
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_delegates_to_inner() {
+        let consensus_header = TempoHeader {
+            inner: alloy_consensus::Header {
+                timestamp: 1234,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let rpc_header = Header::new(consensus_header);
+
+        let resp = TempoHeaderResponse {
+            inner: rpc_header,
+            timestamp_millis: 1234000,
+        };
+
+        let ts = BlockHeader::timestamp(&resp);
+        assert_eq!(ts, 1234);
+        assert_ne!(ts, 0);
+        assert_ne!(ts, 1);
+    }
+}

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -558,6 +558,25 @@ mod tests {
     }
 
     #[test]
+    fn test_as_ref_returns_inner() {
+        let mut req = TempoTransactionRequest::default();
+        req.inner.nonce = Some(42);
+        req.inner.gas = Some(100_000);
+        let as_ref: &TransactionRequest = req.as_ref();
+        assert_eq!(as_ref.nonce, Some(42));
+        assert_eq!(as_ref.gas, Some(100_000));
+    }
+
+    #[test]
+    fn test_as_mut_returns_inner() {
+        let mut req = TempoTransactionRequest::default();
+        req.inner.nonce = Some(1);
+        let as_mut: &mut TransactionRequest = req.as_mut();
+        as_mut.nonce = Some(99);
+        assert_eq!(req.inner.nonce, Some(99));
+    }
+
+    #[test]
     fn test_build_aa_preserves_key_authorization() {
         use tempo_primitives::transaction::{
             KeyAuthorization, PrimitiveSignature, SignedKeyAuthorization,


### PR DESCRIPTION
## Summary
Strengthen existing tests in `crates/alloy/src/` to eliminate 33+ surviving mutants.

## Motivation
Mutation testing on c727e905 found survivors across RPC compat (21), network (9), request (2), header (2), receipt (4), and nonce filler (1).

## Changes
- Added try_into_sim_tx / try_into_tx_env coverage in compat.rs
- Added mock signature variant tests for all 3 key types
- Added create_mock_tempo_signature Primitive vs Keychain tests
- Added from_consensus_header field preservation test
- Added try_build_and_sign tests for AA and non-AA paths
- Added TransactionBuilder accessor round-trip tests
- Added isolated output_tx_type tests for each AA-triggering field
- Added NetworkWallet and IntoWallet tests
- Added AsRef/AsMut validation tests in request.rs
- Added fill_sync skip/fill behavior tests in nonce.rs
- Added header timestamp delegation and receipt status/gas_price tests

## Testing
`cargo test -p tempo-alloy --features tempo-compat --lib` — 61 tests pass

Prompted by: zerosnacks