### PR TITLE
feat: add per-chain snapshot URL, make download chain-aware

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -120,14 +120,23 @@ pub(crate) struct TelemetryConfig {
     pub(crate) metrics_auth_header: Option<String>,
 }
 
-fn init_download_urls() {
+fn init_download_urls(chain: &str) {
+    let default_base_url: Cow<'static, str> =
+        match tempo_chainspec::spec::chain_value_parser(chain) {
+            Ok(spec) => match spec.default_snapshot_base_url() {
+                Some(url) => Cow::Owned(url.to_string()),
+                None => Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
+            },
+            Err(_) => Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
+        };
+
     let download_defaults = DownloadDefaults {
         available_snapshots: vec![
             Cow::Owned(format!("{DEFAULT_DOWNLOAD_URL} (mainnet)")),
             Cow::Borrowed("https://snapshots.tempoxyz.dev/42431 (moderato)"),
             Cow::Borrowed("https://snapshots.tempoxyz.dev/42429 (andantino)"),
         ],
-        default_base_url: Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
+        default_base_url,
         long_help: None,
     };
 
@@ -168,8 +177,8 @@ fn init_txpool_defaults() {
         .expect("failed to initialize txpool defaults");
 }
 
-pub(crate) fn init_defaults() {
-    init_download_urls();
+pub(crate) fn init_defaults(chain: &str) {
+    init_download_urls(chain);
     init_payload_builder_defaults();
     init_txpool_defaults();
 }

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -143,7 +143,22 @@ fn main() -> eyre::Result<()> {
     }
 
     tempo_node::init_version_metadata();
-    defaults::init_defaults();
+
+    // Early-parse --chain so the download command picks the right snapshot base URL.
+    // Full CLI parsing happens below; this just looks for the value that follows --chain.
+    let chain_arg = std::env::args()
+        .skip_while(|a| a != "--chain" && !a.starts_with("--chain="))
+        .next()
+        .and_then(|a| {
+            if let Some(val) = a.strip_prefix("--chain=") {
+                Some(val.to_string())
+            } else {
+                std::env::args().skip_while(|a| a != "--chain").nth(1)
+            }
+        })
+        .unwrap_or_else(|| "mainnet".to_string());
+
+    defaults::init_defaults(&chain_arg);
 
     let mut cli = Cli::<
         TempoChainSpecParser,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -168,6 +168,7 @@ pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/andantino.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.testnet.tempo.xyz")
+        .with_default_snapshot_base_url("https://snapshots.tempoxyz.dev/42429")
         .into()
 });
 
@@ -176,6 +177,7 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/moderato.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.moderato.tempo.xyz")
+        .with_default_snapshot_base_url("https://snapshots.tempoxyz.dev/42431")
         .into()
 });
 
@@ -184,6 +186,7 @@ pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/presto.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.presto.tempo.xyz")
+        .with_default_snapshot_base_url("https://snapshots.tempoxyz.dev/4217")
         .into()
 });
 
@@ -204,12 +207,19 @@ pub struct TempoChainSpec {
     pub info: TempoGenesisInfo,
     /// Default RPC URL for following this chain.
     pub default_follow_url: Option<&'static str>,
+    /// Default snapshot base URL for downloading this chain's snapshot.
+    pub default_snapshot_base_url: Option<&'static str>,
 }
 
 impl TempoChainSpec {
     /// Returns the default RPC URL for following this chain.
     pub fn default_follow_url(&self) -> Option<&'static str> {
         self.default_follow_url
+    }
+
+    /// Returns the default snapshot base URL for downloading this chain's snapshot.
+    pub fn default_snapshot_base_url(&self) -> Option<&'static str> {
+        self.default_snapshot_base_url
     }
 
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].
@@ -250,12 +260,19 @@ impl TempoChainSpec {
             }),
             info,
             default_follow_url: None,
+            default_snapshot_base_url: None,
         }
     }
 
     /// Sets the default follow URL for this chain spec.
     pub fn with_default_follow_url(mut self, url: &'static str) -> Self {
         self.default_follow_url = Some(url);
+        self
+    }
+
+    /// Sets the default snapshot base URL for this chain spec.
+    pub fn with_default_snapshot_base_url(mut self, url: &'static str) -> Self {
+        self.default_snapshot_base_url = Some(url);
         self
     }
 
@@ -278,6 +295,7 @@ impl From<ChainSpec> for TempoChainSpec {
             }),
             info: TempoGenesisInfo::default(),
             default_follow_url: None,
+            default_snapshot_base_url: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds `default_snapshot_base_url`, following the same
pattern as `default_follow_url`. Each chain spec (presto, moderato,
andantino) now carries its own snapshot base URL.

The `tempo download` command previously always fell back to the hardcoded
presto default URL regardless of `--chain`. 

```
tempo download --chain moderato --datadir $HOME/.tempo
2026-03-05T21:25:02.804565Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo-moderato
2026-03-05T21:25:04.091040Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:25:04.091420Z  INFO Starting snapshot download and extraction chain=tempo-moderato dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4

tempo download --chain testnet --datadir $HOME/.tempo
2026-03-05T21:25:38.902193Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo-testnet
2026-03-05T21:25:39.013807Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:25:39.013823Z  INFO Starting snapshot download and extraction chain=tempo-testnet dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4

tempo download --chain mainnet --datadir $HOME/.tempo
2026-03-05T21:25:47.755701Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo
2026-03-05T21:25:47.862454Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:25:47.862525Z  INFO Starting snapshot download and extraction chain=tempo dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4

tempo download --datadir $HOME/.tempo
2026-03-05T21:25:57.081434Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo
2026-03-05T21:25:57.184874Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:25:57.184957Z  INFO Starting snapshot download and extraction chain=tempo dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
```

The fix early-parses `--chain`
from argv before `init_defaults()`, then resolves the chain spec to read its
`default_snapshot_base_url`

## Testing
Builded the binary and tested:
```
tempo download --datadir $HOME/.tempo
2026-03-05T21:37:51.484729Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo
2026-03-05T21:37:52.940221Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:37:52.940318Z  INFO Starting snapshot download and extraction chain=tempo dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4


tempo download --chain mainnet --datadir $HOME/.tempo
2026-03-05T21:38:04.982664Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo
2026-03-05T21:38:05.081689Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4
2026-03-05T21:38:05.081745Z  INFO Starting snapshot download and extraction chain=tempo dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/4217/tempo-4217-7786404-1772686822.tar.lz4

tempo download --chain moderato --datadir $HOME/.tempo
2026-03-05T21:38:14.817397Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo-moderato
2026-03-05T21:38:14.922488Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/42431/tempo-42431-7216295-1772686822.tar.lz4
2026-03-05T21:38:14.922767Z  INFO Starting snapshot download and extraction chain=tempo-moderato dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/42431/tempo-42431-7216295-1772686822.tar.lz4

tempo download --chain testnet --datadir $HOME/.tempo
2026-03-05T21:38:23.911117Z  INFO Initialized tracing, debug log directory: /root/.cache/reth/logs/tempo-testnet
2026-03-05T21:38:24.014561Z  INFO Using default snapshot URL: https://snapshots.tempoxyz.dev/42429/tempo-42429-18633214-1772686822.tar.lz4
2026-03-05T21:38:24.014657Z  INFO Starting snapshot download and extraction chain=tempo-testnet dir="/root/.tempo" url=https://snapshots.tempoxyz.dev/42429/tempo-42429-18633214-1772686822.tar.lz4
```

