### PR TITLE
chore: remove workspace-level reth feature from tempo-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,7 @@ tempo-payload-builder = { path = "crates/payload/builder", default-features = fa
 tempo-payload-types = { path = "crates/payload/types", default-features = false }
 tempo-precompiles = { path = "crates/precompiles", default-features = false }
 tempo-precompiles-macros = { path = "crates/precompiles-macros" }
-tempo-primitives = { path = "crates/primitives", default-features = false, features = [
-  "reth",
-] }
+tempo-primitives = { path = "crates/primitives", default-features = false }
 tempo-contracts = { path = "crates/contracts", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-contracts = { workspace = true, features = ["rpc"] }
-tempo-primitives = { workspace = true, features = ["serde"] }
+tempo-primitives = { workspace = true, features = ["serde", "reth"] }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
 

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -12,7 +12,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 
 reth-cli = { workspace = true, optional = true }
 reth-chainspec.workspace = true

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -15,7 +15,7 @@ tempo-alloy.workspace = true
 tempo-commonware-node-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-node.workspace = true
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true
 tempo-telemetry-util.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-chainspec.workspace = true
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 
 reth-chainspec.workspace = true
 reth-consensus.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -16,7 +16,7 @@ tempo-chainspec.workspace = true
 tempo-consensus.workspace = true
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-revm.workspace = true
 
 commonware-cryptography.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 tempo-chainspec.workspace = true
 tempo-consensus.workspace = true
 tempo-evm.workspace = true
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-transaction-pool.workspace = true
 tempo-payload-types.workspace = true
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-precompiles.workspace = true
-tempo-primitives.workspace = true
+tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 


### PR DESCRIPTION
Remove the implicit `reth` feature from the workspace-level `tempo-primitives` dependency definition. Instead, each crate that actually needs the reth feature now explicitly opts into it.

This is a prerequisite for publishing `tempo-alloy` to crates.io, since the workspace default was forcing reth git deps into crates that don't need them.

### Changes
- Root `Cargo.toml`: `tempo-primitives` no longer includes `features = ["reth"]`
- `tempo-alloy`, `tempo-chainspec`, `tempo-consensus`, `tempo-evm`, `tempo-revm`, `tempo-commonware-node`, `tempo-payload-builder`: explicitly add `features = ["reth"]` since they need it