### PR TITLE
fix(revm): always validate keychain signature version

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1277,16 +1277,14 @@ where
             .map_err(TempoInvalidTransaction::from)?;
 
             // Validate keychain signature version (outer + authorization list).
-            if !cfg.is_balance_check_disabled() {
-                aa_env
-                    .signature
+            aa_env
+                .signature
+                .validate_version(cfg.spec().is_t1c())
+                .map_err(TempoInvalidTransaction::from)?;
+            for auth in &aa_env.tempo_authorization_list {
+                auth.signature()
                     .validate_version(cfg.spec().is_t1c())
                     .map_err(TempoInvalidTransaction::from)?;
-                for auth in &aa_env.tempo_authorization_list {
-                    auth.signature()
-                        .validate_version(cfg.spec().is_t1c())
-                        .map_err(TempoInvalidTransaction::from)?;
-                }
             }
 
             let has_keychain_fields =


### PR DESCRIPTION
Stacked on top of #2973 
Removes the `is_balance_check_disabled` gate around AA keychain signature version checks in the handler.

After #2973, RPC mock signatures are hardfork-aware, so this skip is no longer needed for estimate flows. Keeping the validation unconditional avoids divergent behavior between simulation contexts.