### PR TITLE
fix(validator-config-v2): ed25519 decode check on migration, digest preimage collision fix

### DIFF
--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -199,7 +199,9 @@ mod tests {
             let ingress = b"192.168.1.1:8000";
             msg_data.push(ingress.len() as u8);
             msg_data.extend_from_slice(ingress);
-            msg_data.extend_from_slice(b"192.168.1.1");
+            let egress = b"192.168.1.1";
+            msg_data.push(egress.len() as u8);
+            msg_data.extend_from_slice(egress);
             let message = alloy::primitives::keccak256(&msg_data);
 
             // Sign with namespace

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -196,7 +196,9 @@ mod tests {
                 tempo_contracts::precompiles::VALIDATOR_CONFIG_V2_ADDRESS.as_slice(),
             );
             msg_data.extend_from_slice(validator_addr.as_slice());
-            msg_data.extend_from_slice(b"192.168.1.1:8000");
+            let ingress = b"192.168.1.1:8000";
+            msg_data.push(ingress.len() as u8);
+            msg_data.extend_from_slice(ingress);
             msg_data.extend_from_slice(b"192.168.1.1");
             let message = alloy::primitives::keccak256(&msg_data);
 

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -1587,8 +1587,8 @@ mod tests {
             let mut v1 = v1();
             v1.initialize(owner)?;
 
-            // Zero is not a valid Ed25519 curve point.
-            let bad_key = [0u8; 32];
+            // [0x02; 32] is not a valid Ed25519 curve point but is non-zero so V1 accepts it.
+            let bad_key = [0x02u8; 32];
             v1.add_validator(
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress))`
+    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || uint8(egress.len) || egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],
@@ -360,6 +360,7 @@ impl ValidatorConfigV2 {
         hasher.update(validator_address.as_slice());
         hasher.update([ingress.len() as u8]);
         hasher.update(ingress.as_bytes());
+        hasher.update([egress.len() as u8]);
         hasher.update(egress.as_bytes());
         let message = hasher.finalize();
 
@@ -666,6 +667,7 @@ mod tests {
         data.extend_from_slice(validator_address.as_slice());
         data.push(ingress.len() as u8);
         data.extend_from_slice(ingress.as_bytes());
+        data.push(egress.len() as u8);
         data.extend_from_slice(egress.as_bytes());
         let message = keccak256(&data);
 

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -584,8 +584,13 @@ impl ValidatorConfigV2 {
         self.require_new_address(v1_val.validatorAddress)?;
         self.require_new_pubkey(v1_val.publicKey)?;
 
-        PublicKey::decode(v1_val.publicKey.as_slice())
-            .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+        let deactivated_at_height = if v1_val.active {
+            PublicKey::decode(v1_val.publicKey.as_slice())
+                .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+            0
+        } else {
+            block_height
+        };
 
         let egress = v1_val
             .outboundAddress
@@ -594,8 +599,6 @@ impl ValidatorConfigV2 {
             .unwrap_or(v1_val.outboundAddress);
 
         let ingress_hash = self.require_unique_ingress_ip(&v1_val.inboundAddress)?;
-
-        let deactivated_at_height = if v1_val.active { 0 } else { block_height };
 
         self.append_validator(
             v1_val.validatorAddress,

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, uint8(ingress.len), ingress, egress))`
+    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -1587,11 +1587,8 @@ mod tests {
             let mut v1 = v1();
             v1.initialize(owner)?;
 
-            // Find a 32-byte value that is not a valid Ed25519 curve point.
-            let bad_key = (0u8..)
-                .map(|i| [i; 32])
-                .find(|k| PublicKey::decode(&k[..]).is_err())
-                .unwrap();
+            // Zero is not a valid Ed25519 curve point.
+            let bad_key = [0u8; 32];
             v1.add_validator(
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, ingress, egress))`
+    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, uint8(ingress.len), ingress, egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],
@@ -358,6 +358,7 @@ impl ValidatorConfigV2 {
         hasher.update(self.storage.chain_id().to_be_bytes());
         hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
         hasher.update(validator_address.as_slice());
+        hasher.update([ingress.len() as u8]);
         hasher.update(ingress.as_bytes());
         hasher.update(egress.as_bytes());
         let message = hasher.finalize();
@@ -582,6 +583,9 @@ impl ValidatorConfigV2 {
         self.require_new_address(v1_val.validatorAddress)?;
         self.require_new_pubkey(v1_val.publicKey)?;
 
+        PublicKey::decode(v1_val.publicKey.as_slice())
+            .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+
         let egress = v1_val
             .outboundAddress
             .parse::<std::net::SocketAddr>()
@@ -660,6 +664,7 @@ mod tests {
         data.extend_from_slice(&1u64.to_be_bytes());
         data.extend_from_slice(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
         data.extend_from_slice(validator_address.as_slice());
+        data.push(ingress.len() as u8);
         data.extend_from_slice(ingress.as_bytes());
         data.extend_from_slice(egress.as_bytes());
         let message = keccak256(&data);
@@ -692,6 +697,11 @@ mod tests {
             egress: egress.to_string(),
             signature: signature.into(),
         }
+    }
+
+    fn valid_pubkey(seed: u64) -> FixedBytes<32> {
+        let pk = PrivateKey::from_seed(seed);
+        FixedBytes::from_slice(&pk.public_key().encode())
     }
 
     /// Helper to make a complete add call with generated keys
@@ -1356,7 +1366,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1367,7 +1377,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v2_addr,
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: false,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1384,7 +1394,7 @@ mod tests {
             assert_eq!(v2.validator_count()?, 1);
             let migrated = v2.validator_by_index(0)?;
             assert_eq!(migrated.validatorAddress, v1_addr);
-            assert_eq!(migrated.publicKey, FixedBytes::<32>::from([0x11; 32]));
+            assert_eq!(migrated.publicKey, valid_pubkey(1));
             assert_eq!(migrated.deactivatedAtHeight, 0);
 
             // Migrate second validator
@@ -1430,7 +1440,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1483,7 +1493,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1494,7 +1504,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1530,7 +1540,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1541,7 +1551,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1560,6 +1570,44 @@ mod tests {
             assert_eq!(
                 result,
                 Err(ValidatorConfigV2Error::migration_not_complete().into())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_migration_rejects_invalid_ed25519_pubkey() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut v1 = v1();
+            v1.initialize(owner)?;
+
+            // Find a 32-byte value that is not a valid Ed25519 curve point.
+            let bad_key = (0u8..)
+                .map(|i| [i; 32])
+                .find(|k| PublicKey::decode(&k[..]).is_err())
+                .unwrap();
+            v1.add_validator(
+                owner,
+                tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
+                    newValidatorAddress: Address::random(),
+                    publicKey: FixedBytes::<32>::from(bad_key),
+                    active: true,
+                    inboundAddress: "192.168.1.1:8000".to_string(),
+                    outboundAddress: "192.168.1.1:9000".to_string(),
+                },
+            )?;
+
+            let mut v2 = ValidatorConfigV2::new();
+            v2.storage.set_block_number(100);
+            let result =
+                v2.migrate_validator(owner, IValidatorConfigV2::migrateValidatorCall { idx: 0 });
+            assert_eq!(
+                result,
+                Err(ValidatorConfigV2Error::invalid_public_key().into())
             );
 
             Ok(())
@@ -1727,7 +1775,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1771,7 +1819,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1856,7 +1904,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1866,7 +1914,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.2.1:9000".to_string(),

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -90,6 +90,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -166,6 +167,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -84,7 +84,14 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _validateAddParams(validatorAddress, publicKey, ingress, egress);
 
         bytes32 message = keccak256(
-            abi.encodePacked(block.chainid, address(this), validatorAddress, ingress, egress)
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
+            )
         );
         _verifyEd25519Signature(
             bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR"), publicKey, message, signature
@@ -153,7 +160,14 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _validateRotateParams(publicKey, ingress, egress);
 
         bytes32 message = keccak256(
-            abi.encodePacked(block.chainid, address(this), validatorAddress, ingress, egress)
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
+            )
         );
         _verifyEd25519Signature(
             bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR"), publicKey, message, signature

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -98,7 +98,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, uint8(bytes(egress).length), egress))
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
     /// @param validatorAddress The address of the new validator
@@ -133,7 +133,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, uint8(bytes(egress).length), egress))
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
     /// @param ingress The new validator's inbound address `<ip>:<port>` for incoming connections

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -98,7 +98,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
     /// @param validatorAddress The address of the new validator
@@ -133,7 +133,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
     /// @param ingress The new validator's inbound address `<ip>:<port>` for incoming connections

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -57,6 +57,7 @@ contract ValidatorConfigV2Test is BaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -86,6 +87,7 @@ contract ValidatorConfigV2Test is BaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -52,7 +52,12 @@ contract ValidatorConfigV2Test is BaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         // Forge's signEd25519 does simple concat(namespace, message), but the Rust
@@ -76,7 +81,12 @@ contract ValidatorConfigV2Test is BaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR");

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -117,7 +117,12 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR");
@@ -138,7 +143,12 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR");

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -122,6 +122,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -148,6 +149,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -106,7 +106,7 @@ interface IValidatorConfigV2 {
     /// @notice Thrown when trying to delete a validator that is already deleted
     error ValidatorAlreadyDeleted();
 
-    /// @notice Thrown when public key is invalid (zero)
+    /// @notice Thrown when public key is invalid (zero or not a valid Ed25519 curve point)
     error InvalidPublicKey();
 
     /// @notice Thrown when the Ed25519 signature verification fails
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
@@ -329,11 +329,12 @@ signature is checked over the a full message containing: the length of the names
 **Message:**
 ```
 message = keccak256(abi.encodePacked(
-    bytes8(chainId),      // uint64: Prevents cross-chain replay
-    contractAddress,      // address: Prevents cross-contract replay
-    validatorAddress,     // address: Binds to specific validator address
-    ingress,              // string: Binds network configuration
-    egress                // string: Binds network configuration
+    bytes8(chainId),           // uint64: Prevents cross-chain replay
+    contractAddress,           // address: Prevents cross-contract replay
+    validatorAddress,          // address: Binds to specific validator address
+    uint8(ingress.length),     // uint8: Length prefix to prevent ingress/egress boundary collision
+    ingress,                   // string: Binds network configuration
+    egress                     // string: Binds network configuration
 ))
 ```
 
@@ -592,7 +593,7 @@ precompile does NOT proxy reads to V1.
 - On first call (when `validatorsArray.length == 0`), copies `owner` from V1 if V2 owner is `address(0)`
 - Reads the validator from V1 at index `idx`
 - Creates a V2 validator entry with:
-  - `publicKey`: copied from V1
+  - `publicKey`: copied from V1 (must be a valid Ed25519 curve point; reverts with `InvalidPublicKey` otherwise)
   - `validatorAddress`: copied from V1
   - `ingress`: copied from V1 `inboundAddress`
   - `egress`: copied from V1 `outboundAddress`
@@ -640,7 +641,7 @@ interface IValidatorConfigV1 {
 - **Validator address copied**: The V2 validator address is copied from V1
 - **Address changeable post-migration**: Owner or validator can update validator addresses via `transferValidatorOwnership`
 - **No signatures required**: V1 validators are imported without Ed25519 signatures
-  (they were already validated in V1)
+  (the public key is validated as a decodable Ed25519 curve point during migration)
 - **All validators imported**: Both active and inactive V1 validators are
   imported; active ones have `addedAtHeight == block.height` and `deactivatedAtHeight == 0`,
   inactive ones have `addedAtHeight == deactivatedAtHeight == block.height`.
@@ -720,7 +721,7 @@ The test suite must cover:
 12. **PublicKeyAlreadyExists**: Cannot re-use same public key
 13. **ValidatorNotFound**: Cannot query/delete non-existent validator
 14. **ValidatorAlreadyDeleted**: Cannot delete twice
-15. **InvalidPublicKey**: Rejects zero public key
+15. **InvalidPublicKey**: Rejects zero public key and invalid Ed25519 curve points
 16. **InvalidSignature**: Rejects wrong signature, wrong length, wrong signer
 17. **IngressAlreadyExists**: Cannot use ingress IP already in use by active validator (even with different port)
 

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length || ingress || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length || ingress || egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || uint8(bytes(egress).length) || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || uint8(bytes(egress).length) || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
@@ -328,14 +328,15 @@ signature is checked over the a full message containing: the length of the names
 
 **Message:**
 ```
-message = keccak256(abi.encodePacked(
-    bytes8(chainId),           // uint64: Prevents cross-chain replay
-    contractAddress,           // address: Prevents cross-contract replay
-    validatorAddress,          // address: Binds to specific validator address
-    uint8(ingress.length),     // uint8: Length prefix to prevent ingress/egress boundary collision
-    ingress,                   // string: Binds network configuration
-    egress                     // string: Binds network configuration
-))
+message = keccak256(
+    bytes8(chainId)            // uint64: Prevents cross-chain replay
+    || contractAddress         // address: Prevents cross-contract replay
+    || validatorAddress        // address: Binds to specific validator address
+    || uint8(ingress.length)   // uint8: Length prefix to prevent ingress/egress boundary collision
+    || ingress                 // string: Binds network configuration
+    || uint8(egress.length)    // uint8: Length prefix to prevent egress boundary collision
+    || egress                  // string: Binds network configuration
+)
 ```
 
 The Ed25519 signature is computed over the message using the namespace parameter

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -1011,13 +1011,14 @@ fn initialize_validator_config_v2(
                 let ingress = addr.to_string();
                 let egress = addr.ip().to_string();
 
-                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress)
+                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || uint8(egress.len) || egress)
                 let mut hasher = Keccak256::new();
                 hasher.update(chain_id.to_be_bytes());
                 hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
                 hasher.update(validator_address.as_slice());
                 hasher.update([ingress.len() as u8]);
                 hasher.update(ingress.as_bytes());
+                hasher.update([egress.len() as u8]);
                 hasher.update(egress.as_bytes());
                 let message = hasher.finalize();
 

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -1011,11 +1011,12 @@ fn initialize_validator_config_v2(
                 let ingress = addr.to_string();
                 let egress = addr.ip().to_string();
 
-                // message: keccak256(chainId || contractAddr || validatorAddr || ingress || egress)
+                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress)
                 let mut hasher = Keccak256::new();
                 hasher.update(chain_id.to_be_bytes());
                 hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
                 hasher.update(validator_address.as_slice());
+                hasher.update([ingress.len() as u8]);
                 hasher.update(ingress.as_bytes());
                 hasher.update(egress.as_bytes());
                 let message = hasher.finalize();


### PR DESCRIPTION
## Summary

Two fixes to ValidatorConfigV2 (TIP-1017):

### 1. Ed25519 decode check during migration

`migrate_validator` now validates that V1 public keys are decodable Ed25519 curve points, reverting with `InvalidPublicKey` if not. V1 did not enforce this, so invalid keys could have been stored.

### 2. Digest preimage collision fix

The signature digest for `addValidator` and `rotateValidator` used `abi.encodePacked(..., ingress, egress)` which is ambiguous — e.g. `("192.168.0.1:800", "12.3.4.5")` and `("192.168.0.1:8001", "2.3.4.5")` produce the same byte sequence. Fixed by adding a `uint8` length prefix before ingress to disambiguate the boundary.

### Files changed

- **Spec**: `tips/tip-1017.md`
- **Solidity**: `ValidatorConfigV2.sol`, `IValidatorConfigV2.sol`
- **Solidity tests**: `ValidatorConfigV2.t.sol`, `invariants/ValidatorConfigV2.t.sol`
- **Rust**: `crates/precompiles/src/validator_config_v2/mod.rs`, `dispatch.rs`
- **Genesis**: `xtask/src/genesis_args.rs`