### PR TITLE
refactor(commonware-node): use Result::flatten in dkg ingress

### DIFF
--- a/crates/commonware-node/src/dkg/manager/ingress.rs
+++ b/crates/commonware-node/src/dkg/manager/ingress.rs
@@ -81,8 +81,7 @@ impl Mailbox {
             .wrap_err("failed sending message to actor")?;
         rx.await
             .wrap_err("actor dropped channel before responding with ceremony info")
-            // TODO: replace by Result::flatten once MRSV >= 1.89
-            .and_then(|res| res)
+            .flatten()
     }
 }
 


### PR DESCRIPTION
Replaces a nested Result unwrapping pattern in DKG ingress with Result::flatten and removes the outdated MSRV workaround comment. This keeps behavior unchanged while simplifying the code path.