### PR TITLE
chore: make clippy happy

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -1180,7 +1180,7 @@ async fn assert_receipts<R: ReceiptResponse, F: Future<Output = eyre::Result<R>>
     receipts: impl IntoIterator<Item = F>,
     max_concurrent_requests: usize,
 ) -> eyre::Result<()> {
-    stream::iter(receipts.into_iter())
+    stream::iter(receipts)
         .buffer_unordered(max_concurrent_requests)
         .try_for_each(|receipt| assert_receipt(receipt))
         .await


### PR DESCRIPTION
With latest nightly we get on main:
```
warning: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
    --> bin/tempo-bench/src/cmd/max_tps.rs:1183:18
     |
1183 |     stream::iter(receipts.into_iter())
     |                  ^^^^^^^^^^^^^^^^^^^^
     |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
    --> /home/home-link/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/stream/iter.rs:48:8
     |
  48 |     I: IntoIterator,
     |        ^^^^^^^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
     = note: `#[warn(clippy::useless_conversion)]` on by default
help: consider removing the `.into_iter()`
     |
1183 -     stream::iter(receipts.into_iter())
1183 +     stream::iter(receipts)
```