### PR TITLE
fix(commonware-node): avoid panic when executor mailbox is closed

### DIFF
--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -4,7 +4,7 @@ use futures::{
     SinkExt as _,
     channel::{mpsc, oneshot},
 };
-use tracing::Span;
+use tracing::{Span, warn};
 
 use crate::consensus::{Digest, block::Block};
 
@@ -79,9 +79,8 @@ impl Reporter for Mailbox {
     type Activity = Update<Block>;
 
     async fn report(&mut self, update: Self::Activity) {
-        self.inner
-            .send(Message::in_current_span(update))
-            .await
-            .expect("actor is present and ready to receive broadcasts");
+        if let Err(error) = self.inner.send(Message::in_current_span(update)).await {
+            warn!(%error, "executor mailbox is closed; dropping finalization activity");
+        }
     }
 }


### PR DESCRIPTION
Stops panicking in the executor ingress report path when the mailbox receiver is closed. Failed sends are now logged at warn level and the activity is dropped, which keeps shutdown and teardown paths non-fatal.