### PR TITLE
tip: add AccessKeySpend event to TIP-1011

### DIFF
--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -112,6 +112,26 @@ struct KeyAuthorization {
 
 ## Interface Changes
 
+### Events
+
+```solidity
+/// @notice Emitted when an access key spends tokens against a spending limit
+/// @param account The account whose key was used
+/// @param publicKey The public key (address) that initiated the spend
+/// @param token The token address being spent
+/// @param amount The amount spent in this transaction
+/// @param remainingLimit The remaining spending limit after this spend
+event AccessKeySpend(
+    address indexed account,
+    address indexed publicKey,
+    address indexed token,
+    uint256 amount,
+    uint256 remainingLimit
+);
+```
+
+This event MUST be emitted whenever an access key transaction deducts from a spending limit (both one-time and periodic). For periodic limits, `remainingLimit` reflects the remaining allowance in the current period after the spend.
+
 ### IAccountKeychain.sol
 
 ```solidity


### PR DESCRIPTION
## Summary
Adds the `AccessKeySpend` event to TIP-1011's interface specification, emitted whenever an access key transaction deducts from a spending limit.

## Changes
- Added `Events` section to TIP-1011 Interface Changes with the `AccessKeySpend` event definition
- Event has 3 indexed params (`account`, `publicKey`, `token`) plus `amount` and `remainingLimit`
- Specifies the event MUST be emitted for both one-time and periodic limit spends

Prompted by: tanishk