### PR TITLE
feat(evm): add no_std support

### DIFF
--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -7,6 +7,7 @@ set -eo pipefail
 no_std_crates=(
     tempo-contracts
     tempo-primitives
+    tempo-evm
 )
 
 for crate in "${no_std_crates[@]}"; do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "tem
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -171,7 +171,7 @@ alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.27.3"
+alloy-evm = { version = "0.27.3", default-features = false }
 revm-inspectors = "0.34.2"
 alloy-genesis = "1.6.1"
 alloy-hardforks = "0.4.7"
@@ -235,7 +235,7 @@ serde_json = { version = "1.0.149", features = ["alloc"], default-features = fal
 schnellru = "0.2"
 sha2 = { version = "0.10", default-features = false }
 tempfile = "3.24.0"
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }
 # TODO: restrict this to only the required features
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-util = "0.7.18"

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -18,7 +18,7 @@ reth-cli = { workspace = true, optional = true }
 reth-chainspec.workspace = true
 reth-network-peers.workspace = true
 
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true

--- a/crates/commonware-node-config/Cargo.toml
+++ b/crates/commonware-node-config/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 commonware-codec.workspace = true
 commonware-cryptography.workspace = true
 const-hex.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 commonware-utils.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -15,13 +15,13 @@ tempo-chainspec.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 
 reth-chainspec.workspace = true
-reth-consensus.workspace = true
+reth-consensus = { workspace = true, features = ["std"] }
 reth-consensus-common.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-primitives-traits.workspace = true
 
 alloy-consensus.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 alloy-genesis.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -21,5 +21,6 @@ alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
-default = ["rpc"]
+default = ["std", "rpc"]
+std = ["alloy-primitives/std", "alloy-sol-types/std"]
 rpc = ["dep:alloy-contract"]

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -16,7 +16,7 @@ alloy = { workspace = true, features = [
   "rlp",
   "providers",
 ] }
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -12,21 +12,21 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
-tempo-consensus.workspace = true
+tempo-chainspec = { workspace = true, optional = true }
+tempo-consensus = { workspace = true, optional = true }
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }
 tempo-primitives = { workspace = true, features = ["reth"] }
-tempo-revm.workspace = true
+tempo-revm = { workspace = true, optional = true }
 
-commonware-cryptography.workspace = true
-commonware-codec.workspace = true
+commonware-cryptography = { workspace = true, optional = true }
+commonware-codec = { workspace = true, optional = true }
 
 reth-consensus.workspace = true
-reth-chainspec.workspace = true
-reth-evm.workspace = true
-reth-evm-ethereum.workspace = true
-reth-revm.workspace = true
+reth-chainspec = { workspace = true, optional = true }
+reth-evm = { workspace = true, optional = true }
+reth-evm-ethereum = { workspace = true, optional = true }
+reth-revm = { workspace = true, optional = true }
 reth-primitives-traits.workspace = true
 reth-rpc-eth-api = { workspace = true, optional = true }
 
@@ -38,13 +38,35 @@ alloy-primitives.workspace = true
 
 derive_more.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 revm.workspace = true
 reth-storage-api.workspace = true
 
 [features]
