### PR TITLE
feat(config): encrypt signing key and signing share at rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12002,11 +12002,14 @@ dependencies = [
 name = "tempo-commonware-node-config"
 version = "1.2.0"
 dependencies = [
+ "aes-gcm",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-utils",
  "const-hex",
+ "pbkdf2",
  "rand 0.8.5",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 

--- a/crates/commonware-node-config/Cargo.toml
+++ b/crates/commonware-node-config/Cargo.toml
@@ -16,6 +16,11 @@ commonware-cryptography.workspace = true
 const-hex.workspace = true
 thiserror.workspace = true
 
+# Encryption-at-rest for key material (issue #1713)
+aes-gcm = "0.10"
+pbkdf2 = "0.12"
+sha2.workspace = true
+
 [dev-dependencies]
 commonware-utils.workspace = true
 rand_08.workspace = true

--- a/crates/commonware-node-config/src/encrypted.rs
+++ b/crates/commonware-node-config/src/encrypted.rs
@@ -1,0 +1,210 @@
+//! Encryption-at-rest for consensus key material.
+//!
+//! Provides AES-256-GCM authenticated encryption with PBKDF2-HMAC-SHA256 key
+//! derivation. The on-disk format is intentionally simple and self-describing:
+//!
+//! ```text
+//!  0..4   magic   b"TENC"
+//!  4..5   version 0x01
+//!  5..37  salt    32 bytes (random, per file)
+//! 37..49  nonce   12 bytes (random, per encryption)
+//! 49..    ciphertext + 16-byte GCM auth tag
+//! ```
+//!
+//! The passphrase is never stored; it must be supplied at runtime, typically
+//! via an environment variable (`TEMPO_KEY_PASSPHRASE`).
+
+use std::path::Path;
+
+use aes_gcm::{
+    aead::{Aead, OsRng},
+    Aes256Gcm, KeyInit, Nonce,
+};
+use pbkdf2::pbkdf2_hmac;
+use sha2::Sha256;
+
+/// File header that identifies an encrypted key file.
+const MAGIC: &[u8; 4] = b"TENC";
+
+/// Current envelope version. Bump when the format changes.
+const VERSION: u8 = 0x01;
+
+/// PBKDF2 iteration count. 600 000 aligns with current OWASP guidance for
+/// PBKDF2-HMAC-SHA256 (as of 2024).
+const PBKDF2_ITERATIONS: u32 = 600_000;
+
+const SALT_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+const HEADER_LEN: usize = 4 + 1 + SALT_LEN + NONCE_LEN; // 49
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptionError {
+    #[error("failed reading encrypted file")]
+    Read(#[source] std::io::Error),
+    #[error("failed writing encrypted file")]
+    Write(#[source] std::io::Error),
+    #[error("file too short to contain a valid encrypted envelope")]
+    TruncatedFile,
+    #[error("not an encrypted key file (bad magic)")]
+    BadMagic,
+    #[error("unsupported envelope version {0}")]
+    UnsupportedVersion(u8),
+    #[error("decryption failed (wrong passphrase or corrupted file)")]
+    DecryptionFailed,
+}
+
+/// Derives a 256-bit key from `passphrase` and `salt` using PBKDF2-HMAC-SHA256.
+fn derive_key(passphrase: &[u8], salt: &[u8; SALT_LEN]) -> [u8; 32] {
+    let mut key = [0u8; 32];
+    pbkdf2_hmac::<Sha256>(passphrase, salt, PBKDF2_ITERATIONS, &mut key);
+    key
+}
+
+/// Encrypts `plaintext` and returns the full on-disk envelope.
+pub fn seal(plaintext: &[u8], passphrase: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+    use aes_gcm::aead::rand_core::RngCore;
+
+    let mut salt = [0u8; SALT_LEN];
+    OsRng.fill_bytes(&mut salt);
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    OsRng.fill_bytes(&mut nonce_bytes);
+
+    let key = derive_key(passphrase, &salt);
+    let cipher = Aes256Gcm::new_from_slice(&key).expect("key is always 32 bytes");
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| EncryptionError::DecryptionFailed)?;
+
+    let mut envelope = Vec::with_capacity(HEADER_LEN + ciphertext.len());
+    envelope.extend_from_slice(MAGIC);
+    envelope.push(VERSION);
+    envelope.extend_from_slice(&salt);
+    envelope.extend_from_slice(&nonce_bytes);
+    envelope.extend_from_slice(&ciphertext);
+    Ok(envelope)
+}
+
+/// Decrypts an on-disk envelope produced by [`seal`].
+pub fn open(envelope: &[u8], passphrase: &[u8]) -> Result<Vec<u8>, EncryptionError> {
+    if envelope.len() < HEADER_LEN {
+        return Err(EncryptionError::TruncatedFile);
+    }
+
+    if &envelope[..4] != MAGIC {
+        return Err(EncryptionError::BadMagic);
+    }
+
+    let version = envelope[4];
+    if version != VERSION {
+        return Err(EncryptionError::UnsupportedVersion(version));
+    }
+
+    let salt: &[u8; SALT_LEN] = envelope[5..5 + SALT_LEN]
+        .try_into()
+        .expect("slice length matches SALT_LEN");
+    let nonce_bytes = &envelope[5 + SALT_LEN..HEADER_LEN];
+    let ciphertext = &envelope[HEADER_LEN..];
+
+    let key = derive_key(passphrase, salt);
+    let cipher = Aes256Gcm::new_from_slice(&key).expect("key is always 32 bytes");
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| EncryptionError::DecryptionFailed)
+}
+
+/// Returns `true` if `data` starts with the encrypted envelope magic bytes.
+pub fn is_encrypted(data: &[u8]) -> bool {
+    data.len() >= 4 && &data[0..4] == MAGIC
+}
+
+/// Reads a file, decrypting it if the contents are an encrypted envelope.
+/// Falls back to returning raw bytes for plaintext files, enabling transparent
+/// migration.
+pub fn read_maybe_encrypted(
+    path: &Path,
+    passphrase: Option<&[u8]>,
+) -> Result<Vec<u8>, EncryptionError> {
+    let raw = std::fs::read(path).map_err(EncryptionError::Read)?;
+
+    if is_encrypted(&raw) {
+        let passphrase = passphrase.ok_or(EncryptionError::DecryptionFailed)?;
+        open(&raw, passphrase)
+    } else {
+        // Plaintext file — return as-is for backward compatibility.
+        Ok(raw)
+    }
+}
+
+/// Encrypts `plaintext` and writes the envelope to `path`.
+pub fn write_encrypted(
+    path: &Path,
+    plaintext: &[u8],
+    passphrase: &[u8],
+) -> Result<(), EncryptionError> {
+    let envelope = seal(plaintext, passphrase)?;
+    std::fs::write(path, envelope).map_err(EncryptionError::Write)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let passphrase = b"correct horse battery staple";
+        let plaintext = b"0x7848b5d711bc9883996317a3f9c90269d56771005d540a19184939c9e8d0db2a";
+
+        let envelope = seal(plaintext, passphrase).unwrap();
+        assert!(is_encrypted(&envelope));
+
+        let recovered = open(&envelope, passphrase).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn wrong_passphrase_is_rejected() {
+        let envelope = seal(b"secret", b"right").unwrap();
+        assert!(matches!(
+            open(&envelope, b"wrong"),
+            Err(EncryptionError::DecryptionFailed)
+        ));
+    }
+
+    #[test]
+    fn truncated_file_is_rejected() {
+        // Anything shorter than HEADER_LEN triggers TruncatedFile first.
+        assert!(matches!(
+            open(&[0u8; 10], b"pass"),
+            Err(EncryptionError::TruncatedFile)
+        ));
+
+        // A full-length header with wrong magic triggers BadMagic.
+        let bad = vec![0u8; HEADER_LEN + 32];
+        assert!(matches!(
+            open(&bad, b"pass"),
+            Err(EncryptionError::BadMagic)
+        ));
+    }
+
+    #[test]
+    fn plaintext_is_not_detected_as_encrypted() {
+        assert!(!is_encrypted(b"0xdeadbeef"));
+    }
+
+    #[test]
+    fn each_seal_produces_unique_envelope() {
+        let pass = b"pass";
+        let data = b"key material";
+        let a = seal(data, pass).unwrap();
+        let b = seal(data, pass).unwrap();
+        // Different salt + nonce means different ciphertext each time.
+        assert_ne!(a, b);
+        // But both decrypt to the same plaintext.
+        assert_eq!(open(&a, pass).unwrap(), open(&b, pass).unwrap());
+    }
+}

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -39,11 +39,13 @@ pub async fn run_consensus_stack(
     execution_node: TempoFullNode,
     feed_state: feed::FeedStateHandle,
 ) -> eyre::Result<()> {
+    let passphrase = config.resolve_passphrase()?;
+
     let share = config
         .signing_share
         .as_ref()
         .map(|share| {
-            SigningShare::read_from_file(share).wrap_err_with(|| {
+            SigningShare::read_maybe_encrypted(share, passphrase.as_deref()).wrap_err_with(|| {
                 format!(
                     "failed reading private bls12-381 key share from file `{}`",
                     share.display()


### PR DESCRIPTION
## Summary

Implements encryption-at-rest for consensus key material (`--consensus.signing-key` and `--consensus.signing-share`), addressing the concern raised in #1713 that these secrets are currently stored as plaintext hex on disk.

## Design

**Cipher:** AES-256-GCM (authenticated encryption, NIST-approved)
**KDF:** PBKDF2-HMAC-SHA256, 600 000 iterations (current OWASP recommendation)
**Envelope format (49-byte header + ciphertext):**

```
 0.. 4   magic   b"TENC"
 4.. 5   version 0x01
 5..37   salt    32 bytes (random per file)
37..49   nonce   12 bytes (random per encryption)
49..     ciphertext + 16-byte GCM authentication tag
```

The format is self-describing: the node distinguishes encrypted from plaintext files by the 4-byte magic prefix. This enables **incremental migration** — existing plaintext key files continue to work whether or not a passphrase is configured, so operators can adopt encryption at their own pace without downtime.

## CLI

A new flag `--consensus.key-passphrase-env <ENV_VAR>` specifies the name of an environment variable that holds the passphrase. This keeps the passphrase out of process arguments and shell history:

```bash
export TEMPO_KEY_PASSPHRASE="..."
tempo node \
  --consensus.signing-key /path/to/key.enc \
  --consensus.key-passphrase-env TEMPO_KEY_PASSPHRASE \
  ...
```

When not set, behavior is identical to today (plaintext read).

## Changes

| File | What |
|---|---|
| `crates/commonware-node-config/src/encrypted.rs` | New module: `seal`, `open`, `is_encrypted`, file I/O helpers |
| `crates/commonware-node-config/src/lib.rs` | `read_maybe_encrypted` + `write_encrypted` on `SigningKey` and `SigningShare` |
| `crates/commonware-node/src/args.rs` | `--consensus.key-passphrase-env` flag + `resolve_passphrase()` |
| `crates/commonware-node/src/lib.rs` | Wire passphrase into signing share loading |
| Tests | 12 tests covering roundtrips, backward compat, wrong passphrase rejection, envelope format validation |

## Dependencies

`aes-gcm 0.10` and `pbkdf2 0.12` — both already present in the lockfile as transitive dependencies; no new crate trees introduced.

## Future work

- `tempo consensus encrypt-key` subcommand for offline migration of existing plaintext files
- Extend `ShareState` enum with an `Encrypted` variant for DKG share persistence (the placeholder is already in `dkg/manager/actor/state.rs`)

Closes #1713