### PR TITLE
docs(tip-1022): unify quote and swap fill logic

### DIFF
--- a/tips/tip-1022.md
+++ b/tips/tip-1022.md
@@ -4,21 +4,11 @@ title: Unify quote() with swap() fill logic
 description: Route quote paths through the same fill engine as swap paths to eliminate deterministic quote/swap drift and simplify swap execution bookkeeping.
 authors: Dan Robinson
 status: Draft
-related: TIP-1001
+related: N/A
 protocolVersion: T3
 ---
 
-# Unify quote() with swap() fill logic
-
-- TIP ID: `TIP-1022`
-- Authors/Owners: `Dan Robinson`
-- Status: `Draft`
-- Related Specs: `TIP-1001`
-- Protocol Version: `T2`
-
----
-
-# Overview
+# TIP-1022: Unify quote() with swap() fill logic
 
 ## Abstract
 


### PR DESCRIPTION
Routes quote through the same fill logic as swap in a read-only simulation path to eliminate quote/swap rounding divergence.

Removes maintained per-tick totalLiquidity write tracking and computes getTickLevel.totalLiquidity on demand by summing remaining order amounts at the tick.

This keeps the external API shape unchanged, makes quote more accurate, and accepts O(N) getTickLevel reads for simpler swap execution logic.