### PR TITLE
docs(tip-1028): Address-Level Receive Policies

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1025
+id: TIP-1028
 title: Address-Level Receive Policies
 description: Extends TIP-403 with token sets and address-level receive policies, allowing individual addresses to control who can send to them and which tokens they can receive.
 authors: Mallesh Pai
@@ -8,7 +8,7 @@ related: TIP-403, TIP-1015, TIP-20
 protocolVersion: TBD
 ---
 
-# TIP-1025: Address-Level Receive Policies
+# TIP-1028: Address-Level Receive Policies
 
 ## Abstract
 


### PR DESCRIPTION
Extends TIP-403 with token sets and address-level receive policies. Addresses review feedback: renamed to TIP-1025, Account→Address-Level, added bit flag for zero-ID semantics, orchestrator use cases, built-in policy handling, gas cost analysis.