### PR TITLE
ci(lint): skip docs and deploy-docs jobs on forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -193,5 +193,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
-          allowed-skips: docs
+          allowed-skips: ${{ github.repository != 'tempoxyz/tempo' && 'docs' || '' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
Skips the `docs` and `deploy-docs` jobs in `lint.yml` when the repository is not `tempoxyz/tempo`.

## Changes
- Added `if: github.repository == 'tempoxyz/tempo'` to `docs` job
- Added repo guard to existing `deploy-docs` condition
- Added `docs` to `allowed-skips` in `lint-success` so `alls-green` doesn't fail when docs is skipped

Prompted by: sds