### PR TITLE
fix(contract): avoid validator config v2 resource exhaustion

### DIFF
--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -29,6 +29,10 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
     Validator[] internal validatorsArray;
 
+    // Indices into the validatorsArray. This array does not preserve order.
+    // Stored Values is arrayIndex +1.
+    uint64[] internal activeValidators;
+
     /// @dev 1-indexed: 0 means not found. Stored value is arrayIndex + 1.
     mapping(address => uint64) internal addressToIndex;
 
@@ -98,6 +102,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         external
         onlyOwnerOrValidator(validatorAddress)
     {
+        // idx is 1-indexed.
         uint64 idx = addressToIndex[validatorAddress];
         if (idx == 0) {
             revert ValidatorNotFound();
@@ -112,6 +117,8 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         delete activeIngressIpHashes[ingressIpHash];
 
         v.deactivatedAtHeight = uint64(block.number);
+
+        _deleteActive(idx);
     }
 
     /// @inheritdoc IValidatorConfigV2
@@ -140,6 +147,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         onlyInitialized
         onlyOwnerOrValidator(validatorAddress)
     {
+        // idx is 1-indexed.
         uint64 idx = addressToIndex[validatorAddress];
         if (idx == 0) {
             revert ValidatorNotFound();
@@ -162,6 +170,8 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _updateIngressIp(oldValidator.ingress, ingress);
 
         oldValidator.deactivatedAtHeight = uint64(block.number);
+
+        _deleteActive(idx);
 
         _addValidator(validatorAddress, publicKey, ingress, egress, 0);
     }
@@ -229,26 +239,12 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
     // =========================================================================
 
     /// @inheritdoc IValidatorConfigV2
-    function getAllValidators() external view returns (Validator[] memory) {
-        return validatorsArray;
-    }
-
-    /// @inheritdoc IValidatorConfigV2
     function getActiveValidators() external view returns (Validator[] memory validators) {
-        uint64 len = uint64(validatorsArray.length);
+        uint64 len = uint64(activeValidators.length);
         validators = new Validator[](len);
-        uint64 idx = 0;
         for (uint64 i = 0; i < len; i++) {
-            Validator storage v = validatorsArray[i];
-            if (v.deactivatedAtHeight == 0) {
-                validators[idx] = v;
-                idx++;
-            }
-        }
-        // Modify array.length to the correct length
-        // We're doing this in assembly because it's not possible to do in solidity
-        assembly {
-            mstore(validators, idx)
+            Validator storage v = validatorsArray[activeValidators[i] - 1];
+            validators[i] = v;
         }
     }
 
@@ -432,6 +428,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         if (deactivatedAtHeight == 0) {
             bytes32 ingressIpHash = _getIngressIpHash(ingress);
             activeIngressIpHashes[ingressIpHash] = true;
+            activeValidators.push(idx + 1); // 1-indexed
         }
     }
 
@@ -510,6 +507,26 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         // No port found, return as-is
         return socketAddr;
+    }
+
+    /// Looks for `index` in the `activeValidators` array and removes it.
+    /// This function does not preserve order.
+    ///
+    /// This function expects that `idx` is 1-indexed.
+    function _deleteActive(uint64 idx) internal {
+        uint64 target; // 1-indexed
+        for (uint64 i = 0; i < uint64(activeValidators.length); i++) {
+            if (activeValidators[i] == idx) {
+                target = i+1;
+                break;
+            }
+        }
+
+        // Swap-remove
+        if (target != 0) {
+            activeValidators[target-1] = activeValidators[activeValidators.length-1];
+            activeValidators.pop();
+        }
     }
 
     function _validateIpPort(string calldata input, string memory field) internal pure {

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -183,7 +183,8 @@ interface IValidatorConfigV2 {
     // View Functions
     // =========================================================================
 
-    /// @notice Get only active validators (where deactivatedAtHeight == 0)
+    /// @notice Get only active validators (where deactivatedAtHeight == 0).
+    /// @notice The order of validators is not stable and should not be relied upon.
     /// @return validators Array of active validators
     function getActiveValidators() external view returns (Validator[] memory validators);
 

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -183,10 +183,6 @@ interface IValidatorConfigV2 {
     // View Functions
     // =========================================================================
 
-    /// @notice Get all validators (including deleted ones) in array order
-    /// @return validators Array of all validators with their information
-    function getAllValidators() external view returns (Validator[] memory validators);
-
     /// @notice Get only active validators (where deactivatedAtHeight == 0)
     /// @return validators Array of active validators
     function getActiveValidators() external view returns (Validator[] memory validators);

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -144,7 +144,7 @@ contract ValidatorConfigV2Test is BaseTest {
             _signAdd(PRIV_KEY_2, validator3, ingress3, egress3)
         );
 
-        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getAllValidators();
+        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
         assertEq(vals.length, 5); // 2 setup + 3 added
 
         // First two are migrated setup validators
@@ -331,13 +331,16 @@ contract ValidatorConfigV2Test is BaseTest {
             _signRotate(PRIV_KEY_3, validator1, ingress2, egress2)
         );
 
-        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getAllValidators();
-        assertEq(vals.length, 4); // 2 setup + original (deactivated) + rotated
-        assertEq(vals[2].deactivatedAtHeight, uint64(block.number));
-        assertEq(vals[3].validatorAddress, validator1);
-        assertEq(vals[3].publicKey, PUB_KEY_3);
-        assertEq(vals[3].addedAtHeight, uint64(block.number));
-        assertEq(vals[3].deactivatedAtHeight, 0);
+        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
+        assertEq(vals.length, 4); // 2 setup + rotated
+        assertEq(vals[2].validatorAddress, validator1);
+        assertEq(vals[2].publicKey, PUB_KEY_3);
+        assertEq(vals[2].addedAtHeight, uint64(block.number));
+        assertEq(vals[2].deactivatedAtHeight, 0);
+
+        // Original validator lives on in the global array.
+        IValidatorConfigV2.Validator memory val = validatorConfigV2.validatorByPublicKey(PUB_KEY_0);
+        assertEq(val.deactivatedAtHeight, uint64(block.number));
     }
 
     function test_rotateValidator_passByValidator() public {
@@ -359,8 +362,8 @@ contract ValidatorConfigV2Test is BaseTest {
             _signRotate(PRIV_KEY_3, validator1, ingress2, egress2)
         );
 
-        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getAllValidators();
-        assertEq(vals.length, 4); // 2 setup + original (deactivated) + rotated
+        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
+        assertEq(vals.length, 4); // 2 setup + rotated
         assertEq(vals[3].publicKey, PUB_KEY_3);
     }
 
@@ -704,35 +707,6 @@ contract ValidatorConfigV2Test is BaseTest {
     /*//////////////////////////////////////////////////////////////
                           VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////*/
-
-    function test_getAllValidators_pass() public {
-        _initializeV2();
-
-        IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getAllValidators();
-        assertEq(vals.length, 2); // 2 setup validators migrated
-        assertEq(vals[0].validatorAddress, setupVal1);
-        assertEq(vals[1].validatorAddress, setupVal2);
-
-        validatorConfigV2.addValidator(
-            validator1,
-            PUB_KEY_0,
-            ingress1,
-            egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
-        );
-        validatorConfigV2.addValidator(
-            validator2,
-            PUB_KEY_1,
-            ingress2,
-            egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
-        );
-
-        vals = validatorConfigV2.getAllValidators();
-        assertEq(vals.length, 4); // 2 setup + 2 added
-        assertEq(vals[2].validatorAddress, validator1);
-        assertEq(vals[3].validatorAddress, validator2);
-    }
 
     function test_getActiveValidators_pass() public {
         _initializeV2();

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -332,7 +332,7 @@ contract ValidatorConfigV2Test is BaseTest {
         );
 
         IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
-        assertEq(vals.length, 4); // 2 setup + rotated
+        assertEq(vals.length, 3); // 2 setup + rotated
         assertEq(vals[2].validatorAddress, validator1);
         assertEq(vals[2].publicKey, PUB_KEY_3);
         assertEq(vals[2].addedAtHeight, uint64(block.number));
@@ -363,8 +363,8 @@ contract ValidatorConfigV2Test is BaseTest {
         );
 
         IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
-        assertEq(vals.length, 4); // 2 setup + rotated
-        assertEq(vals[3].publicKey, PUB_KEY_3);
+        assertEq(vals.length, 3); // 2 setup + rotated
+        assertEq(vals[2].publicKey, PUB_KEY_3);
     }
 
     function test_rotateValidator_fail() public {

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -422,7 +422,7 @@ The contract stores the following state:
 - `initialized`: Whether V2 has been initialized from V1 (boolean)
 - `initializedAtHeight`: Block height when V2 was initialized (uint64)
 - `validatorsArray`: Append-only array of all validators (Validator[])
-- `activeValidators`: array of indices into `validatorsArray` (uint64])
+- `activeValidators`: array of indices into `validatorsArray` (uint64[])
 - `addressToIndex`: Mapping from validator address to array index (mapping)
 - `pubkeyToIndex`: Mapping from public key to array index (mapping)
 - `nextDkgCeremony`: Next full DKG ceremony epoch (uint64)

--- a/tips/tip-1017.md
+++ b/tips/tip-1017.md
@@ -140,10 +140,6 @@ interface IValidatorConfigV2 {
         uint64 deactivatedAtHeight;
     }
 
-    /// @notice Get all validators (including deleted ones) in array order
-    /// @return validators Array of all validators with their information
-    function getAllValidators() external view returns (Validator[] memory validators);
-
     /// @notice Get only active validators (where deactivatedAtHeight == 0)
     /// @return validators Array of active validators
     function getActiveValidators() external view returns (Validator[] memory validators);
@@ -426,6 +422,7 @@ The contract stores the following state:
 - `initialized`: Whether V2 has been initialized from V1 (boolean)
 - `initializedAtHeight`: Block height when V2 was initialized (uint64)
 - `validatorsArray`: Append-only array of all validators (Validator[])
+- `activeValidators`: array of indices into `validatorsArray` (uint64])
 - `addressToIndex`: Mapping from validator address to array index (mapping)
 - `pubkeyToIndex`: Mapping from public key to array index (mapping)
 - `nextDkgCeremony`: Next full DKG ceremony epoch (uint64)
@@ -443,7 +440,7 @@ Implementation details such as slot packing are left to the implementation.
 | Deletion | Sets `active = false` | Sets `deactivatedAtHeight = block.number` |
 | Re-registration | Allowed after deletion | Pubkey reserved forever; address reassignable via `transferValidatorOwnership` |
 | Key ownership | Not verified | Ed25519 signature required |
-| Historical queries | Requires historical state | Filter `getAllValidators()` by `addedAtHeight`/`deactivatedAtHeight` |
+| Historical queries | Requires historical state | Query via `validatorByPublicKey` and filter by `addedAtHeight`/`deactivatedAtHeight` |
 | Uniqueness | Address only | Address AND public key |
 | Precompile address | `0xCCCC...0000` | `0xCCCC...0001` |
 
@@ -706,98 +703,96 @@ The test suite must cover:
 
 ### Query Functions
 
-6. **getAllValidators**: Returns all validators including deleted with correct
-   `addedAtHeight` and `deactivatedAtHeight`
-7. **getActiveValidators**: Returns only validators with `deactivatedAtHeight == 0`
+6. **getActiveValidators**: Returns only validators with `deactivatedAtHeight == 0`
    (note: validators with `addedAtHeight == deactivatedAtHeight` are excluded)
-8. **validatorByPublicKey**: Returns validator by public key lookup
-9. **validatorCount**: Returns total count including deleted
+7. **validatorByPublicKey**: Returns validator by public key lookup
+8. **validatorCount**: Returns total count including deleted
 
 ### Error Conditions
 
-10. **Unauthorized**: Non-owner cannot call protected functions
-11. **ValidatorAlreadyExists**: Cannot re-add same address
-12. **PublicKeyAlreadyExists**: Cannot re-use same public key
-13. **ValidatorNotFound**: Cannot query/delete non-existent validator
-14. **ValidatorAlreadyDeleted**: Cannot delete twice
-15. **InvalidPublicKey**: Rejects zero public key
-16. **InvalidSignature**: Rejects wrong signature, wrong length, wrong signer
-17. **IngressAlreadyExists**: Cannot use ingress IP already in use by active validator (even with different port)
+9. **Unauthorized**: Non-owner cannot call protected functions
+10. **ValidatorAlreadyExists**: Cannot re-add same address
+11. **PublicKeyAlreadyExists**: Cannot re-use same public key
+12. **ValidatorNotFound**: Cannot query/delete non-existent validator
+13. **ValidatorAlreadyDeleted**: Cannot delete twice
+14. **InvalidPublicKey**: Rejects zero public key
+15. **InvalidSignature**: Rejects wrong signature, wrong length, wrong signer
+16. **IngressAlreadyExists**: Cannot use ingress IP already in use by active validator (even with different port)
 
 ### rotateValidator
 
-17. **rotateValidator by owner**: Owner can rotate any active validator
-18. **rotateValidator by validator**: Validator can rotate themselves
-19. **rotateValidator unauthorized**: Non-owner and non-validator cannot rotate
-20. **rotateValidator already deleted**: Cannot rotate already-deleted validator
-21. **rotateValidator new pubkey exists**: Cannot rotate to existing public key
-22. **rotateValidator invalid signature**: Rejects invalid signature for rotation
-23. **rotateValidator validator not found**: Reverts if validatorAddress does not exist
-24. **rotateValidator atomicity**: Old validator is deleted and new one added in same block
-25. **rotateValidator preserves index**: New validator gets next available index, old index remains deleted
+16. **rotateValidator by owner**: Owner can rotate any active validator
+17. **rotateValidator by validator**: Validator can rotate themselves
+18. **rotateValidator unauthorized**: Non-owner and non-validator cannot rotate
+19. **rotateValidator already deleted**: Cannot rotate already-deleted validator
+20. **rotateValidator new pubkey exists**: Cannot rotate to existing public key
+21. **rotateValidator invalid signature**: Rejects invalid signature for rotation
+22. **rotateValidator validator not found**: Reverts if validatorAddress does not exist
+23. **rotateValidator atomicity**: Old validator is deleted and new one added in same block
+24. **rotateValidator preserves index**: New validator gets next available index, old index remains deleted
 
 ### Address Validation
 
-26. **Valid IPv4:port**: Accepts `192.168.1.1:8080`
-27. **Valid IPv6:port**: Accepts `[2001:db8::1]:8080`
-28. **Invalid format**: Rejects malformed addresses
+25. **Valid IPv4:port**: Accepts `192.168.1.1:8080`
+26. **Valid IPv6:port**: Accepts `[2001:db8::1]:8080`
+27. **Invalid format**: Rejects malformed addresses
 
 ### Historical Filtering (Caller-side)
 
-29. **addedAtHeight correctness**: Validators have correct `addedAtHeight` set
+28. **addedAtHeight correctness**: Validators have correct `addedAtHeight` set
     at creation
-30. **deactivatedAtHeight correctness**: Deleted validators have correct
+29. **deactivatedAtHeight correctness**: Deleted validators have correct
     `deactivatedAtHeight` set
-31. **Filter logic**: Caller can correctly filter by
+30. **Filter logic**: Caller can correctly filter by
     `addedAtHeight <= H && (deactivatedAtHeight == 0 || deactivatedAtHeight > H)`
 
 ### Manual Migration
 
-32. **migrateValidator imports validator**: Calling `migrateValidator(i)`
+31. **migrateValidator imports validator**: Calling `migrateValidator(i)`
     correctly imports validator at index i from V1 with the same address
-33. **migrateValidator copies address from V1**: The V2 validator uses the address from V1
-34. **migrateValidator reverts on duplicate**: Calling `migrateValidator(i)` reverts
+32. **migrateValidator copies address from V1**: The V2 validator uses the address from V1
+33. **migrateValidator reverts on duplicate**: Calling `migrateValidator(i)` reverts
     if `i != validatorsArray.length`
-35. **migrateValidator reverts if initialized**: Calling `migrateValidator` reverts
+34. **migrateValidator reverts if initialized**: Calling `migrateValidator` reverts
     if `isInitialized() == true`
-36. **migrateValidator owner only**: Non-owner cannot call `migrateValidator`
-37. **All validators imported on migration**: Both V1 active and inactive validators
+35. **migrateValidator owner only**: Non-owner cannot call `migrateValidator`
+36. **All validators imported on migration**: Both V1 active and inactive validators
     are imported; active ones have `addedAtHeight > 0` and `deactivatedAtHeight == 0`,
     inactive ones have `addedAtHeight == deactivatedAtHeight > 0`.
-38. **addedAtHeight set correctly**: All migrated validators have `addedAtHeight > 0` (block.height at migration time).
-39. **deactivatedAtHeight set correctly**: Active validators have `deactivatedAtHeight == 0`.
+37. **addedAtHeight set correctly**: All migrated validators have `addedAtHeight > 0` (block.height at migration time).
+38. **deactivatedAtHeight set correctly**: Active validators have `deactivatedAtHeight == 0`.
     Inactive validators have `addedAtHeight == deactivatedAtHeight > 0` at migration time.
-40. **initialize sets flag**: After `initializeIfMigrated()`, `isInitialized()` returns true
-41. **migrateValidator copies owner**: V2 `owner()` matches V1 after first `migrateValidator` call
-42. **initialize copies DKG ceremony**: V2 `getNextFullDkgCeremony()` matches V1
+39. **initialize sets flag**: After `initializeIfMigrated()`, `isInitialized()` returns true
+40. **migrateValidator copies owner**: V2 `owner()` matches V1 after first `migrateValidator` call
+41. **initialize copies DKG ceremony**: V2 `getNextFullDkgCeremony()` matches V1
     after `initializeIfMigrated()`
-43. **initialize owner only**: Non-owner cannot call `initialize`
-44. **isInitialized returns correct value**: Returns false before initialize, true after
-45. **Writes blocked before init**: `addValidator`, `rotateValidator`, `transferValidatorOwnership`
-46. **initialize reverts if not all migrated**: `initializeIfMigrated()` reverts if
+42. **initialize owner only**: Non-owner cannot call `initialize`
+43. **isInitialized returns correct value**: Returns false before initialize, true after
+44. **Writes blocked before init**: `addValidator`, `rotateValidator`, `transferValidatorOwnership`
+45. **initialize reverts if not all migrated**: `initializeIfMigrated()` reverts if
     `validatorsArray.length < V1.getAllValidators().length`
 
 ### transferValidatorOwnership
 
-47. **transferValidatorOwnership by owner**: Owner can transfer any validator to a new address
-48. **transferValidatorOwnership by validator**: Validator can transfer themselves to a new address
-49. **transferValidatorOwnership unauthorized**: Non-owner and non-validator cannot transfer
-50. **transferValidatorOwnership reverts on invalid validator**: Reverts if `validatorAddress` does not exist
-51. **transferValidatorOwnership reverts on duplicate address**: Reverts if `newAddress` already exists
-52. **transferValidatorOwnership updates lookup maps**: Old address is removed, new address is added to lookup
+46. **transferValidatorOwnership by owner**: Owner can transfer any validator to a new address
+47. **transferValidatorOwnership by validator**: Validator can transfer themselves to a new address
+48. **transferValidatorOwnership unauthorized**: Non-owner and non-validator cannot transfer
+49. **transferValidatorOwnership reverts on invalid validator**: Reverts if `validatorAddress` does not exist
+50. **transferValidatorOwnership reverts on duplicate address**: Reverts if `newAddress` already exists
+51. **transferValidatorOwnership updates lookup maps**: Old address is removed, new address is added to lookup
 
 ### setIpAddresses
 
-53. **setIpAddresses by owner**: Owner can update any validator's IP addresses
-54. **setIpAddresses by validator**: Validator can update their own IP addresses
-55. **setIpAddresses unauthorized**: Non-owner and non-validator cannot update IP addresses
-56. **setIpAddresses reverts on invalid validator**: Reverts if validator does not exist
-57. **setIpAddresses reverts on deactivated validator**: Reverts if validator is already deactivated
-58. **setIpAddresses validates format**: Rejects invalid `<ip>:<port>` format
-59. **setIpAddresses before init (self)**: Validator can update their own IPs before initialization
-60. **setIpAddresses before init (owner)**: Owner can update validator IPs before initialization
-61. **deactivateValidator before init (self)**: Validator can deactivate themselves before initialization
-62. **deactivateValidator before init (owner)**: Owner can deactivate validators before initialization
+52. **setIpAddresses by owner**: Owner can update any validator's IP addresses
+53. **setIpAddresses by validator**: Validator can update their own IP addresses
+54. **setIpAddresses unauthorized**: Non-owner and non-validator cannot update IP addresses
+55. **setIpAddresses reverts on invalid validator**: Reverts if validator does not exist
+56. **setIpAddresses reverts on deactivated validator**: Reverts if validator is already deactivated
+57. **setIpAddresses validates format**: Rejects invalid `<ip>:<port>` format
+58. **setIpAddresses before init (self)**: Validator can update their own IPs before initialization
+59. **setIpAddresses before init (owner)**: Owner can update validator IPs before initialization
+60. **deactivateValidator before init (self)**: Validator can deactivate themselves before initialization
+61. **deactivateValidator before init (owner)**: Owner can deactivate validators before initialization
 
 ---
 


### PR DESCRIPTION
This patch fixes a potential resource exhaustion in `ValidatorConfigV2.getAllValidators`.

Active V2 validators are now tracked in a separate array that holds indices into the global append only `validatorsArray`. Consistency is ensured by deleting entries on `deactiveValidator` and `rotateValidator`.