### PR TITLE
feat(payload): `TempoBuiltPayload`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12069,6 +12069,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
+ "either",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -12076,6 +12077,7 @@ dependencies = [
  "reth-engine-tree",
  "reth-errors",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -12096,6 +12098,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.3.0"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -12103,6 +12106,7 @@ dependencies = [
  "derive_more",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "tem
 reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
 reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.11.0" }
@@ -209,6 +210,7 @@ bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 const-hex = { version = "1.17.0" }
 derive_more = { version = "2.1.1" }
+either = "1"
 eyre = "0.6.12"
 futures = "0.3.31"
 governor = "0.10.4"

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -35,7 +35,7 @@ use futures::{
 };
 use rand_08::{CryptoRng, Rng};
 use reth_ethereum::chainspec::EthChainSpec as _;
-use reth_node_builder::{Block as _, ConsensusEngineHandle};
+use reth_node_builder::{Block as _, BuiltPayload, ConsensusEngineHandle};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::{TempoExecutionData, TempoFullNode, TempoPayloadTypes};
 

--- a/crates/node/tests/it/backfill.rs
+++ b/crates/node/tests/it/backfill.rs
@@ -9,7 +9,7 @@ use alloy_network::TxSignerSync;
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_e2e_test_utils::wallet::Wallet;
-use reth_node_api::EngineApiMessageVersion;
+use reth_node_api::{BuiltPayload, EngineApiMessageVersion};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_primitives_traits::{AlloyBlockHeader as _, transaction::TxHashRef};
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -10,6 +10,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{Ethereum, TxSignerSync};
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::TransactionRequest;
+use reth_node_api::BuiltPayload;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{IRolesAuth, ITIP20, ITIP20Factory};
 use tempo_node::node::TempoNode;

--- a/crates/node/tests/it/max_gas_limit.rs
+++ b/crates/node/tests/it/max_gas_limit.rs
@@ -12,6 +12,7 @@ use alloy::{
 use alloy_eips::{eip2718::Encodable2718, eip7825::MAX_TX_GAS_LIMIT_OSAKA};
 use alloy_network::TxSignerSync;
 use alloy_primitives::Bytes;
+use reth_node_api::BuiltPayload;
 use reth_primitives_traits::transaction::TxHashRef;
 use tempo_chainspec::spec::{TEMPO_T1_BASE_FEE, TEMPO_T1_TX_GAS_LIMIT_CAP};
 

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -47,6 +47,7 @@ use alloy_eips::{Decodable2718, Encodable2718};
 use alloy_primitives::TxKind;
 use p256::ecdsa::signature::hazmat::PrehashSigner;
 use reth_ethereum::network::{NetworkSyncUpdater, SyncState};
+use reth_node_api::BuiltPayload;
 use reth_primitives_traits::transaction::TxHashRef;
 use reth_transaction_pool::TransactionPool;
 use tempo_alloy::TempoNetwork;

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -23,18 +23,20 @@ reth-chainspec.workspace = true
 reth-consensus-common.workspace = true
 reth-engine-tree.workspace = true
 reth-errors.workspace = true
+reth-execution-types.workspace = true
 reth-evm.workspace = true
 reth-metrics.workspace = true
 reth-payload-builder.workspace = true
+reth-payload-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-revm.workspace = true
 reth-storage-api.workspace = true
 reth-transaction-pool.workspace = true
-reth-payload-primitives.workspace = true
 
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp = "0.3"
 
+either.workspace = true
 metrics.workspace = true
 tracing.workspace = true

--- a/crates/payload/types/Cargo.toml
+++ b/crates/payload/types/Cargo.toml
@@ -15,8 +15,10 @@ tempo-primitives = { workspace = true, features = ["reth-codec", "serde"] }
 
 reth-ethereum-engine-primitives.workspace = true
 reth-node-api.workspace = true
+reth-payload-primitives.workspace = true
 reth-primitives-traits.workspace = true
 
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-serde.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -9,9 +9,12 @@ use alloy_primitives::B256;
 pub use attrs::{InterruptHandle, TempoPayloadAttributes, TempoPayloadBuilderAttributes};
 use std::sync::Arc;
 
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::U256;
 use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_node_api::{BlockBody, ExecutionPayload, PayloadBuilderAttributes, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
 use reth_primitives_traits::{AlloyBlockHeader as _, SealedBlock};
 use serde::{Deserialize, Serialize};
 use tempo_primitives::{Block, TempoPrimitives};
@@ -20,6 +23,51 @@ use tempo_primitives::{Block, TempoPrimitives};
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
 pub struct TempoPayloadTypes;
+
+/// Built payload type for Tempo node.
+///
+/// Wraps [`EthBuiltPayload`] and optionally includes the executed block data
+/// to enable the engine tree fast path (skipping re-execution for self-built payloads).
+#[derive(Debug, Clone)]
+pub struct TempoBuiltPayload {
+    /// The inner built payload.
+    inner: EthBuiltPayload<TempoPrimitives>,
+    /// The executed block data, used to skip re-execution in the engine tree.
+    executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+}
+
+impl TempoBuiltPayload {
+    /// Creates a new [`TempoBuiltPayload`].
+    pub fn new(
+        inner: EthBuiltPayload<TempoPrimitives>,
+        executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+    ) -> Self {
+        Self {
+            inner,
+            executed_block,
+        }
+    }
+}
+
+impl BuiltPayload for TempoBuiltPayload {
+    type Primitives = TempoPrimitives;
+
+    fn block(&self) -> &SealedBlock<Block> {
+        self.inner.block()
+    }
+
+    fn fees(&self) -> U256 {
+        self.inner.fees()
+    }
+
+    fn executed_block(&self) -> Option<BuiltPayloadExecutedBlock<Self::Primitives>> {
+        self.executed_block.clone()
+    }
+
+    fn requests(&self) -> Option<Requests> {
+        self.inner.requests()
+    }
+}
 
 /// Execution data for Tempo node. Simply wraps a sealed block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,7 +122,7 @@ impl ExecutionPayload for TempoExecutionData {
 
 impl PayloadTypes for TempoPayloadTypes {
     type ExecutionData = TempoExecutionData;
-    type BuiltPayload = EthBuiltPayload<TempoPrimitives>;
+    type BuiltPayload = TempoBuiltPayload;
     type PayloadAttributes =
         <Self::PayloadBuilderAttributes as PayloadBuilderAttributes>::RpcPayloadAttributes;
     type PayloadBuilderAttributes = TempoPayloadBuilderAttributes;


### PR DESCRIPTION
Custom built payload type allows insertion of self-built blocks directly into the tree, avoiding going through full engine validation. Will additionally allow to reuse execution cache between building and validation by always anchoring to one parent block.