### PR TITLE
feat: sharpen tip-1020 standard

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -36,24 +36,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 interface ISignatureVerifier {
     error InvalidSignature();
 
-    /// @notice Verifies a stateless Tempo signature (secp256k1, P256, WebAuthn).
-    ///         Does NOT support Keychain signatures.
+    /// @notice Verifies a Tempo signature (secp256k1, P256, WebAuthn).
     /// @param signer The expected signer address
     /// @param hash The message hash that was signed
     /// @param signature The encoded signature (see Tempo Transaction spec for formats)
     /// @return True if valid, reverts otherwise
     function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
-
-    /// @notice Verifies any Tempo signature, including Keychain signatures.
-    ///         For stateless key types (secp256k1, P256, WebAuthn), behaves identically to `verify`.
-    ///         For Keychain signatures, additionally validates the access key against
-    ///         the AccountKeychain precompile (existence, revocation, expiry).
-    /// @param signer The expected signer address
-    /// @param hash The message hash that was signed
-    /// @param signature The encoded signature (see Tempo Transaction spec for formats)
-    /// @return result True if valid, reverts otherwise
-    /// @return keyId The keyId of the access key if it was used, otherwise `address(0)`
-    function verifyStateful(address signer, bytes32 hash, bytes calldata signature) external view returns (bool result, address keyId);
 }
 ```
 
@@ -66,26 +54,10 @@ Signatures MUST be encoded using the same format as [Tempo Transaction signature
 | secp256k1 | `r \|\| s \|\| v` | 65 bytes |
 | P256 | `0x01 \|\| r \|\| s \|\| x \|\| y \|\| prehash` | 130 bytes |
 | WebAuthn | `0x02 \|\| webauthn_data \|\| r \|\| s \|\| x \|\| y` | 129–2049 bytes |
-| Keychain | `0x03 \|\| user_address \|\| inner_signature` | variable |
 
 ### Verification Logic
 
 The precompile MUST use the same verification logic as Tempo transaction signature validation. See the [Tempo Transaction Signature Validation spec](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#signature-validation) for details.
-
-#### `verifyStateful` Implementation
-
-For stateless signature types (secp256k1, P256, WebAuthn), `verifyStateful` MUST behave identically to `verify`.
-
-For Keychain signatures (type prefix `0x03`), `verifyStateful` MUST perform the following steps:
-
-1. **Decode the Keychain signature** — strip the `0x03` prefix, extract the `user_address` (20 bytes) and the `inner_signature` (remaining bytes).
-2. **Verify the `signer` matches** — the `signer` parameter MUST equal the `user_address` extracted from the Keychain signature.
-3. **Derive the access key address** from the inner signature (the access key signs the inner signature).
-4. **Verify the inner signature** — validate that the inner signature is cryptographically valid for the given `hash`.
-5. **Validate the access key is authorized** — query the [AccountKeychain precompile](https://docs.tempo.xyz/protocol/transactions/AccountKeychain) (`0xaAAAaaAA00000000000000000000000000000000`) and check that:
-   - The key exists (i.e., `keyInfo.keyId != address(0)`)
-   - The key is not revoked (`keyInfo.isRevoked == false`)
-   - The key has not expired (`keyInfo.expiry > block.timestamp` or `keyInfo.expiry == type(uint64).max`)
 
 ### Gas Costs
 
@@ -96,9 +68,6 @@ The precompile MUST charge gas and verify sufficient gas is available **before**
 | secp256k1 | 3,000 |
 | P256 | 8,000 |
 | WebAuthn | 8,000 |
-| Keychain | Inner signature cost + State access cost for access key info |
-
-For Keychain signatures, the precompile MUST parse `inner_signature` to determine its type and associated cost. The inner signature cost is paid first, then the state access cost for the accessed slot in the AccountKeychain precompile in the `keys` map for that `signer` and `keyId`. Standard EVM warm/cold rules apply for this state access.
 
 **Note**: Gas costs are in-line with the [Tempo Transaction Signature Gas Schedule](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#signature-verification-gas-schedule). WebAuthn signatures do not incur additional calldata gas in the precompile since the caller pays for the additional size within the EVM via calldata or memory expansion costs.
 
@@ -125,27 +94,15 @@ For backwards compatibility, secp256k1 signatures are encoded as **65 bytes `r |
 
 ### Forward Compatibility
 
