### PR TITLE
fix(evm): return error instead of panicking on empty validator set

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -219,7 +219,7 @@ where
         let gas_per_subblock = self
             .shared_gas_limit
             .checked_div(validator_set.len() as u64)
-            .expect("validator set must not be empty");
+            .ok_or_else(|| BlockValidationError::msg("validator set must not be empty"))?;
 
         let mut incentive_gas = 0;
         let mut seen = HashSet::new();


### PR DESCRIPTION
when validator_set is Some but empty, checked_div(0) returns None and the expect panics. the None case wasn't handled — added ok_or_else to propagate it as a BlockValidationError instead.