### PR TITLE
feat(tempo-contracts): add feature-gated serde support for sol! types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12020,6 +12020,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-sol-types",
+ "serde",
  "tokio",
 ]
 

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 alloy-contract = { workspace = true, optional = true }
 alloy-primitives.workspace = true
 alloy-sol-types = { workspace = true, features = ["json"] }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
@@ -23,3 +24,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 [features]
 default = ["rpc"]
 rpc = ["dep:alloy-contract"]
+serde = ["dep:serde", "alloy-primitives/serde"]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -18,15 +18,26 @@ pub const PERMIT2_SALT: B256 =
 pub const ARACHNID_CREATE2_FACTORY_ADDRESS: Address =
     address!("0x4e59b44847b379578588920cA78FbF26c0B4956C");
 
-/// Helper macro to allow feature-gating rpc implementations behind the `rpc` feature.
+/// Helper macro to allow feature-gating rpc and serde implementations.
 macro_rules! sol {
     ($($input:tt)*) => {
-        #[cfg(feature = "rpc")]
+        #[cfg(all(feature = "rpc", feature = "serde"))]
+        alloy_sol_types::sol! {
+            #[sol(rpc)]
+            #[derive(serde::Serialize, serde::Deserialize)]
+            $($input)*
+        }
+        #[cfg(all(feature = "rpc", not(feature = "serde")))]
         alloy_sol_types::sol! {
             #[sol(rpc)]
             $($input)*
         }
-        #[cfg(not(feature = "rpc"))]
+        #[cfg(all(not(feature = "rpc"), feature = "serde"))]
+        alloy_sol_types::sol! {
+            #[derive(serde::Serialize, serde::Deserialize)]
+            $($input)*
+        }
+        #[cfg(all(not(feature = "rpc"), not(feature = "serde")))]
         alloy_sol_types::sol! {
             $($input)*
         }


### PR DESCRIPTION
Adds a `serde` feature to `tempo-contracts` that derives `Serialize` and `Deserialize` on all `sol!`-generated types (both the precompile interfaces and the predeployed contract bindings). The existing `sol!` wrapper macro is extended to conditionally inject the derives, so all current and future `sol!` invocations in the crate get serde support automatically when the feature is enabled.

The feature also enables `alloy-primitives/serde` so the underlying types (`Address`, `U256`, `B256`, etc.) are serializable.