### PR TITLE
ci(docker): skip publish event steps for non-tempo repos

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -193,6 +193,7 @@ jobs:
           done
 
       - name: Publish event (sha tag)
+        if: ${{ github.repository == 'tempoxyz/tempo' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -208,7 +209,7 @@ jobs:
             }'
 
       - name: Publish event (nightly tag)
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.nightly == 'true' }}
+        if: ${{ github.repository == 'tempoxyz/tempo' && (github.event_name == 'schedule' || github.event.inputs.nightly == 'true') }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
Prevents the two "Publish event" steps in `docker.yml` from running unless the repository is `tempoxyz/tempo`.

## Changes
- Added `if: github.repository == 'tempoxyz/tempo'` to the "Publish event (sha tag)" step
- Added `github.repository == 'tempoxyz/tempo'` guard to the existing condition on the "Publish event (nightly tag)" step

## Testing
N/A — CI workflow logic change, verified expressions manually.

Prompted by: sds