### PR TITLE
test(ci): add pre-hardfork test job to catch regressions in new-binary-old-fork window

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,27 @@ jobs:
             coverage/precompiles-bin/
           retention-days: 1
 
+  test-pre-hardfork:
+    name: test (pre-hardfork)
+    runs-on: depot-ubuntu-latest-32
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19
+        with:
+          tool: nextest@0.9.124
+      - name: Run integration tests with latest hardforks deactivated
+        run: cargo nextest run --profile ci -p tempo-node -E 'binary(it)'
+        env:
+          TEMPO_PRE_HARDFORK_TEST: "1"
+
   cli:
     name: CLI smoke tests
     runs-on: depot-ubuntu-latest-4
@@ -188,6 +209,7 @@ jobs:
     needs:
       - check-precompiles
       - test
+      - test-pre-hardfork
       - cli
       - msrv
       - genesis

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod utils;
+
 mod backfill;
 mod base_fee;
 mod block_building;
@@ -16,7 +19,6 @@ mod tip20_factory;
 mod tip20_gas_fees;
 mod tip_fee_amm;
 mod tip_fee_manager;
-mod utils;
 
 use tempo_node as _;
 

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -2969,7 +2969,6 @@ async fn run_send_transaction_test_case(test_case: &SendTestCase) -> eyre::Resul
 #[tokio::test(flavor = "multi_thread")]
 // Covers key type (secp256k1/p256/webauthn) x fee payer; P256/WebAuthn also cover access key and batch calls.
 async fn test_eth_send_transaction_matrix() -> eyre::Result<()> {
-    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let transfer_amount = U256::from(1u64) * U256::from(10).pow(U256::from(6));
@@ -3181,7 +3180,6 @@ where
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_send_raw_transaction_matrix() -> eyre::Result<()> {
-    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let test_matrix = [

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -3812,7 +3812,7 @@ async fn test_tempo_authorization_list() -> eyre::Result<()> {
 /// Test that keychain signatures in tempo_authorization_list are rejected.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_keychain_authorization_in_auth_list_is_skipped() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     // Setup test node with funded sender account
@@ -3942,7 +3942,7 @@ async fn test_keychain_authorization_in_auth_list_is_skipped() -> eyre::Result<(
 /// Outer sig is a normal secp256k1 primitive, only the auth list entry carries V1 keychain.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_v1_keychain_in_auth_list_rejected_post_t1c() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     let (setup, provider, sender_signer, sender_addr) = setup_test_with_funded_account().await?;
@@ -4066,7 +4066,7 @@ async fn test_aa_bump_nonce_on_failure() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_aa_access_key() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -4487,7 +4487,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
 /// Tests: zero public key, duplicate key, unauthorized authorize
 #[tokio::test]
 async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use tempo_precompiles::account_keychain::{SignatureType, authorizeKeyCall};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -4738,7 +4738,7 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use alloy::sol_types::SolCall;
     use tempo_contracts::precompiles::ITIP20::{balanceOfCall, transferCall};
     use tempo_precompiles::account_keychain::updateSpendingLimitCall;
@@ -5019,7 +5019,7 @@ async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Resul
 /// Test enforce_limits flag behavior with unlimited and restricted spending keys
 #[tokio::test]
 async fn test_aa_keychain_enforce_limits() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing enforce_limits Flag Behavior ===\n");
@@ -5296,7 +5296,7 @@ async fn test_aa_keychain_enforce_limits() -> eyre::Result<()> {
 /// - expiry < block.timestamp (past) - should fail during block building (rejected by builder)
 #[tokio::test]
 async fn test_aa_keychain_expiry() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing Key Expiry Functionality ===\n");
@@ -5609,7 +5609,7 @@ async fn test_aa_keychain_expiry() -> eyre::Result<()> {
 /// Tests both positive (authorized key) and negative (unauthorized key) cases in a single test
 #[tokio::test]
 async fn test_aa_keychain_rpc_validation() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -5998,7 +5998,7 @@ async fn test_aa_keychain_rpc_validation() -> eyre::Result<()> {
 /// Tests both secp256k1 and P256.
 #[tokio::test]
 async fn test_v2_keychain_blocks_cross_account_replay() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
@@ -6351,7 +6351,7 @@ async fn test_propagate_2d_transactions() -> eyre::Result<()> {
 /// 2. A KeyAuthorization with chain_id = 0 (wildcard) is accepted on any chain
 #[tokio::test]
 async fn test_aa_key_authorization_chain_id_validation() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use tempo_primitives::transaction::TokenLimit;
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
@@ -6632,7 +6632,7 @@ async fn test_aa_create_correct_contract_address() -> eyre::Result<()> {
 /// Verifies that transactions signed with a revoked access key cannot be executed.
 #[tokio::test]
 async fn test_aa_keychain_revocation_toctou_dos() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing AA Keychain Revocation TOCTOU DoS ===\n");
@@ -7407,7 +7407,7 @@ async fn test_aa_expiring_nonce_independent_from_protocol_nonce() -> eyre::Resul
 /// 4. Transactions should be evicted from the mempool
 #[tokio::test]
 async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     use tempo_precompiles::account_keychain::updateSpendingLimitCall;
 
     reth_tracing::init_test_tracing();
@@ -8384,7 +8384,7 @@ async fn test_e2e_fill_sign_send_matrix() -> eyre::Result<()> {
 /// Also verifies that V1 signatures are rejected (current chain runs post-T1C).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_aa_keychain_v2_signature() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;

--- a/crates/node/tests/it/tempo_transaction.rs
+++ b/crates/node/tests/it/tempo_transaction.rs
@@ -2969,6 +2969,7 @@ async fn run_send_transaction_test_case(test_case: &SendTestCase) -> eyre::Resul
 #[tokio::test(flavor = "multi_thread")]
 // Covers key type (secp256k1/p256/webauthn) x fee payer; P256/WebAuthn also cover access key and batch calls.
 async fn test_eth_send_transaction_matrix() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let transfer_amount = U256::from(1u64) * U256::from(10).pow(U256::from(6));
@@ -3180,6 +3181,7 @@ where
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_send_raw_transaction_matrix() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let test_matrix = [
@@ -3812,6 +3814,7 @@ async fn test_tempo_authorization_list() -> eyre::Result<()> {
 /// Test that keychain signatures in tempo_authorization_list are rejected.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_keychain_authorization_in_auth_list_is_skipped() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     // Setup test node with funded sender account
@@ -3941,6 +3944,7 @@ async fn test_keychain_authorization_in_auth_list_is_skipped() -> eyre::Result<(
 /// Outer sig is a normal secp256k1 primitive, only the auth list entry carries V1 keychain.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_v1_keychain_in_auth_list_rejected_post_t1c() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let (setup, provider, sender_signer, sender_addr) = setup_test_with_funded_account().await?;
@@ -4064,6 +4068,7 @@ async fn test_aa_bump_nonce_on_failure() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_aa_access_key() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -4484,6 +4489,7 @@ async fn test_aa_access_key() -> eyre::Result<()> {
 /// Tests: zero public key, duplicate key, unauthorized authorize
 #[tokio::test]
 async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use tempo_precompiles::account_keychain::{SignatureType, authorizeKeyCall};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -4734,6 +4740,7 @@ async fn test_aa_keychain_negative_cases() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use alloy::sol_types::SolCall;
     use tempo_contracts::precompiles::ITIP20::{balanceOfCall, transferCall};
     use tempo_precompiles::account_keychain::updateSpendingLimitCall;
@@ -5014,6 +5021,7 @@ async fn test_transaction_key_authorization_and_spending_limits() -> eyre::Resul
 /// Test enforce_limits flag behavior with unlimited and restricted spending keys
 #[tokio::test]
 async fn test_aa_keychain_enforce_limits() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing enforce_limits Flag Behavior ===\n");
@@ -5290,6 +5298,7 @@ async fn test_aa_keychain_enforce_limits() -> eyre::Result<()> {
 /// - expiry < block.timestamp (past) - should fail during block building (rejected by builder)
 #[tokio::test]
 async fn test_aa_keychain_expiry() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing Key Expiry Functionality ===\n");
@@ -5602,6 +5611,7 @@ async fn test_aa_keychain_expiry() -> eyre::Result<()> {
 /// Tests both positive (authorized key) and negative (unauthorized key) cases in a single test
 #[tokio::test]
 async fn test_aa_keychain_rpc_validation() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use p256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
     use tempo_primitives::transaction::TokenLimit;
 
@@ -5990,6 +6000,7 @@ async fn test_aa_keychain_rpc_validation() -> eyre::Result<()> {
 /// Tests both secp256k1 and P256.
 #[tokio::test]
 async fn test_v2_keychain_blocks_cross_account_replay() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
@@ -6342,6 +6353,7 @@ async fn test_propagate_2d_transactions() -> eyre::Result<()> {
 /// 2. A KeyAuthorization with chain_id = 0 (wildcard) is accepted on any chain
 #[tokio::test]
 async fn test_aa_key_authorization_chain_id_validation() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use tempo_primitives::transaction::TokenLimit;
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
@@ -6622,6 +6634,7 @@ async fn test_aa_create_correct_contract_address() -> eyre::Result<()> {
 /// Verifies that transactions signed with a revoked access key cannot be executed.
 #[tokio::test]
 async fn test_aa_keychain_revocation_toctou_dos() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     println!("\n=== Testing AA Keychain Revocation TOCTOU DoS ===\n");
@@ -7396,6 +7409,7 @@ async fn test_aa_expiring_nonce_independent_from_protocol_nonce() -> eyre::Resul
 /// 4. Transactions should be evicted from the mempool
 #[tokio::test]
 async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     use tempo_precompiles::account_keychain::updateSpendingLimitCall;
 
     reth_tracing::init_test_tracing();
@@ -8372,6 +8386,7 @@ async fn test_e2e_fill_sign_send_matrix() -> eyre::Result<()> {
 /// Also verifies that V1 signatures are rejected (current chain runs post-T1C).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_aa_keychain_v2_signature() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;

--- a/crates/node/tests/it/tip_fee_amm.rs
+++ b/crates/node/tests/it/tip_fee_amm.rs
@@ -577,6 +577,7 @@ async fn test_burn_liquidity_partial() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cant_burn_required_liquidity() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;

--- a/crates/node/tests/it/tip_fee_amm.rs
+++ b/crates/node/tests/it/tip_fee_amm.rs
@@ -577,7 +577,7 @@ async fn test_burn_liquidity_partial() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cant_burn_required_liquidity() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;

--- a/crates/node/tests/it/tip_fee_manager.rs
+++ b/crates/node/tests/it/tip_fee_manager.rs
@@ -580,6 +580,7 @@ async fn test_fee_payer_transfer_whitelist_pre_t1c() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fee_payer_transfer_whitelist_post_t1c() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;
@@ -722,6 +723,7 @@ async fn test_fee_payer_transfer_whitelist_post_t1c() -> eyre::Result<()> {
 /// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;
@@ -751,6 +753,7 @@ async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
 /// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_during_execution() -> eyre::Result<()> {
+    skip_pre_hardfork!();
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;

--- a/crates/node/tests/it/tip_fee_manager.rs
+++ b/crates/node/tests/it/tip_fee_manager.rs
@@ -580,7 +580,7 @@ async fn test_fee_payer_transfer_whitelist_pre_t1c() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fee_payer_transfer_whitelist_post_t1c() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T1C);
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;
@@ -723,7 +723,7 @@ async fn test_fee_payer_transfer_whitelist_post_t1c() -> eyre::Result<()> {
 /// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T2);
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;
@@ -753,7 +753,7 @@ async fn test_get_fee_token_eth_call() -> eyre::Result<()> {
 /// [TIP-1007]: <https://docs.tempo.xyz/protocol/tips/tip-1007>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_fee_token_during_execution() -> eyre::Result<()> {
-    skip_pre_hardfork!();
+    skip_pre_hardfork!(T2);
     reth_tracing::init_test_tracing();
 
     let setup = TestNodeBuilder::new().build_http_only().await?;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -13,13 +13,20 @@ pub(crate) fn is_pre_hardfork() -> bool {
 
 /// Skips the current test when running in pre-hardfork mode.
 ///
-/// Use this for tests that require T1C/T2 features (V2 keychain signatures,
-/// 2D nonces, etc.) which are expected to fail when those hardforks are
-/// deactivated.
+/// Takes the hardfork name that the test requires (e.g., `T1C`, `T2`),
+/// so each skip documents why the test can't run pre-hardfork.
+///
+/// ```ignore
+/// skip_pre_hardfork!(T1C); // test needs V2 keychain (T1C feature)
+/// skip_pre_hardfork!(T2);  // test needs getFeeToken (T2/TIP-1007 feature)
+/// ```
 macro_rules! skip_pre_hardfork {
-    () => {
+    ($fork:ident) => {
         if $crate::utils::is_pre_hardfork() {
-            eprintln!("skipping test in pre-hardfork mode");
+            eprintln!(
+                "skipping test in pre-hardfork mode (requires {})",
+                stringify!($fork)
+            );
             return Ok(());
         }
     };

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3,6 +3,28 @@
 //! This module provides helper functions for setting up and managing test environments,
 //! including test token creation and node setup for integration testing.
 
+/// Returns true when `TEMPO_PRE_HARDFORK_TEST=1` is set, indicating that the
+/// test suite should run against a chain spec with the latest hardforks
+/// (t1cTime, t2Time) deactivated. This simulates the "new binary, old fork"
+/// window that exists between deploying a new binary and activating a hardfork.
+pub(crate) fn is_pre_hardfork() -> bool {
+    std::env::var("TEMPO_PRE_HARDFORK_TEST").is_ok_and(|v| v == "1")
+}
+
+/// Skips the current test when running in pre-hardfork mode.
+///
+/// Use this for tests that require T1C/T2 features (V2 keychain signatures,
+/// 2D nonces, etc.) which are expected to fail when those hardforks are
+/// deactivated.
+macro_rules! skip_pre_hardfork {
+    () => {
+        if $crate::utils::is_pre_hardfork() {
+            eprintln!("skipping test in pre-hardfork mode");
+            return Ok(());
+        }
+    };
+}
+
 /// Standard test mnemonic phrase used across integration tests
 pub(crate) const TEST_MNEMONIC: &str =
     "test test test test test test test test test test test junk";
@@ -338,6 +360,12 @@ impl TestNodeBuilder {
         let mut genesis: serde_json::Value = serde_json::from_str(&self.genesis_content)?;
         if let Some(gas_limit) = &self.custom_gas_limit {
             genesis["gasLimit"] = serde_json::json!(gas_limit);
+        }
+
+        if is_pre_hardfork() {
+            let config = genesis["config"].as_object_mut().unwrap();
+            config.insert("t1cTime".to_string(), serde_json::json!(u64::MAX));
+            config.insert("t2Time".to_string(), serde_json::json!(u64::MAX));
         }
 
         Ok(TempoChainSpec::from_genesis(serde_json::from_value(


### PR DESCRIPTION
Adds a CI job that runs integration tests with the latest hardforks (T1C, T2) deactivated, catching regressions in the "new binary, old fork" window before a hardfork activates on the network.

- `TEMPO_PRE_HARDFORK_TEST=1` env var sets `t1cTime`/`t2Time` to `u64::MAX` in the test genesis, simulating a pre-hardfork chain
- `skip_pre_hardfork!()` macro skips 19 tests that exercise features introduced by T1C/T2 (V2 keychain signatures, access keys, spending limits, key expiry, TIP-1007 getFeeToken, TIP-403 whitelist enforcement, etc.) — these are expected to fail when those forks are deactivated
- New `test-pre-hardfork` CI job runs the remaining integration tests against the old fork rules
