### PR TITLE
WIP: refactor(payload): replace InterruptHandle with pool_fill_deadline

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -369,13 +369,14 @@ where
         {
             let start = Instant::now();
             let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
-            builder.apply_pre_execution_changes().map_err(|err| {
+            let res = builder.apply_pre_execution_changes().map_err(|err| {
                 warn!(%err, "failed to apply pre-execution changes");
                 PayloadBuilderError::Internal(err.into())
-            })?;
+            });
             self.metrics
                 .pre_execution_duration_seconds
                 .record(start.elapsed());
+            res?;
         }
 
         debug!("building new payload");
@@ -404,6 +405,11 @@ where
         let mut pool_transactions_considered = 0u64;
         let mut pool_transactions_executed = 0u64;
         let mut pool_transactions_skipped = 0u64;
+        let mut skipped_exceeds_non_shared_gas_limit = 0u64;
+        let mut skipped_exceeds_non_payment_gas_limit = 0u64;
+        let mut skipped_oversized_block = 0u64;
+        let mut skipped_nonce_too_low = 0u64;
+        let mut skipped_invalid_tx = 0u64;
         let record_pool_selection_metrics =
             |metrics: &TempoPayloadBuilderMetrics, considered: u64, executed: u64, skipped: u64| {
                 metrics
@@ -417,18 +423,51 @@ where
                 metrics.pool_transactions_skipped.record(skipped as f64);
                 metrics.pool_transactions_skipped_last.set(skipped as f64);
             };
+        let flush_skip_reason_counters =
+            |metrics: &TempoPayloadBuilderMetrics,
+             exceeds_non_shared: u64,
+             exceeds_non_payment: u64,
+             oversized: u64,
+             nonce_too_low: u64,
+             invalid_tx: u64| {
+                if exceeds_non_shared > 0 {
+                    metrics
+                        .pool_transactions_skipped_exceeds_non_shared_gas_limit
+                        .increment(exceeds_non_shared);
+                }
+                if exceeds_non_payment > 0 {
+                    metrics
+                        .pool_transactions_skipped_exceeds_non_payment_gas_limit
+                        .increment(exceeds_non_payment);
+                }
+                if oversized > 0 {
+                    metrics
+                        .pool_transactions_skipped_oversized_block
+                        .increment(oversized);
+                }
+                if nonce_too_low > 0 {
+                    metrics
+                        .pool_transactions_skipped_nonce_too_low
+                        .increment(nonce_too_low);
+                }
+                if invalid_tx > 0 {
+                    metrics
+                        .pool_transactions_skipped_invalid_tx
+                        .increment(invalid_tx);
+                }
+            };
 
         let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
         loop {
             let selection_start = Instant::now();
             let maybe_pool_tx = best_txs.next();
-            self.metrics
-                .transaction_selection_duration_seconds
-                .record(selection_start.elapsed());
             let Some(pool_tx) = maybe_pool_tx else {
                 break;
             };
+            self.metrics
+                .transaction_selection_duration_seconds
+                .record(selection_start.elapsed());
             pool_transactions_considered += 1;
 
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
@@ -445,9 +484,7 @@ where
                     ),
                 );
                 pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
-                    .increment(1);
+                skipped_exceeds_non_shared_gas_limit += 1;
                 continue;
             }
 
@@ -463,9 +500,7 @@ where
                     )),
                 );
                 pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
-                    .increment(1);
+                skipped_exceeds_non_payment_gas_limit += 1;
                 continue;
             }
 
@@ -481,6 +516,14 @@ where
                     pool_transactions_considered,
                     pool_transactions_executed,
                     pool_transactions_skipped,
+                );
+                flush_skip_reason_counters(
+                    &self.metrics,
+                    skipped_exceeds_non_shared_gas_limit,
+                    skipped_exceeds_non_payment_gas_limit,
+                    skipped_oversized_block,
+                    skipped_nonce_too_low,
+                    skipped_invalid_tx,
                 );
                 return Ok(BuildOutcome::Cancelled);
             }
@@ -502,9 +545,7 @@ where
                     },
                 );
                 pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_oversized_block
