### PR TITLE
fix: avoid re-walking epochs when generating transition proofs

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -321,6 +321,7 @@ where
             context.with_label("feed"),
             marshal_mailbox.clone(),
             epoch_strategy.clone(),
+            execution_node.clone(),
             self.feed_state,
         );
 

--- a/crates/commonware-node/src/feed/actor.rs
+++ b/crates/commonware-node/src/feed/actor.rs
@@ -22,6 +22,7 @@ use tracing::{info, info_span, instrument};
 
 use super::state::FeedStateHandle;
 use crate::{alias::marshal, consensus::Digest};
+use tempo_node::TempoFullNode;
 
 /// Type alias for the activity type used by the feed actor.
 pub(super) type FeedActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
@@ -48,11 +49,13 @@ impl<TContext: Spawner> Actor<TContext> {
         context: TContext,
         marshal: marshal::Mailbox,
         epocher: FixedEpocher,
+        execution_node: TempoFullNode,
         receiver: Receiver,
         state: FeedStateHandle,
     ) -> Self {
         state.set_marshal(marshal.clone());
         state.set_epocher(epocher);
+        state.set_execution_node(execution_node);
 
         Self {
             context: ContextCell::new(context),

--- a/crates/commonware-node/src/feed/mod.rs
+++ b/crates/commonware-node/src/feed/mod.rs
@@ -14,6 +14,7 @@ mod state;
 use commonware_consensus::types::FixedEpocher;
 use commonware_runtime::Spawner;
 use futures::channel::mpsc;
+use tempo_node::TempoFullNode;
 
 use crate::alias::marshal;
 pub(crate) use actor::Actor;
@@ -25,10 +26,11 @@ pub(crate) fn init<TContext: Spawner>(
     context: TContext,
     marshal: marshal::Mailbox,
     epocher: FixedEpocher,
+    execution_node: TempoFullNode,
     state: FeedStateHandle,
 ) -> (Actor<TContext>, Mailbox) {
     let (tx, rx) = mpsc::unbounded();
     let mailbox = Mailbox::new(tx);
-    let actor = Actor::new(context, marshal, epocher, rx, state);
+    let actor = Actor::new(context, marshal, epocher, execution_node, rx, state);
     (actor, mailbox)
 }

--- a/crates/commonware-node/src/feed/state.rs
+++ b/crates/commonware-node/src/feed/state.rs
@@ -9,16 +9,22 @@ use commonware_consensus::{
     marshal::ingress::mailbox::Identifier,
     types::{Epoch, Epocher as _, FixedEpocher, Height},
 };
+use commonware_cryptography::bls12381::primitives::variant::{MinSig, Variant};
 use parking_lot::RwLock;
+use reth_provider::HeaderProvider as _;
 use reth_rpc_convert::transaction::FromConsensusHeader;
 use std::sync::{Arc, OnceLock};
 use tempo_alloy::rpc::TempoHeaderResponse;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
-use tempo_node::rpc::consensus::{
-    CertifiedBlock, ConsensusFeed, ConsensusState, Event, IdentityProofError, IdentityTransition,
-    IdentityTransitionResponse, Query, TransitionProofData,
+use tempo_node::{
+    TempoFullNode,
+    rpc::consensus::{
+        CertifiedBlock, ConsensusFeed, ConsensusState, Event, IdentityProofError,
+        IdentityTransition, IdentityTransitionResponse, Query, TransitionProofData,
+    },
 };
 use tokio::sync::broadcast;
+use tracing::instrument;
 
 const BROADCAST_CHANNEL_SIZE: usize = 1024;
 
@@ -56,6 +62,7 @@ pub struct FeedStateHandle {
     state: Arc<RwLock<FeedState>>,
     marshal: Arc<OnceLock<marshal::Mailbox>>,
     epocher: Arc<OnceLock<FixedEpocher>>,
+    execution_node: Arc<OnceLock<TempoFullNode>>,
     events_tx: broadcast::Sender<Event>,
     /// Cache for identity transition proofs to avoid re-walking the chain.
     identity_cache: Arc<RwLock<Option<IdentityTransitionCache>>>,
@@ -75,6 +82,7 @@ impl FeedStateHandle {
             })),
             marshal: Arc::new(OnceLock::new()),
             epocher: Arc::new(OnceLock::new()),
+            execution_node: Arc::new(OnceLock::new()),
             events_tx,
             identity_cache: Arc::new(RwLock::new(None)),
         }
@@ -88,6 +96,11 @@ impl FeedStateHandle {
     /// Set the epocher for epoch boundary calculations. Should only be called once.
     pub(crate) fn set_epocher(&self, epocher: FixedEpocher) {
         let _ = self.epocher.set(epocher);
+    }
+
+    /// Set the execution node for header lookups. Should only be called once.
+    pub(crate) fn set_execution_node(&self, execution_node: TempoFullNode) {
+        let _ = self.execution_node.set(execution_node);
     }
 
     /// Get the broadcast sender for events.
@@ -130,49 +143,163 @@ impl FeedStateHandle {
         }
     }
 
-    /// Serve identity transition proof from cache, returning a subsection if needed.
-    fn serve_from_cache(
+    /// Ensure the identity cache covers `start_epoch` by walking backwards
+    /// if needed. After this returns, the cache is guaranteed to contain
+    /// transition data covering `start_epoch` (as far back as available data allows).
+    #[instrument(skip_all, fields(start_epoch), err)]
+    async fn try_fill_transitions(
         &self,
-        cache: &IdentityTransitionCache,
+        marshal: &mut marshal::Mailbox,
+        execution: &TempoFullNode,
+        epocher: &FixedEpocher,
         start_epoch: u64,
-        full: bool,
-    ) -> IdentityTransitionResponse {
-        // Filter transitions to only include those at or before start_epoch
-        let transitions: Vec<_> = cache
-            .transitions
-            .iter()
-            .filter(|t| t.transition_epoch <= start_epoch)
-            .cloned()
-            .collect();
-
-        // Determine identity at start_epoch:
-        // - If start_epoch == from_epoch, use cached identity
-        // - Otherwise, find the first transition AFTER start_epoch and use its old_identity
-        //   (that was the identity at start_epoch before that transition happened)
-        // - If no transition after start_epoch, identity hasn't changed since from_epoch
-        let identity = if start_epoch == cache.from_epoch {
-            cache.identity.clone()
-        } else {
-            // Find first transition that happened AFTER start_epoch
-            cache
-                .transitions
-                .iter()
-                .find(|t| t.transition_epoch > start_epoch)
-                .map(|t| t.old_identity.clone())
-                .unwrap_or_else(|| cache.identity.clone())
-        };
-
-        // If not full, only return the most recent transition
-        let transitions = if full {
-            transitions
-        } else {
-            transitions.into_iter().take(1).collect()
-        };
-
-        IdentityTransitionResponse {
-            identity,
-            transitions,
+    ) -> Result<(), IdentityProofError> {
+        // Check if the cache already covers this epoch
+        let cached = self.identity_cache.read().clone();
+        if let Some(cache) = &cached
+            && (cache.to_epoch..=cache.from_epoch).contains(&start_epoch)
+        {
+            return Ok(());
         }
+
+        // Identity active at epoch N is set by the last block of epoch N-1
+        let epoch_outcome = get_outcome(execution, epocher, start_epoch.saturating_sub(1))?;
+        let epoch_pubkey = *epoch_outcome.sharing().public();
+
+        // Fast path: if the identity matches the cached one, no new transitions
+        if let Some(cache) = &cached
+            && start_epoch > cache.from_epoch
+        {
+            let cache_pubkey_bytes = hex::decode(&cache.identity)
+                .map_err(|_| IdentityProofError::MalformedData(cache.from_epoch))?;
+            let cache_pubkey =
+                <MinSig as Variant>::Public::read(&mut cache_pubkey_bytes.as_slice())
+                    .map_err(|_| IdentityProofError::MalformedData(cache.from_epoch))?;
+
+            if cache_pubkey == epoch_pubkey {
+                let mut updated = cache.clone();
+                updated.from_epoch = start_epoch;
+
+                *self.identity_cache.write() = Some(updated);
+                return Ok(());
+            }
+        }
+
+        // Walk backwards to find all identity transitions
+        let mut transitions = Vec::new();
+        let mut pubkey = epoch_pubkey;
+        let mut search_epoch = start_epoch.saturating_sub(1);
+        while search_epoch > 0 {
+            // Absorb cached transitions and stop.
+            if let Some(cache) = &cached
+                && search_epoch <= cache.from_epoch
+            {
+                transitions.extend(cache.transitions.iter().cloned());
+                search_epoch = cache.to_epoch;
+                // We dont continue downwards past to_epoch since the walk only stops if
+                // DKG parsing fails (Internal Error state) or data is unavailable (Pruned).
+                // Both which are not recoverable in the current runtime.
+                break;
+            }
+
+            let prev_outcome = get_outcome(execution, epocher, search_epoch - 1)?;
+            let prev_pubkey = *prev_outcome.sharing().public();
+
+            // If keys differ, there was a full DKG at search_epoch
+            if pubkey != prev_pubkey {
+                let height = epocher
+                    .last(Epoch::new(search_epoch))
+                    .expect("fixed epocher is valid for all epochs");
+
+                let Some(header) = execution
+                    .provider
+                    .sealed_header(height.get())
+                    .ok()
+                    .flatten()
+                else {
+                    tracing::info!(
+                        height = height.get(),
+                        search_epoch,
+                        "stopping identity transition walk early (header not available)"
+                    );
+                    break;
+                };
+
+                let Some(finalization) = marshal.get_finalization(height).await else {
+                    tracing::info!(
+                        height = height.get(),
+                        search_epoch,
+                        "stopping identity transition walk early (finalization pruned)"
+                    );
+                    break;
+                };
+
+                transitions.push(IdentityTransition {
+                    transition_epoch: search_epoch,
+                    old_identity: hex::encode(prev_pubkey.encode()),
+                    new_identity: hex::encode(pubkey.encode()),
+                    proof: Some(TransitionProofData {
+                        header: TempoHeaderResponse::from_consensus_header(header, 0),
+                        finalization_certificate: hex::encode(finalization.encode()),
+                    }),
+                });
+            }
+
+            pubkey = prev_pubkey;
+            search_epoch -= 1;
+        }
+
+        // Append genesis identity as terminal marker when we reached it.
+        if search_epoch == 0 {
+            let has_genesis = transitions
+                .last()
+                .is_some_and(|t| t.transition_epoch == 0 && t.proof.is_none());
+
+            if !has_genesis {
+                match get_outcome(execution, epocher, 0) {
+                    Ok(genesis_outcome) => {
+                        let genesis_pubkey = *genesis_outcome.sharing().public();
+                        let genesis_identity = hex::encode(genesis_pubkey.encode());
+                        transitions.push(IdentityTransition {
+                            transition_epoch: 0,
+                            old_identity: genesis_identity.clone(),
+                            new_identity: genesis_identity,
+                            proof: None,
+                        });
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            ?err,
+                            "failed to fetch genesis outcome; omitting genesis marker"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Build updated cache. The walk absorbs cached transitions in the correct order
+        let new_cache = if let Some(c) = &cached {
+            IdentityTransitionCache {
+                from_epoch: start_epoch.max(c.from_epoch),
+                to_epoch: search_epoch.min(c.to_epoch),
+                transitions: Arc::new(transitions),
+                identity: if start_epoch >= c.from_epoch {
+                    hex::encode(epoch_pubkey.encode())
+                } else {
+                    c.identity.clone()
+                },
+            }
+        } else {
+            IdentityTransitionCache {
+                from_epoch: start_epoch,
+                to_epoch: search_epoch,
+                identity: hex::encode(epoch_pubkey.encode()),
+                transitions: Arc::new(transitions),
+            }
+        };
+
+        *self.identity_cache.write() = Some(new_cache);
+        Ok(())
     }
 }
 
@@ -189,6 +316,7 @@ impl std::fmt::Debug for FeedStateHandle {
             .field("latest_notarized", &state.latest_notarized)
             .field("latest_finalized", &state.latest_finalized)
             .field("marshal_set", &self.marshal.get().is_some())
+            .field("execution_node_set", &self.execution_node.get().is_some())
             .field("subscriber_count", &self.events_tx.receiver_count())
             .finish()
     }
@@ -248,6 +376,9 @@ impl ConsensusFeed for FeedStateHandle {
         let Some((mut marshal, epocher)) = self.marshal().zip(self.epocher()) else {
             return Err(IdentityProofError::NotReady);
         };
+        let Some(execution_node) = self.execution_node.get() else {
+            return Err(IdentityProofError::NotReady);
+        };
 
         // Determine starting epoch (from param, or latest finalized)
         let start_epoch = if let Some(epoch) = from_epoch {
@@ -262,189 +393,45 @@ impl ConsensusFeed for FeedStateHandle {
                 .get()
         };
 
-        // Check if we can serve from cache
-        let cached = self.identity_cache.read().clone();
-        if let Some(ref cache) = cached {
-            // Requested epoch is within cached range - return subsection
-            if start_epoch <= cache.from_epoch && start_epoch >= cache.to_epoch {
-                return Ok(self.serve_from_cache(cache, start_epoch, full));
-            }
-        }
+        // Ensure cached transitions are up to date
+        self.try_fill_transitions(&mut marshal, execution_node, &epocher, start_epoch)
+            .await?;
 
-        // Identity active at epoch N is set by the last block of epoch N-1
-        // (epoch 0 uses its own last block - genesis identity)
-        let identity_outcome =
-            get_outcome(&mut marshal, &epocher, start_epoch.saturating_sub(1)).await?;
-        let mut curr_pubkey = *identity_outcome.sharing().public();
-        let identity = hex::encode(curr_pubkey.encode());
+        let cache = self
+            .identity_cache
+            .read()
+            .clone()
+            .ok_or(IdentityProofError::NotReady)?;
 
-        let mut transitions = Vec::new();
+        // Filter transitions to only include those at or before start_epoch
+        let transitions: Vec<_> = cache
+            .transitions
+            .iter()
+            .filter(|t| t.transition_epoch <= start_epoch)
+            .cloned()
+            .collect();
 
-        // Walk backwards comparing public keys to detect full DKG transitions.
-        // On errors, we return what we've collected so far rather than failing entirely.
-        let mut search_epoch = start_epoch.saturating_sub(1);
-        let mut reached_genesis = start_epoch == 0;
+        // Determine identity at start_epoch by finding the closest transition
+        // AFTER start_epoch and using its old_identity (the key before that change).
+        // Transitions are newest-to-oldest, so the last match is the closest.
+        let identity = cache
+            .transitions
+            .iter()
+            .filter(|t| t.transition_epoch > start_epoch)
+            .last()
+            .map(|t| t.old_identity.clone())
+            .unwrap_or_else(|| cache.identity.clone());
 
-        // If we have a cache, try to connect to it instead of walking all the way
-        let cache_connect_epoch = cached.as_ref().map(|c| c.from_epoch);
-
-        while search_epoch > 0 {
-            // Check if we can connect to cached data
-            if let Some(connect_epoch) = cache_connect_epoch
-                && search_epoch <= connect_epoch
-                && let Some(ref cache) = cached
-            {
-                // Append cached transitions and stop walking
-                transitions.extend(cache.transitions.iter().cloned());
-                search_epoch = cache.to_epoch;
-                reached_genesis = cache.to_epoch == 0;
-                break;
-            }
-
-            let prev_outcome = match get_outcome(&mut marshal, &epocher, search_epoch - 1).await {
-                Ok(o) => o,
-                Err(err) => {
-                    tracing::info!(
-                        ?err,
-                        start_epoch,
-                        search_epoch,
-                        "stopping identity transition walk early (failed to fetch previous outcome)"
-                    );
-                    break;
-                }
-            };
-            let prev_pubkey = *prev_outcome.sharing().public();
-
-            // If keys differ, there was a full DKG at search_epoch
-            if curr_pubkey != prev_pubkey {
-                // Fetch the block and certificate that committed the new identity
-                let proof_height = epocher
-                    .last(Epoch::new(search_epoch))
-                    .expect("fixed epocher is valid for all epochs");
-
-                let Some(proof_block) = marshal.get_block(proof_height).await else {
-                    tracing::info!(
-                        height = proof_height.get(),
-                        start_epoch,
-                        search_epoch,
-                        "stopping identity transition walk early (proof block pruned)"
-                    );
-                    break;
-                };
-
-                let Some(finalization) = marshal.get_finalization(proof_height).await else {
-                    tracing::info!(
-                        height = proof_height.get(),
-                        start_epoch,
-                        search_epoch,
-                        "stopping identity transition walk early (finalization pruned)"
-                    );
-                    break;
-                };
-
-                transitions.push(IdentityTransition {
-                    transition_epoch: search_epoch,
-                    old_identity: hex::encode(prev_pubkey.encode()),
-                    new_identity: hex::encode(curr_pubkey.encode()),
-                    proof: Some(TransitionProofData {
-                        header: TempoHeaderResponse::from_consensus_header(
-                            proof_block.clone_sealed_header(),
-                            0,
-                        ),
-                        finalization_certificate: hex::encode(finalization.encode()),
-                    }),
-                });
-
-                if !full {
-                    break;
-                }
-            }
-
-            curr_pubkey = prev_pubkey;
-            search_epoch -= 1;
-        }
-
-        // If we walked all the way to epoch 0, we reached genesis
-        if full && search_epoch == 0 {
-            reached_genesis = true;
-        }
-
-        // Include genesis identity as explicit terminal marker when we reached it.
-        // There is never a finalization certificate for genesis, so proof is None.
-        if full && reached_genesis {
-            // Only add genesis marker if not already present from cache
-            let has_genesis = transitions
-                .last()
-                .is_some_and(|t| t.transition_epoch == 0 && t.proof.is_none());
-            if !has_genesis {
-                match get_outcome(&mut marshal, &epocher, 0).await {
-                    Ok(genesis_outcome) => {
-                        let genesis_pubkey = *genesis_outcome.sharing().public();
-                        let genesis_identity = hex::encode(genesis_pubkey.encode());
-                        transitions.push(IdentityTransition {
-                            transition_epoch: 0,
-                            old_identity: genesis_identity.clone(),
-                            new_identity: genesis_identity,
-                            proof: None,
-                        });
-                    }
-                    Err(err) => {
-                        tracing::debug!(
-                            ?err,
-                            "failed to fetch genesis outcome; omitting genesis marker"
-                        );
-                    }
-                }
-            }
-        }
-
-        // Update cache if this is a full query and we made progress
-        if full {
-            let new_cache = IdentityTransitionCache {
-                from_epoch: start_epoch,
-                to_epoch: search_epoch,
-                identity: identity.clone(),
-                transitions: Arc::new(transitions.clone()),
-            };
-            // Only update if this extends the cache (newer start OR older end)
-            let should_update = cached
-                .as_ref()
-                .map(|c| start_epoch > c.from_epoch || search_epoch < c.to_epoch)
-                .unwrap_or(true);
-            // Merge with existing cache if we're extending
-            let new_cache = if let Some(ref c) = cached {
-                IdentityTransitionCache {
-                    from_epoch: start_epoch.max(c.from_epoch),
-                    to_epoch: search_epoch.min(c.to_epoch),
-                    identity: if start_epoch >= c.from_epoch {
-                        identity.clone()
-                    } else {
-                        c.identity.clone()
-                    },
-                    transitions: if start_epoch > c.from_epoch {
-                        // Merge: new transitions + cached (deduplicated)
-                        let mut merged = transitions.clone();
-                        for t in c.transitions.iter() {
-                            if !merged
-                                .iter()
-                                .any(|m| m.transition_epoch == t.transition_epoch)
-                            {
-                                merged.push(t.clone());
-                            }
-                        }
-                        merged.sort_by_key(|t| std::cmp::Reverse(t.transition_epoch));
-                        Arc::new(merged)
-                    } else {
-                        Arc::new(transitions.clone())
-                    },
-                }
-            } else {
-                new_cache
-            };
-            if should_update {
-                *self.identity_cache.write() = Some(new_cache);
-            }
-        }
+        // If not full, only return the most recent real transition (exclude genesis marker)
+        let transitions = if full {
+            transitions
+        } else {
+            transitions
+                .into_iter()
+                .filter(|t| t.transition_epoch > 0)
+                .take(1)
+                .collect()
+        };
 
         Ok(IdentityTransitionResponse {
             identity,
@@ -454,18 +441,20 @@ impl ConsensusFeed for FeedStateHandle {
 }
 
 /// Fetch last block of epoch and decode DKG outcome.
-async fn get_outcome(
-    marshal: &mut marshal::Mailbox,
+fn get_outcome(
+    execution: &TempoFullNode,
     epocher: &FixedEpocher,
     epoch: u64,
 ) -> Result<OnchainDkgOutcome, IdentityProofError> {
     let height = epocher
         .last(Epoch::new(epoch))
         .expect("fixed epocher is valid for all epochs");
-    let block = marshal
-        .get_block(height)
-        .await
+    let header = execution
+        .provider
+        .header_by_number(height.get())
+        .ok()
+        .flatten()
         .ok_or(IdentityProofError::PrunedData(height.get()))?;
-    OnchainDkgOutcome::read(&mut block.header().extra_data().as_ref())
+    OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
         .map_err(|_| IdentityProofError::MalformedData(height.get()))
 }

--- a/crates/e2e/src/tests/consensus_rpc.rs
+++ b/crates/e2e/src/tests/consensus_rpc.rs
@@ -140,19 +140,22 @@ async fn wait_for_height(context: &Context, target_height: u64) {
     }
 }
 
-/// Test that `get_identity_transition_proof` returns valid proofs after a full DKG ceremony.
+/// Test that `get_identity_transition_proof` returns valid proofs after two full DKG ceremonies.
 ///
 /// This verifies:
-/// 1. After a full DKG, the RPC returns a transition with different old/new public keys
-/// 2. The transition epoch matches where the full DKG occurred
-/// 3. The proof contains a valid header and certificate
+/// 1. After two full DKGs, `full=true` returns both transitions plus genesis marker
+/// 2. `full=false` returns only the most recent transition
+/// 3. Transition epochs, identities, and proofs are correct
+/// 4. Repeated calls return consistent results (cache correctness)
+/// 5. Querying from epoch 0 returns no transitions
 #[test_traced]
 fn get_identity_transition_proof_after_full_dkg() {
     let _ = tempo_eyre::install();
 
     let how_many_signers = 1;
     let epoch_length = 10;
-    let full_dkg_epoch: u64 = 1;
+    let first_full_dkg_epoch: u64 = 1;
+    let second_full_dkg_epoch: u64 = 3;
 
     let setup = Setup::new()
         .how_many_signers(how_many_signers)
@@ -176,39 +179,69 @@ fn get_identity_transition_proof_after_full_dkg() {
             .parse()
             .unwrap();
 
-        // Schedule full DKG for epoch 1
+        // --- First full DKG ---
         execution_runtime
-            .set_next_full_dkg_ceremony(http_url.clone(), full_dkg_epoch)
+            .set_next_full_dkg_ceremony(http_url.clone(), first_full_dkg_epoch)
             .await
             .unwrap();
 
-        // Wait for is_next_full_dkg flag
-        let outcome_before =
-            wait_for_outcome(&context, &validators, full_dkg_epoch - 1, epoch_length).await;
+        let outcome_before = wait_for_outcome(
+            &context,
+            &validators,
+            first_full_dkg_epoch - 1,
+            epoch_length,
+        )
+        .await;
         assert!(
             outcome_before.is_next_full_dkg,
             "Epoch {} outcome should have is_next_full_dkg=true",
-            full_dkg_epoch - 1
+            first_full_dkg_epoch - 1
         );
-        let pubkey_before = *outcome_before.sharing().public();
 
-        // Wait for full DKG to complete
-        wait_for_epoch(&context, full_dkg_epoch + 1, how_many_signers).await;
+        wait_for_epoch(&context, first_full_dkg_epoch + 1, how_many_signers).await;
         assert_no_dkg_failures(&context);
 
-        // Verify the full DKG created a new public key
-        let outcome_after =
-            wait_for_outcome(&context, &validators, full_dkg_epoch, epoch_length).await;
-        let pubkey_after = *outcome_after.sharing().public();
+        let outcome_after_first =
+            wait_for_outcome(&context, &validators, first_full_dkg_epoch, epoch_length).await;
         assert_ne!(
-            pubkey_before, pubkey_after,
-            "Full DKG must produce a DIFFERENT group public key"
+            outcome_before.sharing().public(),
+            outcome_after_first.sharing().public(),
+            "First full DKG must produce a different group public key"
         );
 
-        // Test 1: Query from latest epoch (after full DKG) - should have transition
-        // Run on execution runtime's tokio runtime since jsonrpsee requires tokio
+        // --- Second full DKG ---
+        execution_runtime
+            .set_next_full_dkg_ceremony(http_url.clone(), second_full_dkg_epoch)
+            .await
+            .unwrap();
+
+        let outcome_before_second = wait_for_outcome(
+            &context,
+            &validators,
+            second_full_dkg_epoch - 1,
+            epoch_length,
+        )
+        .await;
+        assert!(
+            outcome_before_second.is_next_full_dkg,
+            "Epoch {} outcome should have is_next_full_dkg=true",
+            second_full_dkg_epoch - 1
+        );
+
+        wait_for_epoch(&context, second_full_dkg_epoch + 1, how_many_signers).await;
+        assert_no_dkg_failures(&context);
+
+        let outcome_after_second =
+            wait_for_outcome(&context, &validators, second_full_dkg_epoch, epoch_length).await;
+        assert_ne!(
+            outcome_after_first.sharing().public(),
+            outcome_after_second.sharing().public(),
+            "Second full DKG must produce a different group public key"
+        );
+
+        // --- Test 1: full=false returns only the most recent transition ---
         let http_url_str = http_url.to_string();
-        let response = execution_runtime
+        let response_partial = execution_runtime
             .run_async(async move {
                 let http_client = HttpClientBuilder::default().build(&http_url_str).unwrap();
                 http_client
@@ -219,35 +252,70 @@ fn get_identity_transition_proof_after_full_dkg() {
             .await
             .unwrap();
 
-        assert!(
-            !response.identity.is_empty(),
-            "Identity should always be present"
-        );
         assert_eq!(
-            response.transitions.len(),
+            response_partial.transitions.len(),
             1,
-            "Expected exactly one transition"
-        );
-
-        let transition = &response.transitions[0];
-        assert_eq!(
-            transition.transition_epoch, full_dkg_epoch,
-            "Transition epoch should match full DKG epoch"
-        );
-        assert_ne!(
-            transition.old_identity, transition.new_identity,
-            "Old and new public keys should be different"
+            "full=false should return only the most recent transition"
         );
         assert_eq!(
-            response.identity, transition.new_identity,
-            "Identity should match the new public key from the latest transition"
+            response_partial.transitions[0].transition_epoch, second_full_dkg_epoch,
+            "Most recent transition should be from the second full DKG"
         );
 
-        // Decode and verify the BLS signature
-        let old_pubkey_bytes = hex::decode(&transition.old_identity).unwrap();
+        // --- Test 2: full=true returns both transitions plus genesis ---
+        let http_url_str = http_url.to_string();
+        let response_full = execution_runtime
+            .run_async(async move {
+                let http_client = HttpClientBuilder::default().build(&http_url_str).unwrap();
+                http_client
+                    .get_identity_transition_proof(None, Some(true))
+                    .await
+                    .unwrap()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response_full.transitions.len(),
+            3,
+            "full=true should return 2 transitions + genesis marker"
+        );
+
+        // Transitions should be ordered newest to oldest
+        assert_eq!(
+            response_full.transitions[0].transition_epoch, second_full_dkg_epoch,
+            "First transition should be from second full DKG"
+        );
+        assert_eq!(
+            response_full.transitions[1].transition_epoch, first_full_dkg_epoch,
+            "Second transition should be from first full DKG"
+        );
+        assert_eq!(
+            response_full.transitions[2].transition_epoch, 0,
+            "Third entry should be the genesis marker"
+        );
+
+        // Genesis marker should have no proof
+        assert!(
+            response_full.transitions[2].proof.is_none(),
+            "Genesis marker should have no proof"
+        );
+
+        // Identity chain should be consistent
+        assert_eq!(
+            response_full.identity, response_full.transitions[0].new_identity,
+            "Identity should match newest transition's new_identity"
+        );
+        assert_eq!(
+            response_full.transitions[0].old_identity, response_full.transitions[1].new_identity,
+            "Transition chain should be linked"
+        );
+
+        // Verify a BLS signature on the most recent transition
+        let old_pubkey_bytes = hex::decode(&response_full.transitions[0].old_identity).unwrap();
         let old_pubkey = <MinSig as Variant>::Public::read(&mut old_pubkey_bytes.as_slice())
             .expect("valid BLS public key");
-        let proof = transition
+        let proof = response_full.transitions[0]
             .proof
             .as_ref()
             .expect("non-genesis transition should have proof");
@@ -267,8 +335,7 @@ fn get_identity_transition_proof_after_full_dkg() {
             "BLS signature verification failed"
         );
 
-        // Test 2: Query from epoch 0 (before full DKG) - should have identity but no transitions
-        let old_identity = transition.old_identity.clone();
+        // --- Test 3: Query from epoch 0 - no transitions ---
         let http_url_str = http_url.to_string();
         let response_epoch0 = execution_runtime
             .run_async(async move {
@@ -282,16 +349,12 @@ fn get_identity_transition_proof_after_full_dkg() {
             .unwrap();
 
         assert!(
-            !response_epoch0.identity.is_empty(),
-            "Identity should be present even at epoch 0"
-        );
-        assert!(
             response_epoch0.transitions.is_empty(),
             "Should have no transitions when querying from epoch 0"
         );
         assert_eq!(
-            response_epoch0.identity, old_identity,
-            "Identity at epoch 0 should be the old public key (before full DKG)"
+            response_epoch0.identity, response_full.transitions[1].old_identity,
+            "Identity at epoch 0 should be the original genesis key"
         );
     });
 }


### PR DESCRIPTION
- Always cache even if full=false. Data can be used on both queries.
- Avoid walking if identity hasn't changed. Just forward the marker
- Unrelated bug - When finding the identity of the requested epoch, we should used the oldest transition. The transitions are newest->oldest so [this](https://github.com/tempoxyz/tempo/blob/185025ab3487b05d478cde9b56bf664a310d1b15/crates/commonware-node/src/feed/state.rs#L160) returns the wrong identity (newest)