### PR TITLE
docs(precompiles): add crate description

### DIFF
--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tempo-precompiles"
-description = "TODO:"
+description = "Tempo EVM precompile implementations for TIP-20 tokens, stablecoin DEX, fee manager, validator config, account keychain, and nonce management"
 
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Replaces the `TODO:` placeholder with a description covering the precompiles in this crate: TIP-20 tokens, stablecoin DEX, fee manager, validator config, account keychain, and nonce management.

Prompted by: mattsse