-                    .increment(1);
+                skipped_oversized_block += 1;
                 continue;
             }
 
@@ -525,9 +566,7 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        self.metrics
-                            .pool_transactions_skipped_nonce_too_low
-                            .increment(1);
+                        skipped_nonce_too_low += 1;
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -538,15 +577,29 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
-                        self.metrics
-                            .pool_transactions_skipped_invalid_tx
-                            .increment(1);
+                        skipped_invalid_tx += 1;
                     }
                     pool_transactions_skipped += 1;
                     continue;
                 }
                 // this is an error that we should treat as fatal for this attempt
-                Err(err) => return Err(PayloadBuilderError::evm(err)),
+                Err(err) => {
+                    record_pool_selection_metrics(
+                        &self.metrics,
+                        pool_transactions_considered,
+                        pool_transactions_executed,
+                        pool_transactions_skipped,
+                    );
+                    flush_skip_reason_counters(
+                        &self.metrics,
+                        skipped_exceeds_non_shared_gas_limit,
+                        skipped_exceeds_non_payment_gas_limit,
+                        skipped_oversized_block,
+                        skipped_nonce_too_low,
+                        skipped_invalid_tx,
+                    );
+                    return Err(PayloadBuilderError::evm(err));
+                }
             };
             pool_transactions_executed += 1;
             let elapsed = execution_start.elapsed();
@@ -569,6 +622,14 @@ where
             pool_transactions_considered,
             pool_transactions_executed,
             pool_transactions_skipped,
+        );
+        flush_skip_reason_counters(
+            &self.metrics,
+            skipped_exceeds_non_shared_gas_limit,
+            skipped_exceeds_non_payment_gas_limit,
+            skipped_oversized_block,
+            skipped_nonce_too_low,
+            skipped_invalid_tx,
         );
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -60,6 +60,7 @@ use tempo_transaction_pool::{
     TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
+use tracing::debug_span;
 use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
@@ -240,21 +241,37 @@ where
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
 
-        let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
+        let state_provider = {
+            let start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "state_provider").entered();
+            let res = self.provider.state_by_block_hash(parent_header.hash());
+            self.metrics
+                .state_provider_duration_seconds
+                .record(start.elapsed());
+            res?
+        };
         let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
         } else {
             state_provider
         };
-        let state = StateProviderDatabase::new(&state_provider);
-        let mut db = State::builder()
-            .with_database(if self.disable_state_cache {
-                Box::new(state) as Box<dyn Database<Error = ProviderError>>
-            } else {
-                Box::new(cached_reads.as_db_mut(state))
-            })
-            .with_bundle_update()
-            .build();
+        let mut db = {
+            let start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "build_state_db").entered();
+            let state = StateProviderDatabase::new(&state_provider);
+            let db = State::builder()
+                .with_database(if self.disable_state_cache {
+                    Box::new(state) as Box<dyn Database<Error = ProviderError>>
+                } else {
+                    Box::new(cached_reads.as_db_mut(state))
+                })
+                .with_bundle_update()
+                .build();
+            self.metrics
+                .build_state_db_duration_seconds
+                .record(start.elapsed());
+            db
+        };
 
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
@@ -318,33 +335,48 @@ where
             })
             .collect();
 
