### PR TITLE
chore: build Docker images on branches matching `rc/*`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - "rc/*"
     tags:
       - "v*.*.*"
   merge_group:


### PR DESCRIPTION
We want to support triggering a build for "release candidate" branches. These won't tag with a version number--we simply use the `rc/*` prefix as a signal to indicate that a Docker image should be created without requiring a merge to `main`, since we don't want to merge to `main` in a fork.
