### PR TITLE
docs: add TIP-1023 Tempo Hex Address Format (hex alternative)

### DIFF
--- a/tips/tip-1023.md
+++ b/tips/tip-1023.md
@@ -48,7 +48,7 @@ All hex data MUST be lowercase. Decoders SHOULD accept uppercase or mixed-case i
 
 ### Human-Readable Prefix
 
-The literal string `tempo`, identifying this as a Tempo address.
+The literal string `tempo`, identifying this as a Tempo address. The HRP MUST NOT contain the character `x`, since `x` serves as the component separator.
 
 ### Version
 
@@ -114,7 +114,7 @@ where α = 2 in GF(256).
    - Raw address bytes: 20 bytes
    - Total: 27 bytes
 
-2. Compute the RS remainder: divide the input polynomial by g(x) over GF(256) using synthetic division. The 4-byte remainder is the checksum.
+2. Compute the RS remainder: append 4 zero bytes to the input sequence (equivalent to multiplying the message polynomial by x⁴), then compute the remainder modulo g(x) over GF(256) using synthetic division. The 4-byte remainder is the checksum.
 
 3. Encode the 4 checksum bytes as 8 lowercase hex characters.
 
@@ -208,6 +208,8 @@ For user interfaces, addresses SHOULD be displayed with:
 
 Example: `tempox00x 742d35cc 6634c053 2925a3b8 44bc9e75 95f2bd28 xf4b7acd9`
 
+For QR codes, addresses SHOULD be uppercase to leverage the efficient Alphanumeric encoding mode, producing denser/smaller QR codes.
+
 ---
 
 # Invariants
@@ -231,7 +233,7 @@ Complete Python implementation for encoding and decoding Tempo hex addresses. Th
 ```python
 # === GF(256) with primitive polynomial x^8 + x^4 + x^3 + x^2 + 1 (0x11D) ===
 
-EXP = [0] * 512
+EXP = [0] * 256
 LOG = [0] * 256
 
 _x = 1
@@ -241,8 +243,6 @@ for _i in range(255):
     _x <<= 1
     if _x & 0x100:
         _x ^= 0x11D
-for _i in range(255, 512):
-    EXP[_i] = EXP[_i - 255]
 
 def gf_mul(a, b):
     if a == 0 or b == 0:
@@ -312,6 +312,18 @@ Raw address: 0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28
 Version: 0x00
 
 Tempo address: tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9 (58 chars)
+```
+
+### Valid: Zero Address
+
+The zero address MUST produce a non-zero checksum (due to the HRP bytes included in the checksum input).
+
+```
+Raw address: 0x0000000000000000000000000000000000000000
+Version: 0x00
+
+Tempo address: tempox00x0000000000000000000000000000000000000000x705dcbd9 (58 chars)
+Checksum: 705dcbd9 (non-zero)
 ```
 
 ### Invalid: Unsupported Version Byte

