### PR TITLE
fix(subblocks): downgrade invalid subblock parent log to debug

### DIFF
--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -403,11 +403,14 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
         };
 
         // Skip subblocks that are not built on top of the tip.
-        eyre::ensure!(
-            subblock.parent_hash == tip,
-            "invalid subblock parent, expected {tip}, got {}",
-            subblock.parent_hash
-        );
+        if subblock.parent_hash != tip {
+            debug!(
+                expected = %tip,
+                got = %subblock.parent_hash,
+                "invalid subblock parent, not expected"
+            );
+            return Ok(());
+        }
 
         // Send acknowledgement to the sender.
         //


### PR DESCRIPTION
## Summary
Downgrades the "invalid subblock parent, not expected" message from WARN to DEBUG.

## Motivation
This fires frequently during normal operation when a validator's view of the tip temporarily diverges from the subblock sender's. The subblock is simply skipped and re-sent — it's not actionable as a warning and creates log noise.

## Changes
- Replaced `eyre::ensure!` (which returned an error logged at WARN via `#[instrument(err(level = Level::WARN))]`) with a `debug!` log + early return in `on_network_message`
- Other actual errors in that function (decode failure, missing tip) still surface at WARN

## Testing
`cargo clippy -p tempo-commonware-node` — clean
`cargo fmt --all --check` — clean

Prompted by: zygis