### PR TITLE
chore(ci): add cyclops PR audit workflow

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,30 +1,10 @@
-name: Pull request audit
+name: PR Audit
 
 on:
   pull_request:
     types: [labeled]
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    if: github.event.label.name == 'agentic-audit'
-    steps:
-      - name: Publish event
-        run: |
-          set -euo pipefail
-
-          echo "${{ secrets.EVENTS_KEY }}" > ${{ runner.temp }}/key
-          echo "${{ secrets.EVENTS_CERT }}" > ${{ runner.temp }}/cert
-
-          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
-            -H "Content-Type: application/json" \
-            --key ${{ runner.temp }}/key \
-            --cert ${{ runner.temp }}/cert \
-            -d '{
-              "repository": "${{ github.repository }}",
-              "event": "pr_audit",
-              "data": {
-                "pr_number": ${{ github.event.pull_request.number }},
-                "sha": "${{ github.event.pull_request.head.sha }}"
-              }
-            }'
+  pr-audit:
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- replace repo-local PR audit workflow with org-shared reusable workflow
- keep trigger as PR label events (`pull_request` with `types: [labeled]`)
- rely on shared workflow default label (`cyclops`)

```yaml
name: PR Audit

on:
  pull_request:
    types: [labeled]

jobs:
  pr-audit:
    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
    secrets: inherit
```
