### PR TITLE
fix(primitives): enable std feature with arbitrary

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -113,6 +113,7 @@ serde-bincode-compat = [
 	"alloy-rpc-types-eth?/serde-bincode-compat",
 ]
 arbitrary = [
+	"std",
 	"dep:arbitrary",
 	"serde",
 	"alloy-consensus/arbitrary",


### PR DESCRIPTION
Adds `std` to the `arbitrary` feature gate. The `arbitrary` derive macro requires std, so `cargo check --no-default-features --features arbitrary` was failing on `tempo-primitives`.

Prompted by: mattsse