-        let mut builder = self
-            .evm_config
-            .builder_for_next_block(
-                &mut db,
-                &parent_header,
-                TempoNextBlockEnvAttributes {
-                    inner: NextBlockEnvAttributes {
-                        timestamp: attributes.timestamp(),
-                        suggested_fee_recipient: attributes.suggested_fee_recipient(),
-                        prev_randao: attributes.prev_randao(),
-                        gas_limit: block_gas_limit,
-                        parent_beacon_block_root: attributes.parent_beacon_block_root(),
-                        withdrawals: Some(attributes.withdrawals().clone()),
-                        extra_data: attributes.extra_data().clone(),
+        let mut builder = {
+            let start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "create_evm").entered();
+            let res = self
+                .evm_config
+                .builder_for_next_block(
+                    &mut db,
+                    &parent_header,
+                    TempoNextBlockEnvAttributes {
+                        inner: NextBlockEnvAttributes {
+                            timestamp: attributes.timestamp(),
+                            suggested_fee_recipient: attributes.suggested_fee_recipient(),
+                            prev_randao: attributes.prev_randao(),
+                            gas_limit: block_gas_limit,
+                            parent_beacon_block_root: attributes.parent_beacon_block_root(),
+                            withdrawals: Some(attributes.withdrawals().clone()),
+                            extra_data: attributes.extra_data().clone(),
+                        },
+                        general_gas_limit,
+                        shared_gas_limit,
+                        timestamp_millis_part: attributes.timestamp_millis_part(),
+                        subblock_fee_recipients,
                     },
-                    general_gas_limit,
-                    shared_gas_limit,
-                    timestamp_millis_part: attributes.timestamp_millis_part(),
-                    subblock_fee_recipients,
-                },
-            )
-            .map_err(PayloadBuilderError::other)?;
+                )
+                .map_err(PayloadBuilderError::other);
+            self.metrics
+                .create_evm_duration_seconds
+                .record(start.elapsed());
+            res?
+        };
 
-        builder.apply_pre_execution_changes().map_err(|err| {
-            warn!(%err, "failed to apply pre-execution changes");
-            PayloadBuilderError::Internal(err.into())
-        })?;
+        {
+            let start = Instant::now();
+            let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
+            builder.apply_pre_execution_changes().map_err(|err| {
+                warn!(%err, "failed to apply pre-execution changes");
+                PayloadBuilderError::Internal(err.into())
+            })?;
+            self.metrics
+                .pre_execution_duration_seconds
+                .record(start.elapsed());
+        }
 
         debug!("building new payload");
 
@@ -369,8 +401,36 @@ where
                 .map(|gasprice| gasprice as u64),
         ));
 
+        let mut pool_transactions_considered = 0u64;
+        let mut pool_transactions_executed = 0u64;
+        let mut pool_transactions_skipped = 0u64;
+        let record_pool_selection_metrics =
+            |metrics: &TempoPayloadBuilderMetrics, considered: u64, executed: u64, skipped: u64| {
+                metrics
+                    .pool_transactions_considered
+                    .record(considered as f64);
+                metrics
+                    .pool_transactions_considered_last
+                    .set(considered as f64);
+                metrics.pool_transactions_executed.record(executed as f64);
+                metrics.pool_transactions_executed_last.set(executed as f64);
+                metrics.pool_transactions_skipped.record(skipped as f64);
+                metrics.pool_transactions_skipped_last.set(skipped as f64);
+            };
+
+        let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
-        while let Some(pool_tx) = best_txs.next() {
+        loop {
+            let selection_start = Instant::now();
+            let maybe_pool_tx = best_txs.next();
+            self.metrics
+                .transaction_selection_duration_seconds
+                .record(selection_start.elapsed());
+            let Some(pool_tx) = maybe_pool_tx else {
+                break;
+            };
+            pool_transactions_considered += 1;
+
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
             // be consumed by proposer's pool transactions.
@@ -384,6 +444,10 @@ where
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
                 );
+                pool_transactions_skipped += 1;
+                self.metrics
+                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
+                    .increment(1);
                 continue;
             }
 
@@ -398,6 +462,10 @@ where
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
+                pool_transactions_skipped += 1;
+                self.metrics
+                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
+                    .increment(1);
                 continue;
             }
 
@@ -408,6 +476,12 @@ where
 
             // check if the job was cancelled, if so we can exit early
             if cancel.is_cancelled() {
+                record_pool_selection_metrics(
+                    &self.metrics,
+                    pool_transactions_considered,
+                    pool_transactions_executed,
+                    pool_transactions_skipped,
+                );
                 return Ok(BuildOutcome::Cancelled);
             }
 
@@ -427,6 +501,10 @@ where
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
                 );
+                pool_transactions_skipped += 1;
+                self.metrics
+                    .pool_transactions_skipped_oversized_block
+                    .increment(1);
                 continue;
             }
 
@@ -447,6 +525,9 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
+                        self.metrics
+                            .pool_transactions_skipped_nonce_too_low
+                            .increment(1);
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -457,12 +538,17 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
+                        self.metrics
+                            .pool_transactions_skipped_invalid_tx
+                            .increment(1);
                     }
+                    pool_transactions_skipped += 1;
                     continue;
                 }
                 // this is an error that we should treat as fatal for this attempt
                 Err(err) => return Err(PayloadBuilderError::evm(err)),
             };
+            pool_transactions_executed += 1;
             let elapsed = execution_start.elapsed();
             self.metrics
                 .transaction_execution_duration_seconds
@@ -477,6 +563,13 @@ where
             }
             block_size_used += tx_rlp_length;
         }
+        drop(_pool_tx_span);
+        record_pool_selection_metrics(
+            &self.metrics,
+            pool_transactions_considered,
+            pool_transactions_executed,
+            pool_transactions_skipped,
+        );
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds
@@ -502,6 +595,8 @@ where
             });
         }
 
+        let _subblock_span =
+            debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
         let subblocks_start = Instant::now();
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
@@ -530,6 +625,7 @@ where
             }
         }
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
+        drop(_subblock_span);
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
             .record(total_subblock_transaction_execution_elapsed);
@@ -543,13 +639,16 @@ where
             .set(subblock_transactions);
 
         // Apply system transactions
-        let system_txs_execution_start = Instant::now();
-        for system_tx in system_txs {
-            builder
-                .execute_transaction(system_tx)
-                .map_err(PayloadBuilderError::evm)?;
-        }
-        let system_txs_execution_elapsed = system_txs_execution_start.elapsed();
+        let system_txs_execution_elapsed = {
+            let _span = debug_span!(target: "payload_builder", "execute_system_txs").entered();
+            let system_txs_execution_start = Instant::now();
+            for system_tx in system_txs {
+                builder
+                    .execute_transaction(system_tx)
+                    .map_err(PayloadBuilderError::evm)?;
+            }
+            system_txs_execution_start.elapsed()
+        };
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
@@ -559,14 +658,23 @@ where
             .total_transaction_execution_duration_seconds
             .record(total_transaction_execution_elapsed);
 
-        let builder_finish_start = Instant::now();
-        let BlockBuilderOutcome {
-            execution_result,
-            block,
-            hashed_state,
-            trie_updates,
-        } = builder.finish(&state_provider)?;
-        let builder_finish_elapsed = builder_finish_start.elapsed();
+        let (builder_finish_elapsed, execution_result, block, hashed_state, trie_updates) = {
+            let _span = debug_span!(target: "payload_builder", "finish_block").entered();
+            let builder_finish_start = Instant::now();
+            let BlockBuilderOutcome {
+                execution_result,
+                block,
+                hashed_state,
+                trie_updates,
+            } = builder.finish(&state_provider)?;
+            (
+                builder_finish_start.elapsed(),
+                execution_result,
+                block,
+                hashed_state,
+                trie_updates,
+            )
+        };
         self.metrics
             .payload_finalization_duration_seconds
             .record(builder_finish_elapsed);

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -234,6 +234,17 @@ where
         } = config;
 
         let start = Instant::now();
+        let record_build_attempt_duration = || {
+            self.metrics
+                .payload_build_duration_seconds
+                .record(start.elapsed())
+        };
+        macro_rules! return_with_build_duration {
+            ($value:expr) => {{
+                record_build_attempt_duration();
+                return $value;
+            }};
+        }
 
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
@@ -247,7 +258,10 @@ where
             self.metrics
                 .state_provider_duration_seconds
                 .record(start.elapsed());
-            res?
+            match res {
+                Ok(provider) => provider,
+                Err(err) => return_with_build_duration!(Err(err.into())),
+            }
         };
         let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
@@ -362,7 +376,10 @@ where
             self.metrics
                 .create_evm_duration_seconds
                 .record(start.elapsed());
