### PR TITLE
fix(docs): remove defunct --disable-thread-pinning from bench README

### DIFF
--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -146,12 +146,6 @@ Run 15 second benchmark with 20k TPS:
 tempo-bench run-max-tps --duration 15 --tps 20000
 ```
 
-Run benchmark on MacOS:
-
-```bash
-tempo-bench run-max-tps --duration 15 --tps 20000 --disable-thread-pinning
-```
-
 Run benchmark with less workers than the default:
 
 ```bash


### PR DESCRIPTION
## Summary

The `--disable-thread-pinning` flag was removed from `tempo-bench` but the macOS example in the README still referenced it, causing a confusing error for anyone following the docs on macOS.

This removes the stale example. The benchmark now runs on macOS without any platform-specific flags.

Closes #1503