### PR TITLE
fix: use pull_request_target so audit triggers on PRs with merge conflicts

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,7 +1,7 @@
 name: Pull request audit
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:


### PR DESCRIPTION
## Problem

The `pr-audit.yml` workflow uses `pull_request` with `types: [labeled]`. GitHub Actions does not trigger `pull_request` events for PRs with a `CONFLICTING` merge state because it cannot create the merge ref. This causes the `agentic-audit` label to silently fail to trigger the audit workflow (e.g. [PR #2870](https://github.com/tempoxyz/tempo/pull/2870)).

## Fix

Switch to `pull_request_target`, which runs against the base branch and doesn't require a merge commit — so it triggers even when the PR has conflicts.

This is safe because the workflow only reads PR event metadata (`number`, `head.sha`) and posts to an events endpoint. It does not checkout or execute any PR code.