### PR TITLE
chore: tip-1023 suggestions

### DIFF
--- a/tips/tip-1023.md
+++ b/tips/tip-1023.md
@@ -1,10 +1,10 @@
 ---
 id: TIP-1023
 title: Tempo Address Format
-description: A human-readable address format for Tempo using bech32m encoding with strong error detection.
-authors: Dankrad Feist @dankrad
+description: A human-readable address format for Tempo with a recognizable prefix and mixed-case checksumming.
+authors: Dankrad Feist @dankrad, Jake Moxey @jxom
 status: Draft
-related: BIP-350 (bech32m)
+related: EIP-55, EIP-1191
 protocolVersion: TBD
 ---
 
@@ -12,331 +12,278 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP defines an address format for Tempo that is easily distinguishable from other blockchain addresses and includes strong error detection. The format uses bech32m encoding (BIP-350) with the human-readable part `tempo`, producing addresses like `tempo1...`.
+This TIP defines an address format for Tempo that is easily distinguishable from other blockchain addresses and includes strong error detection. The format uses a `tempo` human-readable prefix (HRP) for chain recognition, preserves the raw hex address for direct use in EVM tooling, and uses mixed-case checksumming (à la EIP-55) for error detection without adding extra characters. Future address versions can be introduced by adding a version byte as a second colon-separated component.
 
 ## Motivation
 
-Users need a clear way to distinguish Tempo addresses from addresses on other chains (Ethereum, Tron, etc.). Raw hex addresses like `0x742d35Cc...` are identical across all EVM-compatible chains, leading to costly mistakes when users send funds to the wrong chain.
+EVM addresses (e.g., `0x742d35Cc...`) are identical across all EVM-compatible chains. This ambiguity leads to user error when sending funds to the correct address on the wrong chain or zone. A distinct address format with a recognizable prefix and error detection mitigates this class of mistake.
 
-A well-designed address format prevents these mistakes. The `tempo` prefix provides instant recognition, and bech32m encoding provides efficient, case-insensitive representation with guaranteed error detection for up to 4 character substitutions.
+Because Tempo is EVM-compatible, developers routinely work with EVM addresses across developer tooling. If the address format encodes this address into an opaque representation, every interaction with standard tooling requires a manual conversion step — slowing down development, complicating debugging, and increasing the chance of errors.
+
+A Tempo address format should therefore solve both problems at once: make addresses visually distinct from other chains, and keep the underlying EVM address directly readable so that existing EVM tooling continues to work without friction.
 
 ---
 
-# Specification
+## Specification
 
-## Address Structure
+### Address Format
 
-A Tempo address is a bech32m-encoded string (BIP-350) consisting of a human-readable part (HRP), a `1` separator, and base32-encoded data with a 6-character checksum:
+A Tempo address is a colon-separated string beginning with the human-readable prefix `tempo`. The default format encodes a 20-byte EVM address directly after the prefix:
 
-```
-┌─────────┬───┬──────────────────────────────────────────────────────┐
-│   HRP   │ 1 │           Base32-encoded data + checksum             │
-│ 5 chars │sep│                                                      │
-└─────────┴───┴──────────────────────────────────────────────────────┘
-                              │
-          ┌───────────────────┴──────────────────────────┐
-          │               Data (base32)                  │
-          ├─────────┬──────────────┬─────────────────────┤
-          │ Version │ Raw Address  │ Bech32m Checksum    │
-          │ 1 byte  │ 20 bytes     │ 6 chars             │
-          └─────────┴──────────────┴─────────────────────┘
+```sh
+address = HRP ‖ ":" ‖ data
+# Example: tempo:742D35cC6634C0532925A3B844BC9E7595f2Bd28
 ```
 
-## Human-Readable Part (HRP)
+Future address versions introduce a version byte as the second component:
 
-The HRP is `tempo`, producing addresses with the prefix `tempo1`:
+```sh
+address = HRP ‖ ":" ‖ version ‖ ":" ‖ data
+# Example: tempo:01:<version-specific-data>
+```
 
-| HRP | Full Prefix | Meaning |
-|-----|-------------|---------|
-| `tempo` | `tempo1` | Tempo address |
+The format is designed to be extensible. Decoders distinguish between the default format and versioned formats by the number of colon-separated components after the HRP.
 
-The HRP is included in the bech32m checksum, so changing the HRP invalidates the address.
+#### Human-Readable Part (HRP)
 
-## Version Byte
+The HRP is the literal string `tempo`. It identifies the address as belonging to the Tempo network and is included in the checksum computation. The HRP is always followed by a `:` separator.
 
-The first byte of the data payload is a version byte that identifies the address format version. This enables future upgrades to the address scheme (e.g., different address lengths, new key types, or post-quantum schemes) without changing the HRP.
+#### Versioning
 
-| Version | Meaning |
-|---------|---------|
-| `0x00` | Current format: 20-byte raw address |
-| `0x01`–`0xFF` | Reserved for future use |
+The default format (this TIP) has no explicit version byte. The address data immediately follows the HRP separator. This keeps the common case as compact as possible.
+
+If a future TIP introduces a new address version, it occupies the second colon-separated slot:
+
+| Format | Version | Status |
+|--------|---------|--------|
+| `tempo:<address>` | Default (implicit) | Defined in this TIP |
+| `tempo:<version>:<data>` | Explicit (`01`–`ff`) | Reserved for future use |
+
+Decoders distinguish formats by counting the colon-separated components after stripping the `tempo:` prefix:
+- **1 component** (40 hex chars): default format — 20-byte EVM address
+- **2 components**: versioned format — first component is a 2-hex-digit version byte, second is version-specific data
 
 Decoders MUST reject addresses with an unrecognized version byte. This ensures that older software never silently misinterprets a newer address format.
 
-## Raw Address
+### Mixed-Case Checksum
 
-The raw address is the standard 20-byte Ethereum-style address (last 20 bytes of `keccak256` of the public key).
+Error detection is achieved through mixed-case checksumming of hex digits, extending the approach defined in EIP-55. The algorithm operates over all data in the address string and is agnostic to the version or structure of that data.
 
-## Bech32m Encoding
+#### Algorithm
 
-Addresses use the full bech32m encoding as specified in BIP-350:
+1. Extract all hex-encoded data from the address string (everything after `tempo:`, excluding `:` separators)
+2. Construct the canonical input: `"tempo" + lowercase(data)`
+3. Compute `hash = keccak256(canonical_input)`
+4. For each character in the data that is a letter (`a`–`f`): if the corresponding nibble (4-bit value) in `hash` is ≥ 8, uppercase it; otherwise, lowercase it
+5. Digits (`0`–`9`) are unaffected by checksumming
 
-1. **Base32 alphabet**: `qpzry9x8gf2tvdw0s3jn54khce6mua7l` (value 0 → `q`, ..., value 31 → `l`)
-2. **8-to-5 bit conversion**: Payload bytes are converted from 8-bit to 5-bit groups using zero-padding on encode. On decode, padding MUST be validated: non-zero padding bits or excess padding MUST be rejected
-3. **Checksum**: 6-character BCH code computed over the HRP and data, using the bech32m constant `0x2bc830a3`
-4. **Case**: Decoders MUST accept either all-lowercase or all-uppercase encodings. Decoders MUST reject mixed-case strings. Encoders SHOULD produce lowercase
+The nibble index is counted sequentially across all characters that are letters. Only letter characters consume a nibble from the hash.
 
-The bech32m checksum provides:
+#### Checksum Coverage
 
-- **Substitutions** (character replaced with a different one): **guaranteed** detection of up to 4 simultaneous errors anywhere in the address; probabilistic detection (≥ 1 − 2⁻³⁰) for 5 or more
-- **Insertions/deletions** (characters added or omitted): probabilistic detection via the checksum (≥ 1 − 2⁻³⁰), plus the fixed-length validation (raw address must be exactly 20 bytes) rejects any decoded data of the wrong size
+The checksum covers:
+- **HRP**: included literally in the hash input (`"tempo"`), so swapping the prefix invalidates the checksum
+- **Data**: All subsequent data are included — changing any component invalidates the casing
 
-## Address Length
+#### Verification
 
-Data size is 1 byte for version + 20 bytes for the raw address = 21 bytes.
+To verify a checksummed Tempo address:
 
-| Type | Data Size | Base32 Chars | Checksum | Total Length |
-|------|-----------|-------------|----------|-------------|
-| Tempo address (`tempo1`) | 21 bytes | 34 chars | 6 chars | **46 chars** |
+1. Extract all encoded data (excluding `tempo:` prefix and `:` separators)
+2. Recompute the checksum using the algorithm above
+3. Compare the casing of each letter — if any letter's case differs, the address is INVALID
 
-## Encoding Algorithm
+### Validation Rules
 
-```python
-CURRENT_VERSION = 0
-
-def encode_tempo_address(raw_address: bytes, version: int = CURRENT_VERSION) -> str:
-    hrp = "tempo"
-    data = bytes([version]) + raw_address
-    return bech32m_encode(hrp, data)
-```
-
-## Decoding Algorithm
-
-```python
-def decode_tempo_address(address: str) -> tuple[bytes, int]:
-    """Returns (raw_address, version)"""
-    
-    hrp, data = bech32m_decode(address)
-    
-    if hrp != "tempo":
-        raise InvalidHRP(hrp)
-    
-    if len(data) < 1:
-        raise InvalidLength()
-    
-    version = data[0]
-    if version != CURRENT_VERSION:
-        raise UnsupportedVersion(version)
-    
-    raw_address = data[1:]
-    
-    if len(raw_address) != 20:
-        raise InvalidLength()
-    
-    return raw_address, version
-```
-
-## Validation Rules
-
-1. Reject if the string length exceeds 90 characters or contains characters outside printable ASCII (33–126)
-2. Reject if the string contains both uppercase and lowercase letters (mixed case)
-3. Decode using standard bech32m (BIP-350); reject if decoding fails (invalid characters, bad checksum, data part shorter than 6 characters, etc.)
-4. Verify HRP is `tempo`
-5. Extract and validate version byte (first byte of data); reject if unrecognized
-6. Extract raw address (remaining bytes)
-7. If raw address is not exactly 20 bytes, address is INVALID
-8. If any step fails, address is INVALID
-
-## Display Recommendations
-
-For user interfaces, addresses SHOULD be displayed with:
-- Monospace font
-- Full address always shown (no truncation for important operations)
-- Optional visual grouping with spaces for readability (spaces are **not** part of the address and MUST NOT be included in the encoded form)
-- Copy buttons MUST copy the canonical form without spaces
-
-Example display: `tempo1 qp6z6 dwvvc 6vq5e fyk3m s39un e6etu 4a9qt j2kk0`
-
-Canonical form: `tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0`
-
-## Example
-
-Raw address: `0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28`
-
-1. HRP: `tempo`
-2. Data: version `0x00` (1 byte) + raw address (20 bytes) = 21 bytes
-3. Bech32m encode (HRP + data → base32 + checksum)
-
-Result: `tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0` (46 chars)
+- Address MUST start with `tempo:`
+- After stripping the HRP, split on `:` to determine the format:
+  - **1 part** (40 hex chars): default format
+  - **2 parts**: versioned format — version byte MUST be exactly 2 hex digits and MUST be a recognized value
+- Mixed-case checksum MUST be verified across all data
+- If any step fails, the address is INVALID
 
 ---
 
-# Invariants
+## Default Format: Address
 
-1. **Prefix visibility**: The HRP and separator (`tempo1`) MUST always be visible in the address
-2. **Checksum coverage**: The bech32m checksum covers both HRP and data (including version byte), preventing HRP swaps and version tampering
+The default format encodes a standard 20-byte EVM address.
+
+### Format
+
+```sh
+address = HRP ‖ ":" ‖ address
+# Example: tempo:742D35cC6634C0532925A3B844BC9E7595f2Bd28
+```
+
+### Data
+
+The data field is the standard 20-byte EVM address (last 20 bytes of `keccak256` of the public key), hex-encoded as exactly 40 characters.
+
+### Length
+
+| Component | Length |
+|-----------|--------|
+| HRP + separator | 6 chars (`tempo:`) |
+| Address | 40 chars |
+| **Total** | **46 chars** |
+
+### Validation
+
+- Data MUST be exactly 40 characters (20 bytes)
+- All general validation rules apply
+
+---
+
+## Invariants
+
+1. **Hex preservation**: The raw hex data is directly readable in the address string without conversion
+2. **Checksum coverage**: The mixed-case checksum covers the HRP and all hex data — changing any component invalidates the casing
 3. **Version validity**: Decoders MUST reject addresses with unrecognized version bytes
-4. **Unique decoding**: Any valid address string MUST decode to exactly one (raw_address, version) tuple
-5. **Round-trip**: `decode(encode(addr, version)) == (addr, version)` for all valid inputs
-6. **Error detection**: Up to 4 character substitutions are guaranteed to be detected; insertions/deletions are caught probabilistically by the checksum and deterministically by fixed-length validation
-7. **Case handling**: Decoders MUST accept all-lowercase or all-uppercase encodings. Decoders MUST reject mixed-case strings. Encoders SHOULD produce lowercase
-8. **BIP-350 compliance**: Encoding and decoding MUST conform to BIP-350 (bech32m)
-9. **Fixed length**: All version 0 Tempo addresses MUST be exactly 46 characters
+4. **Unique decoding**: Any valid address string MUST decode to exactly one `(version, data)` tuple
+5. **Round-trip**: `decode(encode(version, data)) == (version, data)` for all valid inputs
+6. **Case sensitivity**: The checksum is encoded in letter casing — addresses are case-sensitive for validation, but decoders SHOULD accept unchecksummed (all-lowercase) addresses with a warning
+7. **Extensibility**: Future versions define their own data format; the checksum algorithm is shared across all versions
 
 ---
 
-# Reference Implementation
-
-Complete Python implementation for encoding and decoding Tempo addresses. The bech32m primitives follow BIP-350.
+## Reference Implementation
 
 ```python
-CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
-BECH32M_CONST = 0x2bc830a3
+from Crypto.Hash import keccak
 
-def bech32_polymod(values):
-    GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
-    chk = 1
-    for v in values:
-        b = (chk >> 25)
-        chk = (chk & 0x1ffffff) << 5 ^ v
-        for i in range(5):
-            chk ^= GEN[i] if ((b >> i) & 1) else 0
-    return chk
+HRP = "tempo"
 
-def bech32_hrp_expand(hrp):
-    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+def checksum(hrp: str, hex_parts: list[str]) -> list[str]:
+    """Apply mixed-case checksum over HRP and all hex data.
 
-def bech32m_verify_checksum(hrp, data):
-    return bech32_polymod(bech32_hrp_expand(hrp) + data) == BECH32M_CONST
+    This function is agnostic to the meaning of the hex parts.
+    It checksums the concatenated hex data and splits the result
+    back into the original part lengths.
+    """
+    all_hex = "".join(hex_parts).lower()
 
-def bech32m_create_checksum(hrp, data):
-    values = bech32_hrp_expand(hrp) + data
-    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ BECH32M_CONST
-    return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+    h = keccak.new(digest_bits=256)
+    h.update((hrp + all_hex).encode('ascii'))
+    hash_hex = h.hexdigest()
 
