### PR TITLE
perf(evm): precompute TIP-20 balance slot keccaks during tx recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12087,6 +12087,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-sol-types",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -35,6 +35,7 @@ alloy-rlp.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
 
 derive_more.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Decodes TIP-20 transfer/transferFrom calldata in `tx_iterator_for_payload` and computes `keccak256` balance storage slots for sender and recipient in parallel during signature recovery. The precomputed slots are stored in `TempoTxEnv::precomputed_balance_slots` as `Vec<(Address, U256)>` pairs (token address, balance slot).

Handles `transfer`, `transferWithMemo`, `transferFrom`, and `transferFromWithMemo` selectors targeting contracts with the TIP-20 prefix.

Prompted by: alexey