### PR TITLE
feat(alloy): add NonceKeyFiller for cached 2D nonce management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11866,6 +11866,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
+ "dashmap 6.1.0",
  "derive_more",
  "eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ base64 = { version = "0.22", features = ["alloc"], default-features = false }
 bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }
 const-hex = { version = "1.17.0" }
+dashmap = "6"
 derive_more = { version = "2.1.1", default-features = false }
 either = "1"
 eyre = "0.6.12"

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -34,14 +34,15 @@ reth-primitives-traits = { workspace = true, optional = true }
 reth-rpc-convert = { workspace = true, optional = true }
 reth-rpc-eth-types = { workspace = true, optional = true }
 
+dashmap.workspace = true
 derive_more.workspace = true
+futures.workspace = true
 serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["providers", "rpc-types-eth", "sol-types"] }
 eyre.workspace = true
-futures.workspace = true
 test-case.workspace = true
 tokio.workspace = true
 

--- a/crates/alloy/src/fillers/mod.rs
+++ b/crates/alloy/src/fillers/mod.rs
@@ -1,4 +1,4 @@
 //! Transaction fillers for Tempo network.
 
 mod nonce;
-pub use nonce::{ExpiringNonceFiller, Random2DNonceFiller};
+pub use nonce::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller};

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -1,12 +1,17 @@
 use crate::rpc::TempoTransactionRequest;
 use alloy_network::{Network, TransactionBuilder};
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use alloy_provider::{
-    SendableTx,
+    Provider, SendableTx,
     fillers::{FillerControlFlow, TxFiller},
 };
-use alloy_transport::TransportResult;
-use std::time::{SystemTime, UNIX_EPOCH};
+use alloy_transport::{TransportErrorKind, TransportResult};
+use dashmap::DashMap;
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tempo_contracts::precompiles::{INonce, NONCE_PRECOMPILE_ADDRESS};
 use tempo_primitives::{
     subblock::has_sub_block_nonce_key_prefix, transaction::TEMPO_EXPIRING_NONCE_KEY,
 };
@@ -166,6 +171,102 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for E
         _fillable: Self::Fillable,
         tx: SendableTx<N>,
     ) -> TransportResult<SendableTx<N>> {
+        Ok(tx)
+    }
+}
+
+/// A [`TxFiller`] that fills the nonce for transactions with a pre-set `nonce_key`.
+///
+/// This filler requires `nonce_key` to already be set on the transaction request and fills
+/// the correct next nonce by querying the chain. Nonces are cached per `(address, nonce_key)`
+/// pair so that batched sends get sequential nonces without extra RPC calls.
+///
+/// Nonce resolution depends on the key:
+/// - `U256::ZERO` (protocol nonce): uses `get_transaction_count`
+/// - `TEMPO_EXPIRING_NONCE_KEY` (U256::MAX): always 0, no caching (use [`ExpiringNonceFiller`]
+///   instead for full expiring nonce support including `valid_before`)
+/// - Any other key: queries the `NonceManager` precompile via `eth_call`
+#[derive(Clone, Debug, Default)]
+pub struct NonceKeyFiller {
+    #[allow(clippy::type_complexity)]
+    nonces: Arc<DashMap<(Address, U256), Arc<futures::lock::Mutex<u64>>>>,
+}
+
+/// Sentinel value indicating the nonce has not been fetched yet.
+const NONCE_NOT_FETCHED: u64 = u64::MAX;
+
+impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for NonceKeyFiller {
+    type Fillable = u64;
+
+    fn status(&self, tx: &N::TransactionRequest) -> FillerControlFlow {
+        if tx.nonce().is_some() {
+            return FillerControlFlow::Finished;
+        }
+        if tx.nonce_key.is_none() {
+            return FillerControlFlow::missing("NonceKeyFiller", vec!["nonce_key"]);
+        }
+        if TransactionBuilder::from(tx).is_none() {
+            return FillerControlFlow::missing("NonceKeyFiller", vec!["from"]);
+        }
+        FillerControlFlow::Ready
+    }
+
+    fn fill_sync(&self, _tx: &mut SendableTx<N>) {}
+
+    async fn prepare<P>(
+        &self,
+        provider: &P,
+        tx: &N::TransactionRequest,
+    ) -> TransportResult<Self::Fillable>
+    where
+        P: Provider<N>,
+    {
+        let from = TransactionBuilder::from(tx)
+            .ok_or_else(|| TransportErrorKind::custom_str("missing `from` address"))?;
+        let nonce_key = tx
+            .nonce_key
+            .ok_or_else(|| TransportErrorKind::custom_str("missing `nonce_key`"))?;
+
+        // Expiring nonces always use nonce 0
+        if nonce_key == TEMPO_EXPIRING_NONCE_KEY {
+            return Ok(0);
+        }
+
+        let key = (from, nonce_key);
+        let mutex = self
+            .nonces
+            .entry(key)
+            .or_insert_with(|| Arc::new(futures::lock::Mutex::new(NONCE_NOT_FETCHED)))
+            .clone();
+
+        let mut nonce = mutex.lock().await;
+
+        if *nonce == NONCE_NOT_FETCHED {
+            *nonce = if nonce_key.is_zero() {
+                provider.get_transaction_count(from).await?
+            } else {
+                let contract = INonce::new(NONCE_PRECOMPILE_ADDRESS, provider);
+                contract
+                    .getNonce(from, nonce_key)
+                    .call()
+                    .await
+                    .map_err(|e| TransportErrorKind::custom_str(&e.to_string()))?
+            };
+        } else {
+            *nonce += 1;
+        }
+
+        Ok(*nonce)
+    }
+
+    async fn fill(
+        &self,
+        fillable: Self::Fillable,
+        mut tx: SendableTx<N>,
+    ) -> TransportResult<SendableTx<N>> {
+        if let Some(builder) = tx.as_mut_builder() {
+            builder.set_nonce(fillable);
+        }
         Ok(tx)
     }
 }

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -5,7 +5,7 @@ use alloy_provider::{
 
 use crate::{
     TempoFillers, TempoNetwork,
-    fillers::{ExpiringNonceFiller, Random2DNonceFiller},
+    fillers::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller},
 };
 
 /// Extension trait for [`ProviderBuilder`] with Tempo-specific functionality.
