### PR TITLE
docs: add community tools section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ Start a `localnet`:
 just localnet
 ```
 
+## Community Tools
+
+| Tool | Description | Link |
+| ---- | ----------- | ---- |
+| **Tempo Monitor** | Real-time network monitoring dashboard for Moderato (block latency, TPS, gas, validators) | [tempo.hedgequantx.com](https://tempo.hedgequantx.com) |
+
+> Want to list a community tool here? Open a PR adding it to the table above.
+
 ## Contributing
 
 Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/tempo?tab=contributing-ov-file).


### PR DESCRIPTION
## Summary

- Adds a **Community Tools** section to the README for listing third-party tools built on the Tempo network
- Includes [Tempo Monitor](https://tempo.hedgequantx.com), a real-time network monitoring dashboard for the Moderato testnet
- Uses a table format so other community members can easily add their own tools via PR

## What is Tempo Monitor?

A lightweight, single-page dashboard that connects to the Moderato testnet via WebSocket and displays:

- **Block latency analytics** — percentile distribution (P5/P25/P50/P75/P95), stability scoring, waterfall view per block
- **Transaction throughput** — per-block TX count with burst detection and 3-block SMA
- **Gas utilization** — real-time gas usage with pressure zones and efficiency scoring
- **Validator status** — active/inactive counts, block production distribution, decentralization index

Built with Next.js, viem, and Recharts. Fully open source at [github.com/HedgeQuantX](https://github.com/HedgeQuantX).

## Why add a Community Tools section?

As the Tempo ecosystem grows, community-built tools will become increasingly valuable for operators and developers. Having a dedicated section in the README makes these tools discoverable and encourages further community contributions. The table format keeps it clean and extensible.