### PR TITLE
test: orderbook invariants after drain

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -4461,4 +4461,203 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_orderbook_invariants_after_all_orders_filled() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            // Verify initial next_order_id is 1
+            assert_eq!(exchange.next_order_id()?, 1);
+
+            let alice = Address::random();
+            let bob = Address::random();
+            let admin = Address::random();
+            let amount = MIN_ORDER_AMOUNT;
+            let tick = 100i16;
+
+            let price = orderbook::tick_to_price(tick) as u128;
+            let quote_amount = (amount * price).div_ceil(orderbook::PRICE_SCALE as u128);
+
+            let base = TIP20Setup::create("BASE", "BASE", admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(amount * 4))
+                .with_mint(bob, U256::from(amount * 4))
+                .with_approval(alice, exchange.address, U256::MAX)
+                .with_approval(bob, exchange.address, U256::MAX)
+                .apply()?;
+            let base_token = base.address();
+            let quote_token = base.quote_token()?;
+
+            TIP20Setup::path_usd(admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(quote_amount * 4))
+                .with_mint(bob, U256::from(quote_amount * 4))
+                .with_approval(alice, exchange.address, U256::MAX)
+                .with_approval(bob, exchange.address, U256::MAX)
+                .apply()?;
+
+            let book_key = compute_book_key(base_token, quote_token);
+            exchange.create_pair(base_token)?;
+
+            // Place a bid and an ask
+            let bid_id = exchange.place(alice, base_token, amount, true, tick)?;
+            assert_eq!(bid_id, 1);
+            let ask_id = exchange.place(bob, base_token, amount, false, tick)?;
+            assert_eq!(ask_id, 2);
+
+            // Verify book has liquidity
+            let book = exchange.books[book_key].read()?;
+            assert_eq!(book.best_bid_tick, tick);
+            assert_eq!(book.best_ask_tick, tick);
+
+            // Fill the bid by selling base into it
+            exchange.swap_exact_amount_in(bob, base_token, quote_token, amount, 0)?;
+
+            // Fill the ask by buying base from it
+            exchange.swap_exact_amount_in(alice, quote_token, base_token, quote_amount, 0)?;
+
+            // Verify sentinel values are restored
+            let book = exchange.books[book_key].read()?;
+            assert_eq!(
+                book.best_bid_tick,
+                i16::MIN,
+                "best_bid_tick must be sentinel after all bids filled"
+            );
+            assert_eq!(
+                book.best_ask_tick,
+                i16::MAX,
+                "best_ask_tick must be sentinel after all asks filled"
+            );
+
+            // Verify tick levels are cleared
+            let bid_level = exchange.books[book_key]
+                .tick_level_handler(tick, true)
+                .read()?;
+            assert_eq!(bid_level.head, 0, "bid level head must be 0 after drain");
+            assert_eq!(bid_level.tail, 0, "bid level tail must be 0 after drain");
+            assert_eq!(
+                bid_level.total_liquidity, 0,
+                "bid level liquidity must be 0 after drain"
+            );
+
+            let ask_level = exchange.books[book_key]
+                .tick_level_handler(tick, false)
+                .read()?;
+            assert_eq!(ask_level.head, 0, "ask level head must be 0 after drain");
+            assert_eq!(ask_level.tail, 0, "ask level tail must be 0 after drain");
+            assert_eq!(
+                ask_level.total_liquidity, 0,
+                "ask level liquidity must be 0 after drain"
+            );
+
+            // Verify next_order_id is monotonic (never resets)
+            assert_eq!(
+                exchange.next_order_id()?,
+                3,
+                "next_order_id must remain monotonic after drain"
+            );
+
+            // Verify swaps against drained book return insufficient_liquidity
+            // Sell base into (empty) bids
+            let result = exchange.swap_exact_amount_in(bob, base_token, quote_token, amount, 0);
+            assert_eq!(
+                result,
+                Err(StablecoinDEXError::insufficient_liquidity().into()),
+                "swap against drained bid side must fail"
+            );
+            // Buy base from (empty) asks
+            let result =
+                exchange.swap_exact_amount_in(alice, quote_token, base_token, quote_amount, 0);
+            assert_eq!(
+                result,
+                Err(StablecoinDEXError::insufficient_liquidity().into()),
+                "swap against drained ask side must fail"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_orderbook_invariants_after_all_orders_cancelled() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+            let amount = MIN_ORDER_AMOUNT;
+            let tick = 100i16;
+
+            let price = orderbook::tick_to_price(tick) as u128;
+            let quote_amount = (amount * price).div_ceil(orderbook::PRICE_SCALE as u128);
+
+            let base = TIP20Setup::create("BASE", "BASE", admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(amount * 2))
+                .with_approval(alice, exchange.address, U256::MAX)
+                .apply()?;
+            let base_token = base.address();
+            let quote_token = base.quote_token()?;
+
+            TIP20Setup::path_usd(admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(quote_amount * 2))
+                .with_approval(alice, exchange.address, U256::MAX)
+                .apply()?;
+
+            let book_key = compute_book_key(base_token, quote_token);
+            exchange.create_pair(base_token)?;
+
+            // Place a bid and an ask
+            let bid_id = exchange.place(alice, base_token, amount, true, tick)?;
+            let ask_id = exchange.place(alice, base_token, amount, false, tick)?;
+
+            // Cancel both
+            exchange.cancel(alice, bid_id)?;
+            exchange.cancel(alice, ask_id)?;
+
+            // Verify sentinel values are restored
+            let book = exchange.books[book_key].read()?;
+            assert_eq!(
+                book.best_bid_tick,
+                i16::MIN,
+                "best_bid_tick must be sentinel after all bids cancelled"
+            );
+            assert_eq!(
+                book.best_ask_tick,
+                i16::MAX,
+                "best_ask_tick must be sentinel after all asks cancelled"
+            );
+
+            // Verify tick levels are cleared
+            let bid_level = exchange.books[book_key]
+                .tick_level_handler(tick, true)
+                .read()?;
+            assert_eq!(bid_level.head, 0, "bid level head must be 0");
+            assert_eq!(bid_level.tail, 0, "bid level tail must be 0");
+            assert_eq!(bid_level.total_liquidity, 0, "bid liquidity must be 0");
+
+            let ask_level = exchange.books[book_key]
+                .tick_level_handler(tick, false)
+                .read()?;
+            assert_eq!(ask_level.head, 0, "ask level head must be 0");
+            assert_eq!(ask_level.tail, 0, "ask level tail must be 0");
+            assert_eq!(ask_level.total_liquidity, 0, "ask liquidity must be 0");
+
+            // Verify swap against drained book fails
+            let result = exchange.swap_exact_amount_in(alice, base_token, quote_token, amount, 0);
+            assert_eq!(
+                result,
+                Err(StablecoinDEXError::insufficient_liquidity().into()),
+                "swap against cancelled book must fail"
+            );
+
+            Ok(())
+        })
+    }
 }


### PR DESCRIPTION
Add two tests verifying orderbook state after all orders are removed:

- `test_orderbook_invariants_after_all_orders_filled`: Places bid+ask, fills both via swaps, asserts sentinel ticks, zeroed tick levels, monotonic `next_order_id`, and swap rejection on empty book.
- `test_orderbook_invariants_after_all_orders_cancelled`: Places bid+ask, cancels both, asserts same invariants.