### PR TITLE
feat: add no_std support to tempo-chainspec, tempo-alloy, and tempo-evm

### DIFF
--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -7,6 +7,9 @@ set -eo pipefail
 no_std_crates=(
     tempo-contracts
     tempo-primitives
+    tempo-chainspec
+    tempo-alloy
+    tempo-evm
 )
 
 for crate in "${no_std_crates[@]}"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11921,6 +11921,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "eyre",
+ "once_cell",
  "reth-chainspec",
  "reth-cli",
  "reth-network-peers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,13 +117,13 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -141,7 +141,7 @@ reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "
 reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -171,9 +171,9 @@ alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.27.3"
+alloy-evm = { version = "0.27.3", default-features = false }
 revm-inspectors = "0.34.2"
-alloy-genesis = "1.6.1"
+alloy-genesis = { version = "1.6.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-network = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.5.4", default-features = false }
@@ -235,7 +235,7 @@ serde_json = { version = "1.0.149", features = ["alloc"], default-features = fal
 schnellru = "0.2"
 sha2 = { version = "0.10", default-features = false }
 tempfile = "3.24.0"
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }
 # TODO: restrict this to only the required features
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-util = "0.7.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ proptest-arbitrary-interop = "0.1.0"
 rand = "0.9"
 rand_08 = { package = "rand", version = "0.8.5" }
 rand_core = "0.6.4"
+once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1.0.228", features = ["derive"], default-features = false }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -40,7 +40,7 @@ commonware-runtime = { workspace = true, features = ["external"] }
 commonware-utils.workspace = true
 futures = { workspace = true, features = ["executor"] }
 rand_08.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-cli.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -11,32 +11,32 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-contracts = { workspace = true, features = ["rpc"] }
+tempo-contracts = { workspace = true, features = ["rpc"], optional = true }
 tempo-primitives = { workspace = true, features = ["serde", "reth"] }
 tempo-chainspec = { workspace = true, optional = true }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
 
 alloy-consensus.workspace = true
-alloy-contract.workspace = true
+alloy-contract = { workspace = true, optional = true }
 alloy-eips.workspace = true
-alloy-network.workspace = true
-alloy-primitives = { workspace = true, features = ["rand"] }
-alloy-provider.workspace = true
-alloy-rpc-types-eth.workspace = true
-alloy-serde.workspace = true
-alloy-signer.workspace = true
-alloy-signer-local.workspace = true
-alloy-transport.workspace = true
+alloy-network = { workspace = true, optional = true }
+alloy-primitives.workspace = true
+alloy-provider = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-serde = { workspace = true, optional = true }
+alloy-signer = { workspace = true, optional = true }
+alloy-signer-local = { workspace = true, optional = true }
+alloy-transport = { workspace = true, optional = true }
 
 reth-evm = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
 reth-rpc-convert = { workspace = true, optional = true }
 reth-rpc-eth-types = { workspace = true, optional = true }
 
-derive_more.workspace = true
-serde.workspace = true
-tracing.workspace = true
+derive_more = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["providers", "rpc-types-eth", "sol-types"] }
@@ -46,12 +46,40 @@ test-case.workspace = true
 tokio.workspace = true
 
 [features]
-default = []
+default = ["std"]
+std = [
+	"dep:tempo-contracts",
+	"dep:alloy-contract",
+	"dep:alloy-network",
+	"dep:alloy-provider",
+	"dep:alloy-rpc-types-eth",
+	"dep:alloy-serde",
+	"dep:alloy-signer",
+	"dep:alloy-signer-local",
+	"dep:alloy-transport",
+	"dep:derive_more",
+	"dep:serde",
+	"dep:tracing",
+	"alloy-consensus/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"alloy-primitives/rand",
+	"derive_more?/std",
+	"serde?/std",
+	"tempo-primitives/std",
+	"alloy/std",
+	"alloy-serde?/std",
+	"reth-primitives-traits?/std",
+	"tempo-chainspec?/std",
+	"tempo-contracts?/std",
+	"tempo-evm?/std"
+]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "alloy/asm-keccak",
 ]
 tempo-compat = [
+    "std",
     "dep:reth-evm",
     "dep:reth-rpc-convert",
     "dep:reth-primitives-traits",

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,20 +1,27 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "std")]
 mod network;
