### PR TITLE
perf: reduce MAX_PENDING_UPDATES to 10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "yk/pending-updates-10" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }


### PR DESCRIPTION
## Summary
Reduces `MAX_PENDING_UPDATES` in reth-engine-tree sparse trie from 100 to 10 to test if flushing more frequently improves state root computation.

## Changes
- Points `reth-engine-tree` dep to `yk/pending-updates-10` branch on paradigmxyz/reth
- That branch changes `MAX_PENDING_UPDATES` from 100 → 10 in `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`

## Testing
Submitting to reth-bench for comparison.

Prompted by: yk