### PR TITLE
fix(consensus): race canonical stream against retry in read_validator_config_with_retry

### DIFF
--- a/crates/commonware-node/src/validators.rs
+++ b/crates/commonware-node/src/validators.rs
@@ -22,7 +22,7 @@ use tempo_precompiles::{
     validator_config::{IValidatorConfig, ValidatorConfig},
 };
 
-use tracing::{Level, info, instrument, warn};
+use tracing::{Level, debug, info, instrument, warn};
 
 pub(crate) enum ReadTarget {
     AtLeast { height: Height },
@@ -81,8 +81,16 @@ pub(crate) async fn read_validator_config_with_retry(
             );
         });
         tokio::select! {
-            _ = canon_events.next() => {}
-            _ = context.sleep(retry_after) => {}
+            _ = canon_events.next() => {
+                tracing::info_span!("read_validator_config_with_retry").in_scope(|| {
+                    debug!("woke from canonical state notification");
+                });
+            }
+            _ = context.sleep(retry_after) => {
+                tracing::info_span!("read_validator_config_with_retry").in_scope(|| {
+                    debug!("woke from retry timeout");
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #2929

Subscribes to `canonical_state_stream()` before the retry loop and `tokio::select!`s it against the existing sleep. Whichever fires first wins — at the tip the stream wakes within one tick of the block landing instead of waiting the full 1s minimum retry. During historical sync the stream is silent (pipeline doesn't emit canonical notifications) so the existing backoff kicks in unchanged.

**Why:** At epoch boundaries, `read_validator_config_with_retry` blocks until the boundary block is available to read the next validator set. The 1s minimum retry means a validator assigned to propose on view 2 of the new epoch can miss its proposal window — the boundary block may land milliseconds after a failed read, but the node sleeps the full 1s before retrying. This is especially problematic because view 2 is the first proposal slot after the epoch transition, so any unnecessary delay directly risks a skipped view.

Prompted by: joshie