@@ -33,6 +33,16 @@ pub trait TempoProviderBuilderExt {
         JoinFill<Identity, TempoFillers<ExpiringNonceFiller>>,
         TempoNetwork,
     >;
+
+    /// Returns a provider builder with the recommended Tempo fillers and the nonce key filler.
+    ///
+    /// The nonce key filler requires `nonce_key` to be set on the transaction request and
+    /// fills the correct next nonce by querying the chain, with caching for batched sends.
+    ///
+    /// See [`NonceKeyFiller`] for more information.
+    fn with_nonce_key_filler(
+        self,
+    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>;
 }
 
 impl TempoProviderBuilderExt
@@ -61,6 +71,13 @@ impl TempoProviderBuilderExt
     > {
         ProviderBuilder::default().filler(TempoFillers::default())
     }
+
+    fn with_nonce_key_filler(
+        self,
+    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
+    {
+        ProviderBuilder::default().filler(TempoFillers::default())
+    }
 }
 
 #[cfg(test)]
@@ -69,7 +86,7 @@ mod tests {
 
     use crate::{
         TempoFillers, TempoNetwork,
-        fillers::{ExpiringNonceFiller, Random2DNonceFiller},
+        fillers::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller},
         provider::ext::TempoProviderBuilderExt,
     };
 
@@ -83,5 +100,11 @@ mod tests {
     fn test_with_expiring_nonces() {
         let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<ExpiringNonceFiller>>, _> =
             ProviderBuilder::new_with_network::<TempoNetwork>().with_expiring_nonces();
+    }
+
+    #[test]
+    fn test_with_nonce_key_filler() {
+        let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
+            ProviderBuilder::new_with_network::<TempoNetwork>().with_nonce_key_filler();
     }
 }


### PR DESCRIPTION
Adds `NonceKeyFiller`, a `TxFiller` for sequential nonce management with a pre-set `nonce_key`. Where `Random2DNonceFiller` picks a random key and `ExpiringNonceFiller` uses `U256::MAX`, this filler takes a user-specified nonce key and resolves the correct next nonce from the chain, caching it per `(address, nonce_key)` pair for batched sends.

Nonce resolution by key value:
- `U256::ZERO` (protocol nonce) — `get_transaction_count`
- `TEMPO_EXPIRING_NONCE_KEY` — always 0
- Any other key — `eth_call` to the `NonceManager` precompile via `INonce::getNonce`

Also adds `with_nonce_key_filler()` convenience method on `TempoProviderBuilderExt`.