### PR TITLE
feat: update tip1004, remove smart account support

### DIFF
--- a/tips/tip-1004.md
+++ b/tips/tip-1004.md
@@ -179,7 +179,7 @@ The implementation must:
 5. Set `allowance[owner][spender] = value`
 6. Emit an `Approval(owner, spender, value)` event
 
-> **Note**: The nonce is included in the signed digest, so nonce verification is implicit in signature validation — if the wrong nonce was signed, `ecrecover` will return a different address. The nonce is incremented before signature validation (steps 3-4) rather than after. 
+> **Note**: The nonce is included in the signed digest, so nonce verification is implicit in signature validation — if the wrong nonce was signed, `ecrecover` will return a different address.
 
 ## New errors
 


### PR DESCRIPTION
updates TIP1004 Permit to remove smart account support. 

EIP-1271 call will no longer be performed if ecrecover fails and `owner` has code