### PR TITLE
pool: skip aa_2d_pool read lock in retain_unknown when announcement is empty

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -869,6 +869,9 @@ where
 
     fn retain_unknown<A: HandleMempoolData>(&self, announcement: &mut A) {
         self.protocol_pool.retain_unknown(announcement);
+        if announcement.is_empty() {
+            return;
+        }
         let aa_pool = self.aa_2d_pool.read();
         announcement.retain_by_hash(|tx| !aa_pool.contains(tx))
     }


### PR DESCRIPTION
After the protocol pool filters the announcement, if nothing remains there's no need to acquire the `aa_2d_pool` read lock and scan it. Avoids unnecessary lock contention on the p2p announcement hot path.