+#[cfg(feature = "std")]
 pub use network::*;
 
 /// Provider traits.
+#[cfg(feature = "std")]
 pub mod provider;
 
+#[cfg(feature = "std")]
 pub mod rpc;
 
 /// Transaction fillers.
+#[cfg(feature = "std")]
 pub mod fillers;
 
 #[doc(inline)]
 pub use tempo_primitives as primitives;
 
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use tempo_contracts as contracts;

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -26,14 +26,25 @@ alloy-hardforks.workspace = true
 
 eyre = { workspace = true, optional = true }
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, optional = true }
 
 [features]
-default = ["serde", "cli"]
+default = ["std", "serde", "cli"]
+std = [
+    "alloy-eips/std",
+    "alloy-evm/std",
+    "alloy-genesis/std",
+    "alloy-primitives/std",
+    "reth-chainspec/std",
+    "reth-network-peers/std",
+    "serde/std",
+    "serde_json/std",
+    "tempo-primitives/std",
+]
 serde = [
     "alloy-eips/serde",
     "alloy-hardforks/serde",
     "alloy-primitives/serde",
     "tempo-primitives/serde"
 ]
-cli = ["dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]
+cli = ["std", "dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -25,8 +25,9 @@ alloy-eips.workspace = true
 alloy-hardforks.workspace = true
 
 eyre = { workspace = true, optional = true }
+once_cell.workspace = true
 serde.workspace = true
-serde_json = { workspace = true, optional = true }
+serde_json.workspace = true
 
 [features]
 default = ["std", "serde", "cli"]
@@ -38,6 +39,7 @@ std = [
     "reth-chainspec/std",
     "reth-network-peers/std",
     "serde/std",
+    "once_cell/std",
     "serde_json/std",
     "tempo-primitives/std",
 ]

--- a/crates/chainspec/src/bootnodes.rs
+++ b/crates/chainspec/src/bootnodes.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use reth_network_peers::{NodeRecord, parse_nodes};
 
 pub(crate) static ANDANTINO_BOOTNODES: [&str; 4] = [

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -1,7 +1,10 @@
 //! Tempo chainspec implementation.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
 
 mod bootnodes;
 pub mod hardfork;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -2,9 +2,7 @@ use crate::{
     bootnodes::{andantino_nodes, moderato_nodes, presto_nodes},
     hardfork::{TempoHardfork, TempoHardforks},
 };
-#[cfg(feature = "std")]
-use alloc::sync::Arc;
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use alloy_eips::eip7840::BlobParams;
 use alloy_evm::{
     eth::spec::EthExecutorSpec,
@@ -15,14 +13,13 @@ use alloy_evm::{
 };
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
+use once_cell::sync::Lazy as LazyLock;
 use reth_chainspec::{
     BaseFeeParams, Chain, ChainSpec, DepositContract, DisplayHardforks, EthChainSpec,
     EthereumHardfork, EthereumHardforks, ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks,
     Head,
 };
 use reth_network_peers::NodeRecord;
-#[cfg(feature = "std")]
-use std::sync::LazyLock;
 use tempo_primitives::TempoHeader;
 
 /// T0 base fee: 10 billion attodollars (1×10^10)
@@ -167,7 +164,6 @@ impl reth_cli::chainspec::ChainSpecParser for TempoChainSpecParser {
     }
 }
 
-#[cfg(feature = "std")]
 pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/andantino.json"))
         .expect("`./genesis/andantino.json` must be present and deserializable");
@@ -176,7 +172,6 @@ pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .into()
 });
 
-#[cfg(feature = "std")]
 pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/moderato.json"))
         .expect("`./genesis/moderato.json` must be present and deserializable");
@@ -185,7 +180,6 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .into()
 });
 
