### PR TITLE
refactor(bench): use send_transaction_sync for setup transactions

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -331,7 +331,7 @@ impl MaxTpsArgs {
                 .map(async |(_, provider)| {
                     IFeeManagerInstance::new(TIP_FEE_MANAGER_ADDRESS, provider.clone())
                         .setUserToken(self.fee_token)
-                        .send()
+                        .send_sync()
                         .await
                 })
                 .progress(),
@@ -797,7 +797,7 @@ async fn fund_accounts(
         .chunks(max_concurrent_transactions);
 
     for chunk in chunks.into_iter() {
-        let tx_hashes = stream::iter(chunk)
+        let receipts = stream::iter(chunk)
             .buffer_unordered(max_concurrent_requests)
             .try_collect::<Vec<_>>()
             .await?
@@ -805,13 +805,14 @@ async fn fund_accounts(
             .inspect(|_| progress.inc(1))
             .flatten()
             .map(async |hash| {
-                Ok(
-                    PendingTransactionBuilder::new(provider.root().clone(), hash)
-                        .get_receipt()
-                        .await?,
-                )
+                let receipt = PendingTransactionBuilder::new(provider.root().clone(), hash)
+                    .get_receipt()
+                    .await?;
+                assert_receipt(receipt).await
             });
-        assert_receipts(tx_hashes, max_concurrent_requests)
+        stream::iter(receipts)
+            .buffer_unordered(max_concurrent_requests)
+            .try_collect::<()>()
             .await
             .expect("Failed to fund accounts");
     }
@@ -980,43 +981,24 @@ async fn monitor_tps(counters: TransactionCounters, target_count: usize, token: 
     }
 }
 
-async fn join_all<
-    T: Future<Output = alloy::contract::Result<PendingTransactionBuilder<TempoNetwork>>>,
->(
-    futures: impl IntoIterator<Item = T>,
+async fn join_all<R: ReceiptResponse>(
+    futures: impl IntoIterator<
+        Item = impl Future<Output = alloy::contract::Result<R>>,
+    >,
     max_concurrent_requests: usize,
     max_concurrent_transactions: usize,
 ) -> eyre::Result<()> {
     let chunks = futures.into_iter().chunks(max_concurrent_transactions);
 
     for chunk in chunks.into_iter() {
-        // Send transactions and collect pending builders
-        let pending_txs = stream::iter(chunk)
+        stream::iter(chunk)
+            .map(|fut| async { Ok::<_, eyre::Report>(fut.await?) })
             .buffer_unordered(max_concurrent_requests)
-            .try_collect::<Vec<_>>()
+            .try_for_each(|receipt| assert_receipt(receipt))
             .await?;
-
-        // Fetch receipts and assert status
-        assert_receipts(
-            pending_txs
-                .into_iter()
-                .map(|tx| async move { Ok(tx.get_receipt().await?) }),
-            max_concurrent_requests,
-        )
-        .await?;
     }
 
     Ok(())
-}
-
-async fn assert_receipts<R: ReceiptResponse, F: Future<Output = eyre::Result<R>>>(
-    receipts: impl IntoIterator<Item = F>,
-    max_concurrent_requests: usize,
-) -> eyre::Result<()> {
-    stream::iter(receipts)
-        .buffer_unordered(max_concurrent_requests)
-        .try_for_each(|receipt| assert_receipt(receipt))
-        .await
 }
 
 async fn assert_receipt<R: ReceiptResponse>(receipt: R) -> eyre::Result<()> {

--- a/bin/tempo-bench/src/cmd/max_tps/dex.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/dex.rs
@@ -58,7 +58,7 @@ pub(super) async fn setup(
                 let exchange = exchange.clone();
                 Box::pin(async move {
                     let tx = exchange.createPair(token);
-                    tx.send().await
+                    tx.send_sync().await
                 }) as BoxFuture<'static, _>
             })
             .progress(),
@@ -80,7 +80,7 @@ pub(super) async fn setup(
                     let token = token.clone();
                     Box::pin(async move {
                         let tx = token.mint(signer, mint_amount);
-                        tx.send().await
+                        tx.send_sync().await
                     }) as BoxFuture<'static, _>
                 })
             })
@@ -101,7 +101,7 @@ pub(super) async fn setup(
                     let token = ITIP20Instance::new(token, provider.clone());
                     Box::pin(async move {
                         let tx = token.approve(STABLECOIN_DEX_ADDRESS, U256::MAX);
-                        tx.send().await
+                        tx.send_sync().await
                     }) as BoxFuture<'static, _>
                 })
             })
@@ -127,7 +127,7 @@ pub(super) async fn setup(
                     Box::pin(async move {
                         let tx =
                             exchange.placeFlip(token, order_amount, true, tick_under, tick_over);
-                        tx.send().await
+                        tx.send_sync().await
                     }) as BoxFuture<'static, _>
                 })
             })
@@ -160,27 +160,20 @@ where
             admin,
             salt,
         )
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
+        .send_sync()
+        .await
+        .context("Failed to create TIP-20 token")?;
     let event = receipt
         .decoded_log::<ITIP20Factory::TokenCreated>()
         .ok_or_eyre("Token creation event not found")?;
-    assert_receipt(receipt)
-        .await
-        .context("Failed to create TIP-20 token")?;
+    assert_receipt(receipt).await?;
 
     let token_addr = event.token;
     let token = ITIP20::new(token_addr, provider.clone());
     let roles = IRolesAuth::new(*token.address(), provider);
-    let grant_role_receipt = roles
+    roles
         .grantRole(*ISSUER_ROLE, admin)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
-    assert_receipt(grant_role_receipt)
+        .send_sync()
         .await
         .context("Failed to grant issuer role")?;
 

--- a/bin/tempo-bench/src/cmd/max_tps/erc20.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/erc20.rs
@@ -53,7 +53,7 @@ pub(super) async fn setup(
                     let token = token.clone();
                     Box::pin(async move {
                         let tx = token.mint(to, mint_amount);
-                        tx.send().await
+                        tx.send_sync().await
                     }) as BoxFuture<'static, _>
                 })
             })


### PR DESCRIPTION
Adds a `send_transaction_sync` helper that sends a transaction and waits for its receipt, asserting success. Refactors `join_all` and `fund_accounts` to use it for setup/env-prep transactions (DEX pairs, token minting, approvals, fee token config, faucet funding). Actual benchmark transactions remain fire-and-forget.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey