### PR TITLE
feat: add progress bar to init-from-binary-dump command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ futures = "0.3.31"
 governor = "0.10.4"
 indexmap = "2.13.0"
 indicatif = "0.18"
+console = "0.16"
 itertools = "0.14.0"
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,6 @@ futures = "0.3.31"
 governor = "0.10.4"
 indexmap = "2.13.0"
 indicatif = "0.18"
-console = "0.16"
 itertools = "0.14.0"
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -61,6 +61,7 @@ reth-rpc-server-types.workspace = true
 reth-storage-api.workspace = true
 clap.workspace = true
 eyre.workspace = true
+indicatif.workspace = true
 jiff.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -60,7 +60,6 @@ reth-provider.workspace = true
 reth-rpc-server-types.workspace = true
 reth-storage-api.workspace = true
 clap.workspace = true
-console.workspace = true
 eyre.workspace = true
 indicatif.workspace = true
 jiff.workspace = true

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -60,6 +60,7 @@ reth-provider.workspace = true
 reth-rpc-server-types.workspace = true
 reth-storage-api.workspace = true
 clap.workspace = true
+console.workspace = true
 eyre.workspace = true
 indicatif.workspace = true
 jiff.workspace = true

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -13,7 +13,8 @@ use std::{
 use alloy_primitives::{B256, U256, map::HashSet};
 use clap::Parser;
 use eyre::{Context as _, ensure};
-use indicatif::{ProgressBar, ProgressStyle};
+use console::Term;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use reth_chainspec::EthereumHardforks;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use reth_db_api::{
@@ -92,7 +93,10 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
         // Track addresses for account hashing (we need to create empty accounts)
         let mut addresses_seen: HashSet<alloy_primitives::Address> = HashSet::default();
 
-        let pb = ProgressBar::new(file_size);
+        let pb = ProgressBar::with_draw_target(
+            Some(file_size),
+            ProgressDrawTarget::term(Term::stderr(), 20),
+        );
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes}/{total_bytes} ({bytes_per_sec}) ({eta})")

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -13,7 +13,6 @@ use std::{
 use alloy_primitives::{B256, U256, map::HashSet};
 use clap::Parser;
 use eyre::{Context as _, ensure};
-use console::Term;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use reth_chainspec::EthereumHardforks;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
@@ -95,7 +94,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
         let pb = ProgressBar::with_draw_target(
             Some(file_size),
-            ProgressDrawTarget::term(Term::stderr(), 20),
+            ProgressDrawTarget::stderr(),
         );
         pb.set_style(
             ProgressStyle::default_bar()

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -133,12 +133,14 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
             // Read pair count (8 bytes at offset 32)
             let pair_count = u64::from_be_bytes(header_buf[32..40].try_into().unwrap());
 
-            info!(
-                target: "tempo::cli",
-                %address,
-                pair_count,
-                "Processing token storage"
-            );
+            pb.suspend(|| {
+                info!(
+                    target: "tempo::cli",
+                    %address,
+                    pair_count,
+                    "Processing token storage"
+                );
+            });
 
             addresses_seen.insert(address);
 
@@ -158,7 +160,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
             // Read and insert entries
             let mut entry_buf = [0u8; 64];
-            for _ in 0..pair_count {
+            for i in 0..pair_count {
                 reader
                     .read_exact(&mut entry_buf)
                     .wrap_err("failed to read storage entry")?;
@@ -181,6 +183,10 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 storage_entries.push(entry);
 
                 total_entries += 1;
+
+                if i % 65536 == 0 {
+                    pb.set_position(bytes_read);
+                }
             }
 
             pb.set_position(bytes_read);

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -108,7 +108,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
                 Err(e) => return Err(e).wrap_err("failed to read block header"),
             }
-            bytes_read += 40;
+            bytes_read += header_buf.len() as u64;
 
             // Validate magic
             ensure!(
@@ -162,7 +162,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 reader
                     .read_exact(&mut entry_buf)
                     .wrap_err("failed to read storage entry")?;
-                bytes_read += 64;
+                bytes_read += entry_buf.len() as u64;
 
                 let slot = B256::from_slice(&entry_buf[..32]);
                 let value = U256::from_be_bytes::<32>(entry_buf[32..64].try_into().unwrap());

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -13,6 +13,7 @@ use std::{
 use alloy_primitives::{B256, U256, map::HashSet};
 use clap::Parser;
 use eyre::{Context as _, ensure};
+use indicatif::{ProgressBar, ProgressStyle};
 use reth_chainspec::EthereumHardforks;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use reth_db_api::{
@@ -72,12 +73,17 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
         info!(target: "tempo::cli", path = %self.state.display(), "Loading binary state dump");
 
+        let file_size = std::fs::metadata(&self.state)
+            .wrap_err_with(|| format!("failed to stat {}", self.state.display()))?
+            .len();
+
         let file = File::open(&self.state)
             .wrap_err_with(|| format!("failed to open {}", self.state.display()))?;
         let mut reader = BufReader::with_capacity(64 * 1024 * 1024, file);
 
         let mut total_entries = 0u64;
         let mut total_tokens = 0u64;
+        let mut bytes_read = 0u64;
 
         // Collect storage entries per address for hashing
         let mut storage_for_hashing: HashMap<alloy_primitives::Address, Vec<StorageEntry>> =
@@ -85,6 +91,13 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
         // Track addresses for account hashing (we need to create empty accounts)
         let mut addresses_seen: HashSet<alloy_primitives::Address> = HashSet::default();
+
+        let pb = ProgressBar::new(file_size);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes}/{total_bytes} ({bytes_per_sec}) ({eta})")
+                .expect("valid template"),
+        );
 
         // Process blocks from binary file
         loop {
@@ -95,6 +108,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
                 Err(e) => return Err(e).wrap_err("failed to read block header"),
             }
+            bytes_read += 40;
 
             // Validate magic
             ensure!(
@@ -148,6 +162,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 reader
                     .read_exact(&mut entry_buf)
                     .wrap_err("failed to read storage entry")?;
+                bytes_read += 64;
 
                 let slot = B256::from_slice(&entry_buf[..32]);
                 let value = U256::from_be_bytes::<32>(entry_buf[32..64].try_into().unwrap());
@@ -168,8 +183,11 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 total_entries += 1;
             }
 
+            pb.set_position(bytes_read);
             total_tokens += 1;
         }
+
+        pb.finish_with_message("done");
 
         info!(
             target: "tempo::cli",


### PR DESCRIPTION
The generation side (`xtask generate-state-bloat`) already has progress bars. This adds a matching byte-level progress bar to `init-from-binary-dump` so you can track import progress on large state files.

Prompted by: alexey