### PR TITLE
fix(consensus): reject accepted payload status on block verification

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -811,13 +811,19 @@ async fn verify_block<TContext: Pacer>(
         .await
         .wrap_err("failed sending `new payload` message to execution layer to validate block")?;
     match payload_status.status {
-        PayloadStatusEnum::Valid | PayloadStatusEnum::Accepted => Ok(true),
+        PayloadStatusEnum::Valid => Ok(true),
         PayloadStatusEnum::Invalid { validation_error } => {
             info!(
                 validation_error,
                 "execution layer returned that the block was invalid"
             );
             Ok(false)
+        }
+        PayloadStatusEnum::Accepted => {
+            bail!(
+                "failed validating block because payload was accepted, meaning \
+                that this was not actually executed by the execution layer for some reason"
+            )
         }
         PayloadStatusEnum::Syncing => {
             bail!(


### PR DESCRIPTION
Per the [spec](http://github.com/ethereum/execution-apis/blob/a9e9095c453d7b3c95b89abfcf46afb2eff4e1b7/src/engine/paris.md?plain=1#L180), ACCEPTED does not mean the block is valid which is necessary for block proposal/verification.

This never mattered in practice as Reth does not report this status. But we add the safety guard here in consensus