### PR TITLE
docs(tip-1023): hex-preserving address format with mixed-case checksum

### DIFF
--- a/tips/tip-1023.md
+++ b/tips/tip-1023.md
@@ -141,7 +141,7 @@ The data field is the standard 20-byte EVM address (last 20 bytes of `keccak256`
 from Crypto.Hash import keccak
 
 HRP = "tempo"
-CURRENT_VERSION = 0x00
+VERSION = 0x00
 
 def checksum(hrp: str, hex_parts: list[str]) -> list[str]:
     """Apply mixed-case checksum over HRP and all hex data.
@@ -178,7 +178,7 @@ def checksum(hrp: str, hex_parts: list[str]) -> list[str]:
     return result
 
 
-def encode_tempo_address(raw_address: bytes, version: int = CURRENT_VERSION) -> str:
+def encode_tempo_address(raw_address: bytes, version: int = VERSION) -> str:
     version_hex = format(version, '02x')
     addr_hex = raw_address.hex()
 
@@ -205,7 +205,7 @@ def decode_tempo_address(address: str) -> tuple[bytes, int]:
         raise ValueError("Invalid version length")
 
     version = int(version_hex, 16)
-    if version != CURRENT_VERSION:
+    if version != VERSION:
         raise ValueError(f"Unsupported version: {version}")
 
     if len(addr_hex) != 40:


### PR DESCRIPTION
Proposes an alternative encoding for TIP-1023 that preserves the raw hex address in the format string, using mixed-case checksumming (EIP-55 style) instead of bech32m.

Format: `tempo:<version>:<data>`
Example: `tempo:00:742D35cC6634C0532925A3b844bc9e7595F2bd28`

Key differences from the bech32m proposal:
- Hex address is directly readable and extractable — no conversion tools needed
- Mixed-case checksum (keccak over HRP + all data) instead of bech32m BCH code
- Version byte is a visible component separated by `:`
- Checksum algorithm is version-agnostic — operates over all data regardless of structure

Motivated by developer experience concerns: Solidity, Foundry, traces, and debuggers all work with hex natively. An opaque encoding forces constant back-and-forth conversion.

Includes verified reference implementation and test vectors.