### PR TITLE
fix(tempo-bench): use ordered buffer

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -424,7 +424,7 @@ impl MaxTpsArgs {
 
         let mut pending_txs =
             generate_transactions(signer_provider_manager.clone(), gen_input, counters.clone())
-                .buffer_unordered(self.tps as usize)
+                .buffered(self.tps as usize)
                 .filter_map(|result| async {
                     match result {
                         Ok(bytes) => Some(bytes),
@@ -446,7 +446,7 @@ impl MaxTpsArgs {
                     )
                     .await
                 })
-                .buffer_unordered(self.max_concurrent_requests)
+                .buffered(self.max_concurrent_requests)
                 .filter_map({
                     let counters = counters.clone();
                     move |result| {


### PR DESCRIPTION
Using unordered may result in this taking a very long time to complete, because ordering of txs is not guaranteed https://github.com/tempoxyz/tempo/blob/3d39e128dd85871e274c4c5e9f028434d547f9c4/bin/tempo-bench/src/cmd/max_tps.rs#L495-L513