-It is expected that this precompile will be updated when other account types are introduced to maintain forward compatibility with Tempo accounts and Tempo access keys.
-
-## Security Considerations
-
-1. **Access Key Statefulness**: Developers should be mindful that the verification result is stateful and could change if an access key is revoked.
-2. **Access Key Scope**: `verifyStateful` confirms that an access key is authorized for an account (exists, not revoked, not expired), but does **not** enforce key-level permissions. Access keys may carry restricted scopes. Dapps that rely on `verifyStateful` SHOULD independently verify that the access key's permissions are sufficient for the requested operation, to avoid granting privileges the user did not intend to delegate.
-3. **Access Key Replay Across Accounts**: A single access key MAY be authorized on multiple accounts. Because `verifyStateful` accepts the `signer` (account) as a parameter and validates the keychain binding (invariant SV6), application-layer signatures (e.g., EIP-712 permits) verified via `verifyStateful` SHOULD include the account address in the signed digest. Without this, a valid access key signature produced for one account could be replayed against another account that has authorized the same key.
+It is expected that this precompile will be updated when other account types are introduced to maintain forward compatibility with Tempo accounts.
 
 ## Invariants
 
 | ID | Invariant | Description |
 |----|-----------|-------------|
 | **SV1** | Transaction-equivalent verification | For any signature type supported by a given function, the precompile MUST use the same cryptographic verification rules as Tempo transaction signature validation. |
-| **SV2** | Stateless/stateful equivalence | For stateless signature types (secp256k1, P256, WebAuthn), `verifyStateful(signer, hash, signature)` MUST behave identically to `verify(signer, hash, signature)` — same acceptance/rejection, same gas, same revert behavior. |
-| **SV3** | Keychain rejected by `verify` | `verify` MUST revert for keychain type signatures. |
-| **SV4** | Keychain outer binding | For Keychain signatures, `verifyStateful` MUST enforce that `signer` equals the `user_address` extracted from the Keychain signature wrapper. |
-| **SV5** | Keychain inner signature validity | For Keychain signatures, `verifyStateful` MUST verify the inner (access-key) signature cryptographically for the provided `hash` before consulting authorization state. |
-| **SV6** | Keychain authorization required | For Keychain signatures, `verifyStateful` MUST query the AccountKeychain precompile and require: (a) key exists (`keyId != address(0)`), (b) key is not revoked, (c) key has not expired. Any failure MUST revert. |
-| **SV7** | Keychain recursion prevention | The inner signature of a Keychain signature MUST NOT itself be a Keychain signature. Nested Keychain signatures MUST be rejected. |
-| **SV8** | P256 and ECDSA signature malleability resistance | P256 and ECDSA signatures MUST satisfy the low-s requirement (`s <= n/2`). Signatures with high-s values MUST be rejected. |
-| **SV9** | WebAuthn bounds enforcement | WebAuthn signature parsing MUST enforce the length bounds and structural validity checks used by Tempo transaction verification, preventing out-of-bounds reads and pathological resource usage. |
-| **SV10** | Revert on failure | On any invalid signature, invalid encoding, unsupported type, signer mismatch, or Keychain authorization failure, the precompile MUST revert. |
-| **SV11** | Gas schedule consistency | Gas charged MUST follow the Tempo Transaction Signature Gas Schedule. |
-| **SV12** | Signature type disambiguation | Exactly 65 bytes MUST be interpreted as secp256k1 (no prefix). Any non-65-byte signature MUST be interpreted using the leading type byte. Unknown type identifiers MUST revert. |
+| **SV2** | P256 and ECDSA signature malleability resistance | P256 and ECDSA signatures MUST satisfy the low-s requirement (`s <= n/2`). Signatures with high-s values MUST be rejected. |
+| **SV3** | WebAuthn bounds enforcement | WebAuthn signature parsing MUST enforce the length bounds and structural validity checks used by Tempo transaction verification, preventing out-of-bounds reads and pathological resource usage. |
+| **SV4** | Revert on failure | On any invalid signature, invalid encoding, unsupported type, or signer mismatch, the precompile MUST revert. |
+| **SV5** | Gas schedule consistency | Gas charged MUST follow the Tempo Transaction Signature Gas Schedule. |
+| **SV6** | Signature type disambiguation | Exactly 65 bytes MUST be interpreted as secp256k1 (no prefix). Any non-65-byte signature MUST be interpreted using the leading type byte. Unknown type identifiers MUST revert. |


### PR DESCRIPTION
I think a large reason to do this precompile is to allow smart contracts to forward compatibility with future Tempo account types

Changes:
1. Remove `verifyStateful` - this makes more sense as an addition in the access key precompile
2. Improved the gas model of the precompile and added clarification around cost
3. Improved invariants quality