-            res?
+            match res {
+                Ok(builder) => builder,
+                Err(err) => return_with_build_duration!(Err(err)),
+            }
         };
 
         {
@@ -375,7 +392,9 @@ where
             self.metrics
                 .pre_execution_duration_seconds
                 .record(start.elapsed());
-            res?;
+            if let Err(err) = res {
+                return_with_build_duration!(Err(err));
+            }
         }
 
         debug!("building new payload");
@@ -524,7 +543,7 @@ where
                     skipped_nonce_too_low,
                     skipped_invalid_tx,
                 );
-                return Ok(BuildOutcome::Cancelled);
+                return_with_build_duration!(Ok(BuildOutcome::Cancelled));
             }
 
             let is_payment = pool_tx.transaction.is_payment();
@@ -597,7 +616,7 @@ where
                         skipped_nonce_too_low,
                         skipped_invalid_tx,
                     );
-                    return Err(PayloadBuilderError::evm(err));
+                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
                 }
             };
             pool_transactions_executed += 1;
@@ -649,10 +668,10 @@ where
             drop(builder);
             drop(db);
             // can skip building the block
-            return Ok(BuildOutcome::Aborted {
+            return_with_build_duration!(Ok(BuildOutcome::Aborted {
                 fees: total_fees,
                 cached_reads,
-            });
+            }));
         }
 
         let _subblock_span =
@@ -674,11 +693,12 @@ where
                         );
                         self.highest_invalid_subblock
                             .store(builder.evm().block().number.to(), Ordering::Relaxed);
-
-                        return Err(PayloadBuilderError::evm(err));
-                    } else {
-                        return Err(PayloadBuilderError::evm(err));
                     }
+                    let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
+                    self.metrics
+                        .total_subblock_transaction_execution_duration_seconds
+                        .record(total_subblock_transaction_execution_elapsed);
+                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
                 }
 
                 subblock_transactions += 1.0;
@@ -703,9 +723,13 @@ where
             let _span = debug_span!(target: "payload_builder", "execute_system_txs").entered();
             let system_txs_execution_start = Instant::now();
             for system_tx in system_txs {
-                builder
-                    .execute_transaction(system_tx)
-                    .map_err(PayloadBuilderError::evm)?;
+                if let Err(err) = builder.execute_transaction(system_tx) {
+                    let elapsed = system_txs_execution_start.elapsed();
+                    self.metrics
+                        .system_transactions_execution_duration_seconds
+                        .record(elapsed);
+                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
+                }
             }
             system_txs_execution_start.elapsed()
         };
@@ -721,23 +745,28 @@ where
         let (builder_finish_elapsed, execution_result, block, hashed_state, trie_updates) = {
             let _span = debug_span!(target: "payload_builder", "finish_block").entered();
             let builder_finish_start = Instant::now();
+            let res = builder.finish(&state_provider);
+            let builder_finish_elapsed = builder_finish_start.elapsed();
+            self.metrics
+                .payload_finalization_duration_seconds
+                .record(builder_finish_elapsed);
             let BlockBuilderOutcome {
                 execution_result,
                 block,
                 hashed_state,
                 trie_updates,
-            } = builder.finish(&state_provider)?;
+            } = match res {
+                Ok(outcome) => outcome,
+                Err(err) => return_with_build_duration!(Err(err.into())),
+            };
             (
-                builder_finish_start.elapsed(),
+                builder_finish_elapsed,
                 execution_result,
                 block,
                 hashed_state,
                 trie_updates,
             )
         };
-        self.metrics
-            .payload_finalization_duration_seconds
-            .record(builder_finish_elapsed);
 
         let total_transactions = block.transaction_count();
         self.metrics
@@ -759,10 +788,12 @@ where
         let rlp_length = sealed_block.rlp_length();
 
         if is_osaka && rlp_length > MAX_RLP_BLOCK_SIZE {
-            return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
-                rlp_length,
-                max_rlp_length: MAX_RLP_BLOCK_SIZE,
-            }));
+            return_with_build_duration!(Err(PayloadBuilderError::other(
+                ConsensusError::BlockTooLarge {
+                    rlp_length,
+                    max_rlp_length: MAX_RLP_BLOCK_SIZE,
+                }
+            )));
         }
 
         let elapsed = start.elapsed();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -8,7 +8,7 @@ mod metrics;
 use crate::metrics::TempoPayloadBuilderMetrics;
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Encodable;
 use either::Either;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
