### PR TITLE
ci: add workflow to sync fork main with upstream

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,6 +1,5 @@
 # This workflow is only intended to be used in forks of tempoxyz/tempo.
 # It syncs the fork's main branch with the upstream repository hourly.
-# This is only a backup in case the webhook fails to send.
 
 name: Sync main branch with upstream
 


### PR DESCRIPTION
## Summary
Adds a daily workflow for forks to keep their `main` branch in sync with upstream.

## Changes
- New `.github/workflows/sync-from-upstream.yml`
- Skipped on `tempoxyz/tempo` itself via `if: github.repository != 'tempoxyz/tempo'`
- Uses `gh repo sync --force` instead of manual fetch/reset/push — this is GitHub's built-in fork sync and handles upstream detection automatically
- Also supports `workflow_dispatch` for manual runs

Prompted by: sds