### PR TITLE
perf: bump MAX_PENDING_UPDATES to 200

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "yk/bump-pending-updates-200" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }


### PR DESCRIPTION
## Summary
Bumps `MAX_PENDING_UPDATES` in reth-engine-tree sparse trie from 100 to 200 to test if accumulating more updates before applying improves state root computation throughput.

## Changes
- Points `reth-engine-tree` dep to `yk/bump-pending-updates-200` branch on paradigmxyz/reth
- That branch changes `MAX_PENDING_UPDATES` from 100 → 200 in `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`

## Testing
Submitting to reth-bench for comparison.

Prompted by: yk