### PR TITLE
fix(tip-1017): remove field param from NotIpPort and NotIp errors

### DIFF
--- a/crates/contracts/src/precompiles/validator_config_v2.rs
+++ b/crates/contracts/src/precompiles/validator_config_v2.rs
@@ -123,6 +123,7 @@ crate::sol! {
         error InvalidSignature();
         error InvalidSignatureFormat();
         error InvalidValidatorAddress();
+        error MigrationStateMismatch(uint64 idx);
         error MigrationNotComplete();
         error NotInitialized();
         error NotIp(string input, string backtrace);
@@ -178,6 +179,10 @@ impl ValidatorConfigV2Error {
 
     pub const fn already_initialized() -> Self {
         Self::AlreadyInitialized(IValidatorConfigV2::AlreadyInitialized {})
+    }
+
+    pub const fn migration_state_mismatch(idx: u64) -> Self {
+        Self::MigrationStateMismatch(IValidatorConfigV2::MigrationStateMismatch { idx })
     }
 
     pub const fn migration_not_complete() -> Self {

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -199,7 +199,9 @@ mod tests {
             let ingress = b"192.168.1.1:8000";
             msg_data.push(ingress.len() as u8);
             msg_data.extend_from_slice(ingress);
-            msg_data.extend_from_slice(b"192.168.1.1");
+            let egress = b"192.168.1.1";
+            msg_data.push(egress.len() as u8);
+            msg_data.extend_from_slice(egress);
             let message = alloy::primitives::keccak256(&msg_data);
 
             // Sign with namespace

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -196,7 +196,9 @@ mod tests {
                 tempo_contracts::precompiles::VALIDATOR_CONFIG_V2_ADDRESS.as_slice(),
             );
             msg_data.extend_from_slice(validator_addr.as_slice());
-            msg_data.extend_from_slice(b"192.168.1.1:8000");
+            let ingress = b"192.168.1.1:8000";
+            msg_data.push(ingress.len() as u8);
+            msg_data.extend_from_slice(ingress);
             msg_data.extend_from_slice(b"192.168.1.1");
             let message = alloy::primitives::keccak256(&msg_data);
 

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -1587,8 +1587,8 @@ mod tests {
             let mut v1 = v1();
             v1.initialize(owner)?;
 
-            // Zero is not a valid Ed25519 curve point.
-            let bad_key = [0u8; 32];
+            // [0x02; 32] is not a valid Ed25519 curve point but is non-zero so V1 accepts it.
+            let bad_key = [0x02u8; 32];
             v1.add_validator(
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress))`
+    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || uint8(egress.len) || egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],
@@ -360,6 +360,7 @@ impl ValidatorConfigV2 {
         hasher.update(validator_address.as_slice());
         hasher.update([ingress.len() as u8]);
         hasher.update(ingress.as_bytes());
+        hasher.update([egress.len() as u8]);
         hasher.update(egress.as_bytes());
         let message = hasher.finalize();
 
@@ -666,6 +667,7 @@ mod tests {
         data.extend_from_slice(validator_address.as_slice());
         data.push(ingress.len() as u8);
         data.extend_from_slice(ingress.as_bytes());
+        data.push(egress.len() as u8);
         data.extend_from_slice(egress.as_bytes());
         let message = keccak256(&data);
 

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -584,8 +584,13 @@ impl ValidatorConfigV2 {
         self.require_new_address(v1_val.validatorAddress)?;
         self.require_new_pubkey(v1_val.publicKey)?;
 
-        PublicKey::decode(v1_val.publicKey.as_slice())
-            .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+        let deactivated_at_height = if v1_val.active {
+            PublicKey::decode(v1_val.publicKey.as_slice())
+                .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+            0
+        } else {
+            block_height
+        };
 
         let egress = v1_val
             .outboundAddress
@@ -594,8 +599,6 @@ impl ValidatorConfigV2 {
             .unwrap_or(v1_val.outboundAddress);
 
         let ingress_hash = self.require_unique_ingress_ip(&v1_val.inboundAddress)?;
-
-        let deactivated_at_height = if v1_val.active { 0 } else { block_height };
 
         self.append_validator(
             v1_val.validatorAddress,

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, uint8(ingress.len), ingress, egress))`
+    /// - Message: `keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -1587,11 +1587,8 @@ mod tests {
             let mut v1 = v1();
             v1.initialize(owner)?;
 
-            // Find a 32-byte value that is not a valid Ed25519 curve point.
-            let bad_key = (0u8..)
-                .map(|i| [i; 32])
-                .find(|k| PublicKey::decode(&k[..]).is_err())
-                .unwrap();
+            // Zero is not a valid Ed25519 curve point.
+            let bad_key = [0u8; 32];
             v1.add_validator(
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -344,7 +344,7 @@ impl ValidatorConfigV2 {
     ///
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, ingress, egress))`
+    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, uint8(ingress.len), ingress, egress))`
     fn verify_validator_signature(
         &self,
         namespace: &[u8],
@@ -358,6 +358,7 @@ impl ValidatorConfigV2 {
         hasher.update(self.storage.chain_id().to_be_bytes());
         hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
         hasher.update(validator_address.as_slice());
+        hasher.update([ingress.len() as u8]);
         hasher.update(ingress.as_bytes());
         hasher.update(egress.as_bytes());
         let message = hasher.finalize();
@@ -582,6 +583,9 @@ impl ValidatorConfigV2 {
         self.require_new_address(v1_val.validatorAddress)?;
         self.require_new_pubkey(v1_val.publicKey)?;
 
+        PublicKey::decode(v1_val.publicKey.as_slice())
+            .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+
         let egress = v1_val
             .outboundAddress
             .parse::<std::net::SocketAddr>()
@@ -660,6 +664,7 @@ mod tests {
         data.extend_from_slice(&1u64.to_be_bytes());
         data.extend_from_slice(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
         data.extend_from_slice(validator_address.as_slice());
+        data.push(ingress.len() as u8);
         data.extend_from_slice(ingress.as_bytes());
         data.extend_from_slice(egress.as_bytes());
         let message = keccak256(&data);
@@ -692,6 +697,11 @@ mod tests {
             egress: egress.to_string(),
             signature: signature.into(),
         }
+    }
+
+    fn valid_pubkey(seed: u64) -> FixedBytes<32> {
+        let pk = PrivateKey::from_seed(seed);
+        FixedBytes::from_slice(&pk.public_key().encode())
     }
 
     /// Helper to make a complete add call with generated keys
@@ -1356,7 +1366,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1367,7 +1377,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v2_addr,
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: false,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1384,7 +1394,7 @@ mod tests {
             assert_eq!(v2.validator_count()?, 1);
             let migrated = v2.validator_by_index(0)?;
             assert_eq!(migrated.validatorAddress, v1_addr);
-            assert_eq!(migrated.publicKey, FixedBytes::<32>::from([0x11; 32]));
+            assert_eq!(migrated.publicKey, valid_pubkey(1));
             assert_eq!(migrated.deactivatedAtHeight, 0);
 
             // Migrate second validator
@@ -1430,7 +1440,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1483,7 +1493,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1494,7 +1504,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1530,7 +1540,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1541,7 +1551,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.2:8000".to_string(),
                     outboundAddress: "192.168.1.2:9000".to_string(),
@@ -1560,6 +1570,44 @@ mod tests {
             assert_eq!(
                 result,
                 Err(ValidatorConfigV2Error::migration_not_complete().into())
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_migration_rejects_invalid_ed25519_pubkey() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut v1 = v1();
+            v1.initialize(owner)?;
+
+            // Find a 32-byte value that is not a valid Ed25519 curve point.
+            let bad_key = (0u8..)
+                .map(|i| [i; 32])
+                .find(|k| PublicKey::decode(&k[..]).is_err())
+                .unwrap();
+            v1.add_validator(
+                owner,
+                tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
+                    newValidatorAddress: Address::random(),
+                    publicKey: FixedBytes::<32>::from(bad_key),
+                    active: true,
+                    inboundAddress: "192.168.1.1:8000".to_string(),
+                    outboundAddress: "192.168.1.1:9000".to_string(),
+                },
+            )?;
+
+            let mut v2 = ValidatorConfigV2::new();
+            v2.storage.set_block_number(100);
+            let result =
+                v2.migrate_validator(owner, IValidatorConfigV2::migrateValidatorCall { idx: 0 });
+            assert_eq!(
+                result,
+                Err(ValidatorConfigV2Error::invalid_public_key().into())
             );
 
             Ok(())
@@ -1727,7 +1775,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1771,7 +1819,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: v1_addr,
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1856,7 +1904,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x11; 32]),
+                    publicKey: valid_pubkey(1),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.1.1:9000".to_string(),
@@ -1866,7 +1914,7 @@ mod tests {
                 owner,
                 tempo_contracts::precompiles::IValidatorConfig::addValidatorCall {
                     newValidatorAddress: Address::random(),
-                    publicKey: FixedBytes::<32>::from([0x22; 32]),
+                    publicKey: valid_pubkey(2),
                     active: true,
                     inboundAddress: "192.168.1.1:8000".to_string(),
                     outboundAddress: "192.168.2.1:9000".to_string(),

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -622,8 +622,21 @@ impl ValidatorConfigV2 {
 
         // NOTE: this count comparison is sufficient because `add_validator` and
         // `rotate_validator` are blocked until the contract is initialized.
-        if self.validator_count()? < v1.validator_count()? {
+        let v2_count = self.validator_count()?;
+        let v1_count = v1.validator_count()?;
+        if v2_count < v1_count {
             Err(ValidatorConfigV2Error::migration_not_complete())?
+        }
+
+        for i in 0..v1_count {
+            let v1_val = v1.validators(v1.validators_array(i)?)?;
+            let v2_val = self.validators[i as usize].read()?;
+            if v1_val.active && v2_val.deactivated_at_height != 0 {
+                Err(ValidatorConfigV2Error::migration_state_mismatch(i))?
+            }
+            if !v1_val.active && v2_val.deactivated_at_height == 0 {
+                Err(ValidatorConfigV2Error::migration_state_mismatch(i))?
+            }
         }
 
         let v1_next_dkg = v1.get_next_full_dkg_ceremony()?;

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -90,6 +90,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -166,6 +167,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -84,7 +84,14 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _validateAddParams(validatorAddress, publicKey, ingress, egress);
 
         bytes32 message = keccak256(
-            abi.encodePacked(block.chainid, address(this), validatorAddress, ingress, egress)
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
+            )
         );
         _verifyEd25519Signature(
             bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR"), publicKey, message, signature
@@ -153,7 +160,14 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _validateRotateParams(publicKey, ingress, egress);
 
         bytes32 message = keccak256(
-            abi.encodePacked(block.chainid, address(this), validatorAddress, ingress, egress)
+            abi.encodePacked(
+                block.chainid,
+                address(this),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
+            )
         );
         _verifyEd25519Signature(
             bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR"), publicKey, message, signature

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -372,6 +372,17 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             revert MigrationNotComplete();
         }
 
+        for (uint64 i = 0; i < v1Validators.length; i++) {
+            bool v1Active = v1Validators[i].active;
+            uint64 v2Deactivated = validatorsArray[i].deactivatedAtHeight;
+            if (v1Active && v2Deactivated != 0) {
+                revert MigrationStateMismatch(i);
+            }
+            if (!v1Active && v2Deactivated == 0) {
+                revert MigrationStateMismatch(i);
+            }
+        }
+
         nextDkgCeremony = v1.getNextFullDkgCeremony();
 
         _initialized = true;

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -201,8 +201,8 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             revert ValidatorAlreadyDeleted();
         }
 
-        _validateIpPort(ingress, "ingress");
-        _validateIp(egress, "egress");
+        _validateIpPort(ingress);
+        _validateIp(egress);
         _updateIngressIp(v.ingress, ingress);
 
         v.ingress = ingress;
@@ -427,8 +427,8 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         if (pubkeyToIndex[publicKey] != 0) {
             revert PublicKeyAlreadyExists();
         }
-        _validateIpPort(ingress, "ingress");
-        _validateIp(egress, "egress");
+        _validateIpPort(ingress);
+        _validateIp(egress);
         _requireUniqueIngressIp(ingress);
     }
 
@@ -539,44 +539,37 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         return socketAddr;
     }
 
-    function _validateIpPort(string calldata input, string memory field) internal pure {
+    function _validateIpPort(string calldata input) internal pure {
         bytes memory b = bytes(input);
 
         if (b.length == 0) {
-            revert NotIpPort(field, input, "Empty address");
+            revert NotIpPort(input, "Empty address");
         }
 
         if (b[0] == "[") {
-            _validateIpv6Port(b, field, input);
+            _validateIpv6Port(b, input);
         } else {
-            _validateIpv4Port(b, field, input);
+            _validateIpv4Port(b, input);
         }
     }
 
-    function _validateIp(string calldata input, string memory field) internal pure {
+    function _validateIp(string calldata input) internal pure {
         bytes memory b = bytes(input);
 
         if (b.length == 0) {
-            revert NotIpPort(field, input, "Empty address");
+            revert NotIp(input, "Empty address");
         }
 
         if (b[0] == "[") {
-            _validateIpv6Address(b, 1, b.length - 1, field, input);
+            _validateIpv6Address(b, 1, b.length - 1, input);
         } else {
-            _validateIpv4(b, field, input);
+            _validateIpv4(b, input);
         }
     }
 
-    function _validateIpv4Port(
-        bytes memory b,
-        string memory field,
-        string calldata input
-    )
-        internal
-        pure
-    {
+    function _validateIpv4Port(bytes memory b, string calldata input) internal pure {
         if (b.length < 9) {
-            revert NotIpPort(field, input, "Address too short");
+            revert NotIpPort(input, "Address too short");
         }
 
         uint256 i = 0;
@@ -588,7 +581,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             while (i < b.length && b[i] != "." && b[i] != ":") {
                 bytes1 c = b[i];
                 if (c < "0" || c > "9") {
-                    revert NotIpPort(field, input, "Invalid character in octet");
+                    revert NotIpPort(input, "Invalid character in octet");
                 }
                 value = value * 10 + uint8(c) - 48;
                 digitCount++;
@@ -596,41 +589,34 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             }
 
             if (digitCount == 0 || digitCount > 3) {
-                revert NotIpPort(field, input, "Invalid octet length");
+                revert NotIpPort(input, "Invalid octet length");
             }
             if (value > 255) {
-                revert NotIpPort(field, input, "Octet out of range");
+                revert NotIpPort(input, "Octet out of range");
             }
             if (digitCount > 1 && b[i - digitCount] == "0") {
-                revert NotIpPort(field, input, "Leading zeros not allowed");
+                revert NotIpPort(input, "Leading zeros not allowed");
             }
 
             if (octet < 3) {
                 if (i >= b.length || b[i] != ".") {
-                    revert NotIpPort(field, input, "Expected dot separator");
+                    revert NotIpPort(input, "Expected dot separator");
                 }
                 i++;
             }
         }
 
         if (i >= b.length || b[i] != ":") {
-            revert NotIpPort(field, input, "Missing port separator");
+            revert NotIpPort(input, "Missing port separator");
         }
         i++;
 
-        _validatePort(b, i, field, input);
+        _validatePort(b, i, input);
     }
 
-    function _validateIpv4(
-        bytes memory b,
-        string memory field,
-        string calldata input
-    )
-        internal
-        pure
-    {
+    function _validateIpv4(bytes memory b, string calldata input) internal pure {
         if (b.length < 7) {
-            revert NotIpPort(field, input, "Address too short");
+            revert NotIp(input, "Address too short");
         }
 
         uint256 i = 0;
@@ -642,7 +628,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             while (i < b.length && b[i] != ".") {
                 bytes1 c = b[i];
                 if (c < "0" || c > "9") {
-                    revert NotIpPort(field, input, "Invalid character in octet");
+                    revert NotIp(input, "Invalid character in octet");
                 }
                 value = value * 10 + uint8(c) - 48;
                 digitCount++;
@@ -650,38 +636,31 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             }
 
             if (digitCount == 0 || digitCount > 3) {
-                revert NotIpPort(field, input, "Invalid octet length");
+                revert NotIp(input, "Invalid octet length");
             }
             if (value > 255) {
-                revert NotIpPort(field, input, "Octet out of range");
+                revert NotIp(input, "Octet out of range");
             }
             if (digitCount > 1 && b[i - digitCount] == "0") {
-                revert NotIpPort(field, input, "Leading zeros not allowed");
+                revert NotIp(input, "Leading zeros not allowed");
             }
 
             if (octet < 3) {
                 if (i >= b.length || b[i] != ".") {
-                    revert NotIpPort(field, input, "Expected dot separator");
+                    revert NotIp(input, "Expected dot separator");
                 }
                 i++;
             }
         }
 
         if (i != b.length) {
-            revert NotIpPort(field, input, "Unexpected trailing characters");
+            revert NotIp(input, "Unexpected trailing characters");
         }
     }
 
-    function _validateIpv6Port(
-        bytes memory b,
-        string memory field,
-        string calldata input
-    )
-        internal
-        pure
-    {
+    function _validateIpv6Port(bytes memory b, string calldata input) internal pure {
         if (b.length < 6) {
-            revert NotIpPort(field, input, "Address too short");
+            revert NotIpPort(input, "Address too short");
         }
 
         uint256 closeBracket = 0;
@@ -693,30 +672,29 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         }
 
         if (closeBracket == 0) {
-            revert NotIpPort(field, input, "Missing closing bracket");
+            revert NotIpPort(input, "Missing closing bracket");
         }
 
-        _validateIpv6Address(b, 1, closeBracket, field, input);
+        _validateIpv6Address(b, 1, closeBracket, input);
 
         if (closeBracket + 1 >= b.length || b[closeBracket + 1] != ":") {
-            revert NotIpPort(field, input, "Missing port separator after bracket");
+            revert NotIpPort(input, "Missing port separator after bracket");
         }
 
-        _validatePort(b, closeBracket + 2, field, input);
+        _validatePort(b, closeBracket + 2, input);
     }
 
     function _validateIpv6Address(
         bytes memory b,
         uint256 start,
         uint256 end,
-        string memory field,
         string calldata input
     )
         internal
         pure
     {
         if (start >= end) {
-            revert NotIpPort(field, input, "Empty IPv6 address");
+            revert NotIpPort(input, "Empty IPv6 address");
         }
 
         uint256 groupCount = 0;
@@ -739,7 +717,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 bool isHex =
                     (c >= "0" && c <= "9") || (c >= "a" && c <= "f") || (c >= "A" && c <= "F");
                 if (!isHex) {
-                    revert NotIpPort(field, input, "Invalid hex character");
+                    revert NotIpPort(input, "Invalid hex character");
                 }
                 digitCount++;
                 i++;
@@ -747,11 +725,11 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
             if (digitCount == 0) {
                 if (doubleColonPos == type(uint256).max) {
-                    revert NotIpPort(field, input, "Empty group without ::");
+                    revert NotIpPort(input, "Empty group without ::");
                 }
             } else {
                 if (digitCount > 4) {
-                    revert NotIpPort(field, input, "Group exceeds 4 hex digits");
+                    revert NotIpPort(input, "Group exceeds 4 hex digits");
                 }
                 groupCount++;
             }
@@ -760,7 +738,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 if (b[i] == ":") {
                     if (i + 1 < end && b[i + 1] == ":") {
                         if (doubleColonPos != type(uint256).max) {
-                            revert NotIpPort(field, input, "Multiple :: not allowed");
+                            revert NotIpPort(input, "Multiple :: not allowed");
                         }
                         doubleColonPos = groupCount;
                         i += 2;
@@ -776,26 +754,18 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         if (doubleColonPos == type(uint256).max) {
             if (groupCount != 8) {
-                revert NotIpPort(field, input, "Must have 8 groups without ::");
+                revert NotIpPort(input, "Must have 8 groups without ::");
             }
         } else {
             if (groupCount >= 8) {
-                revert NotIpPort(field, input, "Too many groups with ::");
+                revert NotIpPort(input, "Too many groups with ::");
             }
         }
     }
 
-    function _validatePort(
-        bytes memory b,
-        uint256 start,
-        string memory field,
-        string calldata input
-    )
-        internal
-        pure
-    {
+    function _validatePort(bytes memory b, uint256 start, string calldata input) internal pure {
         if (start >= b.length) {
-            revert NotIpPort(field, input, "Missing port number");
+            revert NotIpPort(input, "Missing port number");
         }
 
         uint256 port = 0;
@@ -804,23 +774,23 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         for (uint256 i = start; i < b.length; i++) {
             bytes1 c = b[i];
             if (c < "0" || c > "9") {
-                revert NotIpPort(field, input, "Invalid port character");
+                revert NotIpPort(input, "Invalid port character");
             }
             port = port * 10 + uint8(c) - 48;
             digitCount++;
         }
 
         if (digitCount == 0) {
-            revert NotIpPort(field, input, "Empty port number");
+            revert NotIpPort(input, "Empty port number");
         }
         if (digitCount > 5) {
-            revert NotIpPort(field, input, "Port too long");
+            revert NotIpPort(input, "Port too long");
         }
         if (port > 65_535) {
-            revert NotIpPort(field, input, "Port out of range");
+            revert NotIpPort(input, "Port out of range");
         }
         if (digitCount > 1 && b[start] == "0") {
-            revert NotIpPort(field, input, "Leading zeros in port");
+            revert NotIpPort(input, "Leading zeros in port");
         }
     }
 

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -98,7 +98,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, uint8(bytes(egress).length), egress))
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
     /// @param validatorAddress The address of the new validator
@@ -133,7 +133,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, uint8(bytes(egress).length), egress))
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
     /// @param ingress The new validator's inbound address `<ip>:<port>` for incoming connections

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -51,6 +51,10 @@ interface IValidatorConfigV2 {
     /// @notice Thrown when migration is not complete (not all V1 validators migrated)
     error MigrationNotComplete();
 
+    /// @notice Thrown when a migrated validator's active/deactivated state does not match V1
+    /// @param idx The index of the validator with mismatched state
+    error MigrationStateMismatch(uint64 idx);
+
     /// @notice Thrown when migration index is out of order
     error InvalidMigrationIndex();
 

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -98,7 +98,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ADD_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
     /// @param validatorAddress The address of the new validator
@@ -133,7 +133,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked("TEMPO", "_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR", chainId, contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
     /// @param ingress The new validator's inbound address `<ip>:<port>` for incoming connections

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -11,7 +11,8 @@ pragma solidity >=0.8.13 <0.9.0;
 ///      - `active` bool replaced by `addedAtHeight` and `deactivatedAtHeight`
 ///      - No `updateValidator` - validators are immutable after creation
 ///      - Requires Ed25519 signature on `addValidator` to prove key ownership
-///      - Both address and public key must be unique across all validators (including deleted)
+///      - Addresses must be unique among active validators (reusable after deactivation)
+///      - Public keys must be unique across all validators (including deleted)
 interface IValidatorConfigV2 {
 
     // =========================================================================
@@ -80,7 +81,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Validator information (V2 - append-only, delete-once)
     /// @param publicKey Ed25519 communication public key (non-zero, unique across all validators)
-    /// @param validatorAddress Ethereum-style address of the validator (unique across all validators)
+    /// @param validatorAddress Ethereum-style address of the validator (unique among active validators)
     /// @param ingress Address where other validators can connect (format: `<ip>:<port>`)
     /// @param egress IP address from which this validator will dial, e.g. for firewall whitelisting (format: `<ip>`)
     /// @param index Position in validators array (assigned at creation, immutable)
@@ -122,8 +123,8 @@ interface IValidatorConfigV2 {
     /// @notice Deactivates a validator (owner or validator only)
     /// @dev Marks the validator as deactivated by setting deactivatedAtHeight to the current block height.
     ///      The validator's entry remains in storage for historical queries.
-    ///      The public key remains reserved and cannot be reused. The address remains
-    ///      reserved unless reassigned via transferValidatorOwnership.
+    ///      The public key remains reserved and cannot be reused. The address becomes
+    ///      available for reuse by a new validator or via transferValidatorOwnership.
     /// @param validatorAddress The validator address to deactivate
     function deactivateValidator(address validatorAddress) external;
 

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -60,16 +60,14 @@ interface IValidatorConfigV2 {
     error InvalidMigrationIndex();
 
     /// @notice Thrown when address is not in valid ip:port format
-    /// @param field The field name that failed validation
     /// @param input The invalid input that was provided
     /// @param backtrace Additional error context
-    error NotIpPort(string field, string input, string backtrace);
+    error NotIpPort(string input, string backtrace);
 
     /// @notice Thrown when address is not a valid IP (for egress field)
-    /// @param field The field name that failed validation
     /// @param input The invalid input that was provided
     /// @param backtrace Additional error context
-    error NotIp(string field, string input, string backtrace);
+    error NotIp(string input, string backtrace);
 
     /// @notice Thrown when ingress IP is already in use by another active validator
     /// @param ingress The ingress address that is already in use

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -57,6 +57,7 @@ contract ValidatorConfigV2Test is BaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -86,6 +87,7 @@ contract ValidatorConfigV2Test is BaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -52,7 +52,12 @@ contract ValidatorConfigV2Test is BaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         // Forge's signEd25519 does simple concat(namespace, message), but the Rust
@@ -76,7 +81,12 @@ contract ValidatorConfigV2Test is BaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR");

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -117,7 +117,12 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR");
@@ -138,7 +143,12 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                uint8(bytes(ingress).length),
+                ingress,
+                egress
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR");

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -122,6 +122,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );
@@ -148,6 +149,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
                 validatorAddress,
                 uint8(bytes(ingress).length),
                 ingress,
+                uint8(bytes(egress).length),
                 egress
             )
         );

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -106,7 +106,7 @@ interface IValidatorConfigV2 {
     /// @notice Thrown when trying to delete a validator that is already deleted
     error ValidatorAlreadyDeleted();
 
-    /// @notice Thrown when public key is invalid (zero)
+    /// @notice Thrown when public key is invalid (zero or not a valid Ed25519 curve point)
     error InvalidPublicKey();
 
     /// @notice Thrown when the Ed25519 signature verification fails
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, ingress, egress))
+    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
@@ -329,11 +329,12 @@ signature is checked over the a full message containing: the length of the names
 **Message:**
 ```
 message = keccak256(abi.encodePacked(
-    bytes8(chainId),      // uint64: Prevents cross-chain replay
-    contractAddress,      // address: Prevents cross-contract replay
-    validatorAddress,     // address: Binds to specific validator address
-    ingress,              // string: Binds network configuration
-    egress                // string: Binds network configuration
+    bytes8(chainId),           // uint64: Prevents cross-chain replay
+    contractAddress,           // address: Prevents cross-contract replay
+    validatorAddress,          // address: Binds to specific validator address
+    uint8(ingress.length),     // uint8: Length prefix to prevent ingress/egress boundary collision
+    ingress,                   // string: Binds network configuration
+    egress                     // string: Binds network configuration
 ))
 ```
 
@@ -592,7 +593,7 @@ precompile does NOT proxy reads to V1.
 - On first call (when `validatorsArray.length == 0`), copies `owner` from V1 if V2 owner is `address(0)`
 - Reads the validator from V1 at index `idx`
 - Creates a V2 validator entry with:
-  - `publicKey`: copied from V1
+  - `publicKey`: copied from V1 (must be a valid Ed25519 curve point; reverts with `InvalidPublicKey` otherwise)
   - `validatorAddress`: copied from V1
   - `ingress`: copied from V1 `inboundAddress`
   - `egress`: copied from V1 `outboundAddress`
@@ -640,7 +641,7 @@ interface IValidatorConfigV1 {
 - **Validator address copied**: The V2 validator address is copied from V1
 - **Address changeable post-migration**: Owner or validator can update validator addresses via `transferValidatorOwnership`
 - **No signatures required**: V1 validators are imported without Ed25519 signatures
-  (they were already validated in V1)
+  (the public key is validated as a decodable Ed25519 curve point during migration)
 - **All validators imported**: Both active and inactive V1 validators are
   imported; active ones have `addedAtHeight == block.height` and `deactivatedAtHeight == 0`,
   inactive ones have `addedAtHeight == deactivatedAtHeight == block.height`.
@@ -720,7 +721,7 @@ The test suite must cover:
 12. **PublicKeyAlreadyExists**: Cannot re-use same public key
 13. **ValidatorNotFound**: Cannot query/delete non-existent validator
 14. **ValidatorAlreadyDeleted**: Cannot delete twice
-15. **InvalidPublicKey**: Rejects zero public key
+15. **InvalidPublicKey**: Rejects zero public key and invalid Ed25519 curve points
 16. **InvalidSignature**: Rejects wrong signature, wrong length, wrong signer
 17. **IngressAlreadyExists**: Cannot use ingress IP already in use by active validator (even with different port)
 

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length || ingress || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(abi.encodePacked(bytes8(chainId), contractAddress, validatorAddress, uint8(bytes(ingress).length), ingress, egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -114,10 +114,9 @@ interface IValidatorConfigV2 {
     error InvalidSignature();
 
     /// @notice Thrown when address is not in valid ip:port format
-    /// @param field The field name that failed validation
     /// @param input The invalid input that was provided
     /// @param backtrace Additional error context
-    error NotIpPort(string field, string input, string backtrace);
+    error NotIpPort(string input, string backtrace);
 
     /// @notice Thrown when trying to use an ingress IP already in use by another active validator
     /// @param ingress The ingress address that is already in use

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -183,7 +183,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Add a new validator (owner only)
     /// @dev The signature must be an Ed25519 signature over:
-    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length || ingress || egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || uint8(bytes(egress).length) || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR".
     ///      This proves the caller controls the private key corresponding to publicKey.
     ///      Reverts if isInitialized() returns false.
@@ -219,7 +219,7 @@ interface IValidatorConfigV2 {
     ///      - Egress must be parseable as <ip>.
     ///      - The signature must prove ownership of the new public key
     ///      The signature must be an Ed25519 signature over:
-    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || egress))
+    ///      keccak256(bytes8(chainId) || contractAddress || validatorAddress || uint8(bytes(ingress).length) || ingress || uint8(bytes(egress).length) || egress))
     ///      using the namespace "TEMPO_VALIDATOR_CONFIG_V2_ROTATE_VALIDATOR".
     /// @param validatorAddress The address of the validator to rotate
     /// @param publicKey The new validator's Ed25519 communication public key
@@ -328,14 +328,15 @@ signature is checked over the a full message containing: the length of the names
 
 **Message:**
 ```
-message = keccak256(abi.encodePacked(
-    bytes8(chainId),           // uint64: Prevents cross-chain replay
-    contractAddress,           // address: Prevents cross-contract replay
-    validatorAddress,          // address: Binds to specific validator address
-    uint8(ingress.length),     // uint8: Length prefix to prevent ingress/egress boundary collision
-    ingress,                   // string: Binds network configuration
-    egress                     // string: Binds network configuration
-))
+message = keccak256(
+    bytes8(chainId)            // uint64: Prevents cross-chain replay
+    || contractAddress         // address: Prevents cross-contract replay
+    || validatorAddress        // address: Binds to specific validator address
+    || uint8(ingress.length)   // uint8: Length prefix to prevent ingress/egress boundary collision
+    || ingress                 // string: Binds network configuration
+    || uint8(egress.length)    // uint8: Length prefix to prevent egress boundary collision
+    || egress                  // string: Binds network configuration
+)
 ```
 
 The Ed25519 signature is computed over the message using the namespace parameter

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -88,7 +88,8 @@ pragma solidity ^0.8.13;
 ///      - `active` bool replaced by `addedAtHeight` and `deactivatedAtHeight`
 ///      - No `updateValidator` - validators are immutable after creation
 ///      - Requires Ed25519 signature on `addValidator` to prove key ownership
-///      - Both address and public key must be unique across all validators (including deleted)
+///      - Addresses must be unique among active validators (reusable after deactivation)
+///      - Public keys must be unique across all validators (including deleted)
 interface IValidatorConfigV2 {
 
     /// @notice Thrown when caller lacks authorization to perform the requested action
@@ -124,7 +125,7 @@ interface IValidatorConfigV2 {
 
     /// @notice Validator information (V2 - append-only, delete-once)
     /// @param publicKey Ed25519 communication public key (non-zero, unique across all validators)
-    /// @param validatorAddress Ethereum-style address of the validator (unique across all validators)
+    /// @param validatorAddress Ethereum-style address of the validator (unique among active validators)
     /// @param ingress Address where other validators can connect (format: `<ip>:<port>`)
     /// @param egress IP address from which this validator will dial, e.g. for firewall whitelisting (format: `<ip>`)
     /// @param index Position in validators array (assigned at creation, immutable)
@@ -203,8 +204,8 @@ interface IValidatorConfigV2 {
     /// @notice Deactivates a validator (owner or existing validator)
     /// @dev Marks the validator as deactivated by setting deactivatedAtHeight to the current block height.
     ///      The validator's entry remains in storage for historical queries.
-    ///      The public key remains reserved and cannot be reused. The address remains
-    ///      reserved unless reassigned via transferValidatorOwnership.
+    ///      The public key remains reserved and cannot be reused. The address becomes
+    ///      available for reuse by a new validator or via transferValidatorOwnership.
     ///
     /// @param validatorAddress The validator address to deactivate
     function deactivateValidator(address validatorAddress) external;
@@ -413,10 +414,11 @@ This enables nodes to reconstruct DKG player sets without accessing historical a
 
 ### Uniqueness Constraints
 
-Both the validator address and public key must be globally unique across all
-validators (including deleted ones):
+Validator addresses must be unique among active validators; deactivated addresses
+may be reused. Public keys must be globally unique across all validators
+(including deleted ones):
 
-- `AddressAlreadyHasValidator`: Reverts if the address has ever been registered
+- `AddressAlreadyHasValidator`: Reverts if the address is in use by an active validator
 - `PublicKeyAlreadyExists`: Reverts if the public key has ever been registered
 
 This ensures historical queries always return consistent results.
@@ -446,7 +448,7 @@ Implementation details such as slot packing are left to the implementation.
 | Re-registration | Allowed after deletion | Pubkey reserved forever; address reassignable via `transferValidatorOwnership` |
 | Key ownership | Not verified | Ed25519 signature required |
 | Historical queries | Requires historical state | Filter `getAllValidators()` by `addedAtHeight`/`deactivatedAtHeight` |
-| Uniqueness | Address only | Address AND public key |
+| Uniqueness | Address only | Address (active only) AND public key (global) |
 | Precompile address | `0xCCCC...0000` | `0xCCCC...0001` |
 
 ---
@@ -472,8 +474,8 @@ The following invariants must always hold:
 4. **Delete-once**: A validator's `deactivatedAtHeight` can only transition from 0
    to a non-zero value, never back to 0 or to a different non-zero value.
 
-5. **Unique addresses**: No two validators (including deleted ones) can have the
-   same `validatorAddress`.
+5. **Unique addresses**: No two active validators can have the same
+   `validatorAddress`. Deactivated addresses may be reused.
 
 6. **Unique public keys**: No two validators (including deleted ones) can have
    the same `publicKey`.

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -1011,13 +1011,14 @@ fn initialize_validator_config_v2(
                 let ingress = addr.to_string();
                 let egress = addr.ip().to_string();
 
-                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress)
+                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || uint8(egress.len) || egress)
                 let mut hasher = Keccak256::new();
                 hasher.update(chain_id.to_be_bytes());
                 hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
                 hasher.update(validator_address.as_slice());
                 hasher.update([ingress.len() as u8]);
                 hasher.update(ingress.as_bytes());
+                hasher.update([egress.len() as u8]);
                 hasher.update(egress.as_bytes());
                 let message = hasher.finalize();
 

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -1011,11 +1011,12 @@ fn initialize_validator_config_v2(
                 let ingress = addr.to_string();
                 let egress = addr.ip().to_string();
 
-                // message: keccak256(chainId || contractAddr || validatorAddr || ingress || egress)
+                // message: keccak256(chainId || contractAddr || validatorAddr || uint8(ingress.len) || ingress || egress)
                 let mut hasher = Keccak256::new();
                 hasher.update(chain_id.to_be_bytes());
                 hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
                 hasher.update(validator_address.as_slice());
+                hasher.update([ingress.len() as u8]);
                 hasher.update(ingress.as_bytes());
                 hasher.update(egress.as_bytes());
                 let message = hasher.finalize();


### PR DESCRIPTION
## Summary

Aligns TIP-1017 spec and Solidity ref-impl with the Rust V2 implementation.

**Before (spec/Solidity):**
```solidity
error NotIpPort(string field, string input, string backtrace);
error NotIp(string field, string input, string backtrace);
```

**After (matches Rust):**
```solidity
error NotIpPort(string input, string backtrace);
error NotIp(string input, string backtrace);
```

### Changes
- `tips/tip-1017.md` — Removed `field` param from `NotIpPort` spec
- `IValidatorConfigV2.sol` — Removed `field` from `NotIpPort` and `NotIp` declarations
- `ValidatorConfigV2.sol` — Removed `field` from all 7 internal validation function signatures, call sites, and ~35 revert statements

V1 files untouched (V1 Rust and Solidity both have `field` and are consistent).

Resolves ZELLIC-65