### PR TITLE
feat(evm): make TempoReceiptBuilder public

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -53,7 +53,7 @@ pub(crate) enum BlockSection {
 /// Builder for [`TempoReceipt`].
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
-pub(crate) struct TempoReceiptBuilder;
+pub struct TempoReceiptBuilder;
 
 impl ReceiptBuilder for TempoReceiptBuilder {
     type Transaction = TempoTxEnvelope;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -9,6 +9,7 @@ use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
 mod block;
+pub use block::TempoReceiptBuilder;
 mod context;
 pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
 #[cfg(feature = "engine")]


### PR DESCRIPTION
Export `TempoReceiptBuilder` so downstream crates can reuse it instead of duplicating the receipt building logic.