### PR TITLE
docs(evm): expand TempoBlockExecutor doc comment

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -103,7 +103,11 @@ impl<H> TxResult for TempoTxResult<H> {
     }
 }
 
-/// Block executor for Tempo. Wraps an inner [`EthBlockExecutor`].
+/// Block executor for Tempo.
+///
+/// Wraps an inner [`EthBlockExecutor`] and layers Tempo-specific block execution
+/// logic on top: section-based transaction ordering ([`BlockSection`]), subblock
+/// validation, shared/non-shared gas accounting, and gas incentive tracking.
 pub(crate) struct TempoBlockExecutor<'a, DB: Database, I> {
     pub(crate) inner: EthBlockExecutor<
         'a,


### PR DESCRIPTION
## Summary
Expands the one-liner doc comment on `TempoBlockExecutor` to describe what it actually does beyond wrapping `EthBlockExecutor`: section-based tx ordering, subblock validation, shared/non-shared gas accounting, and gas incentive tracking.

## Changes
- Expanded `///` doc comment on `TempoBlockExecutor` in `crates/evm/src/block.rs`

Prompted by: zygis