### PR TITLE
docs: add TIP-1018 implicit approval for StablecoinDEX

### DIFF
--- a/tips/tip-1018.md
+++ b/tips/tip-1018.md
@@ -1,0 +1,122 @@
+---
+id: TIP-1018
+title: Implicit Approval for StablecoinDEX Token Transfers
+description: Allow the StablecoinDEX precompile to transfer tokens from the caller without requiring a prior ERC-20 approval, improving UX and reducing gas costs.
+authors: Dan Robinson
+status: Draft
+related: TIP-1004
+protocolVersion: TBD (requires hardfork)
+---
+
+# TIP-1018: Implicit Approval for StablecoinDEX Token Transfers
+
+## Abstract
+
+The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the ERC-20 approval check. The TipFeeManager AMM already uses this pattern.
+
+## Motivation
+
+Today, a user who wants to swap or place an order on the StablecoinDEX must first submit a separate `approve` transaction for each token they want to trade. This has three costs:
+
+1. **User experience**: Two transactions instead of one. Wallets must prompt for approval before every new token interaction with the DEX, adding friction to the most common DeFi operation.
+
+2. **Gas cost**: Each `approve` call costs gas for the SSTORE to the allowance slot. Most users set `type(uint256).max` approval to avoid repeating this, which is a well-known antipattern on Ethereum — but on Tempo, the approval is unnecessary in the first place.
+
+3. **State bloat**: Every approval writes a storage slot in the token contract's allowance mapping. For a precompile that is a fixed system address and can only be called directly, this state serves no purpose.
+
+The approval check is redundant because the DEX can only pull tokens from `msg.sender` — every external entry point that transfers tokens passes the caller's address as the source. Since the caller is always the one authorizing the transaction, the approve step provides no additional security.
+
+### Precedent
+
+The TipFeeManager AMM (`rebalanceSwap`, `mint`) already uses `system_transfer_from` to pull tokens from the caller without requiring approval. This TIP extends the same pattern to the StablecoinDEX.
+
+---
+
+# Specification
+
+## Change
+
+Replace the StablecoinDEX's internal `transfer_from` method to use `system_transfer_from` instead of the allowance-based `transferFrom`:
+
+```rust
+// Before
+fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
+    TIP20Token::from_address(token)?.transfer_from(
+        self.address,
+        ITIP20::transferFromCall {
+            from,
+            to: self.address,
+            amount: U256::from(amount),
+        },
+    )?;
+    Ok(())
+}
+
+// After
+fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
+    TIP20Token::from_address(token)?.system_transfer_from(
+        from,
+        self.address,
+        U256::from(amount),
+    )?;
+    Ok(())
+}
+```
+
+This change MUST be gated behind the hardfork activation. Pre-fork transactions must continue to use the allowance-based path to preserve state root consistency.
+
+## Affected Entry Points
+
+The change affects every external function that pulls tokens from the caller's wallet via `decrement_balance_or_transfer_from`:
+
+| Function | Effect |
+|----------|--------|
+| `place(token, amount, isBid, tick)` | Escrows tokens for a new limit order without requiring prior approval |
+| `placeFlip(token, amount, isBid, tick, flipTick)` | Same as `place` for the initial placement |
+| `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` | Pulls input tokens at the start of a swap without requiring prior approval |
+| `swapExactAmountOut(tokenIn, tokenOut, amountOut, maxAmountIn)` | Pulls input tokens at the end of a swap without requiring prior approval |
+
+No other entry points are affected. `withdraw`, `cancel`, `cancelStaleOrder`, `createPair`, and all view functions do not pull tokens from the caller's wallet.
+
+## What Does Not Change
+
+- **TIP-403 transfer policy checks**: `system_transfer_from` still calls `ensure_transfer_authorized`. If a token's transfer policy forbids transfers to the DEX, the transaction will still revert.
+- **AccountKeychain spending limits**: `system_transfer_from` still calls `check_and_update_spending_limit`. Access keys with spending caps remain constrained.
+- **Internal balance logic**: `decrement_balance_or_transfer_from` still checks the user's internal DEX balance first and only pulls from the wallet for the remainder.
+- **Transfer events**: `system_transfer_from` calls `_transfer`, which emits the standard `Transfer` event. Indexers and explorers are unaffected.
+- **Existing approvals**: Users who have already approved the DEX are unaffected. Their approvals remain in storage but are simply no longer consumed.
+
+## Safety Argument
+
+The StablecoinDEX only ever pulls tokens from `msg.sender`. Every external entry point passes the direct caller's address to `decrement_balance_or_transfer_from`. There is no reachable code path where the DEX pulls tokens from a third party's wallet.
+
+Additionally, Tempo precompiles enforce direct-call-only semantics (no `DELEGATECALL`), so the `msg.sender` is always the EOA or contract that initiated the call — it cannot be spoofed by an intermediate contract.
+
+The one internal code path that debits a non-caller address is the flip order re-placement after a fill, where `place_flip` is called with `internal_balance_only: true`. This path only debits the maker's *internal DEX balance* (tokens already escrowed by the DEX) and never calls `transfer_from` on the TIP-20 token.
+
+---
+
+# Invariants
+
+1. **Caller-only pulls**: The DEX MUST only pull tokens from the direct caller (`msg.sender`). No external entry point may pass a different address to `transfer_from` or `system_transfer_from` for wallet-level token pulls.
+
+2. **Policy enforcement**: All token pulls MUST continue to enforce TIP-403 transfer policies via `ensure_transfer_authorized`.
+
+3. **Spending limit enforcement**: All token pulls MUST continue to enforce AccountKeychain spending limits via `check_and_update_spending_limit`.
+
+4. **Event consistency**: All token pulls MUST emit the standard TIP-20 `Transfer` event.
+
+5. **Hardfork gating**: The behavior change MUST be gated behind the hardfork activation. The same transaction must produce the same result pre-fork and post-fork when replaying historical blocks.
+
+## Test Cases
+
+1. **Swap without approval**: `swapExactAmountIn` succeeds without a prior `approve` call (post-fork).
+2. **Place without approval**: `place` succeeds without a prior `approve` call (post-fork).
+3. **PlaceFlip without approval**: `placeFlip` succeeds without a prior `approve` call (post-fork).
+4. **SwapExactAmountOut without approval**: `swapExactAmountOut` succeeds without a prior `approve` call (post-fork).
+5. **Existing approvals still work**: Transactions from users with existing approvals succeed unchanged.
+6. **TIP-403 policy enforcement**: A token with a transfer policy that blocks the DEX still reverts.
+7. **Spending limits enforced**: An access key with a spending cap is still constrained.
+8. **Insufficient balance reverts**: Pulling more tokens than the caller holds still reverts with `InsufficientBalance`.
+9. **Internal balance priority**: If the caller has internal DEX balance, it is consumed before pulling from the wallet.
+10. **Pre-fork behavior preserved**: Before the hardfork, transactions without approval still revert with `InsufficientAllowance`.


### PR DESCRIPTION
Removes the ERC-20 approval requirement for StablecoinDEX token pulls by switching from `transferFrom` to `system_transfer_from` (same pattern the TipFeeManager AMM already uses).

The DEX only ever pulls from `msg.sender`, so the approval is purely self-referential. Dropping it saves gas, reduces state bloat, and removes a UX step.

Affected entry points: `place`, `placeFlip`, `swapExactAmountIn`, `swapExactAmountOut`.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan