### PR TITLE
refactor: make --consensus.signing-key and --follow mutually exclusive

### DIFF
--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -17,6 +17,7 @@ pub struct Args {
     #[arg(
         long = "consensus.signing-key",
         required_unless_present_any = ["follow", "dev"],
+        conflicts_with = "follow",
     )]
     signing_key: Option<PathBuf>,
 
@@ -61,6 +62,7 @@ pub struct Args {
     #[arg(
         long = "consensus.fee-recipient",
         required_unless_present_any = ["follow", "dev"],
+        conflicts_with = "follow",
     )]
     pub fee_recipient: Option<alloy_primitives::Address>,
 

--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -22,7 +22,7 @@ pub struct Args {
     signing_key: Option<PathBuf>,
 
     /// The file containing a share of the bls12-381 threshold signing key.
-    #[arg(long = "consensus.signing-share")]
+    #[arg(long = "consensus.signing-share", conflicts_with = "follow")]
     pub signing_share: Option<PathBuf>,
 
     /// The socket address that will be bound to listen for consensus communication from


### PR DESCRIPTION
Adds `conflicts_with = "follow"` to `--consensus.signing-key` and `--consensus.fee-recipient` so clap rejects passing both at parse time instead of silently ignoring the signing key.

Prompted by: zygis