### PR TITLE
fix(bench): record start block before sending instead of polling 

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -408,6 +408,8 @@ impl MaxTpsArgs {
 
         info!(total_txs, "Generating and sending transactions");
 
+        let start_block_number = provider.get_block_number().await?;
+
         let counters = TransactionCounters::default();
         let target_count = total_txs as usize;
         let cancel_token = CancellationToken::new();
@@ -491,25 +493,6 @@ impl MaxTpsArgs {
         );
 
         let end_block_number = provider.get_block_number().await?;
-
-        info!("Retrieving first block number from sent transactions");
-        let start_block_number = loop {
-            if let Some(first_tx) = pending_txs.pop_front() {
-                debug!(hash = %first_tx.tx_hash(), "Retrieving transaction receipt for first block number");
-                if let Ok(first_tx_receipt) = first_tx
-                    .with_timeout(Some(Duration::from_secs(5)))
-                    .get_receipt()
-                    .await
-                {
-                    break first_tx_receipt.block_number;
-                }
-            } else {
-                break None;
-            }
-        };
-        let Some(start_block_number) = start_block_number else {
-            eyre::bail!("Failed to retrieve start block number")
-        };
 
         // Collect a sample of receipts and print the stats
         let sample_size = pending_txs.len().min(self.sample_size);


### PR DESCRIPTION
The previous approach fetched tx receipts one-by-one (5s timeout each) to find the first mined block, causing the bench to hang for minutes when the node has a large tx backlog. Instead, snapshot the block number before sending starts — instant and avoids the bottleneck.