### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ just localnet
 
 ## Contributing
 
-Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/tempo?tab=contributing-ov-file).
+Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/tempo?tab=contributing.md).
 
 ## Security
 


### PR DESCRIPTION
Hi! 👋

I noticed a small typo in the README and wanted to fix it.

**Change:** Typo in 'ov-file'

Hope this helps! 🚀