### PR TITLE
fix(ci): inline pr-audit workflow for public repo

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,10 +1,31 @@
-name: PR Audit
+name: Pull request audit
 
 on:
   pull_request:
     types: [labeled]
 
 jobs:
-  pr-audit:
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
-    secrets: inherit
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit'
+    steps:
+      - name: Publish event
+        run: |
+          set -euo pipefail
+
+          echo "${{ secrets.EVENTS_KEY }}" > ${{ runner.temp }}/key
+          echo "${{ secrets.EVENTS_CERT }}" > ${{ runner.temp }}/cert
+
+          # EVENTS_ARGS may contain additional curl arguments, not just a URL.
+          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+            -H "Content-Type: application/json" \
+            --key "${{ runner.temp }}/key" \
+            --cert "${{ runner.temp }}/cert" \
+            -d '{
+              "repository": "${{ github.repository }}",
+              "event": "pr_audit",
+              "data": {
+                "pr_number": ${{ github.event.pull_request.number }},
+                "sha": "${{ github.event.pull_request.head.sha }}"
+              }
+            }'


### PR DESCRIPTION
Replaces the reusable workflow call in `.github/workflows/pr-audit.yml` with an inline publish job.

`tempo` is a public repo, so calling a reusable workflow from private `tempoxyz/gh-actions` fails at workflow parse time. Inlining restores label-triggered audit event publishing.

Also accepts both `cyclops` and `agentic-audit` labels to preserve existing tag behavior.
