### PR TITLE
ci(docker): skip build-and-push on main for non-tempo repos

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   build-and-push:
     name: Build and Push Docker Images
+    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository != 'tempoxyz/tempo') }}
     runs-on: depot-ubuntu-latest-16
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Prevents the `build-and-push` job in `docker.yml` from running on pushes to `main` unless the repository is `tempoxyz/tempo`.

## Changes
- Added `if` condition to `build-and-push` job that skips when `event_name == 'push' && ref == 'refs/heads/main' && repository != 'tempoxyz/tempo'`
- All other triggers (tags, `rc/*` branches, schedule, workflow_dispatch, workflow_call, merge_group) are unaffected

## Testing
N/A — CI workflow logic change, verified expression manually.

Prompted by: sds