### PR TITLE
feat: val config v2 - separate vals into active and inactive

### DIFF
--- a/crates/contracts/src/precompiles/validator_config_v2.rs
+++ b/crates/contracts/src/precompiles/validator_config_v2.rs
@@ -32,11 +32,17 @@ crate::sol! {
         // View functions
         // =====================================================================
 
-        /// Get the complete set of validators (including deleted)
-        function getAllValidators() external view returns (Validator[] memory validators);
-
         /// Get only active validators (deactivatedAtHeight == 0)
         function getActiveValidators() external view returns (Validator[] memory validators);
+
+        /// Get inactive (deactivated) validators with pagination
+        function getInactiveValidators(uint64 startIndex) external view returns (Validator[] memory validators);
+
+        /// Get the number of inactive (deactivated) validators
+        function inactiveValidatorCount() external view returns (uint64);
+
+        /// Get the number of currently active validators
+        function activeValidatorCount() external view returns (uint64);
 
         /// Get the block height at which the contract was initialized
         function getInitializedAtHeight() external view returns (uint64);
@@ -76,11 +82,11 @@ crate::sol! {
         ) external;
 
         /// Deactivate a validator (owner or validator)
-        function deactivateValidator(address validatorAddress) external;
+        function deactivateValidator(uint64 idx) external;
 
         /// Rotate a validator to new identity (owner or validator)
         function rotateValidator(
-            address validatorAddress,
+            uint64 idx,
             bytes32 publicKey,
             string calldata ingress,
             string calldata egress,
@@ -89,14 +95,14 @@ crate::sol! {
 
         /// Update IP addresses (owner or validator)
         function setIpAddresses(
-            address validatorAddress,
+            uint64 idx,
             string calldata ingress,
             string calldata egress
         ) external;
 
         /// Transfer validator ownership to new address (owner or validator)
         function transferValidatorOwnership(
-            address currentAddress,
+            uint64 idx,
             address newAddress
         ) external;
 
@@ -129,7 +135,6 @@ crate::sol! {
         error NotIpPort(string input, string backtrace);
         error PublicKeyAlreadyExists();
         error Unauthorized();
-        error ValidatorAlreadyDeleted();
         error AddressAlreadyHasValidator();
         error ValidatorNotFound();
     }
@@ -150,10 +155,6 @@ impl ValidatorConfigV2Error {
 
     pub const fn validator_not_found() -> Self {
         Self::ValidatorNotFound(IValidatorConfigV2::ValidatorNotFound {})
-    }
-
-    pub const fn validator_already_deleted() -> Self {
-        Self::ValidatorAlreadyDeleted(IValidatorConfigV2::ValidatorAlreadyDeleted {})
     }
 
     pub const fn invalid_public_key() -> Self {

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -223,6 +223,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         self.gas_limit - self.gas_remaining
     }
 
+    fn gas_remaining(&self) -> u64 {
+        self.gas_remaining
+    }
+
     #[inline]
     fn gas_refunded(&self) -> i64 {
         self.gas_refunded

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -137,6 +137,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         0
     }
 
+    fn gas_remaining(&self) -> u64 {
+        u64::MAX
+    }
+
     fn gas_refunded(&self) -> i64 {
         0
     }

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -75,6 +75,9 @@ pub trait PrecompileStorageProvider {
     /// Returns the gas used so far.
     fn gas_used(&self) -> u64;
 
+    /// Returns the gas remaining.
+    fn gas_remaining(&self) -> u64;
+
     /// Returns the gas refunded so far.
     fn gas_refunded(&self) -> i64;
 

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -76,7 +76,9 @@ pub trait PrecompileStorageProvider {
     fn gas_used(&self) -> u64;
 
     /// Returns the gas remaining.
-    fn gas_remaining(&self) -> u64;
+    fn gas_remaining(&self) -> u64 {
+        u64::MAX
+    }
 
     /// Returns the gas refunded so far.
     fn gas_refunded(&self) -> i64;

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -163,6 +163,10 @@ impl StorageCtx {
         Self::with_storage(|s| s.gas_used())
     }
 
+    pub fn gas_remaining(&self) -> u64 {
+        Self::with_storage(|s| s.gas_remaining())
+    }
+
     pub fn gas_refunded(&self) -> i64 {
         Self::with_storage(|s| s.gas_refunded())
     }

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -23,11 +23,17 @@ impl Precompile for ValidatorConfigV2 {
             IValidatorConfigV2Calls::abi_decode,
             |call| match call {
                 IValidatorConfigV2Calls::owner(call) => view(call, |_| self.owner()),
-                IValidatorConfigV2Calls::getAllValidators(call) => {
-                    view(call, |_| self.get_validators())
-                }
                 IValidatorConfigV2Calls::getActiveValidators(call) => {
                     view(call, |_| self.get_active_validators())
+                }
+                IValidatorConfigV2Calls::getInactiveValidators(call) => {
+                    view(call, |c| self.get_inactive_validators(c.startIndex))
+                }
+                IValidatorConfigV2Calls::inactiveValidatorCount(call) => {
+                    view(call, |_| self.inactive_validator_count())
+                }
+                IValidatorConfigV2Calls::activeValidatorCount(call) => {
+                    view(call, |_| self.active_validator_count())
                 }
                 IValidatorConfigV2Calls::getInitializedAtHeight(call) => {
                     view(call, |_| self.get_initialized_at_height())
@@ -221,7 +227,7 @@ mod tests {
             let result = vc.call(&calldata, owner)?;
             assert!(!result.reverted);
 
-            let validators = vc.get_validators()?;
+            let validators = vc.get_active_validators()?;
             assert_eq!(validators.len(), 1);
             assert_eq!(validators[0].validatorAddress, validator_addr);
             assert_eq!(validators[0].publicKey, public_key);

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -289,6 +289,7 @@ impl ValidatorConfigV2 {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn append_validator(
         &mut self,
         addr: Address,

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -398,6 +398,10 @@ where
         unreachable!("'gas_used' not implemented in read-only context yet")
     }
 
+    fn gas_remaining(&self) -> u64 {
+        u64::MAX
+    }
+
     fn gas_refunded(&self) -> i64 {
         unreachable!("'gas_refunded' not implemented in read-only context yet")
     }

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -11,7 +11,7 @@ pragma solidity >=0.8.13 <0.9.0;
 ///      - `active` bool replaced by `addedAtHeight` and `deactivatedAtHeight`
 ///      - No `updateValidator` - validators are immutable after creation
 ///      - Requires Ed25519 signature on `addValidator` to prove key ownership
-///      - Both address and public key must be unique across all validators (including deleted)
+///      - Both address and public key must be unique across active validators; deactivated keys are freed for reuse
 interface IValidatorConfigV2 {
 
     // =========================================================================
@@ -115,7 +115,7 @@ interface IValidatorConfigV2 {
     /// @notice Deactivates a validator (owner or validator only)
     /// @dev Marks the validator as deactivated by setting deactivatedAtHeight to the current block height.
     ///      The validator's entry remains in storage for historical queries.
-    ///      The public key remains reserved and cannot be reused. The address remains
+    ///      The public key is freed and may be reused by a future validator. The address remains
     ///      reserved unless reassigned via transferValidatorOwnership.
     /// @param idx The index of the validator to deactivate
     function deactivateValidator(uint64 idx) external;

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -757,8 +757,7 @@ contract ValidatorConfigV2Test is BaseTest {
         active = validatorConfigV2.getActiveValidators();
         assertEq(active.length, 3); // 2 setup + validator2
 
-        IValidatorConfigV2.Validator[] memory inactive =
-            validatorConfigV2.getInactiveValidators(0);
+        IValidatorConfigV2.Validator[] memory inactive = validatorConfigV2.getInactiveValidators(0);
         assertEq(inactive.length, 1);
         assertEq(inactive[0].validatorAddress, validator1);
         assertGt(inactive[0].deactivatedAtHeight, 0);

--- a/tips/ref-impls/test/invariants/README.md
+++ b/tips/ref-impls/test/invariants/README.md
@@ -393,7 +393,7 @@ The ValidatorConfigV2 precompile replaces V1 with append-only, delete-once seman
   - `rotateValidator`: sets old validator's `deactivatedAtHeight = block.number`; sets new validator's `addedAtHeight = block.number`, `deactivatedAtHeight = 0`
   - `deactivateValidator`: sets validator's `deactivatedAtHeight = block.number`
   - `migrateValidator`: sets new validator's `addedAtHeight = block.number`, `deactivatedAtHeight = 0` (if V1 active) or `block.number` (if V1 inactive)
-- **TEMPO-VALV2-5**: Init gate enforcement - post-init functions (`addValidator`, `rotateValidator`, `setIpAddresses`, `transferValidatorOwnership`, `setNextDkgCeremony`) fail with `NotInitialized` when `isInitialized() == false`; pre-init functions (`migrateValidator`, `initializeIfMigrated`) fail with `AlreadyInitialized` when `isInitialized() == true`.
+- **TEMPO-VALV2-5**: Init gate enforcement - post-init functions (`addValidator`, `rotateValidator`, `transferValidatorOwnership`, `setNextDkgCeremony`) fail with `NotInitialized` when `isInitialized() == false`; pre-init functions (`migrateValidator`, `initializeIfMigrated`) fail with `AlreadyInitialized` when `isInitialized() == true`. Note: `setIpAddresses` and `deactivateValidator` are not init-gated.
 - **TEMPO-VALV2-6**: Address uniqueness per-handler - `addValidator` rejects addresses already in use by an active validator; `rotateValidator` verifies address mapping points to the new entry after deactivating the old (per-handler supplement to global VALV2-11).
 - **TEMPO-VALV2-7**: Public key validation per-handler - `addValidator` and `rotateValidator` reject zero public keys and public keys already registered (per-handler supplement to global VALV2-12).
 - **TEMPO-VALV2-25**: Migration preserves v1 values - V2 active status matches V1 (`V1.active == true` ↔ `V2.deactivatedAtHeight == 0`) immediately after `migrateValidator`.
@@ -406,19 +406,19 @@ These are checked after every fuzz run:
 - **TEMPO-VALV2-9**: Delete-once - no validator can have `deactivatedAtHeight` transition from non-zero back to zero or to a different non-zero value; once deactivated, the validator remains deactivated permanently.
 - **TEMPO-VALV2-10**: Height tracking - for all validators: `addedAtHeight > 0` (set when added); `deactivatedAtHeight` is either `0` (active) or `>= addedAtHeight` (deactivated at or after addition).
 - **TEMPO-VALV2-11**: Address uniqueness among active - at most one active validator (where `deactivatedAtHeight == 0`) has any given address; deactivated addresses may be reused.
-- **TEMPO-VALV2-12**: Public key uniqueness - all public keys are globally unique and non-zero across all validators (including deactivated); once registered, a public key cannot be reused.
+- **TEMPO-VALV2-12**: Public key uniqueness among active - all public keys are non-zero and unique across active validators (where `deactivatedAtHeight == 0`); deactivated validators' public keys are freed and may be reused.
 - **TEMPO-VALV2-13**: Ingress IP uniqueness - no two active validators share the same ingress IP (port excluded from comparison); deactivated validators' ingress IPs may be reused.
-- **TEMPO-VALV2-14**: Sequential indices - each validator's `index` field equals its position in the validators array (validator at array position `i` has `index == i`).
+- **TEMPO-VALV2-14**: Sequential indices - each active validator's `index` field equals its position in the active validators array (active validator at array position `i` has `index == i`).
 - **TEMPO-VALV2-15**: Active validator subset correctness - `getActiveValidators()` returns exactly the set of validators where `deactivatedAtHeight == 0` (no more, no fewer).
-- **TEMPO-VALV2-16**: Validator data consistency - all validator data (publicKey, validatorAddress, ingress, egress, index, addedAtHeight, deactivatedAtHeight) in contract matches ghost state for each validator.
-- **TEMPO-VALV2-17**: Validator count consistency - `validatorCount()` equals the actual length of the validators array; both are always in sync.
-- **TEMPO-VALV2-18**: Address lookup correctness - for every validator, `validatorByAddress(validator.validatorAddress)` returns that exact validator; `addressToIndex` mapping is accurate.
-- **TEMPO-VALV2-19**: Public key lookup correctness - for every validator, `validatorByPublicKey(validator.publicKey)` returns that exact validator; `pubkeyToIndex` mapping is accurate.
+- **TEMPO-VALV2-16**: Validator data consistency - for active validators, all data (publicKey, validatorAddress, ingress, egress, addedAtHeight) in contract matches ghost state via address lookup. For inactive validators, all data matches ghost state in deactivation order (the inactive array is append-only).
+- **TEMPO-VALV2-17**: Validator count consistency - `validatorCount()` equals `activeValidatorCount() + inactiveValidatorCount()`.
+- **TEMPO-VALV2-18**: Address lookup correctness - for every active validator, `validatorByAddress(validator.validatorAddress)` returns that exact validator; `addressToIndex` mapping is accurate.
+- **TEMPO-VALV2-19**: Public key lookup correctness - for every active validator, `validatorByPublicKey(validator.publicKey)` returns that exact validator; `pubkeyToIndex` mapping is accurate.
 - **TEMPO-VALV2-20**: Owner consistency - `owner()` always equals the ghost-tracked owner; ownership transfers are correctly reflected.
 - **TEMPO-VALV2-21**: DKG ceremony consistency - `getNextFullDkgCeremony()` always equals the ghost-tracked epoch; updates via `setNextFullDkgCeremony` are correctly stored.
 - **TEMPO-VALV2-22**: Initialization one-way - once `isInitialized() == true`, it remains true forever; `isInitialized()` only transitions from false to true, never back.
 - **TEMPO-VALV2-23**: Migration completeness - if `isInitialized() == false`, then `validatorCount <= V1.getAllValidators().length`; migration cannot exceed V1 validator count.
-- **TEMPO-VALV2-24**: Migration preserves identity - for each validator at index `i < V1.getAllValidators().length`: `V2.validator[i].publicKey == V1.validator[i].publicKey` and `V2.validator[i].validatorAddress == V1.validator[i].validatorAddress`.
+- **TEMPO-VALV2-24**: Migration preserves identity - for each validator at index `i < V1.getAllValidators().length`: `V2.validator[i].publicKey == V1.validator[i].publicKey`. Note: addresses may change post-migration via `transferValidatorOwnership`.
 
 ## AccountKeychain
 


### PR DESCRIPTION
Changes
1. Separate validator arrays into active and inactive vals so active validator array reads are ungriefable 
2. Add pagination to inactive validator reads for safety
3. State changing functions for validators now operate on `index`
4. `_byIndex` view functions now return 0 if the validator associated with that value is deactivated

**Note: On correctness of migration, there's a future PR that will overhaul migration. So any security issues around migration should be checked in that PR**

Callouts:
1. There's a tiny footgun in which the owner accidentally front runs a validator state change call with a deactivate validator call. In this case, there's a non-zero chance that the swap-and-pop affects the index of the validator. This is a extremely low chance though - the validator has to be the most recent validator, the call has to happen in the same block and the owner's call has to happen first. There's no danger in these cases - the validator's call reverts and they'll need to retry the call - so we'll leave this as a note within the security section of the 1017 spec. 
2. Invariant changes - pubkeys can now be duplicated between active and inactive sets. But because a signature is required to add a key, any duplications must be from the same entity, so we dont need to consider malicious duplications