### PR TITLE
pool: include aa_2d_pool in get_pending_transactions_with_predicate

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -908,11 +908,18 @@ where
 
     fn get_pending_transactions_with_predicate(
         &self,
-        predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+        mut predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        // TODO: support 2d pool
-        self.protocol_pool
-            .get_pending_transactions_with_predicate(predicate)
+        let mut txs = self
+            .protocol_pool
+            .get_pending_transactions_with_predicate(&mut predicate);
+        txs.extend(
+            self.aa_2d_pool
+                .read()
+                .pending_transactions()
+                .filter(|tx| predicate(tx)),
+        );
+        txs
     }
 
     fn get_pending_transactions_by_sender(


### PR DESCRIPTION
Resolves the TODO — `get_pending_transactions_with_predicate` now includes pending transactions from the AA 2D pool, consistent with `get_pending_transactions_by_sender` and other `get_pending_*` methods.