### PR TITLE
fix(test): restore forge-config hardfork overrides for T2 tests

### DIFF
--- a/tips/ref-impls/test/StablecoinDEX.t.sol
+++ b/tips/ref-impls/test/StablecoinDEX.t.sol
@@ -2057,6 +2057,7 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     /// @notice Test cancelStaleOrder with compound policy - maker blocked as sender
+    /// forge-config: default.hardfork = "tempo:T2"
     function test_CancelStaleOrder_Succeeds_BlockedMaker_CompoundPolicy() public {
         // Create compound policy: sender blacklist, recipient always-allow, mint always-allow
         uint64 senderBlacklist = registry.createPolicy(admin, ITIP403Registry.PolicyType.BLACKLIST);
@@ -2086,6 +2087,7 @@ contract StablecoinDEXTest is BaseTest {
     }
 
     /// @notice Test cancelStaleOrder fails with compound policy when maker only blocked as recipient
+    /// forge-config: default.hardfork = "tempo:T2"
     function test_CancelStaleOrder_Fails_MakerOnlyBlockedAsRecipient_CompoundPolicy() public {
         // Create compound policy: sender always-allow, recipient blacklist, mint always-allow
         uint64 recipientBlacklist =

--- a/tips/ref-impls/test/TIP1015.t.sol
+++ b/tips/ref-impls/test/TIP1015.t.sol
@@ -10,6 +10,7 @@ import { BaseTest } from "./BaseTest.t.sol";
 /// @title TIP-1015 Compound Policy Tests
 /// @notice Unit tests and stateless fuzz tests for compound transfer policies as specified in TIP-1015
 /// @dev Tests both TIP403Registry compound policy functions and TIP-20 integration
+/// forge-config: default.hardfork = "tempo:T2"
 contract TIP1015Test is BaseTest {
 
     /*//////////////////////////////////////////////////////////////

--- a/tips/ref-impls/test/TIP20.t.sol
+++ b/tips/ref-impls/test/TIP20.t.sol
@@ -9,6 +9,7 @@ import { ITIP20RolesAuth } from "../src/interfaces/ITIP20RolesAuth.sol";
 import { ITIP403Registry } from "../src/interfaces/ITIP403Registry.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 
+/// forge-config: default.hardfork = "tempo:T2"
 contract TIP20Test is BaseTest {
 
     TIP20 token;

--- a/tips/ref-impls/test/TIP403Registry.t.sol
+++ b/tips/ref-impls/test/TIP403Registry.t.sol
@@ -5,6 +5,7 @@ import { TIP403Registry } from "../src/TIP403Registry.sol";
 import { ITIP403Registry } from "../src/interfaces/ITIP403Registry.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 
+/// forge-config: default.hardfork = "tempo:T2"
 contract TIP403RegistryTest is BaseTest {
 
     address public david = address(0x500);

--- a/tips/ref-impls/test/invariants/TIP1015.t.sol
+++ b/tips/ref-impls/test/invariants/TIP1015.t.sol
@@ -18,6 +18,7 @@ import { InvariantBaseTest } from "./InvariantBaseTest.t.sol";
 ///      TEMPO-1015-6: Built-in Policy Compatibility - compound policies can reference policies 0/1
 ///      TEMPO-1015-7: distributeReward requires both sender AND recipient authorization
 ///      TEMPO-1015-8: claimRewards uses correct directional authorization
+/// forge-config: default.hardfork = "tempo:T2"
 contract TIP1015InvariantTest is InvariantBaseTest {
 
     /*//////////////////////////////////////////////////////////////

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -11,6 +11,7 @@ import { Vm } from "forge-std/Vm.sol";
 /// @dev Tests invariants TEMPO-VALV2-1 through TEMPO-VALV2-25 covering:
 ///      - Per-handler assertions (VALV2-1 to VALV2-7): auth enforcement, count changes, height tracking, init gates
 ///      - Global invariants (VALV2-8 to VALV2-25): append-only, uniqueness, lookups, migration correctness
+/// forge-config: default.hardfork = "tempo:T2"
 contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
 
     /// @dev Starting offset for validator address pool


### PR DESCRIPTION
The invariant-tests CI workflow overrides the hardfork via `--hardfork tempo:T1C`, so contracts requiring T2 precompiles need inline `forge-config` annotations to pin them to `tempo:T2`. These were removed in #2346 assuming `foundry.toml` default was sufficient.

Restores the annotation on 5 contracts + 2 individual StablecoinDEX functions, and adds a missing one for `ValidatorConfigV2InvariantTest`.

Prompted by: rusowsky