### PR TITLE
feat(consensus): track notarizations and forward to EL

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -782,17 +782,9 @@ async fn verify_block<TContext: Pacer>(
         return Ok(false);
     }
 
-    // FIXME: in cases where validate_block is called on the boundary block,
-    // the scheme might not be available.
-    //
-    // The fix is to track directly track notarizations and feed them to the
-    // EL that way, instead of doing this at the automaton/proposal level.
-    //
-    // https://github.com/tempoxyz/tempo/issues/1411
-    //
-    // let scheme = scheme_provider
-    //     .scoped(epoch)
-    //     .ok_or_eyre("cannot determine participants in the current epoch")?;
+    // On epoch boundaries the scheme may not be available yet. This is fine
+    // because the notarization tracker (see #1411) ensures the EL always
+    // receives the block via `new_payload` regardless.
     let validator_set = scheme_provider.scoped(epoch).map(|scheme| {
         scheme
             .participants()

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -325,6 +325,13 @@ where
             self.feed_state,
         );
 
+        let (notarization_tracker, notarization_tracker_mailbox) =
+            crate::notarization_tracker::init(
+                context.with_label("notarization_tracker"),
+                marshal_mailbox.clone(),
+                execution_node.clone(),
+            );
+
         let (executor, executor_mailbox) = crate::executor::init(
             context.with_label("executor"),
             crate::executor::Config {
@@ -364,6 +371,7 @@ where
                 subblocks: subblocks.mailbox(),
                 marshal: marshal_mailbox.clone(),
                 feed: feed_mailbox.clone(),
+                notarization_tracker: notarization_tracker_mailbox.clone(),
                 scheme_provider: scheme_provider.clone(),
                 time_to_collect_notarizations: self.time_to_collect_notarizations,
                 time_to_retry_nullify_broadcast: self.time_to_retry_nullify_broadcast,
@@ -414,6 +422,7 @@ where
             peer_manager_mailbox,
 
             feed,
+            notarization_tracker,
 
             subblocks,
         })
@@ -469,6 +478,8 @@ where
     peer_manager_mailbox: peer_manager::Mailbox,
 
     feed: crate::feed::Actor<TContext>,
+
+    notarization_tracker: crate::notarization_tracker::Actor<TContext>,
 
     subblocks: subblocks::Actor<TContext>,
 }
@@ -599,6 +610,7 @@ where
                 .start(votes_channel, certificates_channel, resolver_channel);
 
         let feed = self.feed.start();
+        let notarization_tracker = self.notarization_tracker.start();
 
         let subblocks = self
             .context
@@ -612,6 +624,7 @@ where
             epoch_manager,
             executor,
             feed,
+            notarization_tracker,
             marshal,
             dkg_manager,
             peer_manager,

--- a/crates/commonware-node/src/epoch/manager/actor.rs
+++ b/crates/commonware-node/src/epoch/manager/actor.rs
@@ -338,7 +338,13 @@ where
                 relay: self.config.application.clone(),
                 reporter: Reporters::from((
                     self.config.subblocks.clone(),
-                    Reporters::from((self.config.marshal.clone(), self.config.feed.clone())),
+                    Reporters::from((
+                        self.config.marshal.clone(),
+                        Reporters::from((
+                            self.config.feed.clone(),
+                            self.config.notarization_tracker.clone(),
+                        )),
+                    )),
                 )),
                 partition: format!(
                     "{partition_prefix}_consensus_epoch_{epoch}",

--- a/crates/commonware-node/src/epoch/manager/mod.rs
+++ b/crates/commonware-node/src/epoch/manager/mod.rs
@@ -18,7 +18,10 @@ use commonware_runtime::{
 };
 use rand_08::{CryptoRng, Rng};
 
-use crate::{consensus::block::Block, epoch::scheme_provider::SchemeProvider, feed, subblocks};
+use crate::{
+    consensus::block::Block, epoch::scheme_provider::SchemeProvider, feed, notarization_tracker,
+    subblocks,
+};
 
 pub(crate) struct Config<TBlocker> {
     pub(crate) application: crate::consensus::application::Mailbox,
@@ -31,6 +34,7 @@ pub(crate) struct Config<TBlocker> {
     pub(crate) subblocks: subblocks::Mailbox,
     pub(crate) marshal: marshal::Mailbox<Scheme<PublicKey, MinSig>, Block>,
     pub(crate) feed: feed::Mailbox,
+    pub(crate) notarization_tracker: notarization_tracker::Mailbox,
     pub(crate) scheme_provider: SchemeProvider,
     pub(crate) time_to_collect_notarizations: Duration,
     pub(crate) time_to_retry_nullify_broadcast: Duration,

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod peer_manager;
 pub(crate) mod utils;
 pub(crate) mod validators;
 
+pub(crate) mod notarization_tracker;
 pub(crate) mod subblocks;
 
 use commonware_cryptography::ed25519::{PrivateKey, PublicKey};

--- a/crates/commonware-node/src/notarization_tracker.rs
+++ b/crates/commonware-node/src/notarization_tracker.rs
@@ -80,13 +80,19 @@ impl<TContext: Spawner> Actor<TContext> {
                 };
 
                 let digest = notarization.proposal.payload;
-                let Some(block) = marshal.get_block(&digest).await else {
-                    debug!(
-                        %digest,
-                        round = %notarization.proposal.round,
-                        "notarized block not yet available in marshal; skipping new_payload",
-                    );
-                    continue;
+                let round = notarization.proposal.round;
+                let rx = marshal.subscribe(Some(round), digest).await;
+                let block = match rx.await {
+                    Ok(block) => block,
+                    Err(err) => {
+                        warn!(
+                            %digest,
+                            %round,
+                            %err,
+                            "marshal dropped channel before notarized block was delivered",
+                        );
+                        continue;
+                    }
                 };
 
                 let height = block.height();

--- a/crates/commonware-node/src/notarization_tracker.rs
+++ b/crates/commonware-node/src/notarization_tracker.rs
@@ -1,0 +1,124 @@
+//! Tracks notarized blocks and forwards them to the execution layer.
+//!
+//! When commonware consensus skips sending a block to the Automaton's `verify`
+//! (because it observed a notarization certificate), the EL never receives a
+//! `new_payload` for that block. This actor closes that gap by listening for
+//! `Activity::Notarization` events, fetching the block from the marshal, and
+//! forwarding it to reth.
+//!
+//! See <https://github.com/tempoxyz/tempo/issues/1411>.
+
+use std::sync::Arc;
+
+use commonware_consensus::{
+    Heightable as _, Reporter,
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_runtime::{Handle, Spawner};
+use futures::channel::mpsc;
+use tempo_node::{TempoExecutionData, TempoFullNode};
+use tracing::{debug, error, warn};
+
+use crate::{alias::marshal, consensus::Digest};
+
+/// Type alias for the activity type used by this actor.
+type TrackerActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
+
+/// Mailbox for sending consensus activity to the notarization tracker.
+#[derive(Clone, Debug)]
+pub(crate) struct Mailbox {
+    sender: mpsc::UnboundedSender<TrackerActivity>,
+}
+
+impl Reporter for Mailbox {
+    type Activity = TrackerActivity;
+
+    async fn report(&mut self, activity: Self::Activity) {
+        if self.sender.unbounded_send(activity).is_err() {
+            error!("failed sending activity to notarization tracker because it is no longer running");
+        }
+    }
+}
+
+pub(crate) struct Actor<TContext> {
+    context: TContext,
+    receiver: mpsc::UnboundedReceiver<TrackerActivity>,
+    marshal: marshal::Mailbox,
+    execution_node: TempoFullNode,
+}
+
+pub(crate) fn init<TContext: Spawner>(
+    context: TContext,
+    marshal: marshal::Mailbox,
+    execution_node: TempoFullNode,
+) -> (Actor<TContext>, Mailbox) {
+    let (tx, rx) = mpsc::unbounded();
+    let mailbox = Mailbox { sender: tx };
+    let actor = Actor {
+        context,
+        receiver: rx,
+        marshal,
+        execution_node,
+    };
+    (actor, mailbox)
+}
+
+impl<TContext: Spawner> Actor<TContext> {
+    pub(crate) fn start(self) -> Handle<()> {
+        let context = self.context;
+        let mut receiver = self.receiver;
+        let mut marshal = self.marshal;
+        let execution_node = self.execution_node;
+
+        context.spawn(|_| async move {
+            use futures::StreamExt as _;
+
+            while let Some(activity) = receiver.next().await {
+                let Activity::Notarization(notarization) = activity else {
+                    continue;
+                };
+
+                let digest = notarization.proposal.payload;
+                let Some(block) = marshal.get_block(&digest).await else {
+                    debug!(
+                        %digest,
+                        round = %notarization.proposal.round,
+                        "notarized block not yet available in marshal; skipping new_payload",
+                    );
+                    continue;
+                };
+
+                let height = block.height();
+                let block = block.into_inner();
+
+                match execution_node
+                    .add_ons_handle
+                    .beacon_engine_handle
+                    .new_payload(TempoExecutionData {
+                        block: Arc::new(block),
+                        validator_set: None,
+                    })
+                    .await
+                {
+                    Ok(status) => {
+                        debug!(
+                            %digest,
+                            %height,
+                            %status,
+                            "forwarded notarized block to execution layer",
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            %digest,
+                            %height,
+                            %err,
+                            "failed forwarding notarized block to execution layer",
+                        );
+                    }
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
Closes #1411

Adds a `notarization_tracker` actor that listens for `Activity::Notarization` events, fetches the block from marshal by digest, and sends `new_payload` to the execution layer. This ensures reth sees blocks that commonware skipped sending to the Automaton's `verify` path.

Wired into the simplex reporter chain alongside marshal, feed, and subblocks.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie