### PR TITLE
Fix incorrect test directory in README

### DIFF
--- a/tips/ref-impls/README.md
+++ b/tips/ref-impls/README.md
@@ -26,7 +26,7 @@ Using tempo-foundry, will run tests against the rust precompiles.
 Run tests against the Solidity reference implementations:
 
 ```bash
-cd docs/specs
+cd tips/ref-impls
 forge test
 ```
 
@@ -47,7 +47,7 @@ forge test --match-test test_mint
 Run tests against the actual Rust precompile implementations:
 
 ```bash
-cd docs/specs
+cd tips/ref-impls
 ./tempo-forge test
 ```
 


### PR DESCRIPTION
PR Description

The README currently instructs users to run tests from `docs/specs`, but this directory does not exist in the repository.

All Foundry configuration and tests are located in:

`tips/ref-impls/`

This is also the only directory containing foundry.toml, which indicates the root of the Foundry project (`src/` and `test/` are located there as well). Because of this, running the commands from docs/specs results in a path error.

Updated the instructions to:
`cd tips/ref-impls` 
`forge test`

`cd tips/ref-impls` 
`./tempo-forge test`