### PR TITLE
chore(workspace): replace placeholder crate descriptions

### DIFF
--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-chainspec"
-description = "TODO:"
+description = "Tempo chain specification and hardfork configuration"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-contracts"
-description = "TODO:"
+description = "Generated bindings and helpers for Tempo system contracts"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-evm"
-description = "TODO:"
+description = "Tempo EVM integration and execution pipeline extensions"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-precompiles"
-description = "TODO:"
+description = "Tempo precompile implementations and runtime hooks"
 
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Replaces placeholder Cargo package descriptions in chainspec, contracts, evm, and precompiles crates with concise summaries. This improves crate metadata quality without changing runtime behavior.