-#[cfg(feature = "std")]
 pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/presto.json"))
         .expect("`./genesis/presto.json` must be present and deserializable");
@@ -197,7 +191,6 @@ pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
 /// Development chainspec with funded dev accounts and activated tempo hardforks
 ///
 /// `cargo x generate-genesis -o dev.json --accounts 10 --no-dkg-in-genesis`
-#[cfg(feature = "std")]
 pub static DEV: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/dev.json"))
         .expect("`./genesis/dev.json` must be present and deserializable");
@@ -236,7 +229,7 @@ impl TempoChainSpec {
         // Create base chainspec from genesis (already has ordered Ethereum hardforks)
         let mut base_spec = ChainSpec::from_genesis(genesis);
 
-        let tempo_forks: Vec<_> = vec![
+        let tempo_forks = vec![
             (TempoHardfork::Genesis, Some(0)),
             (TempoHardfork::T0, t0_time),
             (TempoHardfork::T1, t1_time),
@@ -246,10 +239,7 @@ impl TempoChainSpec {
             (TempoHardfork::T2, t2_time),
         ]
         .into_iter()
-        .filter_map(|(fork, time): (TempoHardfork, Option<u64>)| {
-            time.map(|time| (fork, ForkCondition::Timestamp(time)))
-        })
-        .collect();
+        .filter_map(|(fork, time)| time.map(|time| (fork, ForkCondition::Timestamp(time))));
         base_spec.hardforks.extend(tempo_forks);
 
         Self {
@@ -271,7 +261,6 @@ impl TempoChainSpec {
     }
 
     /// Returns the mainnet chainspec.
-    #[cfg(feature = "std")]
     pub fn mainnet() -> Self {
         PRESTO.as_ref().clone()
     }
@@ -398,7 +387,7 @@ impl TempoHardforks for TempoChainSpec {
     }
 }
 
-#[cfg(all(test, feature = "cli"))]
+#[cfg(test)]
 mod tests {
     use crate::hardfork::{TempoHardfork, TempoHardforks};
     use reth_chainspec::{ForkCondition, Hardforks};

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -2,6 +2,9 @@ use crate::{
     bootnodes::{andantino_nodes, moderato_nodes, presto_nodes},
     hardfork::{TempoHardfork, TempoHardforks},
 };
+#[cfg(feature = "std")]
+use alloc::sync::Arc;
+use alloc::{boxed::Box, vec, vec::Vec};
 use alloy_eips::eip7840::BlobParams;
 use alloy_evm::{
     eth::spec::EthExecutorSpec,
@@ -18,7 +21,8 @@ use reth_chainspec::{
     Head,
 };
 use reth_network_peers::NodeRecord;
-use std::sync::{Arc, LazyLock};
+#[cfg(feature = "std")]
+use std::sync::LazyLock;
 use tempo_primitives::TempoHeader;
 
 /// T0 base fee: 10 billion attodollars (1×10^10)
@@ -163,6 +167,7 @@ impl reth_cli::chainspec::ChainSpecParser for TempoChainSpecParser {
     }
 }
 
+#[cfg(feature = "std")]
 pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/andantino.json"))
         .expect("`./genesis/andantino.json` must be present and deserializable");
@@ -171,6 +176,7 @@ pub static ANDANTINO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .into()
 });
 
+#[cfg(feature = "std")]
 pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/moderato.json"))
         .expect("`./genesis/moderato.json` must be present and deserializable");
@@ -179,6 +185,7 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .into()
 });
 
+#[cfg(feature = "std")]
 pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/presto.json"))
         .expect("`./genesis/presto.json` must be present and deserializable");
@@ -190,6 +197,7 @@ pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
 /// Development chainspec with funded dev accounts and activated tempo hardforks
 ///
 /// `cargo x generate-genesis -o dev.json --accounts 10 --no-dkg-in-genesis`
