### PR TITLE
feat(consensus): add --consensus.disable-subblocks flag

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -219,6 +219,11 @@ pub struct Args {
     #[arg(long = "consensus.backfill-frequency", default_value = "8")]
     pub backfill_frequency: std::num::NonZeroU32,
 
+    /// Disable local subblock production and broadcasting. The node will still
+    /// accept and validate subblocks from other validators.
+    #[arg(long = "consensus.disable-subblocks", default_value_t = false)]
+    pub disable_subblocks: bool,
+
     /// The interval at which to broadcast subblocks to the next proposer.
     /// Each built subblock is immediately broadcasted to the next proposer (if it's known).
     /// We broadcast subblock every `subblock-broadcast-interval` to ensure the next

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -90,6 +90,7 @@ pub struct Builder<TBlocker, TPeerManager> {
     pub new_payload_wait_time: Duration,
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,
+    pub disable_subblocks: bool,
     pub fcu_heartbeat_interval: Duration,
 
     pub feed_state: crate::feed::FeedStateHandle,
@@ -314,6 +315,7 @@ where
             fee_recipient: self.fee_recipient,
             time_to_build_subblock: self.time_to_build_subblock,
             subblock_broadcast_interval: self.subblock_broadcast_interval,
+            disabled: self.disable_subblocks,
             epoch_strategy: epoch_strategy.clone(),
         });
 

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -110,6 +110,7 @@ pub async fn run_consensus_stack(
         new_payload_wait_time: config.time_to_build_proposal.into_duration(),
         time_to_build_subblock: config.time_to_build_subblock.into_duration(),
         subblock_broadcast_interval: config.subblock_broadcast_interval.into_duration(),
+        disable_subblocks: config.disable_subblocks,
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),
 
         feed_state,

--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -43,7 +43,7 @@ use tempo_primitives::{
     RecoveredSubBlock, SignedSubBlock, SubBlock, SubBlockVersion, TempoTxEnvelope,
 };
 use tokio::sync::broadcast;
-use tracing::{Instrument, Level, Span, debug, error, instrument, warn};
+use tracing::{Instrument, Level, Span, debug, error, info, instrument, warn};
 
 /// Maximum number of stored subblock transactions. Used to prevent DOS attacks.
 ///
@@ -59,6 +59,7 @@ pub(crate) struct Config<TContext> {
     pub(crate) fee_recipient: Address,
     pub(crate) time_to_build_subblock: Duration,
     pub(crate) subblock_broadcast_interval: Duration,
+    pub(crate) disabled: bool,
     pub(crate) epoch_strategy: FixedEpocher,
 }
 
@@ -96,6 +97,8 @@ pub(crate) struct Actor<TContext> {
     time_to_build_subblock: Duration,
     /// How often to broadcast subblocks to the current proposer.
     subblock_broadcast_interval: Duration,
+    /// Whether subblock building and broadcasting is disabled.
+    disabled: bool,
     /// The epoch strategy used by tempo.
     epoch_strategy: FixedEpocher,
 
@@ -118,9 +121,13 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
             fee_recipient,
             time_to_build_subblock,
             subblock_broadcast_interval,
+            disabled,
             epoch_strategy,
         }: Config<TContext>,
     ) -> Self {
+        if disabled {
+            info!("subblock actor is disabled, will not build or broadcast subblocks");
+        }
         let (actions_tx, actions_rx) = mpsc::unbounded();
         Self {
             our_subblock: PendingSubblock::None,
@@ -134,6 +141,7 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
             fee_recipient,
             time_to_build_subblock,
             subblock_broadcast_interval,
+            disabled,
             epoch_strategy,
             consensus_tip: None,
             subblocks: Default::default(),
@@ -237,6 +245,9 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
 
     #[instrument(skip_all, fields(transaction.tx_hash = %transaction.tx_hash()))]
     fn on_new_subblock_transaction(&self, transaction: Recovered<TempoTxEnvelope>) {
+        if self.disabled {
+            return;
+        }
         if !transaction
             .subblock_proposer()
             .is_some_and(|k| k.matches(self.signer.public_key()))
@@ -325,8 +336,9 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
         debug!(?next_proposer, ?next_round, "determined next proposer");
 
         // Spawn new subblock building task if the current one is assuming different proposer or parent hash.
-        if self.our_subblock.parent_hash() != Some(*tip)
-            || self.our_subblock.target_proposer() != Some(&next_proposer)
+        if !self.disabled
+            && (self.our_subblock.parent_hash() != Some(*tip)
+                || self.our_subblock.target_proposer() != Some(&next_proposer))
         {
             debug!(%tip, %next_proposer, "building new subblock");
             self.build_new_subblock(*tip, next_proposer, scheme);


### PR DESCRIPTION
Adds `--consensus.disable-subblocks` CLI flag that prevents the node from building
and broadcasting its own subblocks. The actor still runs and accepts/validates
subblocks from other validators, so block building works normally when this node
is proposer.

Useful for debugging elevated block latency caused by subblock-driven state growth.

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis