### PR TITLE
refactor: extract PolicyAuthorizer trait from TIP20Token

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     storage::{Handler, Mapping},
     tip20::{rewards::UserRewardInfo, roles::DEFAULT_ADMIN_ROLE},
     tip20_factory::TIP20Factory,
-    tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
+    tip403_registry::{self, AuthRole},
 };
 use alloy::{
     hex,
@@ -214,9 +214,7 @@ impl TIP20Token {
         self.check_role(msg_sender, DEFAULT_ADMIN_ROLE)?;
 
         // Validate that the policy exists
-        if !TIP403Registry::new().policy_exists(ITIP403Registry::policyExistsCall {
-            policyId: call.newPolicyId,
-        })? {
+        if !tip403_registry::check_policy_exists(call.newPolicyId)? {
             return Err(TIP20Error::invalid_transfer_policy_id().into());
         }
 
@@ -373,7 +371,7 @@ impl TIP20Token {
 
         // Check if the `to` address is authorized to receive minted tokens
         let policy_id = self.transfer_policy_id()?;
-        if !TIP403Registry::new().is_authorized_as(policy_id, to, AuthRole::mint_recipient())? {
+        if !tip403_registry::authorize(policy_id, to, AuthRole::mint_recipient())? {
             return Err(TIP20Error::policy_forbids().into());
         }
 
@@ -446,7 +444,7 @@ impl TIP20Token {
 
         // Check if the address is blocked from transferring (sender authorization)
         let policy_id = self.transfer_policy_id()?;
-        if TIP403Registry::new().is_authorized_as(policy_id, call.from, AuthRole::sender())? {
+        if tip403_registry::authorize(policy_id, call.from, AuthRole::sender())? {
             // Only allow burning from addresses that are blocked from transferring
             return Err(TIP20Error::policy_forbids().into());
         }
@@ -803,14 +801,13 @@ impl TIP20Token {
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     pub fn is_transfer_authorized(&self, from: Address, to: Address) -> Result<bool> {
         let policy_id = self.transfer_policy_id()?;
-        let registry = TIP403Registry::new();
 
         // (spec: +T2) short-circuit and skip recipient check if sender fails
-        let sender_auth = registry.is_authorized_as(policy_id, from, AuthRole::sender())?;
+        let sender_auth = tip403_registry::authorize(policy_id, from, AuthRole::sender())?;
         if self.storage.spec().is_t2() && !sender_auth {
             return Ok(false);
         }
-        let recipient_auth = registry.is_authorized_as(policy_id, to, AuthRole::recipient())?;
+        let recipient_auth = tip403_registry::authorize(policy_id, to, AuthRole::recipient())?;
         Ok(sender_auth && recipient_auth)
     }
 
@@ -977,6 +974,7 @@ pub(crate) mod tests {
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, setup_storage},
+        tip403_registry::{ITIP403Registry, TIP403Registry},
     };
     use rand_08::{Rng, distributions::Alphanumeric, thread_rng};
     use tempo_chainspec::hardfork::TempoHardfork;

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -1,6 +1,7 @@
 pub mod dispatch;
 
 use crate::StorageCtx;
+use scoped_tls::scoped_thread_local;
 pub use tempo_contracts::precompiles::{
     ITIP403Registry::{self, PolicyType},
     TIP403RegistryError, TIP403RegistryEvent,
@@ -71,6 +72,60 @@ pub enum AuthRole {
     Recipient,
     /// Check mint recipient authorization only (spec: +T2).
     MintRecipient,
+}
+
+/// Abstraction over policy authorization backends.
+///
+/// `TIP403Registry` is the default on-chain implementation. Zones can provide their own
+/// (e.g. cache-backed) implementation via [`with_policy_authorizer`].
+pub trait PolicyAuthorizer {
+    /// Check whether `user` is authorized under `policy_id` for the given `role`.
+    fn is_authorized_as(&self, policy_id: u64, user: Address, role: AuthRole) -> Result<bool>;
+
+    /// Check whether a policy with the given ID has been created.
+    fn policy_exists(&self, policy_id: u64) -> Result<bool>;
+}
+
+impl PolicyAuthorizer for TIP403Registry {
+    fn is_authorized_as(&self, policy_id: u64, user: Address, role: AuthRole) -> Result<bool> {
+        self.is_authorized_as(policy_id, user, role)
+    }
+
+    fn policy_exists(&self, policy_id: u64) -> Result<bool> {
+        self.policy_exists(ITIP403Registry::policyExistsCall {
+            policyId: policy_id,
+        })
+    }
+}
+
+scoped_thread_local!(static POLICY_AUTHORIZER: &dyn PolicyAuthorizer);
+
+/// Enter a scoped policy authorizer context. While inside `f`, all TIP-20
+/// authorization checks use `authorizer` instead of the default `TIP403Registry`.
+pub fn with_policy_authorizer<R>(authorizer: &dyn PolicyAuthorizer, f: impl FnOnce() -> R) -> R {
+    // SAFETY: `scoped_tls` ensures the reference is only accessible within the closure scope.
+    let authorizer: &(dyn PolicyAuthorizer + 'static) = unsafe { std::mem::transmute(authorizer) };
+    POLICY_AUTHORIZER.set(&authorizer, f)
+}
+
+/// Check authorization using the thread-local override, falling back to `TIP403Registry`.
+pub(crate) fn authorize(policy_id: u64, user: Address, role: AuthRole) -> Result<bool> {
+    if POLICY_AUTHORIZER.is_set() {
+        POLICY_AUTHORIZER.with(|a| a.is_authorized_as(policy_id, user, role))
+    } else {
+        TIP403Registry::new().is_authorized_as(policy_id, user, role)
+    }
+}
+
+/// Check policy existence using the thread-local override, falling back to `TIP403Registry`.
+pub(crate) fn check_policy_exists(policy_id: u64) -> Result<bool> {
+    if POLICY_AUTHORIZER.is_set() {
+        POLICY_AUTHORIZER.with(|a| a.policy_exists(policy_id))
+    } else {
+        TIP403Registry::new().policy_exists(ITIP403Registry::policyExistsCall {
+            policyId: policy_id,
+        })
+    }
 }
 
 /// Base policy metadata. Packed into a single storage slot.

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -98,6 +98,15 @@ impl PolicyAuthorizer for TIP403Registry {
     }
 }
 
+// Optional override for the policy authorization backend used by TIP-20 tokens.
+//
+// By default this is **unset**. When no override is installed, `authorize()` and
+// `check_policy_exists()` fall back to `TIP403Registry::new()`, which reads policy
+// data directly from on-chain storage (the standard L1 behaviour).
+//
+// Zones (L2) can install a custom `PolicyAuthorizer` (e.g. one backed by a local
+// cache) by calling `with_policy_authorizer` before entering the precompile closure.
+// This follows the same scoped thread-local pattern used by `StorageCtx`.
 scoped_thread_local!(static POLICY_AUTHORIZER: &dyn PolicyAuthorizer);
 
 /// Enter a scoped policy authorizer context. While inside `f`, all TIP-20


### PR DESCRIPTION
TIP20Token hardcodes `TIP403Registry::new()` in four call sites to check transfer/mint authorization. On zones, the registry storage is empty so `ZoneTip20Token` wraps and intercepts these calls, resulting in double checks and fragile coupling.

This introduces a `PolicyAuthorizer` trait and a scoped thread-local override following the same pattern as `StorageCtx`. TIP20Token now calls `tip403_registry::authorize()` / `tip403_registry::check_policy_exists()`, which check for a thread-local override before falling back to `TIP403Registry::new()`. Zones can inject their cache-backed implementation via `with_policy_authorizer()`.

**Changes:**

- `tip403_registry/mod.rs`: define `PolicyAuthorizer` trait, implement for `TIP403Registry`, add `scoped_thread_local` + `with_policy_authorizer` entry point, add `pub(crate)` helper functions
- `tip20/mod.rs`: replace all four `TIP403Registry::new()` call sites with the new helpers