### PR TITLE
Remove unsupported `--disable-thread-pinning` flag

### DIFF
--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -149,7 +149,7 @@ tempo-bench run-max-tps --duration 15 --tps 20000
 Run benchmark on MacOS:
 
 ```bash
-tempo-bench run-max-tps --duration 15 --tps 20000 --disable-thread-pinning
+tempo-bench run-max-tps --duration 15 --tps 20000
 ```
 
 Run benchmark with less workers than the default:


### PR DESCRIPTION
The README (tempo/bin/tempo-bench/README.md) for the MacOS example run-max-tps specifies the `--disable-thread-pinning` flag, which is not present in the actual CLI.

- The `--disable-thread-pinning` flag has been removed from the example for MacOS.
- The example has been left working with the supported options:
```bash
tempo-bench run-max-tps --duration 15 --tps 20000
```