### PR TITLE
perf(payload): cache subblocks count on TempoBuiltPayload

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -8,7 +8,7 @@ mod metrics;
 use crate::metrics::TempoPayloadBuilderMetrics;
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Encodable;
 use either::Either;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
@@ -25,7 +25,7 @@ use reth_evm::{
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
-use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
+use reth_payload_primitives::{BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
 use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
 use reth_revm::{
     State,
@@ -644,7 +644,8 @@ where
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
 
-        let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
+        let payload =
+            TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
 
         drop(db);
         Ok(BuildOutcome::Better {
@@ -661,25 +662,15 @@ pub fn is_more_subblocks(
     let Some(best_payload) = best_payload else {
         return false;
     };
-    let Some(best_metadata) = best_payload
-        .block()
-        .body()
-        .transactions
-        .iter()
-        .rev()
-        .find_map(|tx| Vec::<SubBlockMetadata>::decode(&mut tx.input().as_ref()).ok())
-    else {
-        return false;
-    };
 
-    subblocks.len() > best_metadata.len()
+    subblocks.len() > best_payload.subblocks_count()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy_consensus::BlockBody;
-    use alloy_primitives::{Address, B256, Bytes, Signature};
+    use alloy_primitives::{Address, B256, Bytes};
     use reth_payload_builder::PayloadId;
     use reth_primitives_traits::SealedBlock;
     use tempo_primitives::{
@@ -694,17 +685,6 @@ mod tests {
             Self: Sized,
         {
             Self::random()
-        }
-    }
-
-    impl TestExt for SubBlockMetadata {
-        fn random() -> Self {
-            Self {
-                version: SubBlockVersion::V1,
-                validator: B256::random(),
-                fee_recipient: Address::random(),
-                signature: Bytes::new(),
-            }
         }
     }
 
@@ -735,31 +715,17 @@ mod tests {
     }
 
     fn payload_with_metadata(count: usize) -> TempoBuiltPayload {
-        let metadata: Vec<_> = (0..count).map(|_| SubBlockMetadata::random()).collect();
-        let input: Bytes = alloy_rlp::encode(&metadata).into();
-        let tx = TempoTxEnvelope::Legacy(Signed::new_unhashed(
-            TxLegacy {
-                chain_id: None,
-                nonce: 0,
-                gas_price: 0,
-                gas_limit: 0,
-                to: Address::random().into(),
-                value: U256::ZERO,
-                input,
-            },
-            Signature::test_signature(),
-        ));
         let block = Block {
             header: TempoHeader::default(),
             body: BlockBody {
-                transactions: vec![tx],
+                transactions: vec![],
                 ommers: vec![],
                 withdrawals: None,
             },
         };
         let sealed = Arc::new(SealedBlock::seal_slow(block));
         let eth = EthBuiltPayload::new(PayloadId::default(), sealed, U256::ZERO, None);
-        TempoBuiltPayload::new(eth, None)
+        TempoBuiltPayload::new(eth, None, count)
     }
 
     #[test]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -644,8 +644,7 @@ where
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
 
-        let payload =
-            TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
+        let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
 
         drop(db);
         Ok(BuildOutcome::Better {

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -34,6 +34,8 @@ pub struct TempoBuiltPayload {
     inner: EthBuiltPayload<TempoPrimitives>,
     /// The executed block data, used to skip re-execution in the engine tree.
     executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+    /// The number of subblocks included in this payload, cached to avoid RLP decoding.
+    subblocks_count: usize,
 }
 
 impl TempoBuiltPayload {
@@ -41,11 +43,18 @@ impl TempoBuiltPayload {
     pub fn new(
         inner: EthBuiltPayload<TempoPrimitives>,
         executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+        subblocks_count: usize,
     ) -> Self {
         Self {
             inner,
             executed_block,
+            subblocks_count,
         }
+    }
+
+    /// Returns the number of subblocks included in this payload.
+    pub fn subblocks_count(&self) -> usize {
+        self.subblocks_count
     }
 }
 


### PR DESCRIPTION
Adds a `subblocks_count` field to `TempoBuiltPayload`, set at build time, so `is_more_subblocks` reads a stored `usize` instead of iterating all transactions and RLP-decoding `SubBlockMetadata` on every rebuild check.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk