### PR TITLE
feat(rpc): add reth_newPayload endpoint for RLP-encoded blocks

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -43,6 +43,8 @@ reth-engine-local.workspace = true
 
 alloy-serde.workspace = true
 alloy-eips.workspace = true
+alloy-rlp.workspace = true
+alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy.workspace = true
 alloy-primitives.workspace = true
@@ -64,7 +66,6 @@ tempo-e2e.workspace = true
 tempo-transaction-pool = { workspace = true, features = ["test-utils"] }
 alloy-network.workspace = true
 tempo-precompiles.workspace = true
-alloy-rpc-types-engine.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "test-utils", "pool"] }
 reth-e2e-test-utils.workspace = true
 reth-node-core.workspace = true
@@ -78,7 +79,6 @@ alloy = { workspace = true, features = [
 	"signers",
 	"signer-mnemonic-all-languages",
 ] }
-alloy-rlp.workspace = true
 rand.workspace = true
 futures.workspace = true
 test-case.workspace = true

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod consensus;
 pub mod error;
 pub mod eth_ext;
+pub mod reth_api;
 pub mod token;
 
 pub use admin::{TempoAdminApi, TempoAdminApiServer};
@@ -10,6 +11,7 @@ use alloy_rpc_types_eth::{Log, ReceiptWithBloom};
 pub use consensus::{TempoConsensusApiServer, TempoConsensusRpc};
 pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
 use futures::{TryFutureExt, future::Either};
+pub use reth_api::{TempoRethApiServer, TempoRethRpc};
 use reth_errors::RethError;
 use reth_primitives_traits::{
     Recovered, TransactionMeta, TxTy, WithEncoded, transaction::TxHashRef,

--- a/crates/node/src/rpc/reth_api.rs
+++ b/crates/node/src/rpc/reth_api.rs
@@ -1,0 +1,65 @@
+use alloy_primitives::Bytes;
+use alloy_rpc_types_engine::PayloadStatus;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_node_builder::ConsensusEngineHandle;
+use reth_primitives_traits::SealedBlock;
+use std::sync::Arc;
+use tempo_payload_types::TempoExecutionData;
+
+use crate::TempoPayloadTypes;
+
+/// `reth_` namespace RPC trait.
+#[rpc(server, namespace = "reth")]
+pub trait TempoRethApi {
+    /// Accepts an RLP-encoded block, decodes it, converts it to `ExecutionData`,
+    /// and submits it to the engine for execution.
+    #[method(name = "newPayload")]
+    async fn new_payload(&self, block: Bytes) -> RpcResult<PayloadStatus>;
+}
+
+/// Tempo-specific `reth_` namespace implementation.
+#[derive(Debug, Clone)]
+pub struct TempoRethRpc {
+    engine_handle: ConsensusEngineHandle<TempoPayloadTypes>,
+}
+
+impl TempoRethRpc {
+    /// Create a new `reth_` namespace RPC handler.
+    pub fn new(engine_handle: ConsensusEngineHandle<TempoPayloadTypes>) -> Self {
+        Self { engine_handle }
+    }
+}
+
+#[async_trait::async_trait]
+impl TempoRethApiServer for TempoRethRpc {
+    async fn new_payload(&self, block: Bytes) -> RpcResult<PayloadStatus> {
+        let block: tempo_primitives::Block = alloy_rlp::Decodable::decode(&mut block.as_ref())
+            .map_err(|e| {
+                jsonrpsee::types::ErrorObject::owned(
+                    jsonrpsee::types::error::INVALID_PARAMS_CODE,
+                    format!("failed to RLP-decode block: {e}"),
+                    None::<()>,
+                )
+            })?;
+
+        let sealed = SealedBlock::seal_slow(block);
+        let execution_data = TempoExecutionData {
+            block: Arc::new(sealed),
+            validator_set: None,
+        };
+
+        let status = self
+            .engine_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| {
+                jsonrpsee::types::ErrorObject::owned(
+                    jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+                    format!("engine error: {e}"),
+                    None::<()>,
+                )
+            })?;
+
+        Ok(status)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `reth_newPayload` RPC method that accepts RLP-encoded primitive blocks, decodes them, and submits them to the engine for execution.

## Changes

- New `reth_api` module in `crates/node/src/rpc/` with `TempoRethApi` trait (`reth_` namespace) and `TempoRethRpc` implementation
- RLP-decodes incoming `Bytes` into `Block`, seals it via `SealedBlock::seal_slow`, wraps in `TempoExecutionData`, and forwards to `ConsensusEngineHandle::new_payload`
- Clones `beacon_engine_handle` from `AddOnsContext` in `launch_add_ons` and passes it to the RPC handler
- Moved `alloy-rlp` and `alloy-rpc-types-engine` from dev-deps to regular deps in `tempo-node`

## Testing

```
cargo check -p tempo-node
cargo clippy -p tempo-node --all-targets -- -D warnings
cargo fmt --all --check
```

All pass clean.

Prompted by: arsenii