### PR TITLE
feat(tip-1017): add feeRecipient updates for validator config v2

### DIFF
--- a/crates/contracts/src/precompiles/validator_config_v2.rs
+++ b/crates/contracts/src/precompiles/validator_config_v2.rs
@@ -153,7 +153,7 @@ crate::sol! {
         error PublicKeyAlreadyExists();
         error Unauthorized();
         error AddressAlreadyHasValidator();
-        error ValidatorAlreadyDeleted();
+        error ValidatorAlreadyDeactivated();
         error ValidatorNotFound();
     }
 }
@@ -175,8 +175,8 @@ impl ValidatorConfigV2Error {
         Self::ValidatorNotFound(IValidatorConfigV2::ValidatorNotFound {})
     }
 
-    pub const fn validator_already_deleted() -> Self {
-        Self::ValidatorAlreadyDeleted(IValidatorConfigV2::ValidatorAlreadyDeleted {})
+    pub const fn validator_already_deactivated() -> Self {
+        Self::ValidatorAlreadyDeactivated(IValidatorConfigV2::ValidatorAlreadyDeactivated {})
     }
 
     pub const fn invalid_public_key() -> Self {

--- a/crates/contracts/src/precompiles/validator_config_v2.rs
+++ b/crates/contracts/src/precompiles/validator_config_v2.rs
@@ -26,6 +26,7 @@ crate::sol! {
             address validatorAddress;
             string ingress;
             string egress;
+            address feeRecipient;
             uint64 index;
             uint64 addedAtHeight;
             uint64 deactivatedAtHeight;
@@ -72,6 +73,7 @@ crate::sol! {
             bytes32 publicKey,
             string calldata ingress,
             string calldata egress,
+            address feeRecipient,
             bytes calldata signature
         ) external returns (uint64 index);
 
@@ -85,6 +87,12 @@ crate::sol! {
             string calldata ingress,
             string calldata egress,
             bytes calldata signature
+        ) external;
+
+        /// Update fee recipient.
+        function setFeeRecipient(
+            uint64 idx,
+            address feeRecipient
         ) external;
 
         /// Update IP addresses (owner or validator)
@@ -116,7 +124,7 @@ crate::sol! {
         // Events
         // =====================================================================
 
-        event ValidatorAdded(uint64 indexed index, address indexed validatorAddress, bytes32 publicKey, string ingress, string egress);
+        event ValidatorAdded(uint64 indexed index, address indexed validatorAddress, bytes32 publicKey, string ingress, string egress, address feeRecipient);
         event ValidatorDeactivated(uint64 indexed index, address indexed validatorAddress);
         event ValidatorRotated(
             uint64 indexed index,
@@ -128,6 +136,7 @@ crate::sol! {
             string egress,
             address caller
         );
+        event FeeRecipientUpdated(uint64 indexed index, address feeRecipient, address caller);
         event IpAddressesUpdated(uint64 indexed index, string ingress, string egress, address caller);
         event ValidatorOwnershipTransferred(uint64 indexed index, address indexed oldAddress, address indexed newAddress, address caller);
         event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -198,6 +198,7 @@ mod tests {
             msg_data.extend_from_slice(validator_addr.as_slice());
             msg_data.extend_from_slice(b"192.168.1.1:8000");
             msg_data.extend_from_slice(b"192.168.1.1");
+            msg_data.extend_from_slice(validator_addr.as_slice());
             let message = alloy::primitives::keccak256(&msg_data);
 
             // Sign with namespace
@@ -214,6 +215,7 @@ mod tests {
                 publicKey: public_key,
                 ingress: "192.168.1.1:8000".to_string(),
                 egress: "192.168.1.1".to_string(),
+                feeRecipient: validator_addr,
                 signature: signature.encode().to_vec().into(),
             };
             let calldata = add_call.abi_encode();
@@ -245,6 +247,7 @@ mod tests {
                 publicKey: FixedBytes::<32>::from([0x42; 32]),
                 ingress: "192.168.1.1:8000".to_string(),
                 egress: "192.168.1.1".to_string(),
+                feeRecipient: validator_addr,
                 signature: vec![0u8; 64].into(),
             };
             let calldata = add_call.abi_encode();

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -57,6 +57,9 @@ impl Precompile for ValidatorConfigV2 {
                 IValidatorConfigV2Calls::rotateValidator(call) => {
                     mutate_void(call, msg_sender, |s, c| self.rotate_validator(s, c))
                 }
+                IValidatorConfigV2Calls::setFeeRecipient(call) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_fee_recipient(s, c))
+                }
                 IValidatorConfigV2Calls::setIpAddresses(call) => {
                     mutate_void(call, msg_sender, |s, c| self.set_ip_addresses(s, c))
                 }

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -873,7 +873,10 @@ mod tests {
         data.extend_from_slice(validator_address.as_slice());
         data.extend_from_slice(ingress.as_bytes());
         data.extend_from_slice(egress.as_bytes());
-        data.extend_from_slice(fee_recipient.as_slice());
+        // `addValidator` signs feeRecipient, while `rotateValidator` does not.
+        if namespace == VALIDATOR_NS_ADD {
+            data.extend_from_slice(fee_recipient.as_slice());
+        }
         let message = keccak256(&data);
 
         // Sign with namespace

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -283,6 +283,7 @@ impl ValidatorConfigV2 {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn append_validator(
         &mut self,
         addr: Address,
@@ -949,8 +950,8 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
-                VALIDATOR_NS_ADD,
                 validator,
+                VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
             vc.add_validator(
@@ -1354,7 +1355,7 @@ mod tests {
 
             // Validator can update its own
             let fee_recipient_2 = Address::random();
-            vc.set_ip_addresses(
+            vc.set_fee_recipient(
                 validator,
                 IValidatorConfigV2::setFeeRecipientCall {
                     idx: 0,
@@ -1384,7 +1385,7 @@ mod tests {
                 make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
-            vc.set_(
+            vc.set_ip_addresses(
                 owner,
                 IValidatorConfigV2::setIpAddressesCall {
                     idx: 0,

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -30,6 +30,7 @@ struct ValidatorV2 {
     validator_address: Address,
     ingress: String,
     egress: String,
+    fee_recipient: Address,
     index: u64,
     active_idx: u64,
     added_at_height: u64,
@@ -168,6 +169,7 @@ impl ValidatorConfigV2 {
             validatorAddress: v.validator_address,
             ingress: v.ingress,
             egress: v.egress,
+            feeRecipient: v.fee_recipient,
             index: v.index,
             addedAtHeight: v.added_at_height,
             deactivatedAtHeight: v.deactivated_at_height,
@@ -287,6 +289,7 @@ impl ValidatorConfigV2 {
         pubkey: B256,
         ingress: String,
         egress: String,
+        fee_recipient: Address,
         added_at_height: u64,
         deactivated_at_height: u64,
     ) -> Result<u64> {
@@ -303,6 +306,7 @@ impl ValidatorConfigV2 {
             validator_address: addr,
             ingress,
             egress,
+            fee_recipient,
             index: count,
             active_idx,
             added_at_height,
@@ -345,17 +349,46 @@ impl ValidatorConfigV2 {
         Ok(())
     }
 
-    /// Verify validator signature for add or rotate operations
+    /// Verify validator signature for add operations.
     ///
     /// Constructs the message according to the validator config v2 specification
     /// and verifies the Ed25519 signature using the appropriate namespace.
-    ///
-    /// **FORMAT**:
-    /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
-    /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, ingress, egress))`
-    fn verify_validator_signature(
+    fn verify_validator_add_signature(
         &self,
-        namespace: &[u8],
+        pubkey: &B256,
+        signature: &[u8],
+        validator_address: Address,
+        ingress: &str,
+        egress: &str,
+        fee_recipient: Address,
+    ) -> Result<()> {
+        let mut hasher = Keccak256::new();
+        hasher.update(self.storage.chain_id().to_be_bytes());
+        hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
+        hasher.update(validator_address.as_slice());
+        hasher.update(ingress.as_bytes());
+        hasher.update(egress.as_bytes());
+        hasher.update(fee_recipient.as_slice());
+        let message = hasher.finalize();
+
+        let public_key = PublicKey::decode(pubkey.as_slice())
+            .map_err(|_| ValidatorConfigV2Error::invalid_public_key())?;
+        let sig = Signature::decode(signature)
+            .map_err(|_| ValidatorConfigV2Error::invalid_signature_format())?;
+
+        if !public_key.verify(VALIDATOR_NS_ADD, message.as_slice(), &sig) {
+            Err(ValidatorConfigV2Error::invalid_signature())?
+        }
+
+        Ok(())
+    }
+
+    /// Verify validator signature for rotate operations.
+    ///
+    /// Constructs the message according to the validator config v2 specification
+    /// and verifies the Ed25519 signature using the appropriate namespace.
+    fn verify_validator_rotate_signature(
+        &self,
         pubkey: &B256,
         signature: &[u8],
         validator_address: Address,
@@ -375,7 +408,7 @@ impl ValidatorConfigV2 {
         let sig = Signature::decode(signature)
             .map_err(|_| ValidatorConfigV2Error::invalid_signature_format())?;
 
-        if !public_key.verify(namespace, message.as_slice(), &sig) {
+        if !public_key.verify(VALIDATOR_NS_ROTATE, message.as_slice(), &sig) {
             Err(ValidatorConfigV2Error::invalid_signature())?
         }
 
@@ -397,13 +430,13 @@ impl ValidatorConfigV2 {
         Self::validate_endpoints(&call.ingress, &call.egress)?;
         let ingress_hash = self.require_unique_ingress_ip(&call.ingress)?;
 
-        self.verify_validator_signature(
-            VALIDATOR_NS_ADD,
+        self.verify_validator_add_signature(
             &call.publicKey,
             &call.signature,
             call.validatorAddress,
             &call.ingress,
             &call.egress,
+            call.feeRecipient,
         )?;
 
         let block_height = self.storage.block_number();
@@ -415,6 +448,7 @@ impl ValidatorConfigV2 {
             call.publicKey,
             call.ingress.clone(),
             call.egress.clone(),
+            call.feeRecipient,
             block_height,
             0,
         )?;
@@ -426,6 +460,7 @@ impl ValidatorConfigV2 {
                 publicKey: call.publicKey,
                 ingress: call.ingress,
                 egress: call.egress,
+                feeRecipient: call.feeRecipient,
             },
         ))?;
 
@@ -526,8 +561,7 @@ impl ValidatorConfigV2 {
         self.require_new_pubkey(call.publicKey)?;
         Self::validate_endpoints(&call.ingress, &call.egress)?;
 
-        self.verify_validator_signature(
-            VALIDATOR_NS_ROTATE,
+        self.verify_validator_rotate_signature(
             &call.publicKey,
             &call.signature,
             v.validator_address,
@@ -546,6 +580,7 @@ impl ValidatorConfigV2 {
             validator_address: v.validator_address,
             ingress: v.ingress,
             egress: v.egress,
+            fee_recipient: v.fee_recipient,
             index: appended_idx,
             active_idx: 0,
             added_at_height: v.added_at_height,
@@ -576,6 +611,28 @@ impl ValidatorConfigV2 {
                 newPublicKey: call.publicKey,
                 ingress: call.ingress,
                 egress: call.egress,
+                caller: sender,
+            },
+        ))
+    }
+
+    pub fn set_fee_recipient(
+        &mut self,
+        sender: Address,
+        call: IValidatorConfigV2::setFeeRecipientCall,
+    ) -> Result<()> {
+        let mut v = self.get_active_validator(call.idx)?;
+        if sender != v.validator_address && !self.config.read()?.is_owner(sender) {
+            Err(ValidatorConfigV2Error::unauthorized())?
+        }
+
+        v.fee_recipient = call.feeRecipient;
+        self.validators[call.idx as usize].write(v)?;
+
+        self.emit_event(ValidatorConfigV2Event::FeeRecipientUpdated(
+            IValidatorConfigV2::FeeRecipientUpdated {
+                index: call.idx,
+                feeRecipient: call.feeRecipient,
                 caller: sender,
             },
         ))
@@ -735,6 +792,7 @@ impl ValidatorConfigV2 {
             v1_val.publicKey,
             v1_val.inboundAddress,
             egress,
+            Address::ZERO,
             block_height,
             if now_active { 0 } else { block_height },
         )?;
@@ -799,6 +857,7 @@ mod tests {
         validator_address: Address,
         ingress: &str,
         egress: &str,
+        fee_recipient: Address,
         namespace: &[u8],
     ) -> (FixedBytes<32>, Vec<u8>) {
         // Generate a random private key for testing
@@ -813,6 +872,7 @@ mod tests {
         data.extend_from_slice(validator_address.as_slice());
         data.extend_from_slice(ingress.as_bytes());
         data.extend_from_slice(egress.as_bytes());
+        data.extend_from_slice(fee_recipient.as_slice());
         let message = keccak256(&data);
 
         // Sign with namespace
@@ -834,6 +894,7 @@ mod tests {
         pubkey: FixedBytes<32>,
         ingress: &str,
         egress: &str,
+        fee_recipient: Address,
         signature: Vec<u8>,
     ) -> IValidatorConfigV2::addValidatorCall {
         IValidatorConfigV2::addValidatorCall {
@@ -841,6 +902,7 @@ mod tests {
             publicKey: pubkey,
             ingress: ingress.to_string(),
             egress: egress.to_string(),
+            feeRecipient: fee_recipient,
             signature: signature.into(),
         }
     }
@@ -850,10 +912,11 @@ mod tests {
         addr: Address,
         ingress: &str,
         egress: &str,
+        fee_recipient: Address,
     ) -> IValidatorConfigV2::addValidatorCall {
         let (pubkey, signature) =
-            make_test_keypair_and_signature(addr, ingress, egress, VALIDATOR_NS_ADD);
-        make_add_call(addr, pubkey, ingress, egress, signature)
+            make_test_keypair_and_signature(addr, ingress, egress, fee_recipient, VALIDATOR_NS_ADD);
+        make_add_call(addr, pubkey, ingress, egress, fee_recipient, signature)
     }
 
     #[test]
@@ -887,6 +950,7 @@ mod tests {
                 "192.168.1.1:8000",
                 "192.168.1.1",
                 VALIDATOR_NS_ADD,
+                validator,
             );
             vc.storage.set_block_number(200);
             vc.add_validator(
@@ -896,6 +960,7 @@ mod tests {
                     pubkey,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    validator,
                     signature,
                 ),
             )?;
@@ -930,7 +995,12 @@ mod tests {
 
             let result = vc.add_validator(
                 non_owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             );
             assert_eq!(result, Err(ValidatorConfigV2Error::unauthorized().into()));
 
@@ -953,6 +1023,7 @@ mod tests {
                     FixedBytes::<32>::ZERO,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    Address::random(),
                     vec![0u8; 64],
                 ),
             );
@@ -977,13 +1048,13 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             vc.storage.set_block_number(201);
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.2:8000", "192.168.1.2"),
+                make_valid_add_call(validator, "192.168.1.2:8000", "192.168.1.2", validator),
             );
             assert_eq!(
                 result,
@@ -1008,12 +1079,20 @@ mod tests {
                 addr1,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                addr1,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_add_call(addr1, pubkey, "192.168.1.1:8000", "192.168.1.1", sig1),
+                make_add_call(
+                    addr1,
+                    pubkey,
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    addr1,
+                    sig1,
+                ),
             )?;
 
             // Try to add second validator with same public key (but different signature for different address)
@@ -1022,12 +1101,20 @@ mod tests {
                 addr2,
                 "192.168.1.2:8000",
                 "192.168.1.2",
+                addr2,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(201);
             let result = vc.add_validator(
                 owner,
-                make_add_call(addr2, pubkey, "192.168.1.2:8000", "192.168.1.2", sig2),
+                make_add_call(
+                    addr2,
+                    pubkey,
+                    "192.168.1.2:8000",
+                    "192.168.1.2",
+                    addr2,
+                    sig2,
+                ),
             );
             assert_eq!(
                 result,
@@ -1050,7 +1137,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             vc.storage.set_block_number(300);
@@ -1091,11 +1178,11 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1", v1),
             )?;
             vc.add_validator(
                 owner,
-                make_valid_add_call(v2, "192.168.1.2:8000", "192.168.1.2"),
+                make_valid_add_call(v2, "192.168.1.2:8000", "192.168.1.2", v2),
             )?;
 
             // Third party cannot deactivate
@@ -1136,6 +1223,7 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
@@ -1146,6 +1234,7 @@ mod tests {
                     old_pubkey,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    validator,
                     old_sig,
                 ),
             )?;
@@ -1155,6 +1244,7 @@ mod tests {
                 validator,
                 "10.0.0.1:8000",
                 "10.0.0.1",
+                validator,
                 VALIDATOR_NS_ROTATE,
             );
             vc.storage.set_block_number(300);
@@ -1209,12 +1299,12 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1", v1),
             )?;
             vc.storage.set_block_number(201);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v2, "192.168.1.2:8000", "192.168.1.2"),
+                make_valid_add_call(v2, "192.168.1.2:8000", "192.168.1.2", v2),
             )?;
 
             assert_eq!(vc.get_active_validators()?.len(), 2);
@@ -1236,6 +1326,50 @@ mod tests {
     }
 
     #[test]
+    fn test_set_fee_recipient() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let owner = Address::random();
+        let validator = Address::random();
+        StorageCtx::enter(&mut storage, || {
+            let mut vc = ValidatorConfigV2::new();
+            vc.initialize(owner)?;
+
+            vc.storage.set_block_number(200);
+            vc.add_validator(
+                owner,
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
+            )?;
+
+            let fee_recipient_1 = Address::random();
+            vc.set_fee_recipient(
+                owner,
+                IValidatorConfigV2::setFeeRecipientCall {
+                    idx: 0,
+                    feeRecipient: fee_recipient_1,
+                },
+            )?;
+
+            let v = vc.validator_by_address(validator)?;
+            assert_eq!(v.feeRecipient, fee_recipient_1);
+
+            // Validator can update its own
+            let fee_recipient_2 = Address::random();
+            vc.set_ip_addresses(
+                validator,
+                IValidatorConfigV2::setFeeRecipientCall {
+                    idx: 0,
+                    feeRecipient: fee_recipient_2,
+                },
+            )?;
+
+            let v = vc.validator_by_address(validator)?;
+            assert_eq!(v.feeRecipient, fee_recipient_2);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_set_ip_addresses() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let owner = Address::random();
@@ -1247,10 +1381,10 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
-            vc.set_ip_addresses(
+            vc.set_(
                 owner,
                 IValidatorConfigV2::setIpAddressesCall {
                     idx: 0,
@@ -1323,12 +1457,20 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_add_call(validator, pubkey, "192.168.1.1:8000", "192.168.1.1", sig),
+                make_add_call(
+                    validator,
+                    pubkey,
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    validator,
+                    sig,
+                ),
             )?;
 
             vc.transfer_validator_ownership(
@@ -1367,7 +1509,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             vc.storage.set_block_number(300);
@@ -1428,7 +1570,12 @@ mod tests {
 
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             );
             assert_eq!(
                 result,
@@ -1452,13 +1599,21 @@ mod tests {
                 addr1,
                 "192.168.1.1:8000",
                 "192.168.1.1:9000",
+                addr1,
                 VALIDATOR_NS_ADD,
             );
 
             // IP:port for egress should fail (egress validation happens before signature)
             let result = vc.add_validator(
                 owner,
-                make_add_call(addr1, pubkey1, "192.168.1.1:8000", "192.168.1.1:9000", sig1),
+                make_add_call(
+                    addr1,
+                    pubkey1,
+                    "192.168.1.1:8000",
+                    "192.168.1.1:9000",
+                    addr1,
+                    sig1,
+                ),
             );
             assert!(result.is_err(), "egress with port should be rejected");
 
@@ -1466,7 +1621,12 @@ mod tests {
             vc.storage.set_block_number(200);
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             );
             assert!(result.is_ok(), "egress with plain IP should succeed");
 
@@ -1711,6 +1871,7 @@ mod tests {
                 validator_addr,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator_addr,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
@@ -1721,6 +1882,7 @@ mod tests {
                     pubkey1,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    validator_addr,
                     sig1,
                 ),
             )?;
@@ -1737,6 +1899,7 @@ mod tests {
                 validator_addr,
                 "192.168.1.2:8000",
                 "192.168.1.2",
+                validator_addr,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(400);
@@ -1747,6 +1910,7 @@ mod tests {
                     pubkey2,
                     "192.168.1.2:8000",
                     "192.168.1.2",
+                    validator_addr,
                     sig2,
                 ),
             )?;
@@ -1794,13 +1958,23 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             )?;
 
             vc.storage.set_block_number(201);
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:9000", "192.168.2.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:9000",
+                    "192.168.2.1",
+                    Address::random(),
+                ),
             );
 
             assert!(result.is_err());
@@ -1820,7 +1994,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1", v1),
             )?;
 
             vc.storage.set_block_number(300);
@@ -1833,7 +2007,12 @@ mod tests {
             vc.storage.set_block_number(400);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             )?;
 
             Ok(())
@@ -1938,11 +2117,11 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1", v1),
             )?;
             vc.add_validator(
                 owner,
-                make_valid_add_call(v2, "192.168.2.1:8000", "192.168.2.1"),
+                make_valid_add_call(v2, "192.168.2.1:8000", "192.168.2.1", v2),
             )?;
 
             // Rotate v1 to v2's IPs should fail
@@ -1950,6 +2129,7 @@ mod tests {
                 v1,
                 "192.168.2.1:8000",
                 "192.168.2.1",
+                v1,
                 VALIDATOR_NS_ROTATE,
             );
 
@@ -2129,7 +2309,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Third party is neither owner nor validator_owner — should be rejected
@@ -2168,7 +2348,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Rotate keeping the same ingress/egress — should succeed
@@ -2176,6 +2356,7 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ROTATE,
             );
             vc.storage.set_block_number(300);
@@ -2216,7 +2397,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Rotate keeping the same ingress/egress — should succeed
@@ -2224,6 +2405,7 @@ mod tests {
                 validator,
                 "192.168.1.1:8001",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ROTATE,
             );
             vc.storage.set_block_number(300);
@@ -2264,7 +2446,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Change ingress only, keep egress the same
@@ -2297,7 +2479,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Change ingress only, keep egress the same
@@ -2330,7 +2512,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Change egress only, keep ingress the same
@@ -2364,11 +2546,11 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(v1, "192.168.1.1:8000", "192.168.1.1", v1),
             )?;
             vc.add_validator(
                 owner,
-                make_valid_add_call(v2, "192.168.2.1:8000", "192.168.2.1"),
+                make_valid_add_call(v2, "192.168.2.1:8000", "192.168.2.1", v2),
             )?;
 
             let result = vc.set_ip_addresses(
@@ -2397,7 +2579,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             vc.set_ip_addresses(
@@ -2429,7 +2611,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Validator transfers its own ownership (not owner)
@@ -2467,12 +2649,13 @@ mod tests {
                 addr1,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                addr1,
                 VALIDATOR_NS_ADD,
             );
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_add_call(addr1, pubkey, "192.168.1.1:8000", "192.168.1.1", sig),
+                make_add_call(addr1, pubkey, "192.168.1.1:8000", "192.168.1.1", addr1, sig),
             )?;
 
             // Deactivate
@@ -2491,6 +2674,7 @@ mod tests {
                     pubkey,
                     "192.168.2.1:8000",
                     "192.168.2.1",
+                    addr2,
                     vec![0u8; 64],
                 ),
             );
@@ -2514,7 +2698,10 @@ mod tests {
 
             // Add validator with IPv6 ingress
             vc.storage.set_block_number(200);
-            vc.add_validator(owner, make_valid_add_call(validator, "[::1]:8000", "::1"))?;
+            vc.add_validator(
+                owner,
+                make_valid_add_call(validator, "[::1]:8000", "::1", validator),
+            )?;
 
             assert_eq!(vc.validator_count()?, 1);
             let v = vc.validator_by_index(0)?;
@@ -2537,14 +2724,24 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[2001:db8::1]:8000", "2001:db8::1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "[2001:db8::1]:8000",
+                    "2001:db8::1",
+                    Address::random(),
+                ),
             )?;
 
             // Try to add another validator with same IPv6 IP (different port)
             vc.storage.set_block_number(201);
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[2001:db8::1]:9000", "2001:db8::2"),
+                make_valid_add_call(
+                    Address::random(),
+                    "[2001:db8::1]:9000",
+                    "2001:db8::2",
+                    Address::random(),
+                ),
             );
 
             assert!(result.is_err());
@@ -2564,7 +2761,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(v1, "[2001:db8::1]:8000", "2001:db8::1"),
+                make_valid_add_call(v1, "[2001:db8::1]:8000", "2001:db8::1", v1),
             )?;
 
             vc.storage.set_block_number(300);
@@ -2577,7 +2774,12 @@ mod tests {
             vc.storage.set_block_number(400);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[2001:db8::1]:8000", "2001:db8::1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "[2001:db8::1]:8000",
+                    "2001:db8::1",
+                    Address::random(),
+                ),
             )?;
 
             Ok(())
@@ -2597,7 +2799,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(validator, "192.168.1.1:8000", "192.168.1.1", validator),
             )?;
 
             // Rotate to IPv6
@@ -2605,6 +2807,7 @@ mod tests {
                 validator,
                 "[2001:db8::1]:8000",
                 "2001:db8::1",
+                validator,
                 VALIDATOR_NS_ROTATE,
             );
             vc.storage.set_block_number(300);
@@ -2644,7 +2847,7 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[::1]:8000", "::1"),
+                make_valid_add_call(Address::random(), "[::1]:8000", "::1", Address::random()),
             )?;
 
             // Try to add another validator with expanded IPv6 notation of same IP
@@ -2652,7 +2855,12 @@ mod tests {
             vc.storage.set_block_number(201);
             let result = vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[0:0:0:0:0:0:0:1]:9000", "::1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "[0:0:0:0:0:0:0:1]:9000",
+                    "::1",
+                    Address::random(),
+                ),
             );
 
             assert!(
@@ -2675,14 +2883,24 @@ mod tests {
             vc.storage.set_block_number(200);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "192.168.1.1:8000", "192.168.1.1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "192.168.1.1:8000",
+                    "192.168.1.1",
+                    Address::random(),
+                ),
             )?;
 
             // Add IPv6 validator - should succeed (different IP)
             vc.storage.set_block_number(201);
             vc.add_validator(
                 owner,
-                make_valid_add_call(Address::random(), "[2001:db8::1]:8000", "2001:db8::1"),
+                make_valid_add_call(
+                    Address::random(),
+                    "[2001:db8::1]:8000",
+                    "2001:db8::1",
+                    Address::random(),
+                ),
             )?;
 
             assert_eq!(vc.validator_count()?, 2);
@@ -2705,6 +2923,7 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ADD,
             );
 
@@ -2716,6 +2935,7 @@ mod tests {
                     pubkey,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    validator,
                     signature,
                 ),
             )?;
@@ -2726,6 +2946,7 @@ mod tests {
                     publicKey: pubkey,
                     ingress: "192.168.1.1:8000".to_string(),
                     egress: "192.168.1.1".to_string(),
+                    feeRecipient: validator,
                 },
             )]);
 
@@ -2809,6 +3030,7 @@ mod tests {
                 validator,
                 "192.168.1.1:8000",
                 "192.168.1.1",
+                validator,
                 VALIDATOR_NS_ADD,
             );
 
@@ -2820,6 +3042,7 @@ mod tests {
                     old_pubkey,
                     "192.168.1.1:8000",
                     "192.168.1.1",
+                    validator,
                     old_sig,
                 ),
             )?;
@@ -2829,6 +3052,7 @@ mod tests {
                 validator,
                 "10.0.0.2:8000",
                 "10.0.0.2",
+                validator,
                 VALIDATOR_NS_ROTATE,
             );
             vc.storage.set_block_number(300);

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -154,7 +154,7 @@ impl ValidatorConfigV2 {
         }
         let v = self.validators[idx as usize].read()?;
         if v.deactivated_at_height != 0 {
-            Err(ValidatorConfigV2Error::validator_already_deleted())?
+            Err(ValidatorConfigV2Error::validator_already_deactivated())?
         }
         Ok(v)
     }
@@ -442,7 +442,7 @@ impl ValidatorConfigV2 {
         }
         let v = self.validators[call.idx as usize].read()?;
         if v.deactivated_at_height != 0 {
-            Err(ValidatorConfigV2Error::validator_already_deleted())?
+            Err(ValidatorConfigV2Error::validator_already_deactivated())?
         }
         let config = self.config.read()?;
         if sender != v.validator_address && !config.is_owner(sender) {
@@ -1070,7 +1070,7 @@ mod tests {
             );
             assert_eq!(
                 result,
-                Err(ValidatorConfigV2Error::validator_already_deleted().into())
+                Err(ValidatorConfigV2Error::validator_already_deactivated().into())
             );
 
             Ok(())
@@ -1385,7 +1385,7 @@ mod tests {
             );
             assert_eq!(
                 result,
-                Err(ValidatorConfigV2Error::validator_already_deleted().into())
+                Err(ValidatorConfigV2Error::validator_already_deactivated().into())
             );
 
             Ok(())

--- a/tips/ref-impls/src/ValidatorConfigV2.sol
+++ b/tips/ref-impls/src/ValidatorConfigV2.sol
@@ -80,6 +80,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         bytes32 publicKey,
         string calldata ingress,
         string calldata egress,
+        address feeRecipient,
         bytes calldata signature
     )
         external
@@ -90,14 +91,16 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         _validateAddParams(validatorAddress, publicKey, ingress, egress);
 
         bytes32 message = keccak256(
-            abi.encodePacked(block.chainid, address(this), validatorAddress, ingress, egress)
+            abi.encodePacked(
+                block.chainid, address(this), validatorAddress, ingress, egress, feeRecipient
+            )
         );
         _verifyEd25519Signature(
             bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR"), publicKey, message, signature
         );
 
-        index = _addValidator(validatorAddress, publicKey, ingress, egress, 0);
-        emit ValidatorAdded(index, validatorAddress, publicKey, ingress, egress);
+        index = _addValidator(validatorAddress, publicKey, ingress, egress, feeRecipient, 0);
+        emit ValidatorAdded(index, validatorAddress, publicKey, ingress, egress, feeRecipient);
     }
 
     /// @inheritdoc IValidatorConfigV2
@@ -108,7 +111,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         ValidatorStorage storage v = validatorsArray[idx];
         if (v.deactivatedAtHeight != 0) {
-            revert ValidatorAlreadyDeleted();
+            revert ValidatorAlreadyDeactivated();
         }
 
         _checkOnlyOwnerOrValidator(v.validatorAddress);
@@ -166,7 +169,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         ValidatorStorage storage oldValidator = validatorsArray[idx];
         if (oldValidator.deactivatedAtHeight != 0) {
-            revert ValidatorAlreadyDeleted();
+            revert ValidatorAlreadyDeactivated();
         }
 
         address validatorAddress = oldValidator.validatorAddress;
@@ -191,6 +194,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
                 validatorAddress: validatorAddress,
                 ingress: oldValidator.ingress,
                 egress: oldValidator.egress,
+                feeRecipient: oldValidator.feeRecipient,
                 index: appendedIdx,
                 activeIdx: 0,
                 addedAtHeight: oldValidator.addedAtHeight,
@@ -224,7 +228,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         ValidatorStorage storage v = validatorsArray[idx];
         if (v.deactivatedAtHeight != 0) {
-            revert ValidatorAlreadyDeleted();
+            revert ValidatorAlreadyDeactivated();
         }
 
         _checkOnlyOwnerOrValidator(v.validatorAddress);
@@ -236,6 +240,24 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         v.ingress = ingress;
         v.egress = egress;
         emit IpAddressesUpdated(idx, ingress, egress, msg.sender);
+    }
+
+    /// @inheritdoc IValidatorConfigV2
+    function setFeeRecipient(uint64 idx, address feeRecipient) external {
+        if (idx >= validatorsArray.length) {
+            revert ValidatorNotFound();
+        }
+
+        ValidatorStorage storage v = validatorsArray[idx];
+        if (v.deactivatedAtHeight != 0) {
+            revert ValidatorAlreadyDeactivated();
+        }
+
+        _checkOnlyOwnerOrValidator(v.validatorAddress);
+
+        v.feeRecipient = feeRecipient;
+
+        emit FeeRecipientUpdated(idx, feeRecipient, msg.sender);
     }
 
     /// @inheritdoc IValidatorConfigV2
@@ -257,7 +279,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
 
         ValidatorStorage storage v = validatorsArray[idx];
         if (v.deactivatedAtHeight != 0) {
-            revert ValidatorAlreadyDeleted();
+            revert ValidatorAlreadyDeactivated();
         }
 
         address currentAddress = v.validatorAddress;
@@ -392,6 +414,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             v1Val.publicKey,
             v1Val.inboundAddress,
             egress,
+            address(0),
             nowActive ? 0 : uint64(block.number)
         );
         emit ValidatorMigrated(migratedIdx, v1Val.validatorAddress, v1Val.publicKey);
@@ -425,6 +448,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             validatorAddress: v.validatorAddress,
             ingress: v.ingress,
             egress: v.egress,
+            feeRecipient: v.feeRecipient,
             index: v.index,
             addedAtHeight: v.addedAtHeight,
             deactivatedAtHeight: v.deactivatedAtHeight
@@ -475,6 +499,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
         bytes32 publicKey,
         string memory ingress,
         string memory egress,
+        address feeRecipient,
         uint64 deactivatedAtHeight
     )
         internal
@@ -495,6 +520,7 @@ contract ValidatorConfigV2 is IValidatorConfigV2 {
             validatorAddress: validatorAddress,
             ingress: ingress,
             egress: egress,
+            feeRecipient: feeRecipient,
             index: idx,
             activeIdx: activeIdx,
             addedAtHeight: uint64(block.number),

--- a/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
+++ b/tips/ref-impls/src/interfaces/IValidatorConfigV2.sol
@@ -23,7 +23,8 @@ interface IValidatorConfigV2 {
         address indexed validatorAddress,
         bytes32 publicKey,
         string ingress,
-        string egress
+        string egress,
+        address feeRecipient
     );
     event ValidatorDeactivated(uint64 indexed index, address indexed validatorAddress);
     event ValidatorRotated(
@@ -36,6 +37,7 @@ interface IValidatorConfigV2 {
         string egress,
         address caller
     );
+    event FeeRecipientUpdated(uint64 indexed index, address feeRecipient, address caller);
     event IpAddressesUpdated(uint64 indexed index, string ingress, string egress, address caller);
     event ValidatorOwnershipTransferred(
         uint64 indexed index, address indexed oldAddress, address indexed newAddress, address caller
@@ -64,7 +66,7 @@ interface IValidatorConfigV2 {
     error ValidatorNotFound();
 
     /// @notice Thrown when trying to deactivate an already-deactivated validator
-    error ValidatorAlreadyDeleted();
+    error ValidatorAlreadyDeactivated();
 
     /// @notice Thrown when public key is invalid (zero)
     error InvalidPublicKey();
@@ -113,6 +115,7 @@ interface IValidatorConfigV2 {
         address validatorAddress;
         string ingress;
         string egress;
+        address feeRecipient;
         uint64 index;
         uint64 activeIdx;
         uint64 addedAtHeight;
@@ -127,11 +130,13 @@ interface IValidatorConfigV2 {
     /// @param index Position in validators array (stable across rotations for the same slot)
     /// @param addedAtHeight Block height when validator was added
     /// @param deactivatedAtHeight Block height when validator was deleted (0 = active)
+    /// @param feeRecipient The fee recipient the node will set when proposing blocks as a leader.
     struct Validator {
         bytes32 publicKey;
         address validatorAddress;
         string ingress;
         string egress;
+        address feeRecipient;
         uint64 index;
         uint64 addedAtHeight;
         uint64 deactivatedAtHeight;
@@ -150,12 +155,14 @@ interface IValidatorConfigV2 {
     /// @param publicKey The validator's Ed25519 communication public key
     /// @param ingress The validator's inbound address `<ip>:<port>` for incoming connections
     /// @param egress The validator's outbound IP address `<ip>` for firewall whitelisting
+    /// @param feeRecipient The fee recipient the validator sets when proposing.
     /// @param signature Ed25519 signature (64 bytes) proving ownership of the public key
     function addValidator(
         address validatorAddress,
         bytes32 publicKey,
         string calldata ingress,
         string calldata egress,
+        address feeRecipient,
         bytes calldata signature
     )
         external
@@ -201,6 +208,12 @@ interface IValidatorConfigV2 {
     /// @param ingress The new inbound address `<ip>:<port>` for incoming connections
     /// @param egress The new outbound IP address `<ip>` for firewall whitelisting
     function setIpAddresses(uint64 idx, string calldata ingress, string calldata egress) external;
+
+    /// @notice Update validator fee recipient (owner or validator only).
+    /// @dev Can be called by the contract owner or by the validator's own address.
+    /// @param idx Validator index.
+    /// @param feeRecipient New fee recipient.
+    function setFeeRecipient(uint64 idx, address feeRecipient) external;
 
     /// @notice Transfer a validator entry to a new address (owner or validator only)
     /// @dev Can be called by the contract owner or by the validator's own address.

--- a/tips/ref-impls/test/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/ValidatorConfigV2.t.sol
@@ -44,7 +44,8 @@ contract ValidatorConfigV2Test is BaseTest {
         bytes32 privateKey,
         address validatorAddress,
         string memory ingress,
-        string memory egress
+        string memory egress,
+        address feeRecipient
     )
         internal
         view
@@ -52,7 +53,12 @@ contract ValidatorConfigV2Test is BaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                ingress,
+                egress,
+                feeRecipient
             )
         );
         // Forge's signEd25519 does simple concat(namespace, message), but the Rust
@@ -127,21 +133,24 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         validatorConfigV2.addValidator(
             validator2,
             PUB_KEY_1,
             ingress2,
             egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
+            validator2,
+            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2, validator2)
         );
         validatorConfigV2.addValidator(
             validator3,
             PUB_KEY_2,
             ingress3,
             egress3,
-            _signAdd(PRIV_KEY_2, validator3, ingress3, egress3)
+            validator3,
+            _signAdd(PRIV_KEY_2, validator3, ingress3, egress3, validator3)
         );
 
         IValidatorConfigV2.Validator[] memory vals = validatorConfigV2.getActiveValidators();
@@ -169,7 +178,9 @@ contract ValidatorConfigV2Test is BaseTest {
 
     function test_addValidator_fail() public {
         // 1. NotInitialized
-        try validatorConfigV2.addValidator(validator1, PUB_KEY_0, ingress1, egress1, "") {
+        try validatorConfigV2.addValidator(
+            validator1, PUB_KEY_0, ingress1, egress1, validator1, ""
+        ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.NotInitialized.selector));
@@ -179,21 +190,25 @@ contract ValidatorConfigV2Test is BaseTest {
 
         // 2. Unauthorized
         vm.prank(nonOwner);
-        try validatorConfigV2.addValidator(validator1, PUB_KEY_0, ingress1, egress1, "") {
+        try validatorConfigV2.addValidator(
+            validator1, PUB_KEY_0, ingress1, egress1, validator1, ""
+        ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.Unauthorized.selector));
         }
 
         // 3. InvalidPublicKey (zero)
-        try validatorConfigV2.addValidator(validator1, bytes32(0), ingress1, egress1, "") {
+        try validatorConfigV2.addValidator(
+            validator1, bytes32(0), ingress1, egress1, validator1, ""
+        ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.InvalidPublicKey.selector));
         }
 
         // 4. AddressAlreadyHasValidator (setupVal1 already migrated)
-        try validatorConfigV2.addValidator(setupVal1, PUB_KEY_1, ingress2, egress2, "") {
+        try validatorConfigV2.addValidator(setupVal1, PUB_KEY_1, ingress2, egress2, setupVal1, "") {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
@@ -202,7 +217,9 @@ contract ValidatorConfigV2Test is BaseTest {
         }
 
         // 5. PublicKeyAlreadyExists (SETUP_PUB_KEY_A already migrated)
-        try validatorConfigV2.addValidator(validator2, SETUP_PUB_KEY_A, ingress2, egress2, "") {
+        try validatorConfigV2.addValidator(
+            validator2, SETUP_PUB_KEY_A, ingress2, egress2, validator2, ""
+        ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
@@ -213,7 +230,7 @@ contract ValidatorConfigV2Test is BaseTest {
         if (isTempo) {
             // 6. InvalidSignatureFormat (short — wrong length)
             try validatorConfigV2.addValidator(
-                validator1, PUB_KEY_0, ingress1, egress1, hex"0000"
+                validator1, PUB_KEY_0, ingress1, egress1, validator1, hex"0000"
             ) {
                 revert CallShouldHaveReverted();
             } catch (bytes memory err) {
@@ -226,6 +243,7 @@ contract ValidatorConfigV2Test is BaseTest {
                 PUB_KEY_0,
                 ingress1,
                 egress1,
+                validator1,
                 hex"0000000000000000000000000000000000000000000000000000000000000000"
                 hex"0000000000000000000000000000000000000000000000000000000000000000"
             ) {
@@ -247,7 +265,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         // validator1 is at global index 2
         validatorConfigV2.deactivateValidator(2);
@@ -263,7 +282,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         vm.prank(validator1);
@@ -280,7 +300,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         // 1. Unauthorized (nonOwner tries to deactivate validator1 at idx 2)
@@ -298,13 +319,13 @@ contract ValidatorConfigV2Test is BaseTest {
             assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorNotFound.selector));
         }
 
-        // 3. ValidatorAlreadyDeleted (already deactivated)
+        // 3. ValidatorAlreadyDeactivated (already deactivated)
         validatorConfigV2.deactivateValidator(2);
         try validatorConfigV2.deactivateValidator(2) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
-                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeleted.selector)
+                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeactivated.selector)
             );
         }
     }
@@ -320,7 +341,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         // Owner rotates validator1 at index 2
@@ -355,7 +377,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         vm.prank(validator1);
@@ -375,14 +398,16 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         validatorConfigV2.addValidator(
             validator2,
             PUB_KEY_1,
             ingress2,
             egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
+            validator2,
+            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2, validator2)
         );
 
         // 1. Unauthorized
@@ -422,7 +447,7 @@ contract ValidatorConfigV2Test is BaseTest {
             );
         }
 
-        // 5. ValidatorAlreadyDeleted (after deactivation)
+        // 5. ValidatorAlreadyDeactivated (after deactivation)
         validatorConfigV2.deactivateValidator(2);
         try validatorConfigV2.rotateValidator(
             2, PUB_KEY_3, ingress2, egress2, _signRotate(PRIV_KEY_3, validator1, ingress2, egress2)
@@ -430,7 +455,7 @@ contract ValidatorConfigV2Test is BaseTest {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
-                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeleted.selector)
+                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeactivated.selector)
             );
         }
 
@@ -441,13 +466,83 @@ contract ValidatorConfigV2Test is BaseTest {
                 PUB_KEY_2,
                 ingress3,
                 egress3,
-                _signAdd(PRIV_KEY_2, validator3, ingress3, egress3)
+                validator3,
+                _signAdd(PRIV_KEY_2, validator3, ingress3, egress3, validator3)
             );
             try validatorConfigV2.rotateValidator(4, PUB_KEY_3, ingress2, egress2, hex"0000") {
                 revert CallShouldHaveReverted();
             } catch (bytes memory err) {
                 assertEq(err, abi.encodeWithSelector(InvalidSignatureFormat.selector));
             }
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         SET FEE RECIPIENT
+    //////////////////////////////////////////////////////////////*/
+    function test_setFeeRecipient_pass() public {
+        _initializeV2();
+        validatorConfigV2.addValidator(
+            validator1,
+            PUB_KEY_0,
+            ingress1,
+            egress1,
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
+        );
+
+        // Owner updates validator1 at idx 2
+        validatorConfigV2.setFeeRecipient(2, validator2);
+        IValidatorConfigV2.Validator memory v = validatorConfigV2.validatorByAddress(validator1);
+        assertEq(v.feeRecipient, validator2);
+
+        // Validator updates own IPs
+        vm.prank(validator1);
+        validatorConfigV2.setFeeRecipient(2, validator3);
+        v = validatorConfigV2.validatorByAddress(validator1);
+        assertEq(v.feeRecipient, validator3);
+
+        // IPv6 ingress
+        validatorConfigV2.setIpAddresses(2, "[2001:db8::1]:8000", "192.168.1.2");
+        v = validatorConfigV2.validatorByAddress(validator1);
+        assertEq(keccak256(bytes(v.ingress)), keccak256(bytes("[2001:db8::1]:8000")));
+    }
+
+    function test_setFeeRecipient_fail() public {
+        _initializeV2();
+
+        // 1. ValidatorNotFound (out of bounds)
+        try validatorConfigV2.setFeeRecipient(99, validator2) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorNotFound.selector));
+        }
+
+        validatorConfigV2.addValidator(
+            validator1,
+            PUB_KEY_0,
+            ingress1,
+            egress1,
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
+        );
+
+        // 2. Unauthorized
+        vm.prank(nonOwner);
+        try validatorConfigV2.setFeeRecipient(2, validator2) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.Unauthorized.selector));
+        }
+
+        // 3. ValidatorAlreadyDeactivated (after deactivation)
+        validatorConfigV2.deactivateValidator(2);
+        try validatorConfigV2.setFeeRecipient(2, validator2) {
+            revert CallShouldHaveReverted();
+        } catch (bytes memory err) {
+            assertEq(
+                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeactivated.selector)
+            );
         }
     }
 
@@ -462,7 +557,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         // Owner updates validator1 at idx 2
@@ -498,7 +594,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         // 2. Unauthorized
@@ -509,13 +606,13 @@ contract ValidatorConfigV2Test is BaseTest {
             assertEq(err, abi.encodeWithSelector(IValidatorConfigV2.Unauthorized.selector));
         }
 
-        // 3. ValidatorAlreadyDeleted (after deactivation)
+        // 3. ValidatorAlreadyDeactivated (after deactivation)
         validatorConfigV2.deactivateValidator(2);
         try validatorConfigV2.setIpAddresses(2, ingress2, egress2) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
-                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeleted.selector)
+                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeactivated.selector)
             );
         }
     }
@@ -531,7 +628,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         // Owner transfers validator1 at idx 2
@@ -555,7 +653,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         vm.prank(validator1);
@@ -580,14 +679,16 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         validatorConfigV2.addValidator(
             validator2,
             PUB_KEY_1,
             ingress2,
             egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
+            validator2,
+            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2, validator2)
         );
 
         // 2. InvalidValidatorAddress (address(0))
@@ -616,13 +717,13 @@ contract ValidatorConfigV2Test is BaseTest {
             );
         }
 
-        // 5. ValidatorAlreadyDeleted (after deactivation)
+        // 5. ValidatorAlreadyDeactivated (after deactivation)
         validatorConfigV2.deactivateValidator(2);
         try validatorConfigV2.transferValidatorOwnership(2, validator3) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(
-                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeleted.selector)
+                err, abi.encodeWithSelector(IValidatorConfigV2.ValidatorAlreadyDeactivated.selector)
             );
         }
     }
@@ -698,14 +799,16 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         validatorConfigV2.addValidator(
             validator2,
             PUB_KEY_1,
             ingress2,
             egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
+            validator2,
+            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2, validator2)
         );
         validatorConfigV2.deactivateValidator(2); // deactivate validator1 at idx 2
 
@@ -722,7 +825,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
         assertEq(validatorConfigV2.validatorCount(), 3);
 
@@ -731,7 +835,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_1,
             ingress2,
             egress2,
-            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2)
+            validator2,
+            _signAdd(PRIV_KEY_1, validator2, ingress2, egress2, validator2)
         );
         assertEq(validatorConfigV2.validatorCount(), 4);
 
@@ -750,7 +855,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         IValidatorConfigV2.Validator memory v2 = validatorConfigV2.validatorByIndex(2);
@@ -772,7 +878,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         IValidatorConfigV2.Validator memory v = validatorConfigV2.validatorByAddress(validator1);
@@ -794,7 +901,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             ingress1,
             egress1,
-            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1)
+            validator1,
+            _signAdd(PRIV_KEY_0, validator1, ingress1, egress1, validator1)
         );
 
         IValidatorConfigV2.Validator memory v = validatorConfigV2.validatorByPublicKey(PUB_KEY_0);
@@ -959,7 +1067,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             "10.0.0.100:9000",
             "10.0.0.200",
-            _signAdd(PRIV_KEY_0, newAddr, "10.0.0.100:9000", "10.0.0.200")
+            newAddr,
+            _signAdd(PRIV_KEY_0, newAddr, "10.0.0.100:9000", "10.0.0.200", newAddr)
         ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
@@ -986,7 +1095,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             "10.0.0.100:9999",
             "10.0.0.200",
-            _signAdd(PRIV_KEY_0, newAddr, "10.0.0.100:9999", "10.0.0.200")
+            newAddr,
+            _signAdd(PRIV_KEY_0, newAddr, "10.0.0.100:9999", "10.0.0.200", newAddr)
         );
 
         // Verify new validator has the reused ingress IP (different port is ok)
@@ -1068,7 +1178,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             "10.0.0.200:8000",
             "10.0.0.200",
-            _signAdd(PRIV_KEY_0, setupVal1, "10.0.0.200:8000", "10.0.0.200")
+            setupVal1,
+            _signAdd(PRIV_KEY_0, setupVal1, "10.0.0.200:8000", "10.0.0.200", setupVal1)
         );
 
         // Should have 3 validators total (2 original + 1 new)
@@ -1091,7 +1202,8 @@ contract ValidatorConfigV2Test is BaseTest {
             PUB_KEY_0,
             "10.0.0.200:8000",
             "10.0.0.200",
-            _signAdd(PRIV_KEY_0, setupVal1, "10.0.0.200:8000", "10.0.0.200")
+            setupVal1,
+            _signAdd(PRIV_KEY_0, setupVal1, "10.0.0.200:8000", "10.0.0.200", setupVal1)
         ) {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {

--- a/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
+++ b/tips/ref-impls/test/invariants/ValidatorConfigV2.t.sol
@@ -116,7 +116,8 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
         bytes32 privateKey,
         address validatorAddress,
         string memory ingress,
-        string memory egress
+        string memory egress,
+        address feeRecipient
     )
         internal
         view
@@ -124,7 +125,12 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
     {
         bytes32 message = keccak256(
             abi.encodePacked(
-                uint64(block.chainid), address(validatorConfigV2), validatorAddress, ingress, egress
+                uint64(block.chainid),
+                address(validatorConfigV2),
+                validatorAddress,
+                ingress,
+                egress,
+                feeRecipient
             )
         );
         bytes memory ns = bytes("TEMPO_VALIDATOR_CONFIG_V2_ADD_VALIDATOR");
@@ -241,7 +247,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
             || selector == IValidatorConfigV2.NotIp.selector
             || selector == IValidatorConfigV2.InvalidSignature.selector
             || selector == IValidatorConfigV2.IngressAlreadyExists.selector
-            || selector == IValidatorConfigV2.ValidatorAlreadyDeleted.selector;
+            || selector == IValidatorConfigV2.ValidatorAlreadyDeactivated.selector;
         assertTrue(isKnown, string.concat("Unknown error: ", vm.toString(selector)));
     }
 
@@ -396,7 +402,7 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
         }
         bytes32 ingressIpHash = _extractIngressIpHash(ingress);
 
-        bytes memory sig = _signAdd(privKey, validatorAddr, ingress, egress);
+        bytes memory sig = _signAdd(privKey, validatorAddr, ingress, egress, validatorAddr);
 
         // Determine expected outcome based on ghost state
         bool pubKeyZero = (pubKey == bytes32(0));
@@ -408,7 +414,9 @@ contract ValidatorConfigV2InvariantTest is InvariantBaseTest {
         uint256 totalCountBefore = _ghostTotalCount;
 
         vm.startPrank(caller);
-        try validatorConfigV2.addValidator(validatorAddr, pubKey, ingress, egress, sig) {
+        try validatorConfigV2.addValidator(
+            validatorAddr, pubKey, ingress, egress, validatorAddr, sig
+        ) {
             vm.stopPrank();
             assertTrue(
                 _ghostInitialized,

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -1011,13 +1011,14 @@ fn initialize_validator_config_v2(
                 let ingress = addr.to_string();
                 let egress = addr.ip().to_string();
 
-                // message: keccak256(chainId || contractAddr || validatorAddr || ingress || egress)
+                // message: keccak256(chainId || contractAddr || validatorAddr || ingress || egress || feeRecipient)
                 let mut hasher = Keccak256::new();
                 hasher.update(chain_id.to_be_bytes());
                 hasher.update(VALIDATOR_CONFIG_V2_ADDRESS.as_slice());
                 hasher.update(validator_address.as_slice());
                 hasher.update(ingress.as_bytes());
                 hasher.update(egress.as_bytes());
+                hasher.update(validator_address.as_slice());
                 let message = hasher.finalize();
 
                 let private_key = validator.signing_key.clone().into_inner();
@@ -1030,6 +1031,7 @@ fn initialize_validator_config_v2(
                         publicKey: pubkey,
                         ingress: ingress.clone(),
                         egress: egress.clone(),
+                        feeRecipient: validator_address,
                         signature: signature.encode().to_vec().into(),
                     },
                 )


### PR DESCRIPTION
Splits the TIP-1017 code implementation changes out of the spec PR.

This carries the validator precompile and reference implementation updates for `feeRecipient`, so the spec PR can stack on top and focus on markdown-only changes.

Also includes a nit change to remove all `delete` and replace with `deactivated` to be more precise