### PR TITLE
fix: use sudo as fallback when running tempoup

### DIFF
--- a/tempoup/install
+++ b/tempoup/install
@@ -68,13 +68,13 @@ main() {
         echo ""
     fi
 
-    # Run tempoup to install tempo binary
-    info "Running tempoup to install tempo..."
-    echo ""
-
-    # Try to run tempoup without sudo, then with sudo if needed
-    if ! TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup" 2>/dev/null; then
-        TEMPO_BIN_DIR="$BIN_DIR" sudo "$BIN_DIR/tempoup"
+    if TEMPO_BIN_DIR="$BIN_DIR" "$BIN_DIR/tempoup" 2>/dev/null; then
+        info "Running tempoup to install tempo..."
+    elif TEMPO_BIN_DIR="$BIN_DIR" sudo "$BIN_DIR/tempoup" 2>/dev/null; then
+        info "Running tempoup with sudo to install tempo..."
+    else
+        echo "error: failed to run tempoup"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
## Summary
Follows up on the sudo fallback added to `install_bin` function applies the same
pattern to the `tempoup` invocation at the end of the script.

- Use if/elif/else to try running tempoup without sudo, fall back to sudo,
  and exit with an error if both fail
- Log which path was taken (direct or sudo)

## Testing
```bash
bash -n tempoup/install # syntax OK
bash -x tempoup/install # trace OK
```