+#[cfg(feature = "std")]
 pub static DEV: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/dev.json"))
         .expect("`./genesis/dev.json` must be present and deserializable");
@@ -228,7 +236,7 @@ impl TempoChainSpec {
         // Create base chainspec from genesis (already has ordered Ethereum hardforks)
         let mut base_spec = ChainSpec::from_genesis(genesis);
 
-        let tempo_forks = vec![
+        let tempo_forks: Vec<_> = vec![
             (TempoHardfork::Genesis, Some(0)),
             (TempoHardfork::T0, t0_time),
             (TempoHardfork::T1, t1_time),
@@ -238,7 +246,10 @@ impl TempoChainSpec {
             (TempoHardfork::T2, t2_time),
         ]
         .into_iter()
-        .filter_map(|(fork, time)| time.map(|time| (fork, ForkCondition::Timestamp(time))));
+        .filter_map(|(fork, time): (TempoHardfork, Option<u64>)| {
+            time.map(|time| (fork, ForkCondition::Timestamp(time)))
+        })
+        .collect();
         base_spec.hardforks.extend(tempo_forks);
 
         Self {
@@ -260,6 +271,7 @@ impl TempoChainSpec {
     }
 
     /// Returns the mainnet chainspec.
+    #[cfg(feature = "std")]
     pub fn mainnet() -> Self {
         PRESTO.as_ref().clone()
     }
@@ -331,7 +343,7 @@ impl EthChainSpec for TempoChainSpec {
         self.inner.prune_delete_limit()
     }
 
-    fn display_hardforks(&self) -> Box<dyn std::fmt::Display> {
+    fn display_hardforks(&self) -> Box<dyn core::fmt::Display> {
         // filter only tempo hardforks
         let tempo_forks = self.inner.hardforks.forks_iter().filter(|(fork, _)| {
             !EthereumHardfork::VARIANTS
@@ -386,7 +398,7 @@ impl TempoHardforks for TempoChainSpec {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cli"))]
 mod tests {
     use crate::hardfork::{TempoHardfork, TempoHardforks};
     use reth_chainspec::{ForkCondition, Hardforks};

--- a/crates/commonware-node-config/Cargo.toml
+++ b/crates/commonware-node-config/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 commonware-codec.workspace = true
 commonware-cryptography.workspace = true
 const-hex.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 commonware-utils.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -14,16 +14,16 @@ workspace = true
 tempo-chainspec.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 
-reth-chainspec.workspace = true
-reth-consensus.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
+reth-consensus = { workspace = true, features = ["std"] }
 reth-consensus-common.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-primitives-traits.workspace = true
 
 alloy-consensus.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-alloy-genesis.workspace = true
+alloy-genesis = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 serde_json.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -21,5 +21,9 @@ alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
-default = ["rpc"]
+default = ["std", "rpc"]
+std = [
+    "alloy-primitives/std",
+    "alloy-sol-types/std",
+]
 rpc = ["dep:alloy-contract"]

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -16,8 +16,8 @@ alloy = { workspace = true, features = [
   "rlp",
   "providers",
 ] }
-alloy-evm.workspace = true
-alloy-genesis.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
+alloy-genesis = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 
 commonware-codec.workspace = true
@@ -39,7 +39,7 @@ reth-ethereum = { workspace = true, features = [
   "test-utils",
   "pool",
 ] }
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["std"] }
 reth-node-builder.workspace = true
 reth-node-core.workspace = true
 reth-node-metrics.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -12,21 +12,21 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
-tempo-consensus.workspace = true
+tempo-chainspec = { workspace = true, optional = true }
+tempo-consensus = { workspace = true, optional = true }
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }
 tempo-primitives = { workspace = true, features = ["reth"] }
-tempo-revm.workspace = true
+tempo-revm = { workspace = true, optional = true }
 
-commonware-cryptography.workspace = true
-commonware-codec.workspace = true
+commonware-cryptography = { workspace = true, optional = true }
+commonware-codec = { workspace = true, optional = true }
 
 reth-consensus.workspace = true
-reth-chainspec.workspace = true
-reth-evm.workspace = true
-reth-evm-ethereum.workspace = true
-reth-revm.workspace = true
+reth-chainspec = { workspace = true, optional = true }
+reth-evm = { workspace = true, optional = true }
+reth-evm-ethereum = { workspace = true, optional = true }
+reth-revm = { workspace = true, optional = true }
 reth-primitives-traits.workspace = true
 reth-rpc-eth-api = { workspace = true, optional = true }
 
@@ -38,13 +38,38 @@ alloy-primitives.workspace = true
 
 derive_more.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 revm.workspace = true
 reth-storage-api.workspace = true
 
 [features]
-default = ["rpc", "engine"]
-rpc = ["dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
-engine = ["dep:tempo-payload-types", "dep:rayon"]
+default = ["std", "rpc", "engine"]
+std = [
+	"dep:tempo-chainspec",
+	"dep:tempo-consensus",
+	"dep:tempo-revm",
+	"dep:commonware-cryptography",
+	"dep:commonware-codec",
+	"dep:reth-chainspec",
+	"dep:reth-evm",
+	"dep:reth-evm-ethereum",
+	"dep:reth-revm",
+	"dep:tracing",
+	"alloy-consensus/std",
+	"alloy-evm/std",
+	"alloy-primitives/std",
+	"alloy-rlp/std",
+	"derive_more/std",
+	"reth-consensus/std",
+	"reth-primitives-traits/std",
+	"tempo-contracts/std",
+	"tempo-primitives/std",
+	"thiserror/std",
+	"reth-chainspec?/std",
+	"revm/std",
+	"tempo-chainspec?/std"
+]
+rpc = ["std", "dep:reth-rpc-eth-api", "tempo-revm?/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
+engine = ["std", "dep:tempo-payload-types", "dep:rayon"]

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,5 +1,8 @@
 //! Error types for Tempo EVM operations.
 
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
 use reth_consensus::ConsensusError;
 
 /// Errors that can occur during EVM configuration and execution.

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,8 +1,5 @@
 //! Error types for Tempo EVM operations.
 
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-
 use reth_consensus::ConsensusError;
 
 /// Errors that can occur during EVM configuration and execution.
@@ -14,7 +11,7 @@ pub enum TempoEvmError {
 
     /// Invalid EVM configuration.
     #[error("invalid EVM configuration: {0}")]
-    InvalidEvmConfig(String),
+    InvalidEvmConfig(alloc::string::String),
 
     /// No subblock metadata system transaction is found in the block.
     #[error("couldn't find subblock metadata transaction in block")]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -1,50 +1,66 @@
 //! Tempo EVM implementation.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+extern crate alloc;
+
+#[cfg(feature = "std")]
 mod assemble;
-use alloy_consensus::{BlockHeader as _, Transaction};
-use alloy_primitives::Address;
-use alloy_rlp::Decodable;
+#[cfg(feature = "std")]
 pub use assemble::TempoBlockAssembler;
+#[cfg(feature = "std")]
 mod block;
+#[cfg(feature = "std")]
 pub use block::TempoReceiptBuilder;
+#[cfg(feature = "std")]
 mod context;
+#[cfg(feature = "std")]
 pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
 #[cfg(feature = "engine")]
 mod engine;
 mod error;
 pub use error::TempoEvmError;
+#[cfg(feature = "std")]
 pub mod evm;
-use std::{borrow::Cow, sync::Arc};
-
-use alloy_evm::{
-    self, Database, EvmEnv,
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
-    revm::{Inspector, database::State},
-};
+#[cfg(feature = "std")]
 pub use evm::TempoEvmFactory;
-use reth_chainspec::EthChainSpec;
-use reth_evm::{self, ConfigureEvm, EvmEnvFor};
-use reth_primitives_traits::{SealedBlock, SealedHeader};
-use tempo_primitives::{
-    Block, SubBlockMetadata, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
-    subblock::PartialValidatorKey,
-};
 
-use crate::{block::TempoBlockExecutor, evm::TempoEvm};
-use reth_evm_ethereum::EthEvmConfig;
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
-use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params};
-
+#[cfg(feature = "std")]
 pub use tempo_revm::{TempoBlockEnv, TempoHaltReason, TempoStateAccess};
 
 #[cfg(test)]
 mod test_utils;
 
+#[cfg(feature = "std")]
+use {
+    crate::{block::TempoBlockExecutor, evm::TempoEvm},
+    alloc::sync::Arc,
+    alloy_consensus::{BlockHeader as _, Transaction},
+    alloy_evm::{
+        self, Database, EvmEnv,
+        block::{BlockExecutorFactory, BlockExecutorFor},
+        eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
+        revm::{Inspector, database::State},
+    },
+    alloy_primitives::Address,
+    alloy_rlp::Decodable,
+    reth_chainspec::EthChainSpec,
+    reth_evm::{self, ConfigureEvm, EvmEnvFor},
+    reth_evm_ethereum::EthEvmConfig,
+    reth_primitives_traits::{SealedBlock, SealedHeader},
+    std::borrow::Cow,
+    tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks},
+    tempo_primitives::{
+        Block, SubBlockMetadata, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
+        subblock::PartialValidatorKey,
+    },
+    tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params},
+};
+
 /// Tempo-related EVM configuration.
+#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub struct TempoEvmConfig {
     /// Inner evm config
@@ -54,6 +70,7 @@ pub struct TempoEvmConfig {
     pub block_assembler: TempoBlockAssembler,
 }
 
+#[cfg(feature = "std")]
 impl TempoEvmConfig {
     /// Create a new [`TempoEvmConfig`] with the given chain spec and EVM factory.
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
@@ -81,6 +98,7 @@ impl TempoEvmConfig {
     }
 }
 
+#[cfg(feature = "std")]
 impl BlockExecutorFactory for TempoEvmConfig {
     type EvmFactory = TempoEvmFactory;
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
@@ -104,6 +122,7 @@ impl BlockExecutorFactory for TempoEvmConfig {
     }
 }
 
+#[cfg(feature = "std")]
 impl ConfigureEvm for TempoEvmConfig {
     type Primitives = TempoPrimitives;
     type Error = TempoEvmError;
@@ -245,7 +264,7 @@ impl ConfigureEvm for TempoEvmConfig {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::test_utils::test_chainspec;
@@ -279,7 +298,7 @@ mod tests {
                 timestamp: 1000,
                 gas_limit: 30_000_000,
                 base_fee_per_gas: Some(1000),
-                beneficiary: alloy_primitives::Address::repeat_byte(0x01),
+                beneficiary: Address::repeat_byte(0x01),
                 ..Default::default()
             },
             general_gas_limit: 10_000_000,
@@ -362,7 +381,7 @@ mod tests {
         let attributes = TempoNextBlockEnvAttributes {
             inner: NextBlockEnvAttributes {
                 timestamp: 1000,
-                suggested_fee_recipient: alloy_primitives::Address::repeat_byte(0x02),
+                suggested_fee_recipient: Address::repeat_byte(0x02),
                 prev_randao: B256::repeat_byte(0x03),
                 gas_limit: 30_000_000,
                 parent_beacon_block_root: Some(B256::ZERO),
@@ -401,7 +420,7 @@ mod tests {
 
         // Create subblock metadata
         let validator_key = B256::repeat_byte(0x01);
-        let fee_recipient = alloy_primitives::Address::repeat_byte(0x02);
+        let fee_recipient = Address::repeat_byte(0x02);
         let metadata = vec![SubBlockMetadata {
             version: SubBlockVersion::V1,
             validator: validator_key,
@@ -421,7 +440,7 @@ mod tests {
                 nonce: 0,
                 gas_price: 0,
                 gas_limit: 0,
-                to: TxKind::Call(alloy_primitives::Address::ZERO),
+                to: TxKind::Call(Address::ZERO),
                 value: U256::ZERO,
                 input: input.freeze().into(),
             },
@@ -479,7 +498,7 @@ mod tests {
                 nonce: 0,
                 gas_price: 1,
                 gas_limit: 21000,
-                to: TxKind::Call(alloy_primitives::Address::repeat_byte(0x01)),
+                to: TxKind::Call(Address::repeat_byte(0x01)),
                 value: U256::ZERO,
                 input: Bytes::new(),
             },
@@ -542,7 +561,7 @@ mod tests {
         let attributes = TempoNextBlockEnvAttributes {
             inner: NextBlockEnvAttributes {
                 timestamp: 1000,
-                suggested_fee_recipient: alloy_primitives::Address::repeat_byte(0x03),
+                suggested_fee_recipient: Address::repeat_byte(0x03),
                 prev_randao: B256::repeat_byte(0x04),
                 gas_limit: 30_000_000,
                 parent_beacon_block_root: Some(B256::repeat_byte(0x05)),

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -21,7 +21,7 @@ tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["default"] }
 
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 reth-errors.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "rpc"] }

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -19,7 +19,7 @@ tempo-transaction-pool.workspace = true
 tempo-payload-types.workspace = true
 
 reth-basic-payload-builder.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-consensus-common.workspace = true
 reth-engine-tree.workspace = true
 reth-errors.workspace = true

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -16,14 +16,14 @@ tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 tempo-precompiles-macros.workspace = true
 alloy = { workspace = true, features = ["sol-types", "consensus"] }
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 revm.workspace = true
 
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true
 
 tracing.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 derive_more.workspace = true
 scoped-tls = "1.0"
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -22,7 +22,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 
 revm.workspace = true
 
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
@@ -30,7 +30,7 @@ alloy-sol-types.workspace = true
 auto_impl.workspace = true
 derive_more.workspace = true
 tracing.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 eyre.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -21,7 +21,7 @@ tempo-precompiles.workspace = true
 
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-provider.workspace = true
@@ -34,7 +34,7 @@ revm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-sol-types.workspace = true
 
 futures.workspace = true
@@ -42,7 +42,7 @@ tracing.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 metrics.workspace = true
 
 [features]


### PR DESCRIPTION
Extends `no_std` / RISC-V compatibility to `tempo-chainspec`, `tempo-alloy`, and `tempo-evm`, following the same pattern used by `tempo-primitives` and `tempo-contracts`: `default = ["std"]`, `#![cfg_attr(not(feature = "std"), no_std)]`, `extern crate alloc;`, and forwarding `std` to all dependencies.

**Workspace `Cargo.toml`** — set `default-features = false` for `reth-chainspec`, `reth-consensus`, `reth-network-peers`, `alloy-evm`, `alloy-genesis`, and `thiserror` so member crates can control `std` via feature forwarding. Downstream crates that need std add explicit `features = ["std"]`.

**`tempo-contracts`** — added `std` feature forwarding `alloy-primitives/std` and `alloy-sol-types/std` so other crates can activate `tempo-contracts/std`.

**`tempo-chainspec`** — `LazyLock` statics and `serde_json` gated behind `std`. `alloc` imports added for `Vec`, `Box`, `Arc`. Tests gated behind `cli` feature (they depend on CLI-only code paths).

**`tempo-alloy`** — all networking/provider modules and deps gated behind `std`. In `no_std` mode only `tempo_primitives` re-export is available.

**`tempo-evm`** — most modules and heavy deps gated behind `std`. Only `TempoEvmError` is available in `no_std` mode. `rpc` and `engine` features now imply `std`.

**CI** — `check_no_std.sh` updated to verify all 5 crates build for `riscv32imac-unknown-none-elf --no-default-features`.