### PR TITLE
fix: disable T2 hardfork by default in dev/devnet genesis

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -25,7 +25,7 @@
     "t1Time": 0,
     "t1aTime": 0,
     "t1bTime": 0,
-    "t2Time": 0
+    "t2Time": 4102444800
   },
   "nonce": "0x42",
   "timestamp": "0x0",

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -513,11 +513,11 @@ mod tests {
             TempoHardfork::Genesis
         );
 
-        // Dev chainspec should return T2 (all hardforks active at 0)
+        // Dev chainspec should return T1B at timestamp 0 (T2 is far future)
         let dev_chainspec = super::TempoChainSpecParser::parse("dev")
             .expect("the dev chainspec must always be well formed");
-        assert_eq!(dev_chainspec.tempo_hardfork_at(0), TempoHardfork::T2);
-        assert_eq!(dev_chainspec.tempo_hardfork_at(1000), TempoHardfork::T2);
+        assert_eq!(dev_chainspec.tempo_hardfork_at(0), TempoHardfork::T1B);
+        assert_eq!(dev_chainspec.tempo_hardfork_at(1000), TempoHardfork::T1B);
     }
 
     #[test]

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -163,8 +163,9 @@ pub(crate) struct GenesisArgs {
     #[arg(long, default_value = "0")]
     t1b_time: u64,
 
-    /// T2 hardfork activation time.
-    #[arg(long, default_value = "0")]
+    /// T2 hardfork activation time. Defaults to far future (disabled).
+    /// Set to 0 to enable at genesis.
+    #[arg(long, default_value = "4102444800")]
     t2_time: u64,
 
     /// Whether to skip initializing validator config v1


### PR DESCRIPTION
## Summary

Disables T2 hardfork by default in dev mode and devnet genesis generation, so nightly devnets are on par with testnet.

## Motivation

T2 was enabled at genesis (`t2Time=0`) in `dev.json` and as the default for `cargo x generate-devnet`. This caused T2 to be active on nightly devnets even though there's no T2 timestamp for testnet/mainnet yet. Testing T1A/T1B changes on devnets with T2 accidentally enabled can cause confusion.

## Changes

- `crates/chainspec/src/genesis/dev.json`: Set `t2Time` to `4102444800` (2100-01-01)
- `xtask/src/genesis_args.rs`: Change `--t2-time` default from `0` to `4102444800`
- `crates/chainspec/src/spec.rs`: Update dev chainspec test to expect T1B at genesis

To explicitly enable T2 on a devnet, pass `--t2-time 0`.

## Testing

`cargo test -p tempo-chainspec` — all 15 tests pass.

Prompted by: kuyziss