### PR TITLE
fix(docs): correct U256 token amount

### DIFF
--- a/crates/alloy/README.md
+++ b/crates/alloy/README.md
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receipt = token 
         .transfer( 
             address!("0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb"), 
-            U256::from(100).pow(U256::from(10e6)), // 100 tokens (6 decimals) 
+            U256::from(100_000_000), // 100 tokens (6 decimals) 
         ) 
         .send() 
         .await?


### PR DESCRIPTION
Replace incorrect `U256::from(100).pow(U256::from(10e6))` with `U256::from(100_000_000)` in `tempo/crates/alloy/README.md` to correctly represent 100 tokens (6 decimals). 

Verified:
- Using `U256::from (100).pow(U256::from(100_000_000))` results in an extremely large value or a compilation problem.
- The expression is correct and also matches the working examples in:
  - `examples/transfer.rs`
  - `examples/transfer_with_memo.rs`