### PR TITLE
fix(txpool): correct AMM recent header window

### DIFF
--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -44,9 +44,9 @@ impl AmmLiquidityCache {
         };
         let tip = client.best_block_number()?;
 
-        for header in
-            client.sealed_headers_range(tip.saturating_sub(LAST_SEEN_WINDOW as u64 + 1)..=tip)?
-        {
+        for header in client.sealed_headers_range(
+            tip.saturating_sub(LAST_SEEN_WINDOW.saturating_sub(1) as u64)..=tip,
+        )? {
             this.on_new_block(&header, &client)?;
         }
 
@@ -134,9 +134,9 @@ impl AmmLiquidityCache {
     {
         self.clear();
         let tip = client.best_block_number()?;
-        for header in
-            client.sealed_headers_range(tip.saturating_sub(LAST_SEEN_WINDOW as u64 + 1)..=tip)?
-        {
+        for header in client.sealed_headers_range(
+            tip.saturating_sub(LAST_SEEN_WINDOW.saturating_sub(1) as u64)..=tip,
+        )? {
             self.on_new_block(&header, client)?;
         }
         Ok(())


### PR DESCRIPTION
The AMM cache bootstrap range used `tip.saturating_sub(LAST_SEEN_WINDOW + 1)..=tip`, which over-fetched headers because the upper bound is inclusive. This made initialization/repopulate process more blocks than the configured window and did not match the intended sliding-window behavior.

This change updates both `new()` and `repopulate() to use `tip.saturating_sub(LAST_SEEN_WINDOW.saturating_sub(1) as u64)..=tip`, so the cache is seeded from at most `LAST_SEEN_WINDOW` recent blocks.