@@ -25,7 +25,7 @@ use reth_evm::{
 };
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
-use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
+use reth_payload_primitives::{BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
 use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
 use reth_revm::{
     State,
@@ -644,7 +644,8 @@ where
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
 
-        let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
+        let payload =
+            TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
 
         drop(db);
         Ok(BuildOutcome::Better {
@@ -661,25 +662,15 @@ pub fn is_more_subblocks(
     let Some(best_payload) = best_payload else {
         return false;
     };
-    let Some(best_metadata) = best_payload
-        .block()
-        .body()
-        .transactions
-        .iter()
-        .rev()
-        .find_map(|tx| Vec::<SubBlockMetadata>::decode(&mut tx.input().as_ref()).ok())
-    else {
-        return false;
-    };
 
-    subblocks.len() > best_metadata.len()
+    subblocks.len() > best_payload.subblocks_count()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy_consensus::BlockBody;
-    use alloy_primitives::{Address, B256, Bytes, Signature};
+    use alloy_primitives::{Address, B256, Bytes};
     use reth_payload_builder::PayloadId;
     use reth_primitives_traits::SealedBlock;
     use tempo_primitives::{
@@ -694,17 +685,6 @@ mod tests {
             Self: Sized,
         {
             Self::random()
-        }
-    }
-
-    impl TestExt for SubBlockMetadata {
-        fn random() -> Self {
-            Self {
-                version: SubBlockVersion::V1,
-                validator: B256::random(),
-                fee_recipient: Address::random(),
-                signature: Bytes::new(),
-            }
         }
     }
 
@@ -735,31 +715,17 @@ mod tests {
     }
 
     fn payload_with_metadata(count: usize) -> TempoBuiltPayload {
-        let metadata: Vec<_> = (0..count).map(|_| SubBlockMetadata::random()).collect();
-        let input: Bytes = alloy_rlp::encode(&metadata).into();
-        let tx = TempoTxEnvelope::Legacy(Signed::new_unhashed(
-            TxLegacy {
-                chain_id: None,
-                nonce: 0,
-                gas_price: 0,
-                gas_limit: 0,
-                to: Address::random().into(),
-                value: U256::ZERO,
-                input,
-            },
-            Signature::test_signature(),
-        ));
         let block = Block {
             header: TempoHeader::default(),
             body: BlockBody {
-                transactions: vec![tx],
+                transactions: vec![],
                 ommers: vec![],
                 withdrawals: None,
             },
         };
         let sealed = Arc::new(SealedBlock::seal_slow(block));
         let eth = EthBuiltPayload::new(PayloadId::default(), sealed, U256::ZERO, None);
-        TempoBuiltPayload::new(eth, None)
+        TempoBuiltPayload::new(eth, None, count)
     }
 
     #[test]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -60,8 +60,7 @@ use tempo_transaction_pool::{
     TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
-use tracing::debug_span;
-use tracing::{Level, debug, error, info, instrument, trace, warn};
+use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -522,8 +522,8 @@ where
                 continue;
             }
 
-            // check if the job was interrupted, if so we can skip remaining transactions
-            if attributes.is_interrupted() {
+            // stop filling from the pool once the deadline expires
+            if attributes.should_stop_pool_fill() {
                 break;
             }
 
@@ -851,8 +851,7 @@ where
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };
 
-        let payload =
-            TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
+        let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block), subblocks.len());
 
         drop(db);
         Ok(BuildOutcome::Better {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -698,6 +698,14 @@ where
                     self.metrics
                         .total_subblock_transaction_execution_duration_seconds
                         .record(total_subblock_transaction_execution_elapsed);
+                    self.metrics.subblocks.record(subblocks_count);
+                    self.metrics.subblocks_last.set(subblocks_count);
+                    self.metrics
+                        .subblock_transactions
+                        .record(subblock_transactions);
+                    self.metrics
+                        .subblock_transactions_last
+                        .set(subblock_transactions);
                     return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
                 }
 

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,5 +1,8 @@
 use metrics::Gauge;
-use reth_metrics::{Metrics, metrics::Histogram};
+use reth_metrics::{
+    Metrics,
+    metrics::{Counter, Histogram},
+};
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_payload_builder")]
@@ -32,6 +35,30 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
+    /// The time it took to select the next candidate transaction from the pool.
+    pub(crate) transaction_selection_duration_seconds: Histogram,
+    /// Number of candidate pool transactions considered per payload attempt.
+    pub(crate) pool_transactions_considered: Histogram,
+    /// Number of candidate pool transactions considered for the latest payload attempt.
+    pub(crate) pool_transactions_considered_last: Gauge,
+    /// Number of pool transactions successfully executed per payload attempt.
+    pub(crate) pool_transactions_executed: Histogram,
+    /// Number of pool transactions successfully executed for the latest payload attempt.
+    pub(crate) pool_transactions_executed_last: Gauge,
+    /// Number of pool transactions skipped per payload attempt.
+    pub(crate) pool_transactions_skipped: Histogram,
+    /// Number of pool transactions skipped for the latest payload attempt.
+    pub(crate) pool_transactions_skipped_last: Gauge,
+    /// Number of pool transactions skipped because they exceed the non-shared gas limit.
+    pub(crate) pool_transactions_skipped_exceeds_non_shared_gas_limit: Counter,
+    /// Number of pool transactions skipped because they exceed the non-payment gas limit.
+    pub(crate) pool_transactions_skipped_exceeds_non_payment_gas_limit: Counter,
+    /// Number of pool transactions skipped because they would exceed the max block RLP size.
+    pub(crate) pool_transactions_skipped_oversized_block: Counter,
+    /// Number of pool transactions skipped because the nonce is too low.
+    pub(crate) pool_transactions_skipped_nonce_too_low: Counter,
+    /// Number of pool transactions skipped because of other validation failures.
+    pub(crate) pool_transactions_skipped_invalid_tx: Counter,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -31,6 +31,14 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used: Histogram,
     /// Amount of gas used in the payload.
     pub(crate) gas_used_last: Gauge,
+    /// Time spent fetching the parent state provider.
+    pub(crate) state_provider_duration_seconds: Histogram,
+    /// Time spent constructing the state DB wrapper.
+    pub(crate) build_state_db_duration_seconds: Histogram,
+    /// Time spent creating the EVM/block builder.
+    pub(crate) create_evm_duration_seconds: Histogram,
+    /// Time spent applying pre-execution changes.
+    pub(crate) pre_execution_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -34,6 +34,8 @@ pub struct TempoBuiltPayload {
     inner: EthBuiltPayload<TempoPrimitives>,
     /// The executed block data, used to skip re-execution in the engine tree.
     executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+    /// The number of subblocks included in this payload, cached to avoid RLP decoding.
+    subblocks_count: usize,
 }
 
 impl TempoBuiltPayload {
@@ -41,11 +43,18 @@ impl TempoBuiltPayload {
     pub fn new(
         inner: EthBuiltPayload<TempoPrimitives>,
         executed_block: Option<BuiltPayloadExecutedBlock<TempoPrimitives>>,
+        subblocks_count: usize,
     ) -> Self {
         Self {
             inner,
             executed_block,
+            subblocks_count,
         }
+    }
+
+    /// Returns the number of subblocks included in this payload.
+    pub fn subblocks_count(&self) -> usize {
+        self.subblocks_count
     }
 }
 


### PR DESCRIPTION
Replaces `InterruptHandle` (`Arc<AtomicBool>`) with a `pool_fill_deadline: Option<Instant>` on `TempoPayloadBuilderAttributes`. 

The old approach required a 3-steps in the actor: create attrs, grab the handle, sleep, call `interrupt()`. 
Now the deadline is baked into the attributes at creation and the builder self-stops via `should_stop_pool_fill()`  no shared mutable state.

The actor-side sleep between `send_new_payload` and `resolve_kind` is preserved to avoid `MissingPayload` errors when the first build tick returns `Aborted`.