--- a/tips/tip-1023.md
+++ b/tips/tip-1023.md
@@ -1,0 +1,371 @@
+---
+id: TIP-1023
+title: Tempo Address Format
+description: A human-readable hex-based address format for Tempo with Reed-Solomon error detection.
+authors: Dankrad Feist @dankrad
+status: Draft
+related: BIP-350 (bech32m)
+protocolVersion: TBD
+---
+
+# TIP-1023: Tempo Address Format
+
+## Abstract
+
+This TIP defines a hex-based address format for Tempo that is easily distinguishable from other blockchain addresses, preserves direct compatibility with standard `0x` hex tooling, and includes strong error detection. The format uses the structure `tempox{VERSION}x{ADDRESS}x{CHECKSUM}` with a Reed-Solomon checksum over GF(256), producing 58-character addresses like `tempox00x742d...f2bd28xf4b7acd9`.
+
+## Motivation
+
+Users need a clear way to distinguish Tempo addresses from addresses on other chains. Raw hex addresses like `0x742d35Cc...` are identical across all EVM-compatible chains, leading to costly mistakes when users send funds to the wrong chain.
+
+Tempo's address format must satisfy two requirements:
+
+1. **Chain identification**: The `tempo` prefix provides instant visual recognition.
+2. **Developer experience**: The address portion is standard hex, directly readable and convertible to/from `0x` addresses without base32 encoding or decoding. This is critical for developers working with low-level tooling, block explorers, and debugging tools that operate on raw hex addresses.
+
+The format uses `x` as the separator between components. Since `x` is not a valid hex character (0-9, a-f), it unambiguously delimits the HRP, version, address, and checksum fields.
+
+---
+
+# Specification
+
+## Address Structure
+
+A Tempo address consists of four `x`-separated components:
+
+```
+tempox{VERSION}x{ADDRESS}x{CHECKSUM}
+  │       │         │         │
+  │       │         │         └─ 8 hex chars (4-byte RS checksum)
+  │       │         └─ 40 hex chars (20-byte raw address)
+  │       └─ 2 hex chars (1-byte version)
+  └─ Human-readable prefix
+```
+
+All hex data MUST be lowercase. Decoders SHOULD accept uppercase or mixed-case input by converting to lowercase before validation.
+
+## Components
+
+### Human-Readable Prefix
+
+The literal string `tempo`, identifying this as a Tempo address.
+
+### Version
+
+A single byte encoded as 2 lowercase hex characters.
+
+| Version | Meaning |
+|---------|---------|
+| `00` | Current format: 20-byte raw address |
+| `01`–`ff` | Reserved for future use |
+
+Decoders MUST reject addresses with an unrecognized version byte.
+
+### Address
+
+The raw 20-byte Ethereum-style address (last 20 bytes of `keccak256` of the public key), encoded as 40 lowercase hex characters.
+
+### Checksum
+
+A 4-byte Reed-Solomon checksum encoded as 8 lowercase hex characters, computed over the HRP, version, and address. See [Checksum Construction](#checksum-construction) for details.
+
+## Address Length
+
+| Component | Characters |
+|-----------|-----------|
+| `tempo` | 5 |
+| `x` separators (×3) | 3 |
+| Version | 2 |
+| Address | 40 |
+| Checksum | 8 |
+| **Total** | **58** |
+
+## Checksum Construction
+
+The checksum uses a Reed-Solomon code over GF(256), providing guaranteed detection of up to 4 hex character substitutions and guaranteed correction of up to 2.
+
+### Field Arithmetic
+
+GF(256) is constructed using the primitive polynomial:
+
+```
+p(x) = x⁸ + x⁴ + x³ + x² + 1  (0x11D)
+```
+
+The primitive element α = 2 has order 255, generating all non-zero elements of GF(256).
+
+### Generator Polynomial
+
+The RS generator polynomial with 4 check symbols is:
+
+```
+g(x) = (x − α)(x − α²)(x − α³)(x − α⁴)
+     = x⁴ + 0x1e·x³ + 0xd8·x² + 0xe7·x + 0x74
+```
+
+where α = 2 in GF(256).
+
+### Checksum Computation
+
+1. Construct the checksum input as a byte sequence:
+   - ASCII bytes of `"tempo"`: `[0x74, 0x65, 0x6d, 0x70, 0x6f]`
+   - Separator byte: `[0x00]`
+   - Version byte: e.g., `[0x00]`
+   - Raw address bytes: 20 bytes
+   - Total: 27 bytes
+
+2. Compute the RS remainder: divide the input polynomial by g(x) over GF(256) using synthetic division. The 4-byte remainder is the checksum.
+
+3. Encode the 4 checksum bytes as 8 lowercase hex characters.
+
+The HRP bytes are included in the checksum input (but not visible in the hex portion of the address) to ensure that different HRPs cannot share checksums.
+
+### Error Detection Properties
+
+The checksum operates at the **byte level** (GF(256) symbols). Each hex character substitution corrupts at most one byte. Therefore:
+
+| Hex char errors | Byte errors | Detection | Correction |
+|----------------|-------------|-----------|------------|
+| 1 | 1 | Guaranteed | Guaranteed |
+| 2 (different bytes) | 2 | Guaranteed | Guaranteed |
+| 2 (same byte) | 1 | Guaranteed | Guaranteed |
+| 3–4 | ≤ 4 | Guaranteed | If ≤ 2 bytes affected |
+| 5+ | Varies | Probabilistic (≈ 1 − 2⁻³²) | — |
+
+The code has minimum distance 5 over GF(256), providing:
+- **Guaranteed detection** of any error pattern affecting up to 4 bytes
+- **Guaranteed correction** of any error pattern affecting up to 2 bytes
+
+### Minimum Checksum Size Rationale
+
+The Singleton bound requires at least d−1 = 4 check symbols for minimum distance 5. Over GF(256), each symbol is one byte (2 hex chars), giving **8 hex characters** as the minimum provable checksum length for distance 5 at our codeword length.
+
+## Encoding Algorithm
+
+```python
+def encode_tempo_address(raw_address: bytes, version: int = 0) -> str:
+    checksum = rs_checksum(b"tempo" + b"\x00" + bytes([version]) + raw_address)
+    return "tempox" + format(version, "02x") + "x" + raw_address.hex() + "x" + checksum.hex()
+```
+
+## Decoding Algorithm
+
+```python
+def decode_tempo_address(address: str) -> tuple[bytes, int]:
+    """Returns (raw_address, version)."""
+    parts = address.lower().split("x")
+
+    if len(parts) != 4 or parts[0] != "tempo":
+        raise InvalidFormat()
+
+    version = int(parts[1], 16)
+    raw_address = bytes.fromhex(parts[2])
+    checksum = bytes.fromhex(parts[3])
+
+    if len(raw_address) != 20:
+        raise InvalidLength()
+    if len(checksum) != 4:
+        raise InvalidLength()
+
+    expected = rs_checksum(b"tempo" + b"\x00" + bytes([version]) + raw_address)
+    if checksum != expected:
+        raise InvalidChecksum()
+
+    if version != 0:
+        raise UnsupportedVersion(version)
+
+    return raw_address, version
+```
+
+## Validation Rules
+
+1. Split the address string by `x`; reject if there are not exactly 4 parts
+2. Verify the first part is `tempo`
+3. Verify version is exactly 2 hex characters (1 byte)
+4. Verify address is exactly 40 hex characters (20 bytes)
+5. Verify checksum is exactly 8 hex characters (4 bytes)
+6. Recompute the RS checksum and compare; reject on mismatch
+7. Verify version byte is recognized; reject if unsupported
+
+## Conversion to/from `0x` Addresses
+
+The raw address is directly embedded in the format as hex:
+
+```python
+def to_0x(tempo_addr: str) -> str:
+    return "0x" + tempo_addr.split("x")[2]
+
+def from_0x(hex_addr: str, version: int = 0) -> str:
+    return encode_tempo_address(bytes.fromhex(hex_addr[2:]), version)
+```
+
+## Display Recommendations
+
+For user interfaces, addresses SHOULD be displayed with:
+- Monospace font
+- Full address always shown (no truncation for important operations)
+- Optional grouping for readability
+
+Example: `tempox00x 742d35cc 6634c053 2925a3b8 44bc9e75 95f2bd28 xf4b7acd9`
+
+---
+
+# Invariants
+
+1. **Prefix visibility**: Every Tempo address MUST begin with `tempo` followed by `x`
+2. **Separator safety**: Since `x` is not a valid hex character, component boundaries are always unambiguous
+3. **Checksum coverage**: The RS checksum covers the HRP, version byte, and raw address; changing any of these invalidates the checksum
+4. **Version validity**: Decoders MUST reject addresses with unrecognized version bytes
+5. **Unique decoding**: Any valid address string MUST decode to exactly one (raw_address, version) tuple
+6. **Round-trip**: `decode(encode(addr, v)) == (addr, v)` for all valid inputs
+7. **Error detection**: Up to 4 hex character substitutions in any position are guaranteed to be detected
+8. **Case insensitivity**: Addresses MUST be valid regardless of case (but SHOULD be produced in lowercase)
+9. **Fixed length**: All version 0 Tempo addresses MUST be exactly 58 characters
+
+---
+
+# Reference Implementation
+
+Complete Python implementation for encoding and decoding Tempo hex addresses. The GF(256) arithmetic uses the primitive polynomial 0x11D with primitive element α = 2.
+
+```python
+# === GF(256) with primitive polynomial x^8 + x^4 + x^3 + x^2 + 1 (0x11D) ===
+
+EXP = [0] * 512
+LOG = [0] * 256
+
+_x = 1
+for _i in range(255):
+    EXP[_i] = _x
+    LOG[_x] = _i
+    _x <<= 1
+    if _x & 0x100:
+        _x ^= 0x11D
+for _i in range(255, 512):
+    EXP[_i] = EXP[_i - 255]
+
+def gf_mul(a, b):
+    if a == 0 or b == 0:
+        return 0
+    return EXP[(LOG[a] + LOG[b]) % 255]
+
+# === RS Generator: g(x) = (x - a)(x - a^2)(x - a^3)(x - a^4), a = 2 ===
+
+NSYM = 4
+
+def _make_gen():
+    g = [1]
+    for i in range(NSYM):
+        new_g = [0] * (len(g) + 1)
+        ai = EXP[i + 1]
+        for j in range(len(g)):
+            new_g[j + 1] ^= g[j]
+            new_g[j] ^= gf_mul(g[j], ai)
+        g = new_g
+    return g[::-1]
+
+GEN = _make_gen()  # high-to-low: [0x01, 0x1e, 0xd8, 0xe7, 0x74]
+
+def rs_checksum(data):
+    buf = list(data) + [0] * NSYM
+    for i in range(len(data)):
+        coef = buf[i]
+        if coef != 0:
+            for j in range(1, len(GEN)):
+                buf[i + j] ^= gf_mul(GEN[j], coef)
+    return bytes(buf[-NSYM:])
+
+# === Tempo Hex Address ===
+
+CURRENT_VERSION = 0
+
+def encode_tempo_address(raw_address, version=CURRENT_VERSION):
+    data = b"tempo\x00" + bytes([version]) + raw_address
+    check = rs_checksum(data)
+    return "tempox" + format(version, "02x") + "x" + raw_address.hex() + "x" + check.hex()
+
+def decode_tempo_address(address):
+    parts = address.lower().split("x")
+    if len(parts) != 4 or parts[0] != "tempo":
+        raise ValueError("Invalid format")
+    version = int(parts[1], 16)
+    addr_bytes = bytes.fromhex(parts[2])
+    check_bytes = bytes.fromhex(parts[3])
+    if len(addr_bytes) != 20:
+        raise ValueError("Invalid address length: " + str(len(addr_bytes)))
+    if len(check_bytes) != 4:
+        raise ValueError("Invalid checksum length: " + str(len(check_bytes)))
+    data = b"tempo\x00" + bytes([version]) + addr_bytes
+    if rs_checksum(data) != check_bytes:
+        raise ValueError("Invalid checksum")
+    if version != CURRENT_VERSION:
+        raise ValueError("Unsupported version: " + str(version))
+    return addr_bytes, version
+```
+
+## Test Vectors
+
+### Valid Address
+
+```
+Raw address: 0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28
+Version: 0x00
+
+Tempo address: tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9 (58 chars)
+```
+
+### Invalid: Unsupported Version Byte
+
+Addresses with unrecognized version bytes MUST be rejected even though the RS checksum is valid.
+
+```
+Version 0x01: tempox01x742d35cc6634c0532925a3b844bc9e7595f2bd28x66327b2f
+  → REJECTED: unsupported version (1)
+```
+
+### Invalid: Incorrect Length
+
+Addresses that decode to a raw address other than exactly 20 bytes MUST be rejected.
+
+```
+19-byte address (too short): tempox00x742d35cc6634c0532925a3b844bc9e7595f2bdx994b64d2
+  → REJECTED: invalid address length (19 bytes, expected 20)
+
+21-byte address (too long):  tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd2800xbde4842c
+  → REJECTED: invalid address length (21 bytes, expected 20)
+```
+
+### Invalid: Incorrect Checksum
+
+An address with a corrupted checksum MUST be rejected.
+
+```
+                                                                ↓
+Valid:   tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9
+Invalid: tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd0
+  → REJECTED: invalid checksum
+```
+
+### Substitution Detection: 2 Characters
+
+The RS checksum guarantees detection of up to 4 hex character substitutions. This vector changes 2 characters in the address:
+
+```
+                 ↓                   ↓
+Valid:   tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9
+Invalid: tempox00x842d35cc6634c0532925b3b844bc9e7595f2bd28xf4b7acd9
+  Changes: pos 9 '7'->'8', pos 29 'a'->'b'
+  → REJECTED: invalid checksum
+```
+
+### Substitution Detection: 4 Characters
+
+This vector changes 4 characters spread across the address:
+
+```
+                 ↓         ↓         ↓         ↓
+Valid:   tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9
+Invalid: tempox00xa42d35cc6664c0532925d3b844bc9ea595f2bd28xf4b7acd9
+  Changes: pos 9 '7'->'a', pos 19 '3'->'6', pos 29 'a'->'d', pos 39 '7'->'a'
+  → REJECTED: invalid checksum
+```


### PR DESCRIPTION
## Summary

Alternative to #2925 (bech32m-based TIP-1023). This version uses a hex-based format for better developer experience.

**Format**: `tempox{VERSION}x{ADDRESS}x{CHECKSUM}` (58 chars)

- Address portion is raw hex, directly convertible to/from `0x` addresses — no base32 encoding/decoding needed
- `x` separator is unambiguous (not a valid hex character)
- 8 hex char checksum (4-byte Reed-Solomon over GF(256) with primitive polynomial 0x11D)
- **Guaranteed detection** of up to 4 hex character substitutions (minimum distance 5)
- **Guaranteed correction** of up to 2 hex character substitutions

**Key difference from bech32m version**: Trades compactness (58 chars vs 46) for direct hex compatibility with existing EVM tooling, debuggers, and block explorers.

**Checksum size rationale**: 8 hex chars is the minimum provable checksum for distance 5 at our codeword length, using a shortened Reed-Solomon code over GF(256). The Singleton bound requires >= 4 check symbols; each GF(256) symbol = 2 hex chars.

Example:
```
0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28
→ tempox00x742d35cc6634c0532925a3b844bc9e7595f2bd28xf4b7acd9
```

## Test plan

- [x] Verify RS generator polynomial roots (α, α², α³, α⁴ are all zeros)
- [x] Verify round-trip encode/decode for test address
- [x] Verify zero address produces non-zero checksum (due to HRP in checksum input)
- [x] Verify 2-char and 4-char substitution detection
- [x] Distance verification: 0/500k random 1-5 byte error patterns undetected


Made with [Cursor](https://cursor.com)