### PR TITLE
fix(rpc): create hardfork-aware mock keychain signatures for gas estimation

### DIFF
--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -9,6 +9,8 @@ use reth_rpc_convert::{
     transaction::FromConsensusHeader,
 };
 use reth_rpc_eth_types::EthApiError;
+use std::any::Any;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
 use tempo_primitives::{
     SignatureType, TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType,
@@ -93,7 +95,7 @@ impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
 impl TryIntoTxEnv<TempoTxEnv, TempoBlockEnv> for TempoTransactionRequest {
     type Err = EthApiError;
 
-    fn try_into_tx_env<Spec>(
+    fn try_into_tx_env<Spec: 'static>(
         self,
         evm_env: &EvmEnv<Spec, TempoBlockEnv>,
     ) -> Result<TempoTxEnv, Self::Err> {
@@ -124,6 +126,11 @@ impl TryIntoTxEnv<TempoTxEnv, TempoBlockEnv> for TempoTransactionRequest {
             fee_payer_signature: _,
         } = self;
 
+        // Determine if T1C is active from the spec to create the correct mock keychain version.
+        let is_t1c = (&evm_env.cfg_env.spec as &dyn Any)
+            .downcast_ref::<TempoHardfork>()
+            .is_some_and(|h| h.is_t1c());
+
         Ok(TempoTxEnv {
             fee_token,
             is_system_tx: false,
@@ -138,8 +145,13 @@ impl TryIntoTxEnv<TempoTxEnv, TempoBlockEnv> for TempoTransactionRequest {
                 // If key_type is not provided, default to secp256k1
                 // For Keychain signatures, use the caller's address as the root key address
                 let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
-                let mock_signature =
-                    create_mock_tempo_signature(&key_type, key_data.as_ref(), key_id, caller_addr);
+                let mock_signature = create_mock_tempo_signature(
+                    &key_type,
+                    key_data.as_ref(),
+                    key_id,
+                    caller_addr,
+                    is_t1c,
+                );
 
                 let mut calls = calls;
                 if let Some(to) = &inner.to {
@@ -190,19 +202,27 @@ impl TryIntoTxEnv<TempoTxEnv, TempoBlockEnv> for TempoTransactionRequest {
 /// - `key_data`: Type-specific data (e.g., WebAuthn size)
 /// - `key_id`: If Some, wraps the signature in a Keychain wrapper (+3,000 gas for key validation)
 /// - `caller_addr`: The transaction caller address (used as root key address for Keychain)
+/// - `is_t1c`: Whether T1C is active — determines keychain version (V1 pre-T1C, V2 post-T1C)
 fn create_mock_tempo_signature(
     key_type: &SignatureType,
     key_data: Option<&Bytes>,
     key_id: Option<Address>,
     caller_addr: alloy_primitives::Address,
+    is_t1c: bool,
 ) -> TempoSignature {
     use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
 
     let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
 
     if key_id.is_some() {
-        // For Keychain signatures, the root_key_address is the caller (account owner)
-        TempoSignature::Keychain(KeychainSignature::new(caller_addr, inner_sig))
+        // Use the keychain version matching the active hardfork to pass handler validation.
+        // Gas cost is identical for V1 and V2.
+        let keychain_sig = if is_t1c {
+            KeychainSignature::new(caller_addr, inner_sig)
+        } else {
+            KeychainSignature::new_v1(caller_addr, inner_sig)
+        };
+        TempoSignature::Keychain(keychain_sig)
     } else {
         TempoSignature::Primitive(inner_sig)
     }

--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -1,4 +1,4 @@
-use crate::utils::{TestNodeBuilder, setup_test_token};
+use crate::utils::{ForkSchedule, TestNodeBuilder, setup_test_token};
 use alloy::{
     primitives::{Address, B256, Bytes, U256},
     providers::{Provider, ProviderBuilder, ext::TraceApi},
@@ -19,12 +19,19 @@ use tempo_contracts::precompiles::{
     ITIPFeeAMM, UnknownFunctionSelector,
 };
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::TIP20Token};
+use test_case::test_case;
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth_call() -> eyre::Result<()> {
+async fn test_eth_call(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
@@ -59,11 +66,17 @@ async fn test_eth_call() -> eyre::Result<()> {
     Ok(())
 }
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth_trace_call() -> eyre::Result<()> {
+async fn test_eth_trace_call(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
@@ -153,11 +166,17 @@ async fn test_eth_trace_call() -> eyre::Result<()> {
     Ok(())
 }
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth_get_logs() -> eyre::Result<()> {
+async fn test_eth_get_logs(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
@@ -212,11 +231,17 @@ async fn test_eth_get_logs() -> eyre::Result<()> {
     Ok(())
 }
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth_estimate_gas() -> eyre::Result<()> {
+async fn test_eth_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
@@ -561,11 +586,17 @@ async fn test_eth_estimate_gas_preseeded_zero_address_validator_token() -> eyre:
     Ok(())
 }
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_unknown_selector_error_via_rpc() -> eyre::Result<()> {
+async fn test_unknown_selector_error_via_rpc(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -74,9 +74,10 @@ use tempo_primitives::{
     },
 };
 
-use crate::utils::{SingleNodeSetup, TEST_MNEMONIC, TestNodeBuilder};
+use crate::utils::{ForkSchedule, SingleNodeSetup, TEST_MNEMONIC, TestNodeBuilder};
 use tempo_node::rpc::TempoTransactionRequest;
 use tempo_primitives::transaction::tt_signature::normalize_p256_s;
+use test_case::test_case;
 
 #[macro_use]
 #[path = "test_macros.rs"]
@@ -277,8 +278,23 @@ async fn setup_test_with_funded_account() -> eyre::Result<(
     impl SignerSync,
     Address,
 )> {
-    // Setup test node with direct access
-    let setup = TestNodeBuilder::new().build_with_node_access().await?;
+    setup_test_with_funded_account_and_schedule(ForkSchedule::Devnet).await
+}
+
+/// Like [`setup_test_with_funded_account`] but accepts a [`ForkSchedule`] to
+/// control which hardforks are active.
+async fn setup_test_with_funded_account_and_schedule(
+    schedule: ForkSchedule,
+) -> eyre::Result<(
+    SingleNodeSetup,
+    impl Provider + Clone,
+    impl SignerSync,
+    Address,
+)> {
+    let setup = TestNodeBuilder::new()
+        .with_schedule(schedule)
+        .build_with_node_access()
+        .await?;
 
     let http_url = setup.node.rpc_url();
 
@@ -3368,11 +3384,15 @@ async fn test_aa_empty_call_batch_should_fail() -> eyre::Result<()> {
     Ok(())
 }
 
+#[test_case(ForkSchedule::Devnet ; "devnet")]
+#[test_case(ForkSchedule::Testnet ; "testnet")]
+#[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_aa_estimate_gas_matrix() -> eyre::Result<()> {
+async fn test_aa_estimate_gas_matrix(schedule: ForkSchedule) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let (_setup, provider, signer, signer_addr) = setup_test_with_funded_account().await?;
+    let (_setup, provider, signer, signer_addr) =
+        setup_test_with_funded_account_and_schedule(schedule).await?;
 
     println!("\n=== eth_estimateGas matrix: key type × keychain × key auth ===\n");
     println!("Test address: {signer_addr}");

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3,6 +3,81 @@
 //! This module provides helper functions for setting up and managing test environments,
 //! including test token creation and node setup for integration testing.
 
+/// Chain profile for integration tests.
+///
+/// Each variant uses the test dev genesis allocations (funded accounts, precompile state) but
+/// overlays hardfork timestamps from the corresponding network config.
+/// Forks whose activation timestamp is in the future (relative to the current wall-clock time)
+/// are deactivated (`u64::MAX`); forks already active are activated at t=0.
+///
+/// This lets the same test run against different fork schedules via `#[test_case]`:
+///
+/// ```ignore
+/// #[test_case(ForkSchedule::Devnet ; "devnet")]
+/// #[test_case(ForkSchedule::Testnet ; "testnet")]
+/// #[test_case(ForkSchedule::Mainnet ; "mainnet")]
+/// #[tokio::test(flavor = "multi_thread")]
+/// async fn test_estimate_gas(schedule: ForkSchedule) -> eyre::Result<()> {
+///     let setup = TestNodeBuilder::new()
+///         .with_schedule(schedule)
+///         .build_http_only()
+///         .await?;
+///     // ...
+/// }
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ForkSchedule {
+    /// Preserves test dev genesis hardfork schedule: typically all active at t=0.
+    Devnet,
+    /// Fork schedule matching testnet (moderato): only forks active *now* are set to t=0.
+    Testnet,
+    /// Fork schedule matching mainnet (presto): only forks active *now* are set to t=0.
+    Mainnet,
+}
+
+impl ForkSchedule {
+    /// Returns the reference genesis JSON whose fork timestamps should be used.
+    fn reference_genesis(&self) -> Option<&'static str> {
+        match self {
+            Self::Devnet => None,
+            Self::Testnet => Some(include_str!("../../../chainspec/src/genesis/moderato.json")),
+            Self::Mainnet => Some(include_str!("../../../chainspec/src/genesis/presto.json")),
+        }
+    }
+
+    /// Apply this profile's fork timestamps to a test genesis JSON value.
+    ///
+    /// Scans the test genesis config for all `*Time` keys and checks each
+    /// against the reference network genesis. Forks active *now* on the
+    /// reference network are set to `0`; forks that are still in the future
+    /// or absent from the reference are set to `u64::MAX`.
+    pub(crate) fn apply(&self, genesis: &mut serde_json::Value) {
+        let Some(reference_json) = self.reference_genesis() else {
+            return; // keep test genesis timestamps unchanged
+        };
+
+        let reference: serde_json::Value =
+            serde_json::from_str(reference_json).expect("reference genesis must parse");
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let config = genesis["config"]
+            .as_object_mut()
+            .expect("genesis must have config");
+
+        for (key, value) in config.iter_mut().filter(|(k, _)| k.ends_with("Time")) {
+            let ts = match reference["config"][key].as_u64() {
+                Some(ts) if ts <= now => 0u64,
+                _ => u64::MAX,
+            };
+            *value = serde_json::json!(ts);
+        }
+    }
+}
+
 /// Standard test mnemonic phrase used across integration tests
 pub(crate) const TEST_MNEMONIC: &str =
     "test test test test test test test test test test test junk";
@@ -166,6 +241,7 @@ pub(crate) struct TestNodeBuilder {
     external_rpc: Option<Url>,
     custom_validator: Option<Address>,
     dynamic_validator: Option<Arc<std::sync::Mutex<Address>>>,
+    schedule: ForkSchedule,
 }
 
 impl TestNodeBuilder {
@@ -179,7 +255,14 @@ impl TestNodeBuilder {
             external_rpc: None,
             custom_validator: None,
             dynamic_validator: None,
+            schedule: ForkSchedule::Devnet,
         }
+    }
+
+    /// Set the fork schedule (Devnet, Testnet, or Mainnet)
+    pub(crate) fn with_schedule(mut self, schedule: ForkSchedule) -> Self {
+        self.schedule = schedule;
+        self
     }
 
     /// Use custom genesis JSON content
@@ -339,6 +422,8 @@ impl TestNodeBuilder {
         if let Some(gas_limit) = &self.custom_gas_limit {
             genesis["gasLimit"] = serde_json::json!(gas_limit);
         }
+
+        self.schedule.apply(&mut genesis);
 
         Ok(TempoChainSpec::from_genesis(serde_json::from_value(
             genesis,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1277,10 +1277,9 @@ where
             .map_err(TempoInvalidTransaction::from)?;
 
             // Validate keychain signature version (outer + authorization list).
-            // Skipped during gas estimation (balance check disabled) because the RPC layer
-            // fabricates mock signatures via `create_mock_tempo_signature` which always
-            // produces V2. Pre-T1C that would be rejected here, but the version has no
-            // effect on gas cost so skipping is safe.
+            // The RPC layer's `create_mock_tempo_signature` creates the correct version
+            // (V1 pre-T1C, V2 post-T1C) based on the active hardfork, so this check
+            // passes for gas estimation.
             // TODO(tanishk): Pre-T1C V2 rejection can be removed after T1C activation.
             if !cfg.is_balance_check_disabled() {
                 aa_env


### PR DESCRIPTION
`create_mock_tempo_signature` always created V2 keychain signatures (`KeychainSignature::new` defaults to V2), but the handler rejects V2 pre-T1C. This broke `eth_estimateGas` for any keychain transaction before T1C activation:

```
V2 keychain signature (type 0x04) is not valid before T1C activation
```

Now creates V1 pre-T1C and V2 post-T1C by passing the active hardfork spec to the mock signature builder. Gas cost is identical for both versions.

Prompted by: daniel