### PR TITLE
feat(contracts): add `transfer_policy_id_at` helper on ITIP20Instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12017,6 +12017,7 @@ name = "tempo-contracts"
 version = "1.4.0"
 dependencies = [
  "alloy-contract",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-provider",
  "alloy-sol-types",

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 alloy-contract = { workspace = true, optional = true }
+alloy-eips = { workspace = true, optional = true }
 alloy-primitives.workspace = true
 alloy-sol-types = { workspace = true, features = ["json"] }
 
@@ -22,4 +23,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = ["rpc"]
-rpc = ["dep:alloy-contract"]
+rpc = ["dep:alloy-contract", "dep:alloy-eips"]

--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -145,6 +145,19 @@ crate::sol! {
     }
 }
 
+#[cfg(feature = "rpc")]
+impl<P: alloy_contract::private::Provider<N>, N: alloy_contract::private::Network>
+    ITIP20::ITIP20Instance<P, N>
+{
+    /// Queries the transfer policy ID at a specific block.
+    pub async fn transfer_policy_id_at(
+        &self,
+        block: alloy_eips::BlockId,
+    ) -> alloy_contract::Result<u64> {
+        self.transferPolicyId().block(block).call().await
+    }
+}
+
 impl RolesAuthError {
     /// Creates an error for unauthorized access.
     pub const fn unauthorized() -> Self {


### PR DESCRIPTION
Adds a convenience method on `ITIP20Instance` to query a token's transfer policy ID at a specific block. This is feature-gated behind the existing `rpc` feature.

```rust
tip20.transfer_policy_id_at(BlockId::number(block_number)).await?
```