### PR TITLE
feat(contracts): add is_* helpers for PolicyType enum

### DIFF
--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -47,6 +47,23 @@ crate::sol! {
     }
 }
 
+impl ITIP403Registry::PolicyType {
+    /// Returns `true` if this is a whitelist policy.
+    pub const fn is_whitelist(&self) -> bool {
+        matches!(self, Self::WHITELIST)
+    }
+
+    /// Returns `true` if this is a blacklist policy.
+    pub const fn is_blacklist(&self) -> bool {
+        matches!(self, Self::BLACKLIST)
+    }
+
+    /// Returns `true` if this is a compound policy.
+    pub const fn is_compound(&self) -> bool {
+        matches!(self, Self::COMPOUND)
+    }
+}
+
 impl TIP403RegistryError {
     /// Creates an error for unauthorized calls
     pub const fn unauthorized() -> Self {


### PR DESCRIPTION
Adds `is_whitelist()`, `is_blacklist()`, and `is_compound()` const helper methods on `PolicyType`.