### PR TITLE
docs(tip-1024): unify quote and swap fill logic

### DIFF
--- a/tips/tip-1024.md
+++ b/tips/tip-1024.md
@@ -47,20 +47,20 @@ This also enables simplifying swap internals by removing per-tick tracking paths
      - no balance transfers
      - no events
 
-4. In `Execute` mode, the engine behavior remains functionally equivalent to current swap semantics, but redundant per-tick liquidity aggregate tracking SHOULD be removed.
-   - Swap write paths SHOULD stop maintaining a stored per-tick `totalLiquidity` accumulator.
+4. In `Execute` mode, the engine behavior remains functionally equivalent to current swap semantics, and redundant per-tick liquidity aggregate tracking MUST be removed.
+   - Swap write paths MUST NOT maintain or update a stored per-tick `totalLiquidity` accumulator.
    - Tick selection data required for matching (`best` tick pointers and initialized-tick bitmap/navigation) remains unchanged.
 
 5. API compatibility:
    - External quote and swap method signatures remain unchanged.
    - Returned values remain semantically identical, except quote precision now matches swap precision exactly for the same state snapshot.
    - `getTickLevel` keeps its current return shape, including `totalLiquidity`.
-   - `getTickLevel.totalLiquidity` is computed on demand by traversing the tick's linked-list orders and summing `remaining`, rather than reading a maintained aggregate slot.
+   - `getTickLevel.totalLiquidity` MUST be computed on demand by traversing the tick's linked-list orders and summing `remaining`, rather than reading a maintained aggregate slot.
 
 6. Performance expectations:
    - `quote()` becomes more expensive because it walks per-order execution logic.
    - `swap()` becomes simpler and may become cheaper by dropping per-fill `totalLiquidity` maintenance writes.
-   - `getTickLevel` becomes O(N) in the number of orders at the requested tick.
+   - `getTickLevel` is intentionally O(N) in the number of orders at the requested tick.
 
 # Invariants
 
@@ -79,5 +79,8 @@ This also enables simplifying swap internals by removing per-tick tracking paths
 5. Tick-level liquidity correctness:
    - `getTickLevel.totalLiquidity` MUST equal the sum of `remaining` across all active orders in that tick's linked list.
 
-6. Regression safety:
+6. No aggregate-liquidity storage tracking:
+   - Swap execution MUST NOT rely on or update a persisted per-tick `totalLiquidity` aggregate.
+
+7. Regression safety:
    - Existing swap slippage and limit checks MUST remain enforced in execute mode.


### PR DESCRIPTION
Routes quote through the same fill logic as swap in a read-only simulation path to eliminate quote/swap rounding divergence.

Removes maintained per-tick totalLiquidity write tracking and computes getTickLevel.totalLiquidity on demand by summing remaining order amounts at the tick.

This keeps the external API shape unchanged, makes quote more accurate, and accepts O(N) getTickLevel reads for simpler swap execution logic.