### PR TITLE
test: add cross-chain replay handler

### DIFF
--- a/tips/ref-impls/test/helpers/GhostState.sol
+++ b/tips/ref-impls/test/helpers/GhostState.sol
@@ -146,6 +146,13 @@ abstract contract GhostState {
     uint256 public ghost_expiringNonceMissingVBAttempted;
     uint256 public ghost_expiringNonceConcurrentExecuted;
 
+    // ============ Cross-Chain Replay Tracking ============
+
+    /// @dev Tracks attempts to execute a tx signed with wrong chain_id
+    uint256 public ghost_crossChainAttempted;
+    /// @dev Violation counter: cross-chain replay unexpectedly allowed
+    uint256 public ghost_crossChainAllowed;
+
     // ============ Update Functions ============
 
     function _updateProtocolNonce(address account) internal {


### PR DESCRIPTION
Add `handler_crossChainReplay` that signs a Tempo transaction with `chain_id != block.chainid` and verifies it is rejected by `validate_tempo_tx()`.