### PR TITLE
docs(tip-1018): calendar precompile spec

### DIFF
--- a/tips/tip-1018.md
+++ b/tips/tip-1018.md
@@ -1,0 +1,306 @@
+---
+id: TIP-1018
+title: Calendar Precompile
+description: A stateless precompile exposing deterministic calendar functions over millisecond timestamps, eliminating the need for expensive on-chain date math.
+authors: Dan
+status: Draft
+protocolVersion: TBD
+---
+
+# TIP-1018: Calendar Precompile
+
+## Abstract
+
+TIP-1018 introduces a stateless precompile that decomposes Unix millisecond timestamps into human-readable calendar components (year, month, day, hour, minute, second, millisecond, day of week, day of year). All functions are pure — they accept an arbitrary `uint64` millisecond timestamp and return deterministic results with no storage access. This precompile replaces gas-expensive Solidity date libraries (e.g. BokkyPooBah's DateTime) and provides the canonical way for contracts to access sub-second time granularity from Tempo's millisecond block timestamps.
+
+## Motivation
+
+### On-chain date math is expensive and error-prone
+
+Computing calendar components from a Unix timestamp in Solidity requires handling leap years, variable-length months, and epoch offset arithmetic. Libraries like BokkyPooBah's DateTime implement this correctly but cost 400–600 gas per decomposition and add non-trivial bytecode to every contract that needs date logic. A native precompile performs the same computation for ~50 gas.
+
+### Millisecond timestamps have no ergonomic accessor
+
+Tempo blocks carry millisecond-resolution timestamps. The `MILLIS_TIMESTAMP` opcode (`0x4F`) exposes the full millisecond timestamp, but there is no convenient way to extract just the millisecond component or any other calendar field from it. Developers must either deploy a datetime library or truncate to seconds and lose precision.
+
+### Use cases
+
+- **Time-locked contracts**: vesting schedules, auction deadlines, and expiry checks that reference calendar dates (e.g. "first of the month")
+- **On-chain scheduling**: contracts that behave differently on weekdays vs weekends, or during specific hours
+- **Millisecond-aware logic**: high-frequency settlement, timestamped event logs, and latency-sensitive protocols that need sub-second granularity
+- **Human-readable events**: emitting `(year, month, day)` in logs for off-chain indexing without requiring off-chain timestamp conversion
+
+---
+
+# Specification
+
+## Precompile Address
+
+```solidity
+address constant CALENDAR_PRECOMPILE_ADDRESS = 0xCA1E000000000000000000000000000000000000;
+```
+
+The prefix `0xCA1E` is a mnemonic for "calendar."
+
+## Calendar System
+
+All functions use the **proleptic Gregorian calendar** in **UTC**. There is no timezone support — timestamps are interpreted as UTC unconditionally. This matches the semantics of Unix timestamps and ensures determinism across all nodes.
+
+The algorithms used are equivalent to Howard Hinnant's `chrono`-compatible civil calendar algorithms, which compute year/month/day from a day count in O(1) time with no loops or table lookups.
+
+## Interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title ICalendar — Calendar Precompile Interface
+/// @notice Pure functions that decompose millisecond timestamps into calendar components.
+///         All functions accept a UTC millisecond timestamp and return deterministic results.
+///         Pass the result of the MILLIS_TIMESTAMP opcode (0x4F) to operate on the current
+///         block's millisecond timestamp.
+/// @dev This is a stateless precompile — no storage reads or writes occur.
+///      All functions revert only on ABI decoding failure (e.g. wrong calldata length).
+interface ICalendar {
+
+    /// @notice Full calendar decomposition of a millisecond timestamp.
+    /// @param timestampMs UTC timestamp in milliseconds since Unix epoch
+    /// @return year     Calendar year (e.g. 2026)
+    /// @return month    Month of the year [1, 12]
+    /// @return day      Day of the month [1, 31]
+    /// @return hour     Hour of the day [0, 23]
+    /// @return minute   Minute of the hour [0, 59]
+    /// @return second   Second of the minute [0, 59]
+    /// @return ms       Millisecond of the second [0, 999]
+    /// @return weekday  Day of the week [1 = Monday, 7 = Sunday] (ISO 8601)
+    /// @return yearday  Day of the year [1, 366]
+    function toComponents(uint64 timestampMs)
+        external
+        pure
+        returns (
+            uint16 year,
+            uint8 month,
+            uint8 day,
+            uint8 hour,
+            uint8 minute,
+            uint8 second,
+            uint16 ms,
+            uint8 weekday,
+            uint16 yearday
+        );
+
+    /// @notice Inverse of toComponents — converts calendar components to a millisecond timestamp.
+    /// @dev Reverts if the inputs do not form a valid date (e.g. month=13, day=31 for a 30-day month,
+    ///      or hour/minute/second/ms out of range).
+    /// @param year   Calendar year
+    /// @param month  Month [1, 12]
+    /// @param day    Day [1, 31] (must be valid for the given month/year)
+    /// @param hour   Hour [0, 23]
+    /// @param minute Minute [0, 59]
+    /// @param second Second [0, 59]
+    /// @param ms     Millisecond [0, 999]
+    /// @return timestampMs UTC millisecond timestamp
+    function fromComponents(
+        uint16 year,
+        uint8 month,
+        uint8 day,
+        uint8 hour,
+        uint8 minute,
+        uint8 second,
+        uint16 ms
+    ) external pure returns (uint64 timestampMs);
+
+    /// @notice Returns the calendar year.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Calendar year (e.g. 2026)
+    function year(uint64 timestampMs) external pure returns (uint16);
+
+    /// @notice Returns the month of the year.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Month [1, 12]
+    function month(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the day of the month.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Day [1, 31]
+    function day(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the hour of the day.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Hour [0, 23]
+    function hour(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the minute of the hour.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Minute [0, 59]
+    function minute(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the second of the minute.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Second [0, 59]
+    function second(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the millisecond of the second.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Millisecond [0, 999]
+    function millisecond(uint64 timestampMs) external pure returns (uint16);
+
+    /// @notice Returns the day of the week per ISO 8601.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Day of week [1 = Monday, 7 = Sunday]
+    function dayOfWeek(uint64 timestampMs) external pure returns (uint8);
+
+    /// @notice Returns the day of the year.
+    /// @param timestampMs UTC timestamp in milliseconds
+    /// @return Day of year [1, 366]
+    function dayOfYear(uint64 timestampMs) external pure returns (uint16);
+
+    /// @notice Returns the number of days in the given month/year.
+    /// @dev Accounts for leap years. Reverts if month is not in [1, 12].
+    /// @param year  Calendar year
+    /// @param month Month [1, 12]
+    /// @return Number of days [28, 29, 30, or 31]
+    function daysInMonth(uint16 year, uint8 month) external pure returns (uint8);
+
+    /// @notice Returns whether the given year is a leap year.
+    /// @param year Calendar year
+    /// @return true if leap year, false otherwise
+    function isLeapYear(uint16 year) external pure returns (bool);
+}
+```
+
+## Function Behavior
+
+### Individual accessors
+
+Each individual accessor (`year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `dayOfWeek`, `dayOfYear`) performs the same decomposition as `toComponents` but returns only the requested field. Implementations may optimize individual accessors to avoid computing unused fields (e.g. `millisecond()` can return `timestampMs % 1000` without any calendar math).
+
+### `toComponents`
+
+Decomposes a millisecond timestamp into all calendar fields in a single call. This is more gas-efficient than calling multiple individual accessors when several fields are needed, since the calendar decomposition is performed once.
+
+### `fromComponents`
+
+Converts calendar components back to a millisecond timestamp. Reverts with `InvalidDate` if the inputs don't form a valid date:
+
+```solidity
+error InvalidDate();
+```
+
+Invalid inputs include:
+- `month` outside `[1, 12]`
+- `day` outside `[1, daysInMonth(year, month)]`
+- `hour` outside `[0, 23]`
+- `minute` outside `[0, 59]`
+- `second` outside `[0, 59]`
+- `ms` outside `[0, 999]`
+
+### `daysInMonth` and `isLeapYear`
+
+Utility functions that do not require a timestamp. `daysInMonth` reverts with `InvalidDate` if `month` is outside `[1, 12]`.
+
+## Gas Costs
+
+All functions cost a flat **50 gas**. The underlying algorithms are O(1) with no loops, branches on unbounded data, or storage access. This is comparable to the `MILLIS_TIMESTAMP` opcode's base cost plus the overhead of a precompile call.
+
+## Usage Examples
+
+### Extracting milliseconds from the block timestamp
+
+```solidity
+import { ICalendar } from "./interfaces/ICalendar.sol";
+
+ICalendar constant CALENDAR = ICalendar(0xCA1E000000000000000000000000000000000000);
+
+function getBlockMillisecond() view returns (uint16) {
+    // 0x4F is the MILLIS_TIMESTAMP opcode — returns block timestamp in ms
+    uint64 blockMs;
+    assembly { blockMs := verbatim_0i_1o(hex"4F") }
+    return CALENDAR.millisecond(blockMs);
+}
+```
+
+### Checking if today is a weekday
+
+```solidity
+function isWeekday() view returns (bool) {
+    uint64 blockMs;
+    assembly { blockMs := verbatim_0i_1o(hex"4F") }
+    uint8 dow = CALENDAR.dayOfWeek(blockMs);
+    return dow >= 1 && dow <= 5; // Mon–Fri
+}
+```
+
+### Computing a deadline for "end of month"
+
+```solidity
+function endOfMonth() view returns (uint64) {
+    uint64 blockMs;
+    assembly { blockMs := verbatim_0i_1o(hex"4F") }
+
+    (uint16 y, uint8 m,,,,,,, ) = CALENDAR.toComponents(blockMs);
+    uint8 lastDay = CALENDAR.daysInMonth(y, m);
+    return CALENDAR.fromComponents(y, m, lastDay, 23, 59, 59, 999);
+}
+```
+
+---
+
+# Invariants
+
+- **Roundtrip**: For any valid `uint64 timestampMs`, `fromComponents(toComponents(timestampMs)) == timestampMs`. The weekday and yearday fields from `toComponents` are not inputs to `fromComponents`; the roundtrip applies to the 7 shared fields.
+- **Determinism**: All functions are pure — identical inputs always produce identical outputs regardless of block context or chain state.
+- **Range consistency**: Individual accessors return the same value as the corresponding field from `toComponents` for the same input.
+- **Leap year correctness**: `isLeapYear(y)` returns `true` iff `y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)`.
+- **Days in month consistency**: `daysInMonth(y, 2)` returns 29 iff `isLeapYear(y)`, 28 otherwise. Other months return their standard lengths.
+- **ISO 8601 weekday**: `dayOfWeek` returns 1 for Monday through 7 for Sunday. January 1, 1970 (timestamp 0) was a Thursday (`dayOfWeek == 4`).
+- **Monotonicity**: If `a < b`, then `toComponents(a)` represents an earlier calendar instant than `toComponents(b)`.
+
+## Test Cases
+
+The test suite must cover:
+
+### Basic decomposition
+
+1. **Epoch zero**: `toComponents(0)` returns `(1970, 1, 1, 0, 0, 0, 0, 4, 1)` — Thursday, Jan 1 1970
+2. **Known date**: `toComponents(1740614400000)` returns `(2025, 2, 27, 0, 0, 0, 0, 4, 58)` — Feb 27 2025
+3. **End of day**: `toComponents(86399999)` returns `(1970, 1, 1, 23, 59, 59, 999, 4, 1)`
+4. **Millisecond extraction**: `millisecond(1234567)` returns `567`
+
+### Leap year handling
+
+5. **Leap year Feb 29**: `day(toMs(2024, 2, 29))` returns `29`
+6. **Non-leap year**: `daysInMonth(2023, 2)` returns `28`
+7. **Century non-leap**: `isLeapYear(1900)` returns `false`
+8. **Quad-century leap**: `isLeapYear(2000)` returns `true`
+
+### Roundtrip
+
+9. **fromComponents ∘ toComponents = identity**: For a set of representative timestamps spanning 1970–2100, `fromComponents(year, month, day, hour, minute, second, ms)` from `toComponents(ts)` returns `ts`
+10. **toComponents ∘ fromComponents = identity**: For known valid dates, `toComponents(fromComponents(...))` returns the original components
+
+### Edge cases
+
+11. **Max reasonable timestamp**: Decomposition of year 9999 Dec 31 23:59:59.999
+12. **Weekday boundaries**: Timestamps at exactly midnight UTC on consecutive days increment `dayOfWeek` by 1 (wrapping 7→1)
+13. **Year boundaries**: Dec 31 23:59:59.999 → Jan 1 00:00:00.000 increments year, resets month/day/yearday
+
+### Invalid inputs (fromComponents)
+
+14. **Month 0**: Reverts with `InvalidDate`
+15. **Month 13**: Reverts with `InvalidDate`
+16. **Feb 29 non-leap**: `fromComponents(2023, 2, 29, 0, 0, 0, 0)` reverts
+17. **Day 32**: Reverts for any month
+18. **Hour 24, Minute 60, Second 60, Ms 1000**: Each reverts individually
+
+### Utility functions
+
+19. **daysInMonth all months**: Returns correct values for all 12 months in both leap and non-leap years
+20. **daysInMonth invalid month**: Reverts for month 0 and month 13
+21. **isLeapYear**: Correct for years 1970–2100
+
+### Gas
+
+22. **Individual accessor cost**: Each individual accessor costs ≤ 50 gas (excluding CALL overhead)
+23. **toComponents cost**: `toComponents` costs ≤ 50 gas
+24. **Batch efficiency**: Calling `toComponents` once is cheaper than calling 7+ individual accessors


### PR DESCRIPTION
Stateless precompile at `0xCA1E...` that decomposes millisecond timestamps into calendar components (year, month, day, hour, minute, second, ms, day-of-week, day-of-year). Includes `fromComponents` inverse, `daysInMonth`, and `isLeapYear` helpers. All pure, all O(1), flat 50 gas.

Replaces BokkyPooBah-style Solidity date math and gives contracts a canonical way to access the millisecond part of Tempo's block timestamps.

Prompted by: dan