-default = ["rpc", "engine"]
-rpc = ["dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
-engine = ["dep:tempo-payload-types", "dep:rayon"]
+default = ["std", "rpc", "engine"]
+std = [
+    "dep:tempo-chainspec",
+    "dep:tempo-consensus",
+    "dep:tempo-revm",
+    "dep:commonware-cryptography",
+    "dep:commonware-codec",
+    "dep:reth-chainspec",
+    "dep:reth-evm",
+    "dep:reth-evm-ethereum",
+    "dep:reth-revm",
+    "dep:tracing",
+    "alloy-consensus/std",
+    "alloy-evm/std",
+    "alloy-primitives/std",
+    "alloy-rlp/std",
+    "derive_more/std",
+    "reth-consensus/std",
+    "reth-primitives-traits/std",
+    "tempo-contracts/std",
+    "tempo-primitives/std",
+    "thiserror/std",
+]
+rpc = ["std", "dep:reth-rpc-eth-api", "tempo-revm?/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
+engine = ["std", "dep:tempo-payload-types", "dep:rayon"]

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -11,7 +11,7 @@ pub enum TempoEvmError {
 
     /// Invalid EVM configuration.
     #[error("invalid EVM configuration: {0}")]
-    InvalidEvmConfig(String),
+    InvalidEvmConfig(alloc::string::String),
 
     /// No subblock metadata system transaction is found in the block.
     #[error("couldn't find subblock metadata transaction in block")]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -1,50 +1,66 @@
 //! Tempo EVM implementation.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+extern crate alloc;
+
+#[cfg(feature = "std")]
 mod assemble;
-use alloy_consensus::{BlockHeader as _, Transaction};
-use alloy_primitives::Address;
-use alloy_rlp::Decodable;
+#[cfg(feature = "std")]
 pub use assemble::TempoBlockAssembler;
+#[cfg(feature = "std")]
 mod block;
+#[cfg(feature = "std")]
 pub use block::TempoReceiptBuilder;
+#[cfg(feature = "std")]
 mod context;
+#[cfg(feature = "std")]
 pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
 #[cfg(feature = "engine")]
 mod engine;
 mod error;
 pub use error::TempoEvmError;
+#[cfg(feature = "std")]
 pub mod evm;
-use std::{borrow::Cow, sync::Arc};
-
-use alloy_evm::{
-    self, Database, EvmEnv,
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
-    revm::{Inspector, database::State},
-};
+#[cfg(feature = "std")]
 pub use evm::TempoEvmFactory;
-use reth_chainspec::EthChainSpec;
-use reth_evm::{self, ConfigureEvm, EvmEnvFor};
-use reth_primitives_traits::{SealedBlock, SealedHeader};
-use tempo_primitives::{
-    Block, SubBlockMetadata, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
-    subblock::PartialValidatorKey,
-};
 
-use crate::{block::TempoBlockExecutor, evm::TempoEvm};
-use reth_evm_ethereum::EthEvmConfig;
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
-use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params};
-
+#[cfg(feature = "std")]
 pub use tempo_revm::{TempoBlockEnv, TempoHaltReason, TempoStateAccess};
 
 #[cfg(test)]
 mod test_utils;
 
+#[cfg(feature = "std")]
+use {
+    crate::{block::TempoBlockExecutor, evm::TempoEvm},
+    alloc::sync::Arc,
+    alloy_consensus::{BlockHeader as _, Transaction},
+    alloy_evm::{
+        self, Database, EvmEnv,
+        block::{BlockExecutorFactory, BlockExecutorFor},
+        eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
+        revm::{Inspector, database::State},
+    },
+    alloy_primitives::Address,
+    alloy_rlp::Decodable,
+    reth_chainspec::EthChainSpec,
+    reth_evm::{self, ConfigureEvm, EvmEnvFor},
+    reth_evm_ethereum::EthEvmConfig,
+    reth_primitives_traits::{SealedBlock, SealedHeader},
+    std::borrow::Cow,
+    tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks},
+    tempo_primitives::{
+        Block, SubBlockMetadata, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
+        subblock::PartialValidatorKey,
+    },
+    tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params},
+};
+
 /// Tempo-related EVM configuration.
+#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub struct TempoEvmConfig {
     /// Inner evm config
@@ -54,6 +70,7 @@ pub struct TempoEvmConfig {
     pub block_assembler: TempoBlockAssembler,
 }
 
+#[cfg(feature = "std")]
 impl TempoEvmConfig {
     /// Create a new [`TempoEvmConfig`] with the given chain spec and EVM factory.
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
@@ -81,6 +98,7 @@ impl TempoEvmConfig {
     }
 }
 
+#[cfg(feature = "std")]
 impl BlockExecutorFactory for TempoEvmConfig {
     type EvmFactory = TempoEvmFactory;
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
@@ -104,6 +122,7 @@ impl BlockExecutorFactory for TempoEvmConfig {
     }
 }
 
+#[cfg(feature = "std")]
 impl ConfigureEvm for TempoEvmConfig {
     type Primitives = TempoPrimitives;
     type Error = TempoEvmError;
@@ -245,7 +264,7 @@ impl ConfigureEvm for TempoEvmConfig {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     use crate::test_utils::test_chainspec;

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -21,7 +21,7 @@ tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["default"] }
 
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 reth-errors.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "rpc"] }

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -16,14 +16,14 @@ tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 tempo-precompiles-macros.workspace = true
 alloy = { workspace = true, features = ["sol-types", "consensus"] }
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 revm.workspace = true
 
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true
 
 tracing.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 derive_more.workspace = true
 scoped-tls = "1.0"
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -22,7 +22,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 
 revm.workspace = true
 
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
@@ -30,7 +30,7 @@ alloy-sol-types.workspace = true
 auto_impl.workspace = true
 derive_more.workspace = true
 tracing.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 eyre.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -34,7 +34,7 @@ revm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-sol-types.workspace = true
 
 futures.workspace = true
@@ -42,7 +42,7 @@ tracing.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 metrics.workspace = true
 
 [features]


### PR DESCRIPTION
Adds `no_std` support to `tempo-evm`. Most modules and heavy dependencies are gated behind the `std` feature. Only `TempoEvmError` is available in no_std mode. The `rpc` and `engine` features now imply `std`.

Workspace-level changes: `default-features = false` added for `reth-consensus`, `thiserror`, and `alloy-evm`. Downstream crates that need std add explicit `features = ["std"]`.