### PR TITLE
feat: lower default time-to-build-proposal from 500ms to 200ms

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -101,7 +101,7 @@ pub struct Args {
     /// This value should be well below `consensus.wait-for-proposal` to account
     /// for the leader to enter the view, build and broadcast the proposal, and
     /// have the other peers receive the proposal.
-    #[arg(long = "consensus.time-to-build-proposal", default_value = "500ms")]
+    #[arg(long = "consensus.time-to-build-proposal", default_value = "200ms")]
     pub time_to_build_proposal: PositiveDuration,
 
     /// The amount of time this node will use to construct a subblock before


### PR DESCRIPTION
Lower the default `--consensus.time-to-build-proposal` from 500ms to 200ms.

Steady <1s block time, can fit 9-10k transactions into a block.

<img width="2171" height="347" alt="image" src="https://github.com/user-attachments/assets/24822592-94ae-4962-9621-8c439ac346f9" />

Prompted by: alexey