### PR TITLE
feat(alloy): add no_std support

### DIFF
--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -7,6 +7,7 @@ set -eo pipefail
 no_std_crates=(
     tempo-contracts
     tempo-primitives
+    tempo-alloy
 )
 
 for crate in "${no_std_crates[@]}"; do

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -11,32 +11,32 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-contracts = { workspace = true, features = ["rpc"] }
+tempo-contracts = { workspace = true, features = ["rpc"], optional = true }
 tempo-primitives = { workspace = true, features = ["serde", "reth"] }
 tempo-chainspec = { workspace = true, optional = true }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
 
 alloy-consensus.workspace = true
-alloy-contract.workspace = true
+alloy-contract = { workspace = true, optional = true }
 alloy-eips.workspace = true
-alloy-network.workspace = true
-alloy-primitives = { workspace = true, features = ["rand"] }
-alloy-provider.workspace = true
-alloy-rpc-types-eth.workspace = true
-alloy-serde.workspace = true
-alloy-signer.workspace = true
-alloy-signer-local.workspace = true
-alloy-transport.workspace = true
+alloy-network = { workspace = true, optional = true }
+alloy-primitives.workspace = true
+alloy-provider = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-serde = { workspace = true, optional = true }
+alloy-signer = { workspace = true, optional = true }
+alloy-signer-local = { workspace = true, optional = true }
+alloy-transport = { workspace = true, optional = true }
 
 reth-evm = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
 reth-rpc-convert = { workspace = true, optional = true }
 reth-rpc-eth-types = { workspace = true, optional = true }
 
-derive_more.workspace = true
-serde.workspace = true
-tracing.workspace = true
+derive_more = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["providers", "rpc-types-eth", "sol-types"] }
@@ -46,12 +46,34 @@ test-case.workspace = true
 tokio.workspace = true
 
 [features]
-default = []
+default = ["std"]
+std = [
+    "dep:tempo-contracts",
+    "dep:alloy-contract",
+    "dep:alloy-network",
+    "dep:alloy-provider",
+    "dep:alloy-rpc-types-eth",
+    "dep:alloy-serde",
+    "dep:alloy-signer",
+    "dep:alloy-signer-local",
+    "dep:alloy-transport",
+    "dep:derive_more",
+    "dep:serde",
+    "dep:tracing",
+    "alloy-consensus/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+    "alloy-primitives/rand",
+    "derive_more?/std",
+    "serde?/std",
+    "tempo-primitives/std",
+]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "alloy/asm-keccak",
 ]
 tempo-compat = [
+    "std",
     "dep:reth-evm",
     "dep:reth-rpc-convert",
     "dep:reth-primitives-traits",

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -1,20 +1,27 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "std")]
 mod network;
+#[cfg(feature = "std")]
 pub use network::*;
 
 /// Provider traits.
+#[cfg(feature = "std")]
 pub mod provider;
 
+#[cfg(feature = "std")]
 pub mod rpc;
 
 /// Transaction fillers.
+#[cfg(feature = "std")]
 pub mod fillers;
 
 #[doc(inline)]
 pub use tempo_primitives as primitives;
 
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use tempo_contracts as contracts;


### PR DESCRIPTION
Adds `no_std` support to `tempo-alloy`. All networking, provider, RPC, signer, and filler modules are gated behind the `std` feature. In no_std mode only the `tempo_primitives` re-export is available.

The `alloy-primitives/rand` feature is moved to the `std` feature since it pulls in `getrandom` which doesn't compile on bare metal targets.