### PR TITLE
docs(precompiles): document Precompile::call method

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -82,7 +82,7 @@ pub trait Precompile {
     ///
     /// Implementations should deduct calldata gas upfront via [`input_cost`], then decode the
     /// 4-byte function selector from `calldata` and route to the matching method using
-    /// [`dispatch_call`] combined with the [`view`], [`mutate`], or [`mutate_void`] helpers.
+    /// `dispatch_call` combined with the `view`, `mutate`, or `mutate_void` helpers.
     ///
     /// Business-logic errors are returned as reverted [`PrecompileOutput`]s with ABI-encoded
     /// error data, while fatal failures (e.g. out-of-gas) are returned as [`PrecompileError`].


### PR DESCRIPTION
Documents the `Precompile::call` trait method — describes the dispatch flow (selector decoding → `view`/`mutate`/`mutate_void`), upfront gas metering via `input_cost`, and error behavior across hardforks.

Prompted by: matthias