-def convertbits(data, frombits, tobits, pad=True):
-    acc, bits, ret = 0, 0, []
-    maxv = (1 << tobits) - 1
-    for value in data:
-        acc = (acc << frombits) | value
-        bits += frombits
-        while bits >= tobits:
-            bits -= tobits
-            ret.append((acc >> bits) & maxv)
-    if pad:
-        if bits:
-            ret.append((acc << (tobits - bits)) & maxv)
-    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
-        raise ValueError("Invalid padding")
-    return ret
+    concatenated = "".join(hex_parts)
+    checksummed = []
+    nibble_idx = 0
+    for c in concatenated:
+        if c.lower() in 'abcdef':
+            if int(hash_hex[nibble_idx], 16) >= 8:
+                checksummed.append(c.upper())
+            else:
+                checksummed.append(c.lower())
+            nibble_idx += 1
+        else:
+            checksummed.append(c)
 
-def bech32m_encode(hrp, data_bytes):
-    data5 = convertbits(data_bytes, 8, 5)
-    checksum = bech32m_create_checksum(hrp, data5)
-    return hrp + "1" + "".join(CHARSET[d] for d in data5 + checksum)
+    result = []
+    offset = 0
+    for part in hex_parts:
+        result.append("".join(checksummed[offset:offset + len(part)]))
+        offset += len(part)
 
