### PR TITLE
test(precompiles): strengthen storage/nonce/misc tests to kill mutation survivors

### DIFF
--- a/.changelog/plain-horses-wake.md
+++ b/.changelog/plain-horses-wake.md
@@ -1,0 +1,5 @@
+---
+tempo-precompiles: patch
+---
+
+Added mutation tests to improve code coverage for precompiles storage operations, policy authorization logic, and boundary conditions in nonce management, account keychain, and TIP20 factory.

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1942,10 +1942,7 @@ mod tests {
             assert_eq!(remaining, U256::from(1000));
 
             // Revoke the key
-            keychain.revoke_key(
-                account,
-                revokeKeyCall { keyId: key_id },
-            )?;
+            keychain.revoke_key(account, revokeKeyCall { keyId: key_id })?;
 
             // After revocation, remaining limit should be zero on T2
             // With `||`: (expiry==0) || (is_revoked==true) → true → return zero ✓

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -340,13 +340,11 @@ mod tests {
     #[test]
     fn test_is_system_error_returns_false_for_domain_errors() {
         // Domain errors should NOT be system errors
-        assert!(!TempoPrecompileError::StablecoinDEX(
-            StablecoinDEXError::order_does_not_exist()
-        )
-        .is_system_error());
         assert!(
-            !TempoPrecompileError::UnknownFunctionSelector([0xAA; 4]).is_system_error()
+            !TempoPrecompileError::StablecoinDEX(StablecoinDEXError::order_does_not_exist())
+                .is_system_error()
         );
+        assert!(!TempoPrecompileError::UnknownFunctionSelector([0xAA; 4]).is_system_error());
     }
 
     #[test]

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -338,6 +338,25 @@ mod tests {
     }
 
     #[test]
+    fn test_is_system_error_returns_false_for_domain_errors() {
+        // Domain errors should NOT be system errors
+        assert!(!TempoPrecompileError::StablecoinDEX(
+            StablecoinDEXError::order_does_not_exist()
+        )
+        .is_system_error());
+        assert!(
+            !TempoPrecompileError::UnknownFunctionSelector([0xAA; 4]).is_system_error()
+        );
+    }
+
+    #[test]
+    fn test_is_system_error_returns_true_for_system_errors() {
+        assert!(TempoPrecompileError::OutOfGas.is_system_error());
+        assert!(TempoPrecompileError::Fatal("boom".into()).is_system_error());
+        assert!(TempoPrecompileError::Panic(PanicKind::UnderOverflow).is_system_error());
+    }
+
+    #[test]
     fn test_decode_error_with_tip20_error() {
         // Use insufficient_allowance which has a unique selector (no collision with other errors)
         let error = TIP20Error::insufficient_allowance();

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -194,3 +194,31 @@ impl HashMapStorageProvider {
             .or_default();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_beneficiary_returns_set_value() {
+        let mut provider = HashMapStorageProvider::new(1);
+        let bene = Address::repeat_byte(0xCC);
+        provider.set_beneficiary(bene);
+        assert_eq!(provider.beneficiary(), bene);
+        assert_ne!(provider.beneficiary(), Address::ZERO);
+    }
+
+    #[test]
+    fn test_gas_refunded_returns_zero() {
+        let provider = HashMapStorageProvider::new(1);
+        assert_eq!(provider.gas_refunded(), 0);
+        assert_ne!(provider.gas_refunded(), 1);
+        assert_ne!(provider.gas_refunded(), -1);
+    }
+
+    #[test]
+    fn test_is_static_returns_false_by_default() {
+        let provider = HashMapStorageProvider::new(1);
+        assert!(!provider.is_static());
+    }
+}

--- a/crates/precompiles/src/storage/packing.rs
+++ b/crates/precompiles/src/storage/packing.rs
@@ -920,8 +920,14 @@ mod tests {
         // With `|`, reinserting the same value produces the same word.
         // With `^`, the bits would cancel out to 0.
         let extracted: u8 = extract_from_word(slot2, 0, 1).unwrap();
-        assert_eq!(extracted, existing, "Reinserting same value must preserve it (| not ^)");
-        assert_eq!(slot, slot2, "Word should be identical after re-insert of same value");
+        assert_eq!(
+            extracted, existing,
+            "Reinserting same value must preserve it (| not ^)"
+        );
+        assert_eq!(
+            slot, slot2,
+            "Word should be identical after re-insert of same value"
+        );
     }
 
     // -- PROPERTY TESTS -----------------------------------------------------------

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -209,7 +209,10 @@ where
 mod tests {
     use super::*;
     use crate::{
-        storage::{Layout, LayoutCtx, PrecompileStorageProvider, StorageCtx, hashmap::HashMapStorageProvider},
+        storage::{
+            Layout, LayoutCtx, PrecompileStorageProvider, StorageCtx,
+            hashmap::HashMapStorageProvider,
+        },
         test_util::setup_storage,
     };
     use proptest::prelude::*;
@@ -505,7 +508,14 @@ mod tests {
 
             // Write distinct values to verify slot arithmetic
             let mut h = <[U256; 5]>::handle(base, LayoutCtx::FULL, address);
-            h.write([U256::from(10), U256::from(20), U256::from(30), U256::from(40), U256::from(50)]).unwrap();
+            h.write([
+                U256::from(10),
+                U256::from(20),
+                U256::from(30),
+                U256::from(40),
+                U256::from(50),
+            ])
+            .unwrap();
 
             // Read back individual elements
             let v0 = handler[0].read().unwrap();

--- a/crates/precompiles/src/storage/types/set.rs
+++ b/crates/precompiles/src/storage/types/set.rs
@@ -803,6 +803,24 @@ mod tests {
     }
 
     #[test]
+    fn test_handler_is_empty_with_elements() -> eyre::Result<()> {
+        let (mut storage, address) = setup_storage();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut handler = SetHandler::<U256>::new(U256::ZERO, address);
+
+            // Empty set should be empty
+            assert!(handler.is_empty()?);
+
+            // After inserting, should NOT be empty
+            handler.insert(U256::from(1))?;
+            assert!(!handler.is_empty()?);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_handler_metadata() {
         let address = Address::ZERO;
         let handler = SetHandler::<U256>::new(U256::from(42), address);

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -1736,7 +1736,9 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut handler = VecHandler::<u32>::new(U256::ZERO, address);
             // Write length manually
-            Slot::<U256>::new(U256::ZERO, address).write(U256::from(16)).unwrap();
+            Slot::<U256>::new(U256::ZERO, address)
+                .write(U256::from(16))
+                .unwrap();
 
             // Write some values via full vec
             let data: Vec<u32> = (0..16).collect();
@@ -1764,7 +1766,8 @@ mod tests {
             assert_eq!(handler.at(2)?.unwrap().read()?, U256::from(300));
 
             Ok::<(), crate::error::TempoPrecompileError>(())
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     // -- PROPTEST STRATEGIES ------------------------------------------------------

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -1720,7 +1720,7 @@ mod tests {
     fn test_vec_max_index_unpacked() {
         // For U256 (32 bytes, unpacked), max_index = u32::MAX / 1 (SLOTS=1)
         let max = VecHandler::<U256>::max_index();
-        assert_eq!(max, u32::MAX as usize / 1);
+        assert_eq!(max, u32::MAX as usize);
     }
 
     #[test]

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -853,17 +853,13 @@ mod tests {
 
             if lower < RESERVED_SIZE {
                 // Should reject
-                let result = factory.get_token_address(ITIP20Factory::getTokenAddressCall {
-                    sender,
-                    salt,
-                });
+                let result =
+                    factory.get_token_address(ITIP20Factory::getTokenAddressCall { sender, salt });
                 assert!(result.is_err());
             } else {
                 // Should succeed
-                let result = factory.get_token_address(ITIP20Factory::getTokenAddressCall {
-                    sender,
-                    salt,
-                });
+                let result =
+                    factory.get_token_address(ITIP20Factory::getTokenAddressCall { sender, salt });
                 assert!(result.is_ok());
             }
 
@@ -900,7 +896,10 @@ mod tests {
                             salt,
                         },
                     );
-                    assert!(result.is_ok(), "lower_bytes == RESERVED_SIZE should be accepted by < check");
+                    assert!(
+                        result.is_ok(),
+                        "lower_bytes == RESERVED_SIZE should be accepted by < check"
+                    );
                     return Ok(());
                 }
                 if lower < RESERVED_SIZE {


### PR DESCRIPTION
## Summary
Strengthen existing tests across precompile storage layer and misc files to eliminate surviving mutants.

## Motivation
Mutation testing on c727e905 found 50+ survivors in precompile storage types, nonce management, and other utilities.

## Changes
- Added accessor value assertions in storage/evm.rs (timestamp, beneficiary, deduct_gas, refund_gas, gas_used, gas_refunded, is_static, emit_event gas deduction)
- Added beneficiary, deduct_gas, gas_refunded tests in storage/thread_local.rs
- Added beneficiary, gas_refunded, is_static tests in storage/hashmap.rs
- Added insert_into_word bit-preservation test in storage/packing.rs (| vs ^)
- Added base_slot, compute_handler slot arithmetic tests in storage/types/array.rs
- Added len_slot, is_empty, delete boundary, max_index, compute_handler tests in storage/types/vec.rs
- Added is_empty with elements test in storage/types/set.rs
- Added calc_string_length long string test in storage/types/bytes_like.rs
- Added expiry boundary tests for is_expiring_nonce_seen and check_and_mark_expiring_nonce in nonce/mod.rs
- Added reserved range boundary tests in tip20_factory/mod.rs
- Added PolicyData::is_default and compound transfer authorization tests in tip403_registry/mod.rs
- Added initialize, get_key match arm 0, get_remaining_limit || vs && tests in account_keychain/mod.rs
- Added is_system_error true/false tests in error.rs
- Added fill_precompile_output reverted refund guard test in lib.rs

## Testing
cargo test -p tempo-precompiles — 648 tests pass

Prompted by: zerosnacks