### PR TITLE
refactor(bench): real-time tx generation with bounded buffer

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -483,10 +483,6 @@ impl MaxTpsArgs {
             swaps = counters.swaps.load(Ordering::Relaxed),
             orders = counters.orders.load(Ordering::Relaxed),
             erc20_transfers = counters.erc20_transfers.load(Ordering::Relaxed),
-            "Generated transactions",
-        );
-
-        info!(
             success = counters.success.load(Ordering::Relaxed),
             failed = counters.failed.load(Ordering::Relaxed),
             "Finished sending transactions"


### PR DESCRIPTION
## Summary

Refactor the bench tool's expiring nonce transaction pipeline from batch-based generation to real-time, continuous generation with a small bounded buffer. This fixes `'valid_before' too close to current time` errors by keeping transaction timestamps fresh.

### Problem

Transactions were pre-signed in large batches, then queued for sending. The gap between signing and sending could exceed the 25s nonce expiry window.

### Solution

- Producer task continuously generates, signs, and encodes one transaction at a time
- Bounded channel (size = TPS) provides backpressure
- `valid_before` is set immediately before signing, keeping it fresh
- Consumer drains channel with rate limiting and concurrent sending

## Performance

I benchmarked on the fly tx generation + signing speed locally and it goes up to 700k txs/s, so it will not be a bottleneck for whatever TPS we're benchmarking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)