-def bech32m_decode(addr):
-    if len(addr) > 90:
-        raise ValueError("Address too long")
-    if any(ord(c) < 33 or ord(c) > 126 for c in addr):
-        raise ValueError("Invalid character range")
-    has_lower = any("a" <= c <= "z" for c in addr)
-    has_upper = any("A" <= c <= "Z" for c in addr)
-    if has_lower and has_upper:
-        raise ValueError("Mixed case")
-    addr = addr.lower()
-    pos = addr.rfind("1")
-    if pos < 1:
-        raise ValueError("No separator found")
-    hrp = addr[:pos]
-    data_part = addr[pos + 1:]
-    if len(data_part) < 6:
-        raise ValueError("Data part too short")
-    data5 = [CHARSET.find(c) for c in data_part]
-    if any(d == -1 for d in data5):
-        raise ValueError("Invalid character")
-    if not bech32m_verify_checksum(hrp, data5):
+    return result
+
+
+def encode_tempo_address(raw_address: bytes, version: int | None = None) -> str:
+    addr_hex = raw_address.hex()
+
+    if version is None or version == 0x00:
+        # Default format: tempo:<address>
+        parts = checksum(HRP, [addr_hex])
+        return HRP + ":" + parts[0]
+    else:
+        # Versioned format: tempo:<version>:<data>
+        version_hex = format(version, '02x')
+        parts = checksum(HRP, [version_hex, addr_hex])
+        return HRP + ":" + ":".join(parts)
+
+
+def decode_tempo_address(address: str) -> tuple[bytes, int]:
+    """Returns (raw_address, version)."""
+
+    if not address.startswith(HRP + ":"):
+        raise ValueError("Invalid HRP")
+
+    parts = address[len(HRP) + 1:].split(":")
+
+    if len(parts) == 1:
+        # Default format: tempo:<address>
+        version = 0x00
+        addr_hex = parts[0]
+    elif len(parts) == 2:
+        # Versioned format: tempo:<version>:<data>
+        version_hex = parts[0]
+        addr_hex = parts[1]
+
+        if len(version_hex) != 2:
+            raise ValueError("Invalid version length")
+
+        version = int(version_hex, 16)
+        if version == 0x00:
+            raise ValueError("Version 00 must use the default format (tempo:<address>)")
+    else:
+        raise ValueError("Invalid address format")
+
+    if len(addr_hex) != 40:
+        raise ValueError("Invalid address length")
+
+    raw_address = bytes.fromhex(addr_hex)
+
+    # Verify checksum
+    expected = encode_tempo_address(raw_address, version)
+    if expected != address:
         raise ValueError("Invalid checksum")
-    return hrp, bytes(convertbits(data5[:-6], 5, 8, pad=False))
 
-CURRENT_VERSION = 0
-
-def encode_tempo_address(raw_address, version=CURRENT_VERSION):
-    hrp = "tempo"
-    data = bytes([version]) + raw_address
-    return bech32m_encode(hrp, data)
-
-def decode_tempo_address(address):
-    hrp, data = bech32m_decode(address)
-    if hrp != "tempo":
-        raise ValueError(f"Invalid HRP: {hrp}")
-    if len(data) < 1:
-        raise ValueError("Address data too short")
-    version = data[0]
-    if version != CURRENT_VERSION:
-        raise ValueError(f"Unsupported version: {version}")
-    raw_address = data[1:]
-    if len(raw_address) != 20:
-        raise ValueError(f"Invalid address length: {len(raw_address)}")
     return raw_address, version
 ```
 
 ## Test Vectors
 
-### Valid Address
+### Valid: Default Format
 
 ```
 Raw address: 0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28
-Version: 0x00
 
-Tempo address: tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0 (46 chars)
+Tempo address: tempo:742D35cC6634C0532925A3B844BC9E7595f2Bd28
 ```
 
 ### Invalid: Unsupported Version Byte
 
-Addresses with unrecognized version bytes MUST be rejected even though the bech32m checksum is valid.
+Addresses with unrecognized version bytes MUST be rejected.
 
 ```
-Version 0x01: tempo1q96z6dwvvc6vq5efyk3ms39une6etu4a9qw3ynt2
+Version 0x01: tempo:01:742d35cc6634c0532925a3b844bc9e7595f2bd28
   → REJECTED: unsupported version (1)
 
-Version 0xFF: tempo1la6z6dwvvc6vq5efyk3ms39une6etu4a9qw8v7dr
+Version 0xFF: tempo:ff:742d35cc6634c0532925a3b844bc9e7595f2bd28
   → REJECTED: unsupported version (255)
 ```
 
-### Invalid: Incorrect Length
+### Invalid: Explicit Version `00`
 
-Addresses that decode to a raw address other than exactly 20 bytes MUST be rejected.
-
-```
-19-byte address (too short): tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a4afx39
-  → REJECTED: invalid address length (19 bytes, expected 20)
-
-21-byte address (too long):  tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qqqr22k2l
-  → REJECTED: invalid address length (21 bytes, expected 20)
-```
-
-### Invalid: Incorrect Checksum
-
-An address with a corrupted checksum MUST be rejected by the bech32m decoder.
+Version `00` MUST use the default format without a version byte.
 
 ```
-                                                     ↓
-Valid:   tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0
-Invalid: tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kkq
-  → REJECTED: invalid checksum
+Invalid: tempo:00:742d35cc6634c0532925a3b844bc9e7595f2bd28
+  → REJECTED: version 00 must use the default format
 ```
 
-### Substitution Detection: 2 Characters
-
-Bech32m guarantees detection of up to 4 character substitutions. This vector changes 2 characters (positions are 0-indexed in the full address string):
+### Invalid: Wrong Checksum (Bad Casing)
 
 ```
-Valid:   tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0
-Invalid: tempo1qpmz6dwvvc6vq56fyk3ms39une6etu4a9qtj2kk0
-                ^           ^
-  Changes: [8] '6'->'m', [20] 'e'->'6'
-  → REJECTED: invalid checksum
+Valid:   tempo:742D35cC6634C0532925A3B844BC9E7595f2Bd28
+Invalid: tempo:742d35cc6634c0532925a3b844bc9e7595f2bd28
+  → REJECTED if checksum verification is strict (all-lowercase
+    MAY be accepted with a warning per invariant 6)
 ```
 
-### Substitution Detection: 4 Characters
-
-This vector changes 4 characters spread across the address (positions are 0-indexed in the full address string):
+### Invalid: Wrong Data Length
 
 ```
-Valid:   tempo1qp6z6dwvvc6vq5efyk3ms39une6etu4a9qtj2kk0
-Invalid: tempo1qpmz6dwvve6vq5efyk3us39une6eta4a9qtj2kk0
-                ^      ^         ^         ^
-  Changes: [8] '6'->'m', [15] 'c'->'e', [25] 'm'->'u', [35] 'u'->'a'
-  → REJECTED: invalid checksum
+Invalid: tempo:742D35cC6634C0532925A3B844BC9E7595f2Bd
+  → REJECTED: address data must be exactly 40 characters (20 bytes)
 ```


### PR DESCRIPTION
Proposes an alternative encoding for TIP-1023 that preserves the raw hex address in the format string, using mixed-case checksumming (EIP-55 style) instead of bech32m.

Format: tempo:<version>:<data>
Example: tempo:00:742D35cC6634C0532925A3b844bc9e7595F2bd28

Key differences from the bech32m proposal:

- Hex address is directly readable and extractable — no conversion tools needed
- Mixed-case checksum (keccak over HRP + all data) instead of bech32m BCH code
- Version byte is a visible component separated by :
- Checksum algorithm is version-agnostic — operates over all data regardless of structure

Motivated by developer experience concerns: Solidity, Foundry, traces, and debuggers all work with hex natively. An opaque encoding forces constant back-and-forth conversion.

Includes verified reference implementation and test vectors.