### PR TITLE
fix(consensus): downgrade invalid subblock parent log to debug

### DIFF
--- a/crates/commonware-node/src/subblocks.rs
+++ b/crates/commonware-node/src/subblocks.rs
@@ -370,7 +370,7 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
         });
     }
 
-    #[instrument(skip_all, err(level = Level::WARN), fields(sender = %sender, msg_bytes = message.len()))]
+    #[instrument(skip_all, err(level = Level::DEBUG), fields(sender = %sender, msg_bytes = message.len()))]
     async fn on_network_message(
         &mut self,
         sender: PublicKey,


### PR DESCRIPTION
Changes `on_network_message` instrument `err` level from WARN to DEBUG. This log fires ~9k/day on both moderato and mainnet validators when they receive subblocks with a parent hash that doesn't match their current tip — noisy but not actionable.

Prompted by: alexey