### PR TITLE
fix(bench): reduce expiring nonce failures by freshening valid_before at sign time

### DIFF
--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -94,8 +94,7 @@ impl ExpiringNonceFiller {
 
     /// Create a new filler with a custom expiry window.
     ///
-    /// For benchmarking purposes, use a large value (e.g., 3600 for 1 hour) to avoid
-    /// transactions expiring before they're sent.
+    /// The protocol enforces a maximum of 30 seconds. The default is 25 seconds.
     pub fn with_expiry_secs(expiry_secs: u64) -> Self {
         Self { expiry_secs }
     }


### PR DESCRIPTION
## Problem

tempo-bench with expiring nonces (TIP-1009) was seeing ~27% transaction failure rates in CI runs. From Argo Workflows logs:

| Workflow | TPS | Duration | Succeeded | Failed | Failure % |
|----------|-----|----------|-----------|--------|-----------|
| tempo-bench-pmmw9 | 20k | 300s | 2,459,668 | 893,633 | **27%** |
| tempo-bench-9sqc4 | 20k | 300s | 3,193,382 | 4 | 0% |

The non-deterministic nature (same params, different results) pointed to a timing issue.

## Root Cause

`valid_before` is stamped during `provider.fill()` early in transaction generation, but transactions aren't signed and sent until much later. With large batches (15s × 20k TPS = 300k txs), the generation + signing + sending time can exceed the 25s expiry window.

## Fix

1. **Reduce default `expiring_batch_secs` from 15 → 5** — keeps total batch lifecycle (generate + sign + send) well within the 25s expiry window
2. **Re-stamp `valid_before` at sign time** — refreshes the timestamp right before signing in the rayon parallel iterator, eliminating the generation delay from the expiry budget
3. **Fix misleading doc comment** on `ExpiringNonceFiller::with_expiry_secs` that suggested using 3600s for benchmarking (protocol enforces 30s max)