### PR TITLE
docs: add links to TIP references in doc comments

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -178,9 +178,11 @@ pub struct MaxTpsArgs {
 
     /// Use 2D nonces instead of expiring nonces.
     ///
-    /// By default, tempo-bench uses expiring nonces (TIP-1009) which use a circular buffer
+    /// By default, tempo-bench uses expiring nonces ([TIP-1009]) which use a circular buffer
     /// for replay protection, avoiding state bloat. Use this flag to switch to 2D nonces
     /// which store nonce state per (address, nonce_key) pair.
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     #[arg(long)]
     use_2d_nonces: bool,
 

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -70,10 +70,12 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for R
     }
 }
 
-/// A [`TxFiller`] that populates transactions with expiring nonce fields (TIP-1009).
+/// A [`TxFiller`] that populates transactions with expiring nonce fields ([TIP-1009]).
 ///
 /// Sets `nonce_key` to `U256::MAX`, `nonce` to `0`, and `valid_before` to current time + expiry window.
 /// This enables transactions to use the circular buffer replay protection instead of 2D nonce storage.
+///
+/// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
 #[derive(Clone, Copy, Debug)]
 pub struct ExpiringNonceFiller {
     /// Expiry window in seconds from current time.
@@ -89,7 +91,9 @@ impl Default for ExpiringNonceFiller {
 }
 
 impl ExpiringNonceFiller {
-    /// Default expiry window in seconds (25s, within the 30s max allowed by TIP-1009).
+    /// Default expiry window in seconds (25s, within the 30s max allowed by [TIP-1009]).
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     pub const DEFAULT_EXPIRY_SECS: u64 = 25;
 
     /// Create a new filler with a custom expiry window.

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -23,7 +23,9 @@ pub trait TempoProviderBuilderExt {
 
     /// Returns a provider builder with the recommended Tempo fillers and the expiring nonce filler.
     ///
-    /// See [`ExpiringNonceFiller`] for more information on expiring nonces (TIP-1009).
+    /// See [`ExpiringNonceFiller`] for more information on expiring nonces ([TIP-1009]).
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     fn with_expiring_nonces(
         self,
     ) -> ProviderBuilder<

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -73,8 +73,10 @@ pub struct TempoTransactionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_authorization: Option<SignedKeyAuthorization>,
 
-    /// Transaction valid before timestamp in seconds (for expiring nonces, TIP-1009).
+    /// Transaction valid before timestamp in seconds (for expiring nonces, [TIP-1009]).
     /// Transaction can only be included in a block before this timestamp.
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -82,8 +84,10 @@ pub struct TempoTransactionRequest {
     )]
     pub valid_before: Option<u64>,
 
-    /// Transaction valid after timestamp in seconds (for expiring nonces, TIP-1009).
+    /// Transaction valid after timestamp in seconds (for expiring nonces, [TIP-1009]).
     /// Transaction can only be included in a block after this timestamp.
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -120,7 +124,9 @@ impl TempoTransactionRequest {
         self
     }
 
-    /// Set the valid_before timestamp for expiring nonces (TIP-1009).
+    /// Set the valid_before timestamp for expiring nonces ([TIP-1009]).
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     pub fn set_valid_before(&mut self, valid_before: u64) {
         self.valid_before = Some(valid_before);
     }
@@ -131,7 +137,9 @@ impl TempoTransactionRequest {
         self
     }
 
-    /// Set the valid_after timestamp for expiring nonces (TIP-1009).
+    /// Set the valid_after timestamp for expiring nonces ([TIP-1009]).
+    ///
+    /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     pub fn set_valid_after(&mut self, valid_after: u64) {
         self.valid_after = Some(valid_after);
     }

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -52,7 +52,9 @@ hardfork!(
         T1B,
         /// T1.C hardfork
         T1C,
-        /// T2 hardfork - adds compound transfer policies (TIP-1015)
+        /// T2 hardfork - adds compound transfer policies ([TIP-1015])
+        ///
+        /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
         T2,
     }
 );
@@ -118,7 +120,9 @@ impl TempoHardfork {
 
     /// Returns the per-transaction gas limit cap.
     /// - Pre-T1A: EIP-7825 Osaka limit (16,777,216 gas)
-    /// - T1A+: 30M gas (allows maximum-sized contract deployments under TIP-1000 state creation)
+    /// - T1A+: 30M gas (allows maximum-sized contract deployments under [TIP-1000] state creation)
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     pub const fn tx_gas_limit_cap(&self) -> Option<u64> {
         match self {
             Self::T1A | Self::T1B | Self::T1C | Self::T2 => {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -38,12 +38,16 @@ pub const TEMPO_T0_BASE_FEE: u64 = 10_000_000_000;
 /// - Economic: 1,000 microdollars = 0.001 USD = 0.1 cents
 pub const TEMPO_T1_BASE_FEE: u64 = 20_000_000_000;
 
-/// TIP-1010 general (non-payment) gas limit: 30 million gas per block.
+/// [TIP-1010] general (non-payment) gas limit: 30 million gas per block.
 /// Cap for non-payment transactions.
+///
+/// [TIP-1010]: <https://docs.tempo.xyz/protocol/tips/tip-1010>
 pub const TEMPO_T1_GENERAL_GAS_LIMIT: u64 = 30_000_000;
 
 /// TIP-1010 per-transaction gas limit cap: 30 million gas.
-/// Allows maximum-sized contract deployments under TIP-1000 state creation costs.
+/// Allows maximum-sized contract deployments under [TIP-1000] state creation costs.
+///
+/// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
 pub const TEMPO_T1_TX_GAS_LIMIT_CAP: u64 = 30_000_000;
 
 // End-of-block system transactions

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -437,7 +437,9 @@ mod tests {
     }
 
     /// Test that TempoEvm applies custom gas params via `tempo_gas_params()`.
-    /// This verifies the TIP-1000 gas parameter override mechanism.
+    /// This verifies the [TIP-1000] gas parameter override mechanism.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     #[test]
     fn test_tempo_evm_applies_gas_params() {
         // Create EVM with T1 hardfork to get TIP-1000 gas params
@@ -454,8 +456,10 @@ mod tests {
     }
 
     /// Test that TempoEvm respects the gas limit cap passed in via EvmEnv.
-    /// Note: The 30M TIP-1000 gas cap is set in ConfigureEvm::evm_env(), not here.
+    /// Note: The 30M [TIP-1000] gas cap is set in ConfigureEvm::evm_env(), not here.
     /// This test verifies that TempoEvm::new() preserves the cap from the input.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     #[test]
     fn test_tempo_evm_respects_gas_cap() {
         let mut env = evm_env_with_spec(TempoHardfork::T1);

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -305,7 +305,9 @@ mod tests {
         assert_eq!(evm_env.block_env.timestamp_millis_part, 500);
     }
 
-    /// Test that evm_env sets 30M gas limit cap for T1 hardfork as per TIP-1000.
+    /// Test that evm_env sets 30M gas limit cap for T1 hardfork as per [TIP-1000].
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     #[test]
     fn test_evm_env_t1_gas_cap() {
         use tempo_chainspec::spec::DEV;

--- a/crates/node/tests/it/max_gas_limit.rs
+++ b/crates/node/tests/it/max_gas_limit.rs
@@ -1,7 +1,10 @@
-//! Tests for per-transaction gas limit caps across hardforks (TIP-1000/1010).
+//! Tests for per-transaction gas limit caps across hardforks ([TIP-1000]/[TIP-1010]).
 //!
 //! Pre-T1A: EIP-7825 Osaka limit (16,777,216 gas).
 //! Post-T1A (TIP-1010): per-tx gas limit cap is 30M (`TEMPO_T1_TX_GAS_LIMIT_CAP`).
+//!
+//! [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
+//! [TIP-1010]: <https://docs.tempo.xyz/protocol/tips/tip-1010>
 
 use alloy::{
     consensus::{SignableTransaction, TxEip1559, TxEnvelope},

--- a/crates/node/tests/it/tip_fee_manager.rs
+++ b/crates/node/tests/it/tip_fee_manager.rs
@@ -465,9 +465,11 @@ async fn test_fee_payer_tx() -> eyre::Result<()> {
     Ok(())
 }
 
-/// TIP-1007: getFeeToken() returns address(0) in eth_call simulation contexts
+/// [TIP-1007]: getFeeToken() returns address(0) in eth_call simulation contexts
 /// because the handler skips writing the fee token to transient storage when
 /// `disable_fee_charge` is set (per TIP-1007 spec).
+///
+/// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -492,9 +494,11 @@ async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
     Ok(())
 }
 
-/// TIP-1007: getFeeToken() returns the correct fee token during real transaction
+/// [TIP-1007]: getFeeToken() returns the correct fee token during real transaction
 /// execution, is consistent across multiple calls within the same tx, and
 /// transient storage is properly cleared between transactions.
+///
+/// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_during_execution() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1080,9 +1080,13 @@ impl StablecoinDEX {
         ))
     }
 
-    /// Cancel a stale order where the maker is forbidden by TIP-403 policy
+    /// Cancel a stale order where the maker is forbidden by [TIP-403] policy
     /// Allows anyone to clean up stale orders from blacklisted makers
-    /// TIP-1015: For T2+, checks sender authorization (maker must be able to send the escrowed token)
+    /// [TIP-1015]: For T2+, checks sender authorization
+    /// (maker must be able to send the escrowed token)
+    ///
+    /// [TIP-403]: <https://docs.tempo.xyz/protocol/tip403>
+    /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn cancel_stale_order(&mut self, order_id: u128) -> Result<()> {
         let order = self.orders[order_id].read()?;
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -57,8 +57,10 @@ pub fn validate_usd_currency(token: Address) -> Result<()> {
 /// TIP-20 token contract — the native token standard on Tempo.
 ///
 /// Implements ERC-20-like functionality (balances, allowances, transfers) with additional
-/// features: role-based access control, pausability, supply caps, transfer policies (TIP-403),
+/// features: role-based access control, pausability, supply caps, transfer policies ([TIP-403]),
 /// and opt-in staking rewards.
+///
+/// [TIP-403]: <https://docs.tempo.xyz/protocol/tip403>
 ///
 /// Each token lives at a deterministic address with the `0x20C0` prefix.
 ///
@@ -793,7 +795,9 @@ impl TIP20Token {
     }
 
     /// Checks if the transfer is authorized.
-    /// TIP-1015: For T2+, uses directional sender/recipient checks.
+    /// [TIP-1015]: For T2+, uses directional sender/recipient checks.
+    ///
+    /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn is_transfer_authorized(&self, from: Address, to: Address) -> Result<bool> {
         let policy_id = self.transfer_policy_id()?;
         let registry = TIP403Registry::new();

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -14,8 +14,10 @@ use crate::{
 };
 use alloy::primitives::{Address, U256};
 
-/// Registry for TIP-403 transfer policies. TIP20 tokens reference an ID from this registry
+/// Registry for [TIP-403] transfer policies. TIP20 tokens reference an ID from this registry
 /// to police transfers between sender and receiver addresses.
+///
+/// [TIP-403]: <https://docs.tempo.xyz/protocol/tip403>
 ///
 /// The struct fields define the on-chain storage layout; the `#[contract]` macro generates the
 /// storage handlers which provide an ergonomic way to interact with the EVM state.
@@ -26,7 +28,9 @@ pub struct TIP403Registry {
     policy_set: Mapping<u64, Mapping<Address, bool>>,
 }
 
-/// Policy record containing base data and optional data for compound policies (TIP-1015)
+/// Policy record containing base data and optional data for compound policies ([TIP-1015])
+///
+/// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
 #[derive(Debug, Clone, Storable)]
 pub struct PolicyRecord {
     /// Base policy data
@@ -35,7 +39,9 @@ pub struct PolicyRecord {
     pub compound: CompoundPolicyData,
 }
 
-/// Data for compound policies (TIP-1015)
+/// Data for compound policies ([TIP-1015])
+///
+/// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
 #[derive(Debug, Clone, Default, Storable)]
 pub struct CompoundPolicyData {
     pub sender_policy_id: u64,
@@ -164,7 +170,9 @@ impl TIP403Registry {
         })
     }
 
-    /// Returns the compound policy data for a compound policy (TIP-1015)
+    /// Returns the compound policy data for a compound policy ([TIP-1015])
+    ///
+    /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn compound_policy_data(
         &self,
         call: ITIP403Registry::compoundPolicyDataCall,
@@ -393,7 +401,9 @@ impl TIP403Registry {
         ))
     }
 
-    /// Creates a new compound policy that references three simple policies (TIP-1015)
+    /// Creates a new compound policy that references three simple policies ([TIP-1015])
+    ///
+    /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn create_compound_policy(
         &mut self,
         msg_sender: Address,
@@ -440,7 +450,9 @@ impl TIP403Registry {
         Ok(new_policy_id)
     }
 
-    /// Core role-based authorization check (TIP-1015).
+    /// Core role-based authorization check ([TIP-1015]).
+    ///
+    /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn is_authorized_as(&self, policy_id: u64, user: Address, role: AuthRole) -> Result<bool> {
         if let Some(auth) = self.builtin_authorization(policy_id) {
             return Ok(auth);

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -43,8 +43,10 @@ pub struct TipFeeManager {
     // WARNING(rusowsky): transient storage slots must always be placed at the very end until the `contract`
     // macro is refactored and has 2 independent layouts (persistent and transient).
     // If new (persistent) storage fields need to be added to the precompile, they must go above this one.
-    /// T2+: The fee token used for the current transaction (TIP-1007).
+    /// T2+: The fee token used for the current transaction ([TIP-1007]).
     /// Set by the handler before execution, read via `getFeeToken()`.
+    ///
+    /// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
     tx_fee_token: Address,
 }
 

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -291,7 +291,9 @@ mod tests {
     }
 
     /// Create an EVM with T1 hardfork enabled and a funded account.
-    /// This applies TIP-1000 gas params via `tempo_gas_params()`.
+    /// This applies [TIP-1000] gas params via `tempo_gas_params()`.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     fn create_funded_evm_t1(address: Address) -> TempoEvm<CacheDB<EmptyDB>, ()> {
         let db = CacheDB::new(EmptyDB::new());
         let mut cfg = CfgEnv::<TempoHardfork>::default();

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -74,7 +74,9 @@ const KEY_AUTH_PER_LIMIT_GAS: u64 = 22_000;
 
 /// Gas cost for expiring nonce transactions (replay check + insert).
 ///
-/// See TIP-1009 for full specification.
+/// See [TIP-1009] for full specification.
+///
+/// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
 ///
 /// Operations charged:
 /// - 2 cold SLOADs: `seen[tx_hash]`, `ring[idx]` (unique slots per tx)
@@ -3251,11 +3253,13 @@ mod tests {
 
     /// Test that T1 hardfork correctly charges 250k gas for nonce == 0.
     ///
-    /// This test validates TIP-1000's requirement:
+    /// This test validates [TIP-1000]'s requirement:
     /// "Tempo transactions with any `nonce_key` and `nonce == 0` require an additional 250,000 gas"
     ///
     /// The test proves the audit finding (claiming only 22,100 gas is charged) is a false positive
     /// by using delta-based assertions: gas(nonce=0) - gas(nonce>0) == new_account_cost.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     #[test]
     fn test_t1_2d_nonce_key_charges_250k_gas() {
         use crate::gas_params::tempo_gas_params;
@@ -3351,12 +3355,14 @@ mod tests {
 
     /// Test that T1 hardfork correctly charges 5k gas for existing 2D nonce keys (nonce > 0).
     ///
-    /// This test validates TIP-1000 Invariant 3:
+    /// This test validates [TIP-1000] Invariant 3:
     /// "SSTORE operations that modify existing non-zero state (non-zero to non-zero)
     /// MUST continue to charge 5,000 gas"
     ///
     /// When using an existing 2D nonce key (nonce_key != 0 && nonce > 0), the nonce value
     /// transitions from N to N+1 (non-zero to non-zero), which must charge EXISTING_NONCE_KEY_GAS.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     #[test]
     fn test_t1_existing_2d_nonce_key_charges_5k_gas() {
         use crate::gas_params::tempo_gas_params;


### PR DESCRIPTION
Replaces bare `TIP-XXXX` references in doc comments and code comments with `[TIP-XXXX](url)` links so readers can jump directly to the spec on docs.tempo.xyz.

Covers TIP-403, TIP-1000, TIP-1004, TIP-1007, TIP-1009, TIP-1010, TIP-1015 across 18 files.

Prompted by: matthias