### PR TITLE
docs: add TIP-1025 implicit approval for StablecoinDEX

### DIFF
--- a/tips/tip-1018.md
+++ b/tips/tip-1018.md
@@ -1,0 +1,122 @@
+---
+id: TIP-1018
+title: Implicit Approval for StablecoinDEX Token Transfers
+description: Allow the StablecoinDEX precompile to transfer tokens from the caller without requiring a prior ERC-20 approval, improving UX and reducing gas costs.
+authors: Dan Robinson
+status: Draft
+related: TIP-1004
+protocolVersion: TBD (requires hardfork)
+---
+
+# TIP-1018: Implicit Approval for StablecoinDEX Token Transfers
+
+## Abstract
+
+The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the ERC-20 approval check. The TipFeeManager AMM already uses this pattern.
+
+## Motivation
+
+Today, a user who wants to swap or place an order on the StablecoinDEX must first submit a separate `approve` transaction for each token they want to trade. This has three costs:
+
+1. **User experience**: Two transactions instead of one. Wallets must prompt for approval before every new token interaction with the DEX, adding friction to the most common DeFi operation.
+
+2. **Gas cost**: Each `approve` call costs gas for the SSTORE to the allowance slot. Most users set `type(uint256).max` approval to avoid repeating this, which is a well-known antipattern on Ethereum — but on Tempo, the approval is unnecessary in the first place.
+
+3. **State bloat**: Every approval writes a storage slot in the token contract's allowance mapping. For a precompile that is a fixed system address and can only be called directly, this state serves no purpose.
+
+The approval check is redundant because the DEX can only pull tokens from `msg.sender` — every external entry point that transfers tokens passes the caller's address as the source. Since the caller is always the one authorizing the transaction, the approve step provides no additional security.
+
+### Precedent
+
+The TipFeeManager AMM (`rebalanceSwap`, `mint`) already uses `system_transfer_from` to pull tokens from the caller without requiring approval. This TIP extends the same pattern to the StablecoinDEX.
+
+---
+
+# Specification
+
+## Change
+
+Replace the StablecoinDEX's internal `transfer_from` method to use `system_transfer_from` instead of the allowance-based `transferFrom`:
+
+```rust
+// Before
+fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
+    TIP20Token::from_address(token)?.transfer_from(
+        self.address,
+        ITIP20::transferFromCall {
+            from,
+            to: self.address,
+            amount: U256::from(amount),
+        },
+    )?;
+    Ok(())
+}
+
+// After
+fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
+    TIP20Token::from_address(token)?.system_transfer_from(
+        from,
+        self.address,
+        U256::from(amount),
+    )?;
+    Ok(())
+}
+```
+
+This change MUST be gated behind the hardfork activation. Pre-fork transactions must continue to use the allowance-based path to preserve state root consistency.
+
+## Affected Entry Points
+
+The change affects every external function that pulls tokens from the caller's wallet via `decrement_balance_or_transfer_from`:
+
+| Function | Effect |
+|----------|--------|
+| `place(token, amount, isBid, tick)` | Escrows tokens for a new limit order without requiring prior approval |
+| `placeFlip(token, amount, isBid, tick, flipTick)` | Same as `place` for the initial placement |
+| `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` | Pulls input tokens at the start of a swap without requiring prior approval |
+| `swapExactAmountOut(tokenIn, tokenOut, amountOut, maxAmountIn)` | Pulls input tokens at the end of a swap without requiring prior approval |
+
+No other entry points are affected. `withdraw`, `cancel`, `cancelStaleOrder`, `createPair`, and all view functions do not pull tokens from the caller's wallet.
+
+## What Does Not Change
+
+- **TIP-403 transfer policy checks**: `system_transfer_from` still calls `ensure_transfer_authorized`. If a token's transfer policy forbids transfers to the DEX, the transaction will still revert.
+- **AccountKeychain spending limits**: `system_transfer_from` still calls `check_and_update_spending_limit`. Access keys with spending caps remain constrained.
+- **Internal balance logic**: `decrement_balance_or_transfer_from` still checks the user's internal DEX balance first and only pulls from the wallet for the remainder.
+- **Transfer events**: `system_transfer_from` calls `_transfer`, which emits the standard `Transfer` event. Indexers and explorers are unaffected.
+- **Existing approvals**: Users who have already approved the DEX are unaffected. Their approvals remain in storage but are simply no longer consumed.
+
+## Safety Argument
+
+The StablecoinDEX only ever pulls tokens from `msg.sender`. Every external entry point passes the direct caller's address to `decrement_balance_or_transfer_from`. There is no reachable code path where the DEX pulls tokens from a third party's wallet.
+
+Additionally, Tempo precompiles enforce direct-call-only semantics (no `DELEGATECALL`), so the `msg.sender` is always the EOA or contract that initiated the call — it cannot be spoofed by an intermediate contract.
+
+The one internal code path that debits a non-caller address is the flip order re-placement after a fill, where `place_flip` is called with `internal_balance_only: true`. This path only debits the maker's *internal DEX balance* (tokens already escrowed by the DEX) and never calls `transfer_from` on the TIP-20 token.
+
+---
+
+# Invariants
+
+1. **Caller-only pulls**: The DEX MUST only pull tokens from the direct caller (`msg.sender`). No external entry point may pass a different address to `transfer_from` or `system_transfer_from` for wallet-level token pulls.
+
+2. **Policy enforcement**: All token pulls MUST continue to enforce TIP-403 transfer policies via `ensure_transfer_authorized`.
+
+3. **Spending limit enforcement**: All token pulls MUST continue to enforce AccountKeychain spending limits via `check_and_update_spending_limit`.
+
+4. **Event consistency**: All token pulls MUST emit the standard TIP-20 `Transfer` event.
+
+5. **Hardfork gating**: The behavior change MUST be gated behind the hardfork activation. The same transaction must produce the same result pre-fork and post-fork when replaying historical blocks.
+
+## Test Cases
+
+1. **Swap without approval**: `swapExactAmountIn` succeeds without a prior `approve` call (post-fork).
+2. **Place without approval**: `place` succeeds without a prior `approve` call (post-fork).
+3. **PlaceFlip without approval**: `placeFlip` succeeds without a prior `approve` call (post-fork).
+4. **SwapExactAmountOut without approval**: `swapExactAmountOut` succeeds without a prior `approve` call (post-fork).
+5. **Existing approvals still work**: Transactions from users with existing approvals succeed unchanged.
+6. **TIP-403 policy enforcement**: A token with a transfer policy that blocks the DEX still reverts.
+7. **Spending limits enforced**: An access key with a spending cap is still constrained.
+8. **Insufficient balance reverts**: Pulling more tokens than the caller holds still reverts with `InsufficientBalance`.
+9. **Internal balance priority**: If the caller has internal DEX balance, it is consumed before pulling from the wallet.
+10. **Pre-fork behavior preserved**: Before the hardfork, transactions without approval still revert with `InsufficientAllowance`.

--- a/tips/tip-1025.md
+++ b/tips/tip-1025.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1025
 title: Implicit Approval for System Precompile Token Transfers
-description: Allow the StablecoinDEX and TipFeeManager precompiles to transfer tokens from the caller without requiring a prior TIP-20 approval, and make approve() a no-op for these addresses.
+description: Remove the TIP-20 approval requirement for the StablecoinDEX (matching the TipFeeManager's existing behavior), and make approve() a no-op for both addresses.
 authors: Dan Robinson
 status: Draft
 related: N/A
@@ -12,9 +12,9 @@ protocolVersion: T3
 
 ## Abstract
 
-The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the TIP-20 approval check. The TipFeeManager AMM already uses `system_transfer_from`, so this TIP also formalizes its implicit approval status.
+The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the TIP-20 approval check. The TipFeeManager AMM already uses `system_transfer_from` and does not require approvals.
 
-Additionally, TIP-20 `approve()` calls where the spender is a system precompile with implicit approval (currently the StablecoinDEX and TipFeeManager) become a no-op post-fork: the call succeeds but writes no allowance state and emits no `Approval` event.
+Additionally, TIP-20 `approve()` calls where the spender is either the StablecoinDEX or the TipFeeManager become a no-op post-fork: the call succeeds but writes no allowance state and emits no `Approval` event.
 
 ## Motivation
 

--- a/tips/tip-1025.md
+++ b/tips/tip-1025.md
@@ -1,18 +1,20 @@
 ---
 id: TIP-1025
-title: Implicit Approval for StablecoinDEX Token Transfers
-description: Allow the StablecoinDEX precompile to transfer tokens from the caller without requiring a prior ERC-20 approval, improving UX and reducing gas costs.
+title: Implicit Approval for System Precompile Token Transfers
+description: Allow the StablecoinDEX and TipFeeManager precompiles to transfer tokens from the caller without requiring a prior TIP-20 approval, and make approve() a no-op for these addresses.
 authors: Dan Robinson
 status: Draft
 related: N/A
 protocolVersion: T3
 ---
 
-# TIP-1025: Implicit Approval for StablecoinDEX Token Transfers
+# TIP-1025: Implicit Approval for System Precompile Token Transfers
 
 ## Abstract
 
-The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the ERC-20 approval check. The TipFeeManager AMM already uses this pattern.
+The StablecoinDEX precompile currently requires users to call `approve` on each TIP-20 token before interacting with the DEX. This TIP removes that requirement by switching the DEX's internal token pull mechanism from the allowance-based `transferFrom` to `system_transfer_from`, which skips the TIP-20 approval check. The TipFeeManager AMM already uses `system_transfer_from`, so this TIP also formalizes its implicit approval status.
+
+Additionally, TIP-20 `approve()` calls where the spender is a system precompile with implicit approval (currently the StablecoinDEX and TipFeeManager) become a no-op post-fork: the call succeeds but writes no allowance state and emits no `Approval` event.
 
 ## Motivation
 
@@ -28,7 +30,7 @@ The approval check is redundant because the DEX can only pull tokens from `msg.s
 
 ### Precedent
 
-The TipFeeManager AMM (`rebalanceSwap`, `mint`) already uses `system_transfer_from` to pull tokens from the caller without requiring approval. This TIP extends the same pattern to the StablecoinDEX.
+The TipFeeManager AMM (`rebalanceSwap`, `mint`) already uses `system_transfer_from` to pull tokens from the caller without requiring approval. This TIP extends the same pattern to the StablecoinDEX, and formalizes both precompiles as implicitly approved system addresses.
 
 ---
 
@@ -59,6 +61,21 @@ fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Resu
 
 This change MUST be gated behind the hardfork activation. Pre-fork transactions must continue to use the allowance-based path to preserve state root consistency.
 
+## TIP-20 `approve()` No-Op for System Precompiles
+
+Post-fork, the TIP-20 precompile maintains a set of implicitly approved system addresses — currently the StablecoinDEX and TipFeeManager. When `approve(spender, amount)` is called and `spender` is in this set, the call:
+
+1. Returns success (does not revert)
+2. Writes no allowance state
+3. Emits no `Approval` event
+4. Does not deduct AccountKeychain spending limits
+
+This ensures that existing flows which call `approve` before interacting with the DEX or FeeManager continue to work without modification, while preventing new allowance state from being written and avoiding unnecessary spending limit deductions on access keys.
+
+## Access Key Spending Limit Edge Case
+
+If an access key called `approve()` on a system precompile address before the fork, the approved amount was permanently deducted from the key's spending limit at that time. Post-fork, when that key performs a swap or other operation, `system_transfer_from` calls `check_and_update_spending_limit` again, deducting the transfer amount a second time. The net effect is that the key's spending limit is charged twice: once for the (now-unused) approval and once for the actual transfer. There is no mechanism to refund the spending limit consumed by the pre-fork approval. This is expected to be rare in practice, since access keys would not typically pre-approve the DEX without immediately spending.
+
 ## Affected Entry Points
 
 The change affects every external function that pulls tokens from the caller's wallet via `decrement_balance_or_transfer_from`:
@@ -78,7 +95,7 @@ No other entry points are affected. `withdraw`, `cancel`, `cancelStaleOrder`, `c
 - **AccountKeychain spending limits**: `system_transfer_from` still calls `check_and_update_spending_limit`. Access keys with spending caps remain constrained.
 - **Internal balance logic**: `decrement_balance_or_transfer_from` still checks the user's internal DEX balance first and only pulls from the wallet for the remainder.
 - **Transfer events**: `system_transfer_from` calls `_transfer`, which emits the standard `Transfer` event. Indexers and explorers are unaffected.
-- **Existing approvals**: Users who have already approved the DEX are unaffected. Their approvals remain in storage but are simply no longer consumed.
+- **Existing approvals**: Users who have already approved the DEX or FeeManager are unaffected. Their approvals remain in storage but are no longer consumed. New `approve()` calls targeting these addresses are a no-op (see above).
 
 ## Safety Argument
 
@@ -102,6 +119,8 @@ The one internal code path that debits a non-caller address is the flip order re
 
 5. **Hardfork gating**: The behavior change MUST be gated behind the hardfork activation. The same transaction must produce the same result pre-fork and post-fork when replaying historical blocks.
 
+6. **Approve no-op for system precompiles**: Post-fork, `approve(spender, amount)` where `spender` is a system precompile MUST succeed, write no allowance state, emit no `Approval` event, and not deduct access key spending limits.
+
 ## Test Cases
 
 1. **Swap without approval**: `swapExactAmountIn` succeeds without a prior `approve` call (post-fork).
@@ -114,3 +133,7 @@ The one internal code path that debits a non-caller address is the flip order re
 8. **Insufficient balance reverts**: Pulling more tokens than the caller holds still reverts with `InsufficientBalance`.
 9. **Internal balance priority**: If the caller has internal DEX balance, it is consumed before pulling from the wallet.
 10. **Pre-fork behavior preserved**: Before the hardfork, transactions without approval still revert with `InsufficientAllowance`.
+11. **Approve no-op (DEX)**: `approve(DEX_ADDRESS, amount)` post-fork succeeds, emits no `Approval` event, writes no allowance state, and does not deduct access key spending limits.
+12. **Approve no-op (FeeManager)**: `approve(FEE_MANAGER_ADDRESS, amount)` post-fork succeeds with the same no-op behavior.
+13. **Approve + swap flow**: A transaction that calls `approve(DEX_ADDRESS, amount)` followed by `swapExactAmountIn` succeeds post-fork (the approve is a no-op, the swap uses `system_transfer_from`).
+14. **Pre-fork approve still works**: Before the hardfork, `approve(DEX_ADDRESS, amount)` still writes allowance state and emits an `Approval` event as before.

--- a/tips/tip-1025.md
+++ b/tips/tip-1025.md
@@ -72,10 +72,6 @@ Post-fork, the TIP-20 precompile maintains a set of implicitly approved system a
 
 This ensures that existing flows which call `approve` before interacting with the DEX or FeeManager continue to work without modification, while preventing new allowance state from being written and avoiding unnecessary spending limit deductions on access keys.
 
-## Access Key Spending Limit Edge Case
-
-If an access key called `approve()` on a system precompile address before the fork, the approved amount was permanently deducted from the key's spending limit at that time. Post-fork, when that key performs a swap or other operation, `system_transfer_from` calls `check_and_update_spending_limit` again, deducting the transfer amount a second time. The net effect is that the key's spending limit is charged twice: once for the (now-unused) approval and once for the actual transfer. There is no mechanism to refund the spending limit consumed by the pre-fork approval. This is expected to be rare in practice, since access keys would not typically pre-approve the DEX without immediately spending.
-
 ## Affected Entry Points
 
 The change affects every external function that pulls tokens from the caller's wallet via `decrement_balance_or_transfer_from`:
@@ -99,6 +95,8 @@ No other entry points are affected. `withdraw`, `cancel`, `cancelStaleOrder`, `c
 ## Behavior Change: AccountKeychain Spending Limits
 
 The previous `transferFrom` path did **not** call `check_and_update_spending_limit` — only direct `transfer` did. `system_transfer_from` does call it, so this TIP **adds** spending limit enforcement to DEX token pulls. Access keys with spending caps will now have those caps enforced when swapping or placing orders on the DEX.
+
+**Edge case**: If an access key called `approve()` on a system precompile address before the fork, the approved amount was permanently deducted from the key's spending limit at that time. Post-fork, when that key performs a swap or other operation, `system_transfer_from` calls `check_and_update_spending_limit` again, deducting the transfer amount a second time. The net effect is that the key's spending limit is charged twice: once for the (now-unused) approval and once for the actual transfer. There is no mechanism to refund the spending limit consumed by the pre-fork approval. This is expected to be rare in practice, since access keys would not typically pre-approve the DEX without immediately spending.
 
 ## What Does Not Change
 

--- a/tips/tip-1025.md
+++ b/tips/tip-1025.md
@@ -4,7 +4,7 @@ title: Implicit Approval for System Precompile Token Transfers
 description: Remove the TIP-20 approval requirement for the StablecoinDEX (matching the TipFeeManager's existing behavior), and make approve() a no-op for both addresses.
 authors: Dan Robinson
 status: Draft
-related: N/A
+related: TIP-1027
 protocolVersion: T3
 ---
 
@@ -20,11 +20,11 @@ Additionally, TIP-20 `approve()` calls where the spender is either the Stablecoi
 
 Today, a user who wants to swap or place an order on the StablecoinDEX must first submit a separate `approve` transaction for each token they want to trade. This has three costs:
 
-1. **User experience**: Two transactions instead of one. Some wallets must prompt for approval before every new token interaction with the DEX, adding friction to the most common DeFi operation.
+1. **User experience**: A user's first interaction with a DEX involving a given token requires two transactions (or a batch call). Some wallets must prompt for approval before every new token interaction with the DEX, adding friction.
 
-2. **Gas cost**: Each `approve` call costs 250,000 gas for the cold SSTORE to the allowance slot. On top of that, every subsequent swap or order placement pays extra gas to load and check the allowance, and (if the user hasn't max-approved) to update it. Most users set `type(uint256).max` approval to avoid the update cost, which is a well-known antipattern on Ethereum — but on Tempo, the approval is unnecessary in the first place.
+2. **Gas cost**: Each `approve` call costs 250,000 gas for the cold SSTORE to the allowance slot. On top of that, every subsequent swap or order placement pays extra gas to load and check the allowance, and (if the user hasn't max-approved) to update it.
 
-3. **State bloat**: Every approval writes a storage slot in the token contract's allowance mapping. For a precompile that is a fixed system address and can only be called directly, this state serves no purpose.
+3. **State bloat**: Every approval writes a storage slot in the token contract's allowance mapping.
 
 The approval check is redundant because the DEX can only pull tokens from `msg.sender` — every external entry point that transfers tokens passes the caller's address as the source. Since the caller is always the one authorizing the transaction, the approve step provides no additional security.
 
@@ -87,12 +87,22 @@ The change affects every external function that pulls tokens from the caller's w
 | `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` | Pulls input tokens at the start of a swap without requiring prior approval |
 | `swapExactAmountOut(tokenIn, tokenOut, amountOut, maxAmountIn)` | Pulls input tokens at the end of a swap without requiring prior approval |
 
+If [TIP-1027](./tip-1027.md) (StablecoinDEX Swap-and-Send) is included, the swap-and-send functions also receive implicit approval:
+
+| Function | Effect |
+|----------|--------|
+| `swapExactAmountInTo(tokenIn, tokenOut, amountIn, minAmountOut, recipient)` | Pulls input tokens and sends output to `recipient` without requiring prior approval |
+| `swapExactAmountOutTo(tokenIn, tokenOut, amountOut, maxAmountIn, recipient)` | Pulls input tokens and sends output to `recipient` without requiring prior approval |
+
 No other entry points are affected. `withdraw`, `cancel`, `cancelStaleOrder`, `createPair`, and all view functions do not pull tokens from the caller's wallet.
+
+## Behavior Change: AccountKeychain Spending Limits
+
+The previous `transferFrom` path did **not** call `check_and_update_spending_limit` — only direct `transfer` did. `system_transfer_from` does call it, so this TIP **adds** spending limit enforcement to DEX token pulls. Access keys with spending caps will now have those caps enforced when swapping or placing orders on the DEX.
 
 ## What Does Not Change
 
 - **TIP-403 transfer policy checks**: `system_transfer_from` still calls `ensure_transfer_authorized`. If a token's transfer policy forbids transfers to the DEX, the transaction will still revert.
-- **AccountKeychain spending limits**: `system_transfer_from` still calls `check_and_update_spending_limit`. Access keys with spending caps remain constrained.
 - **Internal balance logic**: `decrement_balance_or_transfer_from` still checks the user's internal DEX balance first and only pulls from the wallet for the remainder.
 - **Transfer events**: `system_transfer_from` calls `_transfer`, which emits the standard `Transfer` event. Indexers and explorers are unaffected.
 - **Existing approvals**: Users who have already approved the DEX or FeeManager are unaffected. Their approvals remain in storage but are no longer consumed. New `approve()` calls targeting these addresses are a no-op (see above).
@@ -113,7 +123,7 @@ The one internal code path that debits a non-caller address is the flip order re
 
 2. **Policy enforcement**: All token pulls MUST continue to enforce TIP-403 transfer policies via `ensure_transfer_authorized`.
 
-3. **Spending limit enforcement**: All token pulls MUST continue to enforce AccountKeychain spending limits via `check_and_update_spending_limit`.
+3. **Spending limit enforcement**: All token pulls MUST enforce AccountKeychain spending limits via `check_and_update_spending_limit`. (This is new — the previous `transferFrom` path did not check spending limits.)
 
 4. **Event consistency**: All token pulls MUST emit the standard TIP-20 `Transfer` event.
 

--- a/tips/tip-1025.md
+++ b/tips/tip-1025.md
@@ -1,14 +1,14 @@
 ---
-id: TIP-1018
+id: TIP-1025
 title: Implicit Approval for StablecoinDEX Token Transfers
 description: Allow the StablecoinDEX precompile to transfer tokens from the caller without requiring a prior ERC-20 approval, improving UX and reducing gas costs.
 authors: Dan Robinson
 status: Draft
-related: TIP-1004
-protocolVersion: TBD (requires hardfork)
+related: N/A
+protocolVersion: T3
 ---
 
-# TIP-1018: Implicit Approval for StablecoinDEX Token Transfers
+# TIP-1025: Implicit Approval for StablecoinDEX Token Transfers
 
 ## Abstract
 
@@ -18,9 +18,9 @@ The StablecoinDEX precompile currently requires users to call `approve` on each 
 
 Today, a user who wants to swap or place an order on the StablecoinDEX must first submit a separate `approve` transaction for each token they want to trade. This has three costs:
 
-1. **User experience**: Two transactions instead of one. Wallets must prompt for approval before every new token interaction with the DEX, adding friction to the most common DeFi operation.
+1. **User experience**: Two transactions instead of one. Some wallets must prompt for approval before every new token interaction with the DEX, adding friction to the most common DeFi operation.
 
-2. **Gas cost**: Each `approve` call costs gas for the SSTORE to the allowance slot. Most users set `type(uint256).max` approval to avoid repeating this, which is a well-known antipattern on Ethereum — but on Tempo, the approval is unnecessary in the first place.
+2. **Gas cost**: Each `approve` call costs 250,000 gas for the cold SSTORE to the allowance slot. On top of that, every subsequent swap or order placement pays extra gas to load and check the allowance, and (if the user hasn't max-approved) to update it. Most users set `type(uint256).max` approval to avoid the update cost, which is a well-known antipattern on Ethereum — but on Tempo, the approval is unnecessary in the first place.
 
 3. **State bloat**: Every approval writes a storage slot in the token contract's allowance mapping. For a precompile that is a fixed system address and can only be called directly, this state serves no purpose.
 
@@ -39,26 +39,20 @@ The TipFeeManager AMM (`rebalanceSwap`, `mint`) already uses `system_transfer_fr
 Replace the StablecoinDEX's internal `transfer_from` method to use `system_transfer_from` instead of the allowance-based `transferFrom`:
 
 ```rust
-// Before
 fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
-    TIP20Token::from_address(token)?.transfer_from(
-        self.address,
-        ITIP20::transferFromCall {
-            from,
-            to: self.address,
-            amount: U256::from(amount),
-        },
-    )?;
-    Ok(())
-}
-
-// After
-fn transfer_from(&mut self, token: Address, from: Address, amount: u128) -> Result<()> {
-    TIP20Token::from_address(token)?.system_transfer_from(
-        from,
-        self.address,
-        U256::from(amount),
-    )?;
+    let mut tip20 = TIP20Token::from_address(token)?;
+    if self.storage.spec().is_t3() {
+        tip20.system_transfer_from(from, self.address, U256::from(amount))?;
+    } else {
+        tip20.transfer_from(
+            self.address,
+            ITIP20::transferFromCall {
+                from,
+                to: self.address,
+                amount: U256::from(amount),
+            },
+        )?;
+    }
     Ok(())
 }
 ```


### PR DESCRIPTION
Removes the ERC-20 approval requirement for StablecoinDEX token pulls by switching from `transferFrom` to `system_transfer_from` (same pattern the TipFeeManager AMM already uses), gated behind T3.

The DEX only ever pulls from `msg.sender`, so the approval is purely self-referential. Dropping it saves 250k gas per token on the approval tx, plus the per-swap cost of checking/updating the allowance slot.

Affected entry points: `place`, `placeFlip`, `swapExactAmountIn`, `swapExactAmountOut`.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan