### PR TITLE
ci(release): gate on version check and include docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - main
-      - "rc/*"
-    tags:
-      - "v*.*.*"
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
 
   build-release:
     name: Build Release Binaries
-    needs: get-version
+    needs: [get-version, check-version]
+    if: ${{ always() && needs.check-version.result != 'failure' && needs.check-version.result != 'cancelled' }}
     environment: release
     runs-on: ${{ matrix.platform.os }}
     permissions:
@@ -255,3 +256,10 @@ jobs:
           endpoint: ${{ secrets.R2_BINARIES_ENDPOINT }}
           source_dir: "${{ needs.get-version.outputs.version }}"
           destination_dir: "binaries/${{ needs.get-version.outputs.version }}"
+
+  docker:
+    name: Docker Build
+    needs: [get-version, check-version]
+    if: ${{ always() && needs.check-version.result != 'failure' && needs.check-version.result != 'cancelled' }}
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit


### PR DESCRIPTION
Makes two changes to the release workflow:

1. **Version mismatch stops the release** — `build-release` and `docker` now depend on `check-version`. If the Cargo version doesn't match the tag, the release fails fast. On RC branches where `check-version` is skipped, everything proceeds normally.

2. **Docker build is part of the release** — calls `docker.yml` via `workflow_call` from the release workflow. Removed `rc/*` and `v*.*.*` triggers from `docker.yml` to avoid double builds (main, merge_group, schedule, and workflow_dispatch triggers remain).

Prompted by: zygis