### PR TITLE
feat(precompiles): add no_std support

### DIFF
--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 # List of crates to check for no_std compatibility.
 # These crates are expected to build without std on bare-metal targets.
 no_std_crates=(
+    tempo-chainspec
     tempo-contracts
     tempo-primitives
 )

--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -7,6 +7,7 @@ set -eo pipefail
 no_std_crates=(
     tempo-chainspec
     tempo-contracts
+    tempo-precompiles
     tempo-primitives
 )
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11921,6 +11921,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "eyre",
+ "once_cell",
  "reth-chainspec",
  "reth-cli",
  "reth-network-peers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12252,16 +12252,19 @@ dependencies = [
 name = "tempo-precompiles"
 version = "1.4.0"
 dependencies = [
- "alloy",
+ "alloy-consensus",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "commonware-codec",
  "commonware-cryptography",
  "criterion 0.8.2",
  "derive_more",
  "eyre",
+ "hashbrown 0.15.5",
+ "once_cell",
  "proptest",
  "rand 0.8.5",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -141,7 +141,7 @@ reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "
 reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -171,9 +171,9 @@ alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.27.3"
+alloy-evm = { version = "0.27.3", default-features = false }
 revm-inspectors = "0.34.2"
-alloy-genesis = "1.6.1"
+alloy-genesis = { version = "1.6.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-network = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.5.4", default-features = false }
@@ -220,6 +220,7 @@ itertools = "0.14.0"
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
 metrics = "0.24.3"
+once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 p256 = { version = "0.13", default-features = false }
 parking_lot = "0.12.5"
 prometheus-client = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ futures = "0.3.31"
 governor = "0.10.4"
 indexmap = "2.13.0"
 indicatif = "0.18"
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 itertools = "0.14.0"
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
@@ -236,11 +237,11 @@ serde_json = { version = "1.0.149", features = ["alloc"], default-features = fal
 schnellru = "0.2"
 sha2 = { version = "0.10", default-features = false }
 tempfile = "3.24.0"
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }
 # TODO: restrict this to only the required features
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-util = "0.7.18"
-tracing = "0.1.44"
+tracing = { version = "0.1.44", default-features = false }
 tracing-subscriber = "0.3.22"
 url = "2.5"
 criterion = "0.8.2"

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -40,7 +40,7 @@ commonware-runtime = { workspace = true, features = ["external"] }
 commonware-utils.workspace = true
 futures = { workspace = true, features = ["executor"] }
 rand_08.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-cli.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -20,6 +20,7 @@ reth-network-peers.workspace = true
 
 alloy-evm.workspace = true
 alloy-genesis.workspace = true
+once_cell.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-hardforks.workspace = true
@@ -29,11 +30,23 @@ serde.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["serde", "cli"]
+default = ["std", "serde", "cli"]
+std = [
+    "alloy-eips/std",
+    "alloy-evm/std",
+    "alloy-genesis/std",
+    "alloy-primitives/std",
+    "once_cell/std",
+    "reth-chainspec/std",
+    "reth-network-peers/std",
+    "serde/std",
+    "serde_json/std",
+    "tempo-primitives/std",
+]
 serde = [
     "alloy-eips/serde",
     "alloy-hardforks/serde",
     "alloy-primitives/serde",
     "tempo-primitives/serde"
 ]
-cli = ["dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]
+cli = ["std", "dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]

--- a/crates/chainspec/src/bootnodes.rs
+++ b/crates/chainspec/src/bootnodes.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use reth_network_peers::{NodeRecord, parse_nodes};
 
 pub(crate) static ANDANTINO_BOOTNODES: [&str; 4] = [

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -1,7 +1,10 @@
 //! Tempo chainspec implementation.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
 
 mod bootnodes;
 pub mod hardfork;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -13,7 +13,11 @@ use alloy_evm::{
 };
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
+use once_cell as _;
+#[cfg(not(feature = "std"))]
 use once_cell::sync::Lazy as LazyLock;
+#[cfg(feature = "std")]
+use std::sync::LazyLock;
 use reth_chainspec::{
     BaseFeeParams, Chain, ChainSpec, DepositContract, DisplayHardforks, EthChainSpec,
     EthereumHardfork, EthereumHardforks, ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks,

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -16,14 +16,14 @@ use alloy_primitives::{Address, B256, U256};
 use once_cell as _;
 #[cfg(not(feature = "std"))]
 use once_cell::sync::Lazy as LazyLock;
-#[cfg(feature = "std")]
-use std::sync::LazyLock;
 use reth_chainspec::{
     BaseFeeParams, Chain, ChainSpec, DepositContract, DisplayHardforks, EthChainSpec,
     EthereumHardfork, EthereumHardforks, ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks,
     Head,
 };
 use reth_network_peers::NodeRecord;
+#[cfg(feature = "std")]
+use std::sync::LazyLock;
 use tempo_primitives::TempoHeader;
 
 /// T0 base fee: 10 billion attodollars (1×10^10)

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -2,6 +2,7 @@ use crate::{
     bootnodes::{andantino_nodes, moderato_nodes, presto_nodes},
     hardfork::{TempoHardfork, TempoHardforks},
 };
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use alloy_eips::eip7840::BlobParams;
 use alloy_evm::{
     eth::spec::EthExecutorSpec,
@@ -12,13 +13,13 @@ use alloy_evm::{
 };
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
+use once_cell::sync::Lazy as LazyLock;
 use reth_chainspec::{
     BaseFeeParams, Chain, ChainSpec, DepositContract, DisplayHardforks, EthChainSpec,
     EthereumHardfork, EthereumHardforks, ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks,
     Head,
 };
 use reth_network_peers::NodeRecord;
-use std::sync::{Arc, LazyLock};
 use tempo_primitives::TempoHeader;
 
 /// T0 base fee: 10 billion attodollars (1×10^10)
@@ -331,7 +332,7 @@ impl EthChainSpec for TempoChainSpec {
         self.inner.prune_delete_limit()
     }
 
-    fn display_hardforks(&self) -> Box<dyn std::fmt::Display> {
+    fn display_hardforks(&self) -> Box<dyn core::fmt::Display> {
         // filter only tempo hardforks
         let tempo_forks = self.inner.hardforks.forks_iter().filter(|(fork, _)| {
             !EthereumHardfork::VARIANTS

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -17,7 +17,7 @@ tempo-dkg-onchain-artifacts.workspace = true
 tempo-node.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-payload-types.workspace = true
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 tempo-telemetry-util.workspace = true
 
 alloy-consensus.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -14,16 +14,16 @@ workspace = true
 tempo-chainspec.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-primitives-traits.workspace = true
 
 alloy-consensus.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-alloy-genesis.workspace = true
+alloy-genesis = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 serde_json.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -21,5 +21,6 @@ alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [features]
-default = ["rpc"]
+default = ["std", "rpc"]
+std = ["alloy-primitives/std", "alloy-sol-types/std"]
 rpc = ["dep:alloy-contract"]

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -16,8 +16,8 @@ alloy = { workspace = true, features = [
   "rlp",
   "providers",
 ] }
-alloy-evm.workspace = true
-alloy-genesis.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
+alloy-genesis = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 
 commonware-codec.workspace = true
@@ -39,7 +39,7 @@ reth-ethereum = { workspace = true, features = [
   "test-utils",
   "pool",
 ] }
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["std"] }
 reth-node-builder.workspace = true
 reth-node-core.workspace = true
 reth-node-metrics.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,7 +18,7 @@ tempo-chainspec.workspace = true
 tempo-consensus.workspace = true
 tempo-payload-builder.workspace = true
 tempo-payload-types.workspace = true
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 tempo-primitives = { workspace = true, features = ["default"] }
 
 thiserror.workspace = true
@@ -63,7 +63,7 @@ jsonrpsee.workspace = true
 tempo-e2e.workspace = true
 tempo-transaction-pool = { workspace = true, features = ["test-utils"] }
 alloy-network.workspace = true
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 alloy-rpc-types-engine.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "test-utils", "pool"] }
 reth-e2e-test-utils.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -19,7 +19,7 @@ tempo-transaction-pool.workspace = true
 tempo-payload-types.workspace = true
 
 reth-basic-payload-builder.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-consensus-common.workspace = true
 reth-engine-tree.workspace = true
 reth-errors.workspace = true

--- a/crates/precompiles-macros/src/layout.rs
+++ b/crates/precompiles-macros/src/layout.rs
@@ -51,7 +51,7 @@ pub(crate) fn gen_handler_field_init(
     let slot_expr = if is_contract {
         quote! { #const_mod::#slot_const }
     } else {
-        quote! { base_slot.saturating_add(::alloy::primitives::U256::from_limbs([#const_mod::#loc_const.offset_slots as u64, 0, 0, 0])) }
+        quote! { base_slot.saturating_add(::alloy_primitives::U256::from_limbs([#const_mod::#loc_const.offset_slots as u64, 0, 0, 0])) }
     };
 
     match &field.kind {
@@ -114,7 +114,7 @@ pub(crate) fn gen_struct(
     quote! {
         #vis struct #name {
             #(#handler_fields,)*
-            address: ::alloy::primitives::Address,
+            address: ::alloy_primitives::Address,
             storage: crate::storage::StorageCtx,
         }
     }
@@ -149,7 +149,7 @@ pub(crate) fn gen_constructor(
             #new_fn
 
             #[inline(always)]
-            fn __new(address: ::alloy::primitives::Address) -> Self {
+            fn __new(address: ::alloy_primitives::Address) -> Self {
                 // Run collision detection checks in debug builds
                 #[cfg(debug_assertions)]
                 {
@@ -165,19 +165,19 @@ pub(crate) fn gen_constructor(
 
             #[inline(always)]
             fn __initialize(&mut self) -> crate::error::Result<()> {
-                let bytecode = ::revm::state::Bytecode::new_legacy(::alloy::primitives::Bytes::from_static(&[0xef]));
+                let bytecode = ::revm::state::Bytecode::new_legacy(::alloy_primitives::Bytes::from_static(&[0xef]));
                 self.storage.set_code(self.address, bytecode)?;
 
                 Ok(())
             }
 
             #[inline(always)]
-            fn emit_event(&mut self, event: impl ::alloy::primitives::IntoLogData) -> crate::error::Result<()> {
+            fn emit_event(&mut self, event: impl ::alloy_primitives::IntoLogData) -> crate::error::Result<()> {
                 self.storage.emit_event(self.address, event.into_log_data())
             }
 
             #[cfg(any(test, feature = "test-utils"))]
-            pub fn emitted_events(&self) -> &Vec<::alloy::primitives::LogData> {
+            pub fn emitted_events(&self) -> &Vec<::alloy_primitives::LogData> {
                 self.storage.get_events(self.address)
             }
 
@@ -187,7 +187,7 @@ pub(crate) fn gen_constructor(
             }
 
             #[cfg(any(test, feature = "test-utils"))]
-            pub fn assert_emitted_events(&self, expected: Vec<impl ::alloy::primitives::IntoLogData>) {
+            pub fn assert_emitted_events(&self, expected: Vec<impl ::alloy_primitives::IntoLogData>) {
                 let emitted = self.storage.get_events(self.address);
                 assert_eq!(emitted.len(), expected.len());
 
@@ -204,7 +204,7 @@ pub(crate) fn gen_contract_storage_impl(name: &Ident) -> proc_macro2::TokenStrea
     quote! {
         impl crate::storage::ContractStorage for #name {
             #[inline(always)]
-            fn address(&self) -> ::alloy::primitives::Address {
+            fn address(&self) -> ::alloy_primitives::Address {
                 self.address
             }
 

--- a/crates/precompiles-macros/src/packing.rs
+++ b/crates/precompiles-macros/src/packing.rs
@@ -137,8 +137,8 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
         let consts = PackingConstants::new(field.name);
         let (loc_const, (slot_const, offset_const)) = (consts.location(), consts.into_tuple());
         let slots_to_end = quote! {
-            ::alloy::primitives::U256::from_limbs([<#ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
-                .saturating_sub(::alloy::primitives::U256::ONE)
+            ::alloy_primitives::U256::from_limbs([<#ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
+                .saturating_sub(::alloy_primitives::U256::ONE)
         };
 
         // Generate byte count constants for each field
@@ -153,7 +153,7 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
                 // HACK: we leverage compiler evaluation checks to ensure that the full type can fit
                 // by computing the slot as: `SLOT = SLOT + (TYPE_LEN - 1)  - (TYPE_LEN - 1)`
                 let slot_expr = quote! {
-                    ::alloy::primitives::uint!(#slot_lit)
+                    ::alloy_primitives::uint!(#slot_lit)
                         .checked_add(#slots_to_end).expect("slot overflow")
                         .saturating_sub(#slots_to_end)
                 };
@@ -180,7 +180,7 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
                     // HACK: we leverage compiler evaluation checks to ensure that the full type can fit
                     // by computing the slot as: `SLOT = SLOT + (TYPE_LEN - 1)  - (TYPE_LEN - 1)`
                     let slot_expr = quote! {
-                        ::alloy::primitives::U256::from_limbs([#(#limbs),*])
+                        ::alloy_primitives::U256::from_limbs([#(#limbs),*])
                             .checked_add(#slots_to_end).expect("slot overflow")
                             .saturating_sub(#slots_to_end)
                     };
@@ -194,7 +194,7 @@ pub(crate) fn gen_constants_from_ir(fields: &[LayoutField<'_>], gen_location: bo
 
         // Generate slot constant without suffix (U256) and offset constant (usize)
         constants.extend(quote! {
-            pub const #slot_const: ::alloy::primitives::U256 = #slot_expr;
+            pub const #slot_const: ::alloy_primitives::U256 = #slot_expr;
             pub const #offset_const: usize = #offset_expr;
         });
 
@@ -298,11 +298,11 @@ pub(crate) fn gen_slot_packing_logic(
 ) -> (TokenStream, TokenStream) {
     // Helper for converting SLOTS to U256
     let prev_layout_slots = quote! {
-        ::alloy::primitives::U256::from_limbs([<#prev_ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
+        ::alloy_primitives::U256::from_limbs([<#prev_ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
     };
     let curr_slots_to_end = quote! {
-        ::alloy::primitives::U256::from_limbs([<#curr_ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
-            .saturating_sub(::alloy::primitives::U256::ONE)
+        ::alloy_primitives::U256::from_limbs([<#curr_ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
+            .saturating_sub(::alloy_primitives::U256::ONE)
     };
 
     // Compute packing decision at compile-time
@@ -383,7 +383,7 @@ pub(crate) fn gen_collision_check_fn(
     all_fields: &[LayoutField<'_>],
 ) -> (Ident, TokenStream) {
     fn gen_slot_count_expr(ty: &Type) -> TokenStream {
-        quote! { ::alloy::primitives::U256::from_limbs([<#ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0]) }
+        quote! { ::alloy_primitives::U256::from_limbs([<#ty as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0]) }
     }
 
     let check_fn_name = format_ident!("__check_collision_{}", field.name);

--- a/crates/precompiles-macros/src/storable.rs
+++ b/crates/precompiles-macros/src/storable.rs
@@ -111,7 +111,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
             type Handler = #handler_name;
 
-            fn handle(slot: ::alloy::primitives::U256, _ctx: crate::storage::LayoutCtx, address: ::alloy::primitives::Address) -> Self::Handler {
+            fn handle(slot: ::alloy_primitives::U256, _ctx: crate::storage::LayoutCtx, address: ::alloy_primitives::Address) -> Self::Handler {
                 #handler_name::new(slot, address)
             }
         }
@@ -120,7 +120,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
         impl #impl_generics crate::storage::Storable for #strukt #ty_generics #where_clause {
             fn load<S: crate::storage::StorageOps>(
                 storage: &S,
-                base_slot: ::alloy::primitives::U256,
+                base_slot: ::alloy_primitives::U256,
                 ctx: crate::storage::LayoutCtx
             ) -> crate::error::Result<Self> {
                 use crate::storage::Storable;
@@ -137,7 +137,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             fn store<S: crate::storage::StorageOps>(
                 &self,
                 storage: &mut S,
-                base_slot: ::alloy::primitives::U256,
+                base_slot: ::alloy_primitives::U256,
                 ctx: crate::storage::LayoutCtx
             ) -> crate::error::Result<()> {
                 use crate::storage::Storable;
@@ -150,7 +150,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
             fn delete<S: crate::storage::StorageOps>(
                 storage: &mut S,
-                base_slot: ::alloy::primitives::U256,
+                base_slot: ::alloy_primitives::U256,
                 ctx: crate::storage::LayoutCtx
             ) -> crate::error::Result<()> {
                 use crate::storage::Storable;
@@ -195,7 +195,7 @@ fn gen_packing_module_from_ir(fields: &[LayoutField<'_>], mod_ident: &Ident) -> 
 
             #packing_constants
             pub const SLOT_COUNT: usize = (#last_slot_const.saturating_add(
-                ::alloy::primitives::U256::from_limbs([<#last_type as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
+                ::alloy_primitives::U256::from_limbs([<#last_type as crate::storage::StorableType>::SLOTS as u64, 0, 0, 0])
             )).as_limbs()[0] as usize;
         }
     }
@@ -226,15 +226,15 @@ fn gen_handler_struct(
         /// Provides individual field access via public fields and whole-struct operations.
         #[derive(Debug, Clone)]
         pub struct #handler_name {
-            address: ::alloy::primitives::Address,
-            base_slot: ::alloy::primitives::U256,
+            address: ::alloy_primitives::Address,
+            base_slot: ::alloy_primitives::U256,
             #(#handler_fields,)*
         }
 
         impl #handler_name {
             /// Creates a new handler for the struct at the given base slot.
             #[inline]
-            pub fn new(base_slot: ::alloy::primitives::U256, address: ::alloy::primitives::Address) -> Self {
+            pub fn new(base_slot: ::alloy_primitives::U256, address: ::alloy_primitives::Address) -> Self {
                 Self {
                     base_slot,
                     #(#field_inits,)*
@@ -247,7 +247,7 @@ fn gen_handler_struct(
             /// Single-slot structs pack all fields into this slot.
             /// Multi-slot structs use consecutive slots starting from this base.
             #[inline]
-            pub fn base_slot(&self) -> ::alloy::primitives::U256 {
+            pub fn base_slot(&self) -> ::alloy_primitives::U256 {
                 self.base_slot
             }
 
@@ -313,7 +313,7 @@ fn gen_load_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
         let (prev_slot_ref, _) =
             packing::get_neighbor_slot_refs(idx, fields, packing, |(name, _)| name, false);
 
-        let slot_addr = quote! { base_slot + ::alloy::primitives::U256::from(#packing::#loc_const.offset_slots) };
+        let slot_addr = quote! { base_slot + ::alloy_primitives::U256::from(#packing::#loc_const.offset_slots) };
         let packed_ctx = quote! { crate::storage::LayoutCtx::packed(#packing::#loc_const.offset_bytes) };
 
         if let Some(prev_slot_ref) = prev_slot_ref {
@@ -325,12 +325,12 @@ fn gen_load_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
                     if <#ty as crate::storage::StorableType>::IS_PACKABLE && curr_offset == prev_offset {
                         // Same slot as previous packable field - reuse cached value
                         let packed = crate::storage::packing::PackedSlot(cached_slot);
-                        <#ty as crate::storage::Storable>::load(&packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?
+                        <#ty as crate::storage::Storable>::load(&packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?
                     } else if <#ty as crate::storage::StorableType>::IS_PACKABLE {
                         // New slot, but packable - load and cache for potential reuse
                         cached_slot = storage.load(#slot_addr)?;
                         let packed = crate::storage::packing::PackedSlot(cached_slot);
-                        <#ty as crate::storage::Storable>::load(&packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?
+                        <#ty as crate::storage::Storable>::load(&packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?
                     } else {
                         // Non-packable - direct load
                         <#ty as crate::storage::Storable>::load(storage, #slot_addr, crate::storage::LayoutCtx::FULL)?
@@ -343,7 +343,7 @@ fn gen_load_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
                 let #name = if <#ty as crate::storage::StorableType>::IS_PACKABLE {
                     cached_slot = storage.load(#slot_addr)?;
                     let packed = crate::storage::packing::PackedSlot(cached_slot);
-                    <#ty as crate::storage::Storable>::load(&packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?
+                    <#ty as crate::storage::Storable>::load(&packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?
                 } else {
                     <#ty as crate::storage::Storable>::load(storage, #slot_addr, crate::storage::LayoutCtx::FULL)?
                 };
@@ -352,7 +352,7 @@ fn gen_load_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
     });
 
     quote! {
-        let mut cached_slot = ::alloy::primitives::U256::ZERO;
+        let mut cached_slot = ::alloy_primitives::U256::ZERO;
         #(#field_loads)*
     }
 }
@@ -373,7 +373,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
         let (prev_slot_ref, next_slot_ref) =
             packing::get_neighbor_slot_refs(idx, fields, packing, |(name, _)| name, false);
 
-        let slot_addr = quote! { base_slot + ::alloy::primitives::U256::from(#packing::#loc_const.offset_slots) };
+        let slot_addr = quote! { base_slot + ::alloy_primitives::U256::from(#packing::#loc_const.offset_slots) };
         let packed_ctx = quote! { crate::storage::LayoutCtx::packed(#packing::#loc_const.offset_bytes) };
 
         // Determine if we need to store after this field
@@ -396,22 +396,22 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
                 if <#ty as crate::storage::StorableType>::IS_PACKABLE && curr_offset == prev_offset {
                     // Same slot as previous packable field - accumulate in pending slot
                     let mut packed = crate::storage::packing::PackedSlot(pending_val);
-                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?;
+                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?;
                     pending_val = packed.0;
                 } else if <#ty as crate::storage::StorableType>::IS_PACKABLE {
                     // New slot, but packable - commit previous and start new batch
                     if let Some(offset) = pending_offset {
-                        storage.store(base_slot + ::alloy::primitives::U256::from(offset), pending_val)?;
+                        storage.store(base_slot + ::alloy_primitives::U256::from(offset), pending_val)?;
                     }
                     pending_val = storage.load(#slot_addr)?;
                     pending_offset = Some(curr_offset);
                     let mut packed = crate::storage::packing::PackedSlot(pending_val);
-                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?;
+                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?;
                     pending_val = packed.0;
                 } else {
                     // Non-packable - commit pending and do direct store
                     if let Some(offset) = pending_offset {
-                        storage.store(base_slot + ::alloy::primitives::U256::from(offset), pending_val)?;
+                        storage.store(base_slot + ::alloy_primitives::U256::from(offset), pending_val)?;
                         pending_offset = None;
                     }
                     <#ty as crate::storage::Storable>::store(&self.#name, storage, #slot_addr, crate::storage::LayoutCtx::FULL)?;
@@ -419,7 +419,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
 
                 // Store if this is the last field in the current slot group
                 if let Some(offset) = pending_offset && (#should_store) {
-                    storage.store(base_slot + ::alloy::primitives::U256::from(offset), pending_val)?;
+                    storage.store(base_slot + ::alloy_primitives::U256::from(offset), pending_val)?;
                     pending_offset = None;
                 }
             }}
@@ -430,7 +430,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
                     pending_val = storage.load(#slot_addr)?;
                     pending_offset = Some(#packing::#loc_const.offset_slots);
                     let mut packed = crate::storage::packing::PackedSlot(pending_val);
-                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy::primitives::U256::ZERO, #packed_ctx)?;
+                    <#ty as crate::storage::Storable>::store(&self.#name, &mut packed, ::alloy_primitives::U256::ZERO, #packed_ctx)?;
                     pending_val = packed.0;
 
                     // Store if this is the last field in the current slot group
@@ -446,7 +446,7 @@ fn gen_store_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
     });
 
     quote! {
-        let mut pending_val = ::alloy::primitives::U256::ZERO;
+        let mut pending_val = ::alloy_primitives::U256::ZERO;
         let mut pending_offset: Option<usize> = None;
         #(#field_stores)*
     }
@@ -461,7 +461,7 @@ fn gen_delete_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
             if <#ty as crate::storage::StorableType>::IS_DYNAMIC {
                 <#ty as crate::storage::Storable>::delete(
                     storage,
-                    base_slot + ::alloy::primitives::U256::from(#packing::#loc_const.offset_slots),
+                    base_slot + ::alloy_primitives::U256::from(#packing::#loc_const.offset_slots),
                     crate::storage::LayoutCtx::FULL
                 )?;
             }
@@ -485,8 +485,8 @@ fn gen_delete_impl(fields: &[(&Ident, &Type)], packing: &Ident) -> TokenStream {
             // Only zero this slot if a static field occupies it
             if #(#is_static_slot)||* {
                 storage.store(
-                    base_slot + ::alloy::primitives::U256::from(slot_offset),
-                    ::alloy::primitives::U256::ZERO
+                    base_slot + ::alloy_primitives::U256::from(slot_offset),
+                    ::alloy_primitives::U256::ZERO
                 )?;
             }
         }

--- a/crates/precompiles-macros/src/storable_primitives.rs
+++ b/crates/precompiles-macros/src/storable_primitives.rs
@@ -45,7 +45,7 @@ fn gen_storable_layout_impl(type_path: &TokenStream, byte_count: usize) -> Token
             const LAYOUT: Layout = Layout::Bytes(#byte_count);
             type Handler = crate::storage::Slot<Self>;
 
-            fn handle(slot: U256, ctx: LayoutCtx, address: ::alloy::primitives::Address) -> Self::Handler {
+            fn handle(slot: U256, ctx: LayoutCtx, address: ::alloy_primitives::Address) -> Self::Handler {
                 crate::storage::Slot::new_with_ctx(slot, ctx, address)
             }
         }
@@ -78,8 +78,8 @@ fn gen_to_word_impl(type_path: &TokenStream, strategy: &StorableConversionStrate
             quote! {
                 impl FromWord for #type_path {
                     #[inline]
-                    fn to_word(&self) -> ::alloy::primitives::U256 {
-                        ::alloy::primitives::U256::from(*self)
+                    fn to_word(&self) -> ::alloy_primitives::U256 {
+                        ::alloy_primitives::U256::from(*self)
                     }
 
                     #[inline]
@@ -93,14 +93,14 @@ fn gen_to_word_impl(type_path: &TokenStream, strategy: &StorableConversionStrate
             quote! {
                 impl FromWord for #type_path {
                     #[inline]
-                    fn to_word(&self) -> ::alloy::primitives::U256 {
-                        ::alloy::primitives::U256::from(*self)
+                    fn to_word(&self) -> ::alloy_primitives::U256 {
+                        ::alloy_primitives::U256::from(*self)
                     }
 
                     #[inline]
-                    fn from_word(word: ::alloy::primitives::U256) -> crate::error::Result<Self> {
+                    fn from_word(word: ::alloy_primitives::U256) -> crate::error::Result<Self> {
                         // Check if value fits in target type
-                        if word > ::alloy::primitives::U256::from(::alloy::primitives::#ty::MAX) {
+                        if word > ::alloy_primitives::U256::from(::alloy_primitives::#ty::MAX) {
                             return Err(crate::error::TempoPrecompileError::under_overflow());
                         }
                         Ok(word.to::<Self>())
@@ -114,7 +114,7 @@ fn gen_to_word_impl(type_path: &TokenStream, strategy: &StorableConversionStrate
                     #[inline]
                     fn to_word(&self) -> U256 {
                         // Store as right-aligned unsigned representation
-                        ::alloy::primitives::U256::from(*self as #unsigned_type)
+                        ::alloy_primitives::U256::from(*self as #unsigned_type)
                     }
 
                     #[inline]
@@ -131,19 +131,19 @@ fn gen_to_word_impl(type_path: &TokenStream, strategy: &StorableConversionStrate
             quote! {
                 impl FromWord for #type_path {
                     #[inline]
-                    fn to_word(&self) -> ::alloy::primitives::U256 {
+                    fn to_word(&self) -> ::alloy_primitives::U256 {
                         // Store as right-aligned unsigned representation
-                        ::alloy::primitives::U256::from(self.into_raw())
+                        ::alloy_primitives::U256::from(self.into_raw())
                     }
 
                     #[inline]
-                    fn from_word(word: ::alloy::primitives::U256) -> crate::error::Result<Self> {
+                    fn from_word(word: ::alloy_primitives::U256) -> crate::error::Result<Self> {
                         // Check if value fits in the unsigned backing type
-                        if word > ::alloy::primitives::U256::from(::alloy::primitives::#unsigned_type::MAX) {
+                        if word > ::alloy_primitives::U256::from(::alloy_primitives::#unsigned_type::MAX) {
                             return Err(crate::error::TempoPrecompileError::under_overflow());
                         }
                         // Extract low bytes as unsigned, then interpret as signed
-                        let unsigned_val = word.to::<::alloy::primitives::#unsigned_type>();
+                        let unsigned_val = word.to::<::alloy_primitives::#unsigned_type>();
                         Ok(Self::from_raw(unsigned_val))
                     }
                 }
@@ -153,14 +153,14 @@ fn gen_to_word_impl(type_path: &TokenStream, strategy: &StorableConversionStrate
             quote! {
                 impl FromWord for #type_path {
                     #[inline]
-                    fn to_word(&self) -> ::alloy::primitives::U256 {
+                    fn to_word(&self) -> ::alloy_primitives::U256 {
                         let mut bytes = [0u8; 32];
                         bytes[32 - #size..].copy_from_slice(&self[..]);
-                        ::alloy::primitives::U256::from_be_bytes(bytes)
+                        ::alloy_primitives::U256::from_be_bytes(bytes)
                     }
 
                     #[inline]
-                    fn from_word(word: ::alloy::primitives::U256) -> crate::error::Result<Self> {
+                    fn from_word(word: ::alloy_primitives::U256) -> crate::error::Result<Self> {
                         let bytes = word.to_be_bytes::<32>();
                         let mut fixed_bytes = [0u8; #size];
                         fixed_bytes.copy_from_slice(&bytes[32 - #size..]);
@@ -193,7 +193,7 @@ fn gen_complete_impl_set(config: &TypeConfig) -> TokenStream {
                 #[inline]
                 fn load<S: crate::storage::StorageOps>(
                     storage: &S,
-                    slot: ::alloy::primitives::U256,
+                    slot: ::alloy_primitives::U256,
                     _ctx: crate::storage::LayoutCtx
                 ) -> crate::error::Result<Self> {
                     storage.load(slot).and_then(<Self as crate::storage::types::FromWord>::from_word)
@@ -203,7 +203,7 @@ fn gen_complete_impl_set(config: &TypeConfig) -> TokenStream {
                 fn store<S: crate::storage::StorageOps>(
                     &self,
                     storage: &mut S,
-                    slot: ::alloy::primitives::U256,
+                    slot: ::alloy_primitives::U256,
                     _ctx: crate::storage::LayoutCtx
                 ) -> crate::error::Result<()> {
                     storage.store(slot, <Self as crate::storage::types::FromWord>::to_word(self))
@@ -264,7 +264,7 @@ fn gen_alloy_integers() -> Vec<TokenStream> {
 
         // Generate unsigned integer configuration and implementation
         let unsigned_config = TypeConfig {
-            type_path: quote! { ::alloy::primitives::#unsigned_type },
+            type_path: quote! { ::alloy_primitives::#unsigned_type },
             byte_count,
             storable_strategy: StorableConversionStrategy::UnsignedAlloy(unsigned_type.clone()),
             storage_key_strategy: StorageKeyStrategy::WithSize(byte_count),
@@ -273,7 +273,7 @@ fn gen_alloy_integers() -> Vec<TokenStream> {
 
         // Generate signed integer configuration and implementation
         let signed_config = TypeConfig {
-            type_path: quote! { ::alloy::primitives::#signed_type },
+            type_path: quote! { ::alloy_primitives::#signed_type },
             byte_count,
             storable_strategy: StorableConversionStrategy::SignedAlloy(unsigned_type.clone()),
             storage_key_strategy: StorageKeyStrategy::SignedRaw(byte_count),
@@ -291,7 +291,7 @@ fn gen_fixed_bytes(sizes: &[usize]) -> Vec<TokenStream> {
     for &size in sizes {
         // Generate FixedBytes configuration and implementation
         let config = TypeConfig {
-            type_path: quote! { ::alloy::primitives::FixedBytes<#size> },
+            type_path: quote! { ::alloy_primitives::FixedBytes<#size> },
             byte_count: size,
             storable_strategy: StorableConversionStrategy::FixedBytes(size),
             storage_key_strategy: StorageKeyStrategy::AsSlice,
@@ -375,7 +375,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
 
             type Handler = crate::storage::types::array::ArrayHandler<#elem_type, #array_size>;
 
-            fn handle(slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx, address: ::alloy::primitives::Address) -> Self::Handler {
+            fn handle(slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx, address: ::alloy_primitives::Address) -> Self::Handler {
                 debug_assert_eq!(ctx, crate::storage::LayoutCtx::FULL, "Arrays cannot be packed");
                 Self::Handler::new(slot, address)
             }
@@ -384,7 +384,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
         // Implement Storable with full I/O logic
         impl crate::storage::Storable for [#elem_type; #array_size] {
             #[inline]
-            fn load<S: crate::storage::StorageOps>(storage: &S, slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<Self> {
+            fn load<S: crate::storage::StorageOps>(storage: &S, slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<Self> {
                 debug_assert_eq!(
                     ctx, crate::storage::LayoutCtx::FULL,
                     "Arrays can only be loaded with LayoutCtx::FULL"
@@ -396,7 +396,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
             }
 
             #[inline]
-            fn store<S: crate::storage::StorageOps>(&self, storage: &mut S, slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<()> {
+            fn store<S: crate::storage::StorageOps>(&self, storage: &mut S, slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<()> {
                 debug_assert_eq!(
                     ctx, crate::storage::LayoutCtx::FULL,
                     "Arrays can only be stored with LayoutCtx::FULL"
@@ -459,7 +459,7 @@ fn gen_unpacked_array_load(array_size: &usize) -> TokenStream {
     quote! {
         let mut result = [Default::default(); #array_size];
         for i in 0..#array_size {
-            let elem_slot = base_slot + ::alloy::primitives::U256::from(i);
+            let elem_slot = base_slot + ::alloy_primitives::U256::from(i);
             result[i] = crate::storage::Storable::load(storage, elem_slot, crate::storage::LayoutCtx::FULL)?;
         }
         Ok(result)
@@ -470,7 +470,7 @@ fn gen_unpacked_array_load(array_size: &usize) -> TokenStream {
 fn gen_unpacked_array_store() -> TokenStream {
     quote! {
         for (i, elem) in self.iter().enumerate() {
-            let elem_slot = base_slot + ::alloy::primitives::U256::from(i);
+            let elem_slot = base_slot + ::alloy_primitives::U256::from(i);
             crate::storage::Storable::store(elem, storage, elem_slot, crate::storage::LayoutCtx::FULL)?;
         }
         Ok(())
@@ -531,7 +531,7 @@ pub(crate) fn gen_storable_arrays() -> TokenStream {
         let type_ident = quote::format_ident!("U{}", bit_size);
         let byte_count = bit_size / 8;
         all_impls.extend(gen_arrays_for_type(
-            quote! { ::alloy::primitives::#type_ident },
+            quote! { ::alloy_primitives::#type_ident },
             byte_count,
             &sizes,
         ));
@@ -542,7 +542,7 @@ pub(crate) fn gen_storable_arrays() -> TokenStream {
         let type_ident = quote::format_ident!("I{}", bit_size);
         let byte_count = bit_size / 8;
         all_impls.extend(gen_arrays_for_type(
-            quote! { ::alloy::primitives::#type_ident },
+            quote! { ::alloy_primitives::#type_ident },
             byte_count,
             &sizes,
         ));
@@ -550,7 +550,7 @@ pub(crate) fn gen_storable_arrays() -> TokenStream {
 
     // Address (20 bytes, not packable since 32 % 20 != 0)
     all_impls.extend(gen_arrays_for_type(
-        quote! { ::alloy::primitives::Address },
+        quote! { ::alloy_primitives::Address },
         20,
         &sizes,
     ));
@@ -558,7 +558,7 @@ pub(crate) fn gen_storable_arrays() -> TokenStream {
     // Common FixedBytes types
     for &byte_size in &[20, 32] {
         all_impls.extend(gen_arrays_for_type(
-            quote! { ::alloy::primitives::FixedBytes<#byte_size> },
+            quote! { ::alloy_primitives::FixedBytes<#byte_size> },
             byte_size,
             &sizes,
         ));
@@ -663,7 +663,7 @@ fn gen_struct_array_impl(struct_type: &TokenStream, array_size: usize) -> TokenS
 
             type Handler = crate::storage::Slot<Self>;
 
-            fn handle(slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx, address: ::alloy::primitives::Address) -> Self::Handler {
+            fn handle(slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx, address: ::alloy_primitives::Address) -> Self::Handler {
                 crate::storage::Slot::new_with_ctx(slot, ctx, address)
             }
         }
@@ -671,7 +671,7 @@ fn gen_struct_array_impl(struct_type: &TokenStream, array_size: usize) -> TokenS
         // Implement Storable with full I/O logic
         impl crate::storage::Storable for [#struct_type; #array_size] {
             #[inline]
-            fn load<S: crate::storage::StorageOps>(storage: &S, slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<Self> {
+            fn load<S: crate::storage::StorageOps>(storage: &S, slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<Self> {
                 debug_assert_eq!(
                     ctx, crate::storage::LayoutCtx::FULL,
                     "Struct arrays can only be loaded with LayoutCtx::FULL"
@@ -681,7 +681,7 @@ fn gen_struct_array_impl(struct_type: &TokenStream, array_size: usize) -> TokenS
             }
 
             #[inline]
-            fn store<S: crate::storage::StorageOps>(&self, storage: &mut S, slot: ::alloy::primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<()> {
+            fn store<S: crate::storage::StorageOps>(&self, storage: &mut S, slot: ::alloy_primitives::U256, ctx: crate::storage::LayoutCtx) -> crate::error::Result<()> {
                 debug_assert_eq!(
                     ctx, crate::storage::LayoutCtx::FULL,
                     "Struct arrays can only be stored with LayoutCtx::FULL"
@@ -705,8 +705,8 @@ fn gen_struct_array_load(struct_type: &TokenStream, array_size: usize) -> TokenS
         for i in 0..#array_size {
             // Calculate slot for this element: base_slot + (i * element_slot_count)
             let elem_slot = base_slot.checked_add(
-                ::alloy::primitives::U256::from(i).checked_mul(
-                    ::alloy::primitives::U256::from(<#struct_type as crate::storage::StorableType>::SLOTS)
+                ::alloy_primitives::U256::from(i).checked_mul(
+                    ::alloy_primitives::U256::from(<#struct_type as crate::storage::StorableType>::SLOTS)
                 ).ok_or(crate::error::TempoError::SlotOverflow)?
             ).ok_or(crate::error::TempoError::SlotOverflow)?;
 
@@ -722,8 +722,8 @@ fn gen_struct_array_store(struct_type: &TokenStream) -> TokenStream {
         for (i, elem) in self.iter().enumerate() {
             // Calculate slot for this element: base_slot + (i * element_slot_count)
             let elem_slot = base_slot.checked_add(
-                ::alloy::primitives::U256::from(i).checked_mul(
-                    ::alloy::primitives::U256::from(<#struct_type as crate::storage::StorableType>::SLOTS)
+                ::alloy_primitives::U256::from(i).checked_mul(
+                    ::alloy_primitives::U256::from(<#struct_type as crate::storage::StorableType>::SLOTS)
                 ).ok_or(crate::error::TempoError::SlotOverflow)?
             ).ok_or(crate::error::TempoError::SlotOverflow)?;
 

--- a/crates/precompiles-macros/src/storable_tests.rs
+++ b/crates/precompiles-macros/src/storable_tests.rs
@@ -68,8 +68,8 @@ fn gen_alloy_unsigned_arbitrary() -> TokenStream {
             let fn_name = quote::format_ident!("arb_u{size}_alloy");
 
             quote! {
-                fn #fn_name() -> impl Strategy<Value = ::alloy::primitives::#type_name> {
-                    Just(()).prop_perturb(|_, _| ::alloy::primitives::#type_name::random())
+                fn #fn_name() -> impl Strategy<Value = ::alloy_primitives::#type_name> {
+                    Just(()).prop_perturb(|_, _| ::alloy_primitives::#type_name::random())
                 }
             }
         })
@@ -93,23 +93,23 @@ fn gen_alloy_signed_arbitrary() -> TokenStream {
             vec![
                 // Any signed value
                 quote! {
-                    fn #arb_any_fn() -> impl Strategy<Value = ::alloy::primitives::#signed_type> {
-                        #arb_unsigned_fn().prop_map(|u| ::alloy::primitives::#signed_type::from_raw(u))
+                    fn #arb_any_fn() -> impl Strategy<Value = ::alloy_primitives::#signed_type> {
+                        #arb_unsigned_fn().prop_map(|u| ::alloy_primitives::#signed_type::from_raw(u))
                     }
                 },
                 // Positive values only
                 quote! {
-                    fn #arb_pos_fn() -> impl Strategy<Value = ::alloy::primitives::#signed_type> {
+                    fn #arb_pos_fn() -> impl Strategy<Value = ::alloy_primitives::#signed_type> {
                         #arb_unsigned_fn().prop_map(|u| {
-                            ::alloy::primitives::#signed_type::from_raw(
-                                u & (::alloy::primitives::#unsigned_type::MAX >> 1)
+                            ::alloy_primitives::#signed_type::from_raw(
+                                u & (::alloy_primitives::#unsigned_type::MAX >> 1)
                             )
                         })
                     }
                 },
                 // Negative values only
                 quote! {
-                    fn #arb_neg_fn() -> impl Strategy<Value = ::alloy::primitives::#signed_type> {
+                    fn #arb_neg_fn() -> impl Strategy<Value = ::alloy_primitives::#signed_type> {
                         #arb_pos_fn().prop_map(|i| -i)
                     }
                 },
@@ -128,8 +128,8 @@ fn gen_fixed_bytes_arbitrary() -> TokenStream {
             let fn_name = quote::format_ident!("arb_fixed_bytes_{size}");
 
             quote! {
-                fn #fn_name() -> impl Strategy<Value = ::alloy::primitives::FixedBytes<#size>> {
-                    Just(()).prop_perturb(|_, _| ::alloy::primitives::FixedBytes::<#size>::random())
+                fn #fn_name() -> impl Strategy<Value = ::alloy_primitives::FixedBytes<#size>> {
+                    Just(()).prop_perturb(|_, _| ::alloy_primitives::FixedBytes::<#size>::random())
                 }
             }
         })
@@ -273,7 +273,7 @@ fn gen_alloy_unsigned_tests() -> TokenStream {
                 fn #test_name(value in #arb_fn(), base_slot in arb_safe_slot()) {
                     let (mut storage, address) = setup_storage();
                     StorageCtx::enter(&mut storage, || {
-                        let mut slot = Slot::<::alloy::primitives::#type_name>::new(base_slot, address);
+                        let mut slot = Slot::<::alloy_primitives::#type_name>::new(base_slot, address);
 
                         // Verify store → load roundtrip
                         slot.write(value).unwrap();
@@ -285,13 +285,13 @@ fn gen_alloy_unsigned_tests() -> TokenStream {
                         let after_delete = slot.read().unwrap();
                         assert_eq!(
                             after_delete,
-                            ::alloy::primitives::#type_name::ZERO,
+                            ::alloy_primitives::#type_name::ZERO,
                             concat!(#label, " not zero after delete")
                         );
 
                         // EVM word roundtrip
                         let word = value.to_word();
-                        let recovered = ::alloy::primitives::#type_name::from_word(word).unwrap();
+                        let recovered = ::alloy_primitives::#type_name::from_word(word).unwrap();
                         assert_eq!(value, recovered, concat!(#label, " EVM word roundtrip failed"));
 
                     });
@@ -328,7 +328,7 @@ fn gen_alloy_signed_tests() -> TokenStream {
                     fn #pos_test_name(value in #arb_pos_fn(), base_slot in arb_safe_slot()) {
                         let (mut storage, address) = setup_storage();
                         StorageCtx::enter(&mut storage, || {
-                            let mut slot = Slot::<::alloy::primitives::#type_name>::new(base_slot, address);
+                            let mut slot = Slot::<::alloy_primitives::#type_name>::new(base_slot, address);
 
                             // Verify store → load roundtrip
                             slot.write(value).unwrap();
@@ -340,13 +340,13 @@ fn gen_alloy_signed_tests() -> TokenStream {
                             let after_delete = slot.read().unwrap();
                             assert_eq!(
                                 after_delete,
-                                ::alloy::primitives::#type_name::ZERO,
+                                ::alloy_primitives::#type_name::ZERO,
                                 concat!(#label, " not zero after delete")
                             );
 
                             // EVM word roundtrip
                             let word = value.to_word();
-                            let recovered = ::alloy::primitives::#type_name::from_word(word).unwrap();
+                            let recovered = ::alloy_primitives::#type_name::from_word(word).unwrap();
                             assert_eq!(value, recovered, concat!(#label, " positive EVM word roundtrip failed"));
                         });
                     }
@@ -357,7 +357,7 @@ fn gen_alloy_signed_tests() -> TokenStream {
                     fn #neg_test_name(value in #arb_neg_fn(), base_slot in arb_safe_slot()) {
                         let (mut storage, address) = setup_storage();
                         StorageCtx::enter(&mut storage, || {
-                            let mut slot = Slot::<::alloy::primitives::#type_name>::new(base_slot, address);
+                            let mut slot = Slot::<::alloy_primitives::#type_name>::new(base_slot, address);
 
                             // Verify store → load roundtrip
                             slot.write(value).unwrap();
@@ -369,13 +369,13 @@ fn gen_alloy_signed_tests() -> TokenStream {
                             let after_delete = slot.read().unwrap();
                             assert_eq!(
                                 after_delete,
-                                ::alloy::primitives::#type_name::ZERO,
+                                ::alloy_primitives::#type_name::ZERO,
                                 concat!(#label, " not zero after delete")
                             );
 
                             // EVM word roundtrip
                             let word = value.to_word();
-                            let recovered = ::alloy::primitives::#type_name::from_word(word).unwrap();
+                            let recovered = ::alloy_primitives::#type_name::from_word(word).unwrap();
                             assert_eq!(value, recovered, concat!(#label, " negative EVM word roundtrip failed"));
                         });
                     }
@@ -406,7 +406,7 @@ fn gen_fixed_bytes_tests() -> TokenStream {
                 fn #test_name(value in #arb_fn(), base_slot in arb_safe_slot()) {
                     let (mut storage, address) = setup_storage();
                     StorageCtx::enter(&mut storage, || {
-                        let mut slot = Slot::<::alloy::primitives::FixedBytes<#size>>::new(base_slot, address);
+                        let mut slot = Slot::<::alloy_primitives::FixedBytes<#size>>::new(base_slot, address);
 
                         // Verify store → load roundtrip
                         slot.write(value).unwrap();
@@ -421,13 +421,13 @@ fn gen_fixed_bytes_tests() -> TokenStream {
                         let after_delete = slot.read().unwrap();
                         assert_eq!(
                             after_delete,
-                            ::alloy::primitives::FixedBytes::<#size>::ZERO,
+                            ::alloy_primitives::FixedBytes::<#size>::ZERO,
                             concat!("FixedBytes<", stringify!(#size), "> not zero after delete")
                         );
 
                         // EVM word roundtrip
                         let word = value.to_word();
-                        let recovered = ::alloy::primitives::FixedBytes::<#size>::from_word(word).unwrap();
+                        let recovered = ::alloy_primitives::FixedBytes::<#size>::from_word(word).unwrap();
                         assert_eq!(
                             value, recovered,
                             concat!("FixedBytes<", stringify!(#size), "> EVM word roundtrip failed")

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -16,7 +16,7 @@ tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 tempo-precompiles-macros.workspace = true
 alloy = { workspace = true, features = ["sol-types", "consensus"] }
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 revm.workspace = true
 
 commonware-cryptography.workspace = true

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -15,17 +15,21 @@ workspace = true
 tempo-contracts.workspace = true
 tempo-chainspec.workspace = true
 tempo-precompiles-macros.workspace = true
-alloy = { workspace = true, features = ["sol-types", "consensus"] }
-alloy-evm = { workspace = true, features = ["std"] }
+alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
+alloy-consensus = { workspace = true, features = ["k256"] }
+alloy-evm.workspace = true
 revm.workspace = true
 
-commonware-cryptography.workspace = true
-commonware-codec.workspace = true
+commonware-cryptography = { workspace = true, optional = true }
+commonware-codec = { workspace = true, optional = true }
 
-tracing.workspace = true
+hashbrown.workspace = true
+once_cell.workspace = true
+tracing = { workspace = true }
 thiserror.workspace = true
 derive_more.workspace = true
-scoped-tls = "1.0"
+scoped-tls = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -40,9 +44,24 @@ serde_json.workspace = true
 tempo-evm.workspace = true
 
 [features]
-default = ["rpc"]
-test-utils = ["alloy/getrandom"]
-rpc = ["tempo-contracts/rpc"]
+default = ["std", "rpc"]
+std = [
+    "dep:scoped-tls",
+    "dep:commonware-cryptography",
+    "dep:commonware-codec",
+    "alloy-primitives/std",
+    "alloy-sol-types/std",
+    "alloy-consensus/std",
+    "alloy-evm/std",
+    "revm/std",
+    "tempo-contracts/std",
+    "tempo-chainspec/std",
+    "once_cell/std",
+    "tracing/std",
+    "thiserror/std",
+]
+test-utils = ["std", "alloy-primitives/rand"]
+rpc = ["std", "tempo-contracts/rpc"]
 
 [[test]]
 name = "storage"

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -59,6 +59,9 @@ std = [
     "once_cell/std",
     "tracing/std",
     "thiserror/std",
+    "derive_more/std",
+    "serde/std",
+    "serde_json/std",
 ]
 test-utils = ["std", "alloy-primitives/rand"]
 rpc = ["std", "tempo-contracts/rpc"]

--- a/crates/precompiles/benches/tempo_precompiles.rs
+++ b/crates/precompiles/benches/tempo_precompiles.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, FixedBytes, U256};
+use alloy_primitives::{Address, FixedBytes, U256};
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 use tempo_precompiles::{

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,6 +1,7 @@
 use super::AccountKeychain;
 use crate::{Precompile, dispatch_call, input_cost, mutate_void, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy_primitives::Address;
+use alloy_sol_types::SolInterface;
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;
 

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     error::Result,
     storage::{Handler, Mapping, packing::insert_into_word},
 };
-use alloy::primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use tempo_precompiles_macros::{Storable, contract};
 
 /// Key information stored in the precompile
@@ -119,7 +119,7 @@ impl AccountKeychain {
     /// This is used to access `spending_limits[key][token]` where `key` is the result
     /// of this function. The hash combines account and key_id to avoid triple nesting.
     pub fn spending_limit_key(account: Address, key_id: Address) -> B256 {
-        use alloy::primitives::keccak256;
+        use alloy_primitives::keccak256;
         let mut data = [0u8; 40];
         data[..20].copy_from_slice(account.as_slice());
         data[20..].copy_from_slice(key_id.as_slice());
@@ -594,7 +594,7 @@ mod tests {
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
     };
-    use alloy::primitives::{Address, U256};
+    use alloy_primitives::{Address, U256};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::IAccountKeychain::SignatureType;
 

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -1,13 +1,18 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, LazyLock},
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
 };
+use hashbrown::HashMap;
+use once_cell as _;
+#[cfg(not(feature = "std"))]
+use once_cell::sync::Lazy as LazyLock;
+#[cfg(feature = "std")]
+use std::sync::LazyLock;
 
 use crate::tip20::TIP20Error;
-use alloy::{
-    primitives::{Selector, U256},
-    sol_types::{Panic, PanicKind, SolError, SolInterface},
-};
+use alloy_primitives::{Selector, U256};
+use alloy_sol_types::{Panic, PanicKind, SolError, SolInterface};
 use revm::{
     context::journaled_state::JournalLoadErasedError,
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
@@ -91,7 +96,7 @@ impl From<JournalLoadErasedError> for TempoPrecompileError {
 }
 
 /// Result type alias for Tempo precompile operations
-pub type Result<T> = std::result::Result<T, TempoPrecompileError>;
+pub type Result<T> = core::result::Result<T, TempoPrecompileError>;
 
 impl TempoPrecompileError {
     /// Returns true if this error represents a system-level failure that must be propagated
@@ -233,7 +238,7 @@ pub trait IntoPrecompileResult<T> {
     fn into_precompile_result(
         self,
         gas: u64,
-        encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
+        encode_ok: impl FnOnce(T) -> alloy_primitives::Bytes,
     ) -> PrecompileResult;
 }
 
@@ -241,7 +246,7 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
     fn into_precompile_result(
         self,
         gas: u64,
-        encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
+        encode_ok: impl FnOnce(T) -> alloy_primitives::Bytes,
     ) -> PrecompileResult {
         match self {
             Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res))),
@@ -254,7 +259,7 @@ impl<T> IntoPrecompileResult<T> for TempoPrecompileError {
     fn into_precompile_result(
         self,
         gas: u64,
-        _encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
+        _encode_ok: impl FnOnce(T) -> alloy_primitives::Bytes,
     ) -> PrecompileResult {
         Self::into_precompile_result(self, gas)
     }

--- a/crates/precompiles/src/ip_validation.rs
+++ b/crates/precompiles/src/ip_validation.rs
@@ -2,14 +2,26 @@
 //!
 //! This module provides validation functions for ensuring that addresses conform
 //! to expected IP address formats (with or without ports).
+//!
+//! In `no_std` builds, validation is a no-op (always succeeds).
 
+#[cfg(feature = "std")]
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum IpWithPortParseError {
     #[error("input was not of the form `<ip>:<port>`")]
     Parse(#[from] std::net::AddrParseError),
 }
 
+#[cfg(not(feature = "std"))]
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum IpWithPortParseError {
+    #[allow(dead_code)]
+    #[error("IP validation requires std")]
+    NoStd,
+}
+
 /// Validates that `input` is of the form `<ip>:<port>`.
+#[cfg(feature = "std")]
 pub(crate) fn ensure_address_is_ip_port(
     input: &str,
 ) -> core::result::Result<(), IpWithPortParseError> {
@@ -17,13 +29,35 @@ pub(crate) fn ensure_address_is_ip_port(
     Ok(())
 }
 
+#[cfg(not(feature = "std"))]
+pub(crate) fn ensure_address_is_ip_port(
+    _input: &str,
+) -> core::result::Result<(), IpWithPortParseError> {
+    Ok(())
+}
+
+#[cfg(feature = "std")]
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum IpParseError {
     #[error("input was not a valid IP address")]
     Parse(#[from] std::net::AddrParseError),
 }
 
+#[cfg(not(feature = "std"))]
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum IpParseError {
+    #[allow(dead_code)]
+    #[error("IP validation requires std")]
+    NoStd,
+}
+
+#[cfg(feature = "std")]
 pub(crate) fn ensure_address_is_ip(input: &str) -> core::result::Result<(), IpParseError> {
     input.parse::<std::net::IpAddr>()?;
+    Ok(())
+}
+
+#[cfg(not(feature = "std"))]
+pub(crate) fn ensure_address_is_ip(_input: &str) -> core::result::Result<(), IpParseError> {
     Ok(())
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -1,6 +1,10 @@
 //! Tempo precompile implementations.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[macro_use]
+extern crate alloc;
 
 pub mod error;
 pub use error::{IntoPrecompileResult, Result};
@@ -36,14 +40,11 @@ use crate::{
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 
-#[cfg(test)]
-use alloy::sol_types::SolInterface;
-use alloy::{
-    primitives::{Address, Bytes},
-    sol,
-    sol_types::{SolCall, SolError},
-};
 use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_primitives::{Address, Bytes};
+#[cfg(test)]
+use alloy_sol_types::SolInterface;
+use alloy_sol_types::{SolCall, SolError, sol};
 use revm::{
     context::CfgEnv,
     handler::EthPrecompiles,
@@ -294,7 +295,7 @@ pub fn unknown_selector(selector: [u8; 4], gas: u64) -> PrecompileResult {
 #[inline]
 fn dispatch_call<T>(
     calldata: &[u8],
-    decode: impl FnOnce(&[u8]) -> core::result::Result<T, alloy::sol_types::Error>,
+    decode: impl FnOnce(&[u8]) -> core::result::Result<T, alloy_sol_types::Error>,
     f: impl FnOnce(T) -> PrecompileResult,
 ) -> PrecompileResult {
     let storage = StorageCtx::default();
@@ -315,7 +316,7 @@ fn dispatch_call<T>(
 
     match result {
         Ok(call) => f(call).map(|res| fill_precompile_output(res, &storage)),
-        Err(alloy::sol_types::Error::UnknownSelector { selector, .. }) => {
+        Err(alloy_sol_types::Error::UnknownSelector { selector, .. }) => {
             unknown_selector(*selector, storage.gas_used())
                 .map(|res| fill_precompile_output(res, &storage))
         }
@@ -329,7 +330,7 @@ fn dispatch_call<T>(
 #[cfg(test)]
 pub fn expect_precompile_revert<E>(result: &PrecompileResult, expected_error: E)
 where
-    E: SolInterface + PartialEq + std::fmt::Debug,
+    E: SolInterface + PartialEq + core::fmt::Debug,
 {
     match result {
         Ok(result) => {
@@ -347,11 +348,11 @@ where
 mod tests {
     use super::*;
     use crate::tip20::TIP20Token;
-    use alloy::primitives::{Address, Bytes, U256, bytes};
     use alloy_evm::{
         EthEvmFactory, EvmEnv, EvmFactory, EvmInternals,
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
     };
+    use alloy_primitives::{Address, Bytes, U256, bytes};
     use revm::{
         context::{ContextTr, TxEnv},
         database::{CacheDB, EmptyDB},

--- a/crates/precompiles/src/nonce/dispatch.rs
+++ b/crates/precompiles/src/nonce/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::{Precompile, dispatch_call, input_cost, nonce::NonceManager, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy_primitives::Address;
+use alloy_sol_types::SolInterface;
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::INonce::INonceCalls;
 

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     error::Result,
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 
 /// Capacity of the expiring nonce seen set (supports 10k TPS for 30 seconds).
 pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
@@ -181,7 +181,7 @@ mod tests {
     };
 
     use super::*;
-    use alloy::primitives::address;
+    use alloy_primitives::address;
 
     #[test]
     fn test_get_nonce_returns_zero_for_new_key() -> eyre::Result<()> {

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -1,7 +1,8 @@
 //! Stablecoin DEX precompile
 //!
 //! This module provides the precompile interface for the Stablecoin DEX.
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy_primitives::Address;
+use alloy_sol_types::SolInterface;
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::IStablecoinDEX::IStablecoinDEXCalls;
 
@@ -113,10 +114,8 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, assert_full_coverage, check_selector_coverage},
     };
-    use alloy::{
-        primitives::{Address, U256},
-        sol_types::{SolCall, SolValue},
-    };
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::{SolCall, SolValue};
     use tempo_contracts::precompiles::IStablecoinDEX::IStablecoinDEXCalls;
 
     /// Setup a basic exchange with tokens and liquidity for swap tests

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -21,7 +21,8 @@ use crate::{
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, TIP403Registry},
 };
-use alloy::primitives::{Address, B256, U256};
+use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, U256};
 use tempo_precompiles_macros::contract;
 
 /// Minimum order size of $100 USD
@@ -1256,7 +1257,7 @@ impl StablecoinDEX {
 
         // Find the lowest common ancestor (LCA) using O(n+m) algorithm:
         // Build a HashSet from path_out for O(1) lookups, then iterate path_in
-        let path_out_set: std::collections::HashSet<Address> = path_out.iter().copied().collect();
+        let path_out_set: hashbrown::HashSet<Address> = path_out.iter().copied().collect();
         let mut lca = None;
         for token_a in &path_in {
             if path_out_set.contains(token_a) {
@@ -1421,7 +1422,8 @@ impl StablecoinDEX {
 
 #[cfg(test)]
 mod tests {
-    use alloy::{primitives::IntoLogData, sol_types::SolEvent};
+    use alloy_primitives::IntoLogData;
+    use alloy_sol_types::SolEvent;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP20Error;
 

--- a/crates/precompiles/src/stablecoin_dex/order.rs
+++ b/crates/precompiles/src/stablecoin_dex/order.rs
@@ -5,7 +5,7 @@
 //! automatically place opposite-side orders when filled.
 
 use crate::stablecoin_dex::{IStablecoinDEX, error::OrderError};
-use alloy::primitives::{Address, B256};
+use alloy_primitives::{Address, B256};
 use tempo_precompiles_macros::Storable;
 
 /// Represents an order in the stablecoin DEX orderbook.
@@ -306,7 +306,7 @@ mod tests {
     };
 
     use super::*;
-    use alloy::primitives::{address, b256};
+    use alloy_primitives::{address, b256};
 
     const TEST_MAKER: Address = address!("0x1111111111111111111111111111111111111111");
     const TEST_BOOK_KEY: B256 =

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -5,7 +5,7 @@ use crate::{
     stablecoin_dex::{IStablecoinDEX, TICK_SPACING},
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{Address, B256, U256, keccak256};
 use tempo_contracts::precompiles::StablecoinDEXError;
 use tempo_precompiles_macros::Storable;
 
@@ -451,7 +451,7 @@ mod tests {
     use crate::error::TempoPrecompileError;
     use rand_08::Rng;
 
-    use alloy::primitives::address;
+    use alloy_primitives::address;
 
     #[test]
     fn test_tick_level_creation() {

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -1,5 +1,6 @@
-use alloy::primitives::{Address, Log, LogData, U256};
+use alloc::string::ToString;
 use alloy_evm::{EvmInternals, EvmInternalsError};
+use alloy_primitives::{Address, Log, LogData, U256};
 use revm::{
     context::{Block, CfgEnv, journaled_state::JournalCheckpoint},
     context_interface::cfg::{GasParams, gas},
@@ -274,8 +275,8 @@ pub fn deduct_gas(gas: &mut u64, additional_cost: u64) -> Result<(), TempoPrecom
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{address, b256, bytes};
     use alloy_evm::{EvmEnv, EvmFactory, EvmInternals, revm::context::Host};
+    use alloy_primitives::{address, b256, bytes};
     use revm::{
         database::{CacheDB, EmptyDB},
         interpreter::StateLoad,

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -1,9 +1,10 @@
-use alloy::primitives::{Address, LogData, U256};
+use alloc::vec::Vec;
+use alloy_primitives::{Address, LogData, U256};
+use hashbrown::HashMap;
 use revm::{
     context::journaled_state::JournalCheckpoint,
     state::{AccountInfo, Bytecode},
 };
-use std::collections::HashMap;
 use tempo_chainspec::hardfork::TempoHardfork;
 
 use crate::{error::TempoPrecompileError, storage::PrecompileStorageProvider};
@@ -46,6 +47,7 @@ impl HashMapStorageProvider {
             events: HashMap::new(),
             snapshots: Vec::new(),
             chain_id,
+            #[cfg(feature = "std")]
             #[expect(clippy::disallowed_methods)]
             timestamp: U256::from(
                 std::time::SystemTime::now()
@@ -53,6 +55,8 @@ impl HashMapStorageProvider {
                     .unwrap()
                     .as_secs(),
             ),
+            #[cfg(not(feature = "std"))]
+            timestamp: U256::ZERO,
             beneficiary: Address::ZERO,
             block_number: 0,
             spec,

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -11,7 +11,7 @@ pub mod packing;
 pub use packing::FieldLocation;
 pub use types::mapping as slots;
 
-use alloy::primitives::{Address, LogData, U256};
+use alloy_primitives::{Address, LogData, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
     state::{AccountInfo, Bytecode},

--- a/crates/precompiles/src/storage/packing.rs
+++ b/crates/precompiles/src/storage/packing.rs
@@ -12,7 +12,7 @@
 //! - Values are right-aligned within their byte range
 //! - Types smaller than 32 bytes can pack multiple per slot when dimensions align
 
-use alloy::primitives::U256;
+use alloy_primitives::U256;
 
 use crate::{
     error::Result,
@@ -263,7 +263,7 @@ mod tests {
         },
         test_util::{gen_word_from, setup_storage},
     };
-    use alloy::primitives::Address;
+    use alloy_primitives::Address;
 
     // -- HELPER FUNCTION TESTS ----------------------------------------------------
 

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -1,20 +1,24 @@
-use alloy::primitives::{Address, LogData, U256};
 use alloy_evm::{Database, EvmInternals};
+use alloy_primitives::{Address, LogData, U256};
+#[cfg(feature = "std")]
+use core::cell::RefCell;
+use core::fmt::Debug;
 use revm::{
     context::{Block, CfgEnv, JournalTr, Transaction, journaled_state::JournalCheckpoint},
     state::{AccountInfo, Bytecode},
 };
-use scoped_tls::scoped_thread_local;
-use std::{cell::RefCell, fmt::Debug};
 use tempo_chainspec::hardfork::TempoHardfork;
 
+#[cfg(feature = "std")]
+use crate::error::TempoPrecompileError;
 use crate::{
     Precompile,
-    error::{Result, TempoPrecompileError},
+    error::Result,
     storage::{PrecompileStorageProvider, evm::EvmPrecompileStorageProvider},
 };
 
-scoped_thread_local!(static STORAGE: RefCell<&mut dyn PrecompileStorageProvider>);
+#[cfg(feature = "std")]
+scoped_tls::scoped_thread_local!(static STORAGE: RefCell<&mut dyn PrecompileStorageProvider>);
 
 /// Thread-local storage accessor that implements `PrecompileStorageProvider` without the trait bound.
 ///
@@ -42,6 +46,7 @@ impl StorageCtx {
     /// 1. Only one `enter` call is active at a time, in the same thread.
     /// 2. If multiple storage providers are instantiated in parallel threads,
     ///    they CANNOT point to the same storage addresses.
+    #[cfg(feature = "std")]
     pub fn enter<S, R>(storage: &mut S, f: impl FnOnce() -> R) -> R
     where
         S: PrecompileStorageProvider,
@@ -49,15 +54,24 @@ impl StorageCtx {
         // SAFETY: `scoped_tls` ensures the pointer is only accessible within the closure scope.
         let storage: &mut dyn PrecompileStorageProvider = storage;
         let storage_static: &mut (dyn PrecompileStorageProvider + 'static) =
-            unsafe { std::mem::transmute(storage) };
+            unsafe { core::mem::transmute(storage) };
         let cell = RefCell::new(storage_static);
         STORAGE.set(&cell, f)
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn enter<S, R>(_storage: &mut S, _f: impl FnOnce() -> R) -> R
+    where
+        S: PrecompileStorageProvider,
+    {
+        panic!("StorageCtx::enter requires the `std` feature")
     }
 
     /// Execute an infallible function with access to the current thread-local storage provider.
     ///
     /// # Panics
     /// Panics if no storage context is set.
+    #[cfg(feature = "std")]
     fn with_storage<F, R>(f: F) -> R
     where
         F: FnOnce(&mut dyn PrecompileStorageProvider) -> R,
@@ -74,7 +88,16 @@ impl StorageCtx {
         })
     }
 
+    #[cfg(not(feature = "std"))]
+    fn with_storage<F, R>(_f: F) -> R
+    where
+        F: FnOnce(&mut dyn PrecompileStorageProvider) -> R,
+    {
+        panic!("StorageCtx::with_storage requires the `std` feature")
+    }
+
     /// Execute a (fallible) function with access to the current thread-local storage provider.
+    #[cfg(feature = "std")]
     fn try_with_storage<F, R>(f: F) -> Result<R>
     where
         F: FnOnce(&mut dyn PrecompileStorageProvider) -> Result<R>,
@@ -90,6 +113,14 @@ impl StorageCtx {
             let mut guard = cell.borrow_mut();
             f(&mut **guard)
         })
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn try_with_storage<F, R>(_f: F) -> Result<R>
+    where
+        F: FnOnce(&mut dyn PrecompileStorageProvider) -> Result<R>,
+    {
+        panic!("StorageCtx::try_with_storage requires the `std` feature")
     }
 
     // `PrecompileStorageProvider` methods (with modified mutability for read-only methods)

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -11,8 +11,8 @@
 //! - **Packed**: When `T::BYTES <= 16`, multiple elements fit in one slot
 //! - **Unpacked**: When `T::BYTES > 16` or doesn't divide 32, each element uses full slot(s)
 
-use alloy::primitives::{Address, U256};
-use std::ops::{Index, IndexMut};
+use alloy_primitives::{Address, U256};
+use core::ops::{Index, IndexMut};
 use tempo_precompiles_macros;
 
 use crate::{
@@ -84,7 +84,7 @@ impl<T: StorableType, const N: usize> ArrayHandler<T, N> {
     /// Single-slot arrays pack all fields into this slot.
     /// Multi-slot arrays use consecutive slots starting from this base.
     #[inline]
-    pub fn base_slot(&self) -> ::alloy::primitives::U256 {
+    pub fn base_slot(&self) -> ::alloy_primitives::U256 {
         self.base_slot
     }
 

--- a/crates/precompiles/src/storage/types/bytes_like.rs
+++ b/crates/precompiles/src/storage/types/bytes_like.rs
@@ -15,8 +15,9 @@ use crate::{
     error::{Result, TempoPrecompileError},
     storage::{StorageOps, types::*},
 };
-use alloy::primitives::{Address, Bytes, U256, keccak256};
-use std::marker::PhantomData;
+use alloc::{string::String, vec::Vec};
+use alloy_primitives::{Address, Bytes, U256, keccak256};
+use core::marker::PhantomData;
 
 impl StorableType for Bytes {
     const LAYOUT: Layout = Layout::Slots(1);

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -1,7 +1,7 @@
 //! Type-safe wrapper for EVM storage mappings (hash-based key-value storage).
 
-use alloy::primitives::{Address, U256};
-use std::{
+use alloy_primitives::{Address, U256};
+use core::{
     hash::Hash,
     ops::{Index, IndexMut},
 };
@@ -157,7 +157,7 @@ where
 mod tests {
     use super::*;
     use crate::storage::StorageKey;
-    use alloy::primitives::{Address, B256, keccak256};
+    use alloy_primitives::{Address, B256, keccak256};
 
     // Backward compatibility helper to verify the trait impl.
     fn old_mapping_slot<K: AsRef<[u8]>>(key: K, slot: U256) -> U256 {

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -16,8 +16,10 @@ use crate::{
     error::Result,
     storage::{StorageOps, packing},
 };
-use alloy::primitives::{Address, U256, keccak256};
-use std::{cell::RefCell, collections::HashMap, hash::Hash};
+use alloc::boxed::Box;
+use alloy_primitives::{Address, U256, keccak256};
+use core::{cell::RefCell, hash::Hash};
+use hashbrown::HashMap;
 
 /// Describes how a type is laid out in EVM storage.
 ///

--- a/crates/precompiles/src/storage/types/primitives.rs
+++ b/crates/precompiles/src/storage/types/primitives.rs
@@ -1,6 +1,6 @@
 //! Single-word primitives (up-to 32 bytes) implementation for the storage traits.
 
-use alloy::primitives::{Address, U256};
+use alloy_primitives::{Address, U256};
 use revm::interpreter::instructions::utility::{IntoAddress, IntoU256};
 use tempo_precompiles_macros;
 

--- a/crates/precompiles/src/storage/types/set.rs
+++ b/crates/precompiles/src/storage/types/set.rs
@@ -41,8 +41,9 @@
 //! handler.write(vec.into())?;  // `Set::from(vec)` deduplicates
 //! ```
 
-use alloy::primitives::{Address, U256};
-use std::{
+use alloc::vec::Vec;
+use alloy_primitives::{Address, U256};
+use core::{
     fmt,
     hash::Hash,
     ops::{Deref, Index},
@@ -120,7 +121,7 @@ impl<T: Eq + Clone> FromIterator<T> for Set<T> {
 
 impl<T> IntoIterator for Set<T> {
     type Item = T;
-    type IntoIter = std::vec::IntoIter<T>;
+    type IntoIter = alloc::vec::IntoIter<T>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -130,7 +131,7 @@ impl<T> IntoIterator for Set<T> {
 
 impl<'a, T> IntoIterator for &'a Set<T> {
     type Item = &'a T;
-    type IntoIter = std::slice::Iter<'a, T>;
+    type IntoIter = core::slice::Iter<'a, T>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -487,7 +488,7 @@ where
 mod tests {
     use super::*;
     use crate::{storage::StorageCtx, test_util::setup_storage};
-    use alloy::primitives::Address;
+    use alloy_primitives::Address;
     use proptest::prelude::*;
 
     // -- SET TYPE TESTS -------------------------------------------------------

--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -1,5 +1,5 @@
-use alloy::primitives::{Address, U256};
-use std::marker::PhantomData;
+use alloy_primitives::{Address, U256};
+use core::marker::PhantomData;
 
 use crate::{
     error::Result,
@@ -235,7 +235,7 @@ mod tests {
         storage::{Handler, PrecompileStorageProvider, StorageKey},
         test_util::setup_storage,
     };
-    use alloy::primitives::{Address, B256};
+    use alloy_primitives::{Address, B256};
     use proptest::prelude::*;
 
     // Property test strategies

--- a/crates/precompiles/src/storage/types/vec.rs
+++ b/crates/precompiles/src/storage/types/vec.rs
@@ -11,8 +11,9 @@
 //! - Supports both single-slot primitives and multi-slot types (structs, arrays)
 //! - Element at index `i` starts at slot `data_start + i * T::SLOTS`
 
-use alloy::primitives::{Address, U256};
-use std::ops::{Index, IndexMut};
+use alloc::vec::Vec;
+use alloy_primitives::{Address, U256};
+use core::ops::{Index, IndexMut};
 
 use crate::{
     error::{Result, TempoPrecompileError},
@@ -220,7 +221,7 @@ where
 
     /// Returns the slot that stores the length of the dynamic array.
     #[inline]
-    pub fn len_slot(&self) -> ::alloy::primitives::U256 {
+    pub fn len_slot(&self) -> ::alloy_primitives::U256 {
         self.len_slot
     }
 
@@ -229,7 +230,7 @@ where
     /// Single-slot vectors pack all fields into this slot.
     /// Multi-slot vectors use consecutive slots starting from this base.
     #[inline]
-    pub fn data_slot(&self) -> ::alloy::primitives::U256 {
+    pub fn data_slot(&self) -> ::alloy_primitives::U256 {
         calc_data_slot(self.len_slot)
     }
 
@@ -382,7 +383,7 @@ where
 /// For Solidity compatibility, dynamic array data is stored at `keccak256(len_slot)`.
 #[inline]
 pub(crate) fn calc_data_slot(len_slot: U256) -> U256 {
-    U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0)
+    U256::from_be_bytes(alloy_primitives::keccak256(len_slot.to_be_bytes::<32>()).0)
 }
 
 /// Load packed elements from storage.
@@ -538,7 +539,7 @@ mod tests {
         storage::{Handler, StorageCtx},
         test_util::{gen_word_from, setup_storage},
     };
-    use alloy::primitives::Address;
+    use alloy_primitives::Address;
     use proptest::prelude::*;
     use tempo_precompiles_macros::Storable;
 
@@ -582,7 +583,7 @@ mod tests {
         // Verify data slot matches keccak256(len_slot)
         let data_slot = calc_data_slot(len_slot);
         let expected =
-            U256::from_be_bytes(alloy::primitives::keccak256(len_slot.to_be_bytes::<32>()).0);
+            U256::from_be_bytes(alloy_primitives::keccak256(len_slot.to_be_bytes::<32>()).0);
 
         assert_eq!(
             data_slot, expected,

--- a/crates/precompiles/src/test_util.rs
+++ b/crates/precompiles/src/test_util.rs
@@ -8,10 +8,8 @@ use crate::{
     tip20::{self, ITIP20, TIP20Token},
     tip20_factory::{self, TIP20Factory},
 };
-use alloy::{
-    primitives::{Address, B256, U256},
-    sol_types::SolError,
-};
+use alloy_primitives::{Address, B256, U256};
+use alloy_sol_types::SolError;
 use revm::precompile::PrecompileError;
 #[cfg(any(test, feature = "test-utils"))]
 use tempo_contracts::precompiles::TIP20Error;
@@ -381,7 +379,8 @@ fn is_initialized(address: Address) -> Result<bool> {
 
 #[cfg(any(test, feature = "test-utils"))]
 fn get_tip20_admin(token: Address) -> Option<Address> {
-    use alloy::{primitives::Log, sol_types::SolEvent};
+    use alloy_primitives::Log;
+    use alloy_sol_types::SolEvent;
     use tempo_contracts::precompiles::ITIP20Factory;
 
     let events = StorageCtx.get_events(TIP20_FACTORY_ADDRESS);

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -6,10 +6,8 @@ use crate::{
     tip20::{ITIP20, TIP20Token},
     unknown_selector, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy_primitives::Address;
+use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::{IRolesAuth::IRolesAuthCalls, ITIP20::ITIP20Calls, TIP20Error};
 
@@ -20,7 +18,7 @@ enum TIP20Call {
 }
 
 impl TIP20Call {
-    fn decode(calldata: &[u8]) -> Result<Self, alloy::sol_types::Error> {
+    fn decode(calldata: &[u8]) -> Result<Self, alloy_sol_types::Error> {
         // safe to expect as `dispatch_call` pre-validates calldata len
         let selector: [u8; 4] = calldata[..4].try_into().expect("calldata len >= 4");
 
@@ -221,10 +219,8 @@ mod tests {
         tip20::{ISSUER_ROLE, PAUSE_ROLE, UNPAUSE_ROLE},
         tip403_registry::{ITIP403Registry, TIP403Registry},
     };
-    use alloy::{
-        primitives::{Bytes, U256, address},
-        sol_types::{SolCall, SolError, SolInterface, SolValue},
-    };
+    use alloy_primitives::{Bytes, U256, address};
+    use alloy_sol_types::{SolCall, SolError, SolInterface, SolValue};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         IRolesAuth, RolesAuthError, TIP20Error, UnknownFunctionSelector,
@@ -645,7 +641,7 @@ mod tests {
                 .with_mint(sender, initial_balance)
                 .apply()?;
 
-            let memo = alloy::primitives::B256::from([1u8; 32]);
+            let memo = alloy_primitives::B256::from([1u8; 32]);
             let transfer_call = ITIP20::transferWithMemoCall {
                 to: recipient,
                 amount: transfer_amount,
@@ -787,8 +783,8 @@ mod tests {
                 value: U256::ZERO,
                 deadline: U256::MAX,
                 v: 27,
-                r: alloy::primitives::B256::ZERO,
-                s: alloy::primitives::B256::ZERO,
+                r: alloy_primitives::B256::ZERO,
+                s: alloy_primitives::B256::ZERO,
             }
             .abi_encode();
             let result = token.call(&permit_calldata, admin)?;

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -19,11 +19,13 @@ use crate::{
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
 };
-use alloy::{
-    hex,
-    primitives::{Address, B256, Signature, U256, keccak256, uint},
-    sol_types::SolValue,
-};
+use alloc::string::{String, ToString};
+use alloy_primitives::{Address, B256, Signature, U256, hex, keccak256, uint};
+use alloy_sol_types::SolValue;
+use once_cell as _;
+#[cfg(not(feature = "std"))]
+use once_cell::sync::Lazy as LazyLock;
+#[cfg(feature = "std")]
 use std::sync::LazyLock;
 use tempo_precompiles_macros::contract;
 use tracing::trace;
@@ -390,7 +392,7 @@ impl TIP20Token {
 
         self.set_total_supply(new_supply)?;
         let to_balance = self.get_balance(to)?;
-        let new_to_balance: alloy::primitives::Uint<256, 4> = to_balance
+        let new_to_balance: alloy_primitives::Uint<256, 4> = to_balance
             .checked_add(amount)
             .ok_or(TempoPrecompileError::under_overflow())?;
         self.set_balance(to, new_to_balance)?;
@@ -576,7 +578,7 @@ impl TIP20Token {
         }
         let parity = call.v == 28;
         let sig = Signature::from_scalars_and_parity(call.r, call.s, parity);
-        let recovered = alloy::consensus::crypto::secp256k1::recover_signer(&sig, digest)
+        let recovered = alloy_consensus::crypto::secp256k1::recover_signer(&sig, digest)
             .map_err(|_| TIP20Error::invalid_signature())?;
         if recovered.is_zero() || recovered != call.owner {
             return Err(TIP20Error::invalid_signature().into());
@@ -965,7 +967,7 @@ impl TIP20Token {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, FixedBytes, IntoLogData, U256};
+    use alloy_primitives::{Address, FixedBytes, IntoLogData, U256};
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20Factory};
 
     use super::*;
@@ -2322,9 +2324,9 @@ pub(crate) mod tests {
 
     mod permit_tests {
         use super::*;
-        use alloy::sol_types::SolValue;
         use alloy_signer::SignerSync;
         use alloy_signer_local::PrivateKeySigner;
+        use alloy_sol_types::SolValue;
         use tempo_chainspec::hardfork::TempoHardfork;
 
         const CHAIN_ID: u64 = 42;

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -3,7 +3,7 @@ use crate::{
     storage::Handler,
     tip20::TIP20Token,
 };
-use alloy::primitives::{Address, U256, uint};
+use alloy_primitives::{Address, U256, uint};
 use tempo_contracts::precompiles::{ITIP20, TIP20Error, TIP20Event};
 use tempo_precompiles_macros::Storable;
 
@@ -354,7 +354,7 @@ mod tests {
         test_util::TIP20Setup,
         tip403_registry::TIP403Registry,
     };
-    use alloy::primitives::{Address, U256};
+    use alloy_primitives::{Address, U256};
     use tempo_contracts::precompiles::{ITIP403Registry, TIP20Error};
 
     #[test]

--- a/crates/precompiles/src/tip20/roles.rs
+++ b/crates/precompiles/src/tip20/roles.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256};
+use alloy_primitives::{Address, B256};
 
 use crate::{
     error::Result,
@@ -152,7 +152,7 @@ impl TIP20Token {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::keccak256;
+    use alloy_primitives::keccak256;
 
     use super::*;
     use crate::{error::TempoPrecompileError, storage::StorageCtx, test_util::TIP20Setup};

--- a/crates/precompiles/src/tip20_factory/dispatch.rs
+++ b/crates/precompiles/src/tip20_factory/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::{Precompile, dispatch_call, input_cost, mutate, tip20_factory::TIP20Factory, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy_primitives::Address;
+use alloy_sol_types::SolInterface;
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::ITIP20Factory::ITIP20FactoryCalls;
 

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -9,10 +9,8 @@ use crate::{
     error::{Result, TempoPrecompileError},
     tip20::{TIP20Error, TIP20Token, USD_CURRENCY, is_tip20_prefix},
 };
-use alloy::{
-    primitives::{Address, B256, keccak256},
-    sol_types::SolValue,
-};
+use alloy_primitives::{Address, B256, keccak256};
+use alloy_sol_types::SolValue;
 use tracing::trace;
 
 /// Number of reserved addresses (0 to RESERVED_SIZE-1) that cannot be deployed via factory
@@ -225,7 +223,7 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{Address, address};
+    use alloy_primitives::{Address, address};
 
     #[test]
     fn test_is_initialized() -> eyre::Result<()> {
@@ -258,7 +256,9 @@ mod tests {
             assert!(is_tip20_prefix(PATH_USD_ADDRESS));
 
             // Address with TIP20 prefix (0x20C0...)
-            let tip20_addr = Address::from(alloy::hex!("20C0000000000000000000000000000000001234"));
+            let tip20_addr = Address::from(alloy_primitives::hex!(
+                "20C0000000000000000000000000000000001234"
+            ));
             assert!(is_tip20_prefix(tip20_addr));
 
             // Random address does not have TIP20 prefix
@@ -485,8 +485,9 @@ mod tests {
             TIP20Setup::path_usd(sender).apply()?;
 
             // Create an address with TIP20 prefix but no code
-            let non_existent_tip20 =
-                Address::from(alloy::hex!("20C0000000000000000000000000000000009999"));
+            let non_existent_tip20 = Address::from(alloy_primitives::hex!(
+                "20C0000000000000000000000000000000009999"
+            ));
             let invalid_call = ITIP20Factory::createTokenCall {
                 name: "Test Token".to_string(),
                 symbol: "TEST".to_string(),

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -3,10 +3,8 @@ use crate::{
     tip403_registry::{AuthRole, TIP403Registry},
     unknown_selector, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy_primitives::Address;
+use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::ITIP403Registry::{
     ITIP403RegistryCalls, compoundPolicyDataCall, createCompoundPolicyCall,
@@ -114,7 +112,7 @@ mod tests {
         test_util::{assert_full_coverage, check_selector_coverage},
         tip403_registry::ITIP403Registry,
     };
-    use alloy::sol_types::{SolCall, SolValue};
+    use alloy_sol_types::{SolCall, SolValue};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::ITIP403Registry::ITIP403RegistryCalls;
 

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, U256};
+use alloy_primitives::{Address, U256};
 
 /// Registry for [TIP-403] transfer policies. TIP20 tokens reference an ID from this registry
 /// to police transfers between sender and receiver addresses.
@@ -637,10 +637,8 @@ mod tests {
         error::TempoPrecompileError,
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
     };
-    use alloy::{
-        primitives::{Address, Log},
-        sol_types::SolEvent,
-    };
+    use alloy_primitives::{Address, Log};
+    use alloy_sol_types::SolEvent;
     use rand_08::Rng;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -4,10 +4,8 @@ use crate::{
     tip_fee_manager::{ITIPFeeAMM, TIPFeeAMMError, TIPFeeAMMEvent, TipFeeManager},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
 };
-use alloy::{
-    primitives::{Address, B256, U256, keccak256, uint},
-    sol_types::SolValue,
-};
+use alloy_primitives::{Address, B256, U256, keccak256, uint};
+use alloy_sol_types::SolValue;
 use tempo_precompiles_macros::Storable;
 
 /// Constants from the Solidity reference implementation
@@ -511,7 +509,7 @@ impl TipFeeManager {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Address;
+    use alloy_primitives::Address;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP20Error;
 

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -7,10 +7,8 @@ use crate::{
     },
     unknown_selector, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy_primitives::Address;
+use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::{
     IFeeManager::{self, IFeeManagerCalls},
@@ -24,7 +22,7 @@ enum TipFeeManagerCall {
 }
 
 impl TipFeeManagerCall {
-    fn decode(calldata: &[u8]) -> Result<Self, alloy::sol_types::Error> {
+    fn decode(calldata: &[u8]) -> Result<Self, alloy_sol_types::Error> {
         // safe to expect as `dispatch_call` pre-validates calldata len
         let selector: [u8; 4] = calldata[..4].try_into().expect("calldata len >= 4");
 
@@ -161,10 +159,8 @@ mod tests {
             amm::{M, MIN_LIQUIDITY, N, PoolKey, SCALE},
         },
     };
-    use alloy::{
-        primitives::{Address, B256, U256},
-        sol_types::{SolCall, SolError, SolValue},
-    };
+    use alloy_primitives::{Address, B256, U256};
+    use alloy_sol_types::{SolCall, SolError, SolValue};
     use tempo_contracts::precompiles::{
         IFeeManager, IFeeManager::IFeeManagerCalls, ITIPFeeAMM, ITIPFeeAMM::ITIPFeeAMMCalls,
     };

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -8,13 +8,13 @@ use crate::{
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
 };
-use alloy::primitives::B256;
+use alloy_primitives::B256;
 pub use tempo_contracts::precompiles::{
     DEFAULT_FEE_TOKEN, FeeManagerError, FeeManagerEvent, IFeeManager, ITIPFeeAMM,
     TIP_FEE_MANAGER_ADDRESS, TIPFeeAMMError, TIPFeeAMMEvent,
 };
 // Re-export PoolKey for backward compatibility with tests
-use alloy::primitives::{Address, U256, uint};
+use alloy_primitives::{Address, U256, uint};
 use tempo_precompiles_macros::contract;
 
 /// Fee manager precompile that handles transaction fee collection and distribution.

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -3,10 +3,8 @@ use crate::{
     Precompile, dispatch_call, error::TempoPrecompileError, input_cost, mutate_void,
     unknown_selector, view,
 };
-use alloy::{
-    primitives::Address,
-    sol_types::{SolCall, SolInterface},
-};
+use alloy_primitives::Address;
+use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::{PrecompileError, PrecompileResult};
 use tempo_contracts::precompiles::IValidatorConfig::{
     IValidatorConfigCalls, changeValidatorStatusByIndexCall,
@@ -83,10 +81,8 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use alloy::{
-        primitives::{Address, FixedBytes},
-        sol_types::{SolCall, SolValue},
-    };
+    use alloy_primitives::{Address, FixedBytes};
+    use alloy_sol_types::{SolCall, SolValue};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         IValidatorConfig, IValidatorConfig::IValidatorConfigCalls, ValidatorConfigError,
@@ -244,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_change_validator_status_by_index_t1_gating() -> eyre::Result<()> {
-        use alloy::sol_types::SolError;
+        use alloy_sol_types::SolError;
         use tempo_contracts::precompiles::UnknownFunctionSelector;
 
         let owner = Address::random();

--- a/crates/precompiles/src/validator_config/mod.rs
+++ b/crates/precompiles/src/validator_config/mod.rs
@@ -9,7 +9,11 @@ use crate::{
     ip_validation::ensure_address_is_ip_port,
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, B256};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use alloy_primitives::{Address, B256};
 use tracing::trace;
 
 /// Validator information
@@ -361,8 +365,7 @@ impl ValidatorConfig {
 mod tests {
     use super::*;
     use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
-    use alloy::primitives::Address;
-    use alloy_primitives::FixedBytes;
+    use alloy_primitives::{Address, FixedBytes};
 
     #[test]
     fn test_owner_initialization_and_change() -> eyre::Result<()> {

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{Precompile, dispatch_call, input_cost, mutate_void, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use alloy_primitives::Address;
+use alloy_sol_types::SolInterface;
 use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
 use tempo_contracts::precompiles::IValidatorConfigV2::IValidatorConfigV2Calls;
 
@@ -95,10 +96,8 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
-    use alloy::{
-        primitives::{Address, FixedBytes},
-        sol_types::{SolCall, SolValue},
-    };
+    use alloy_primitives::{Address, FixedBytes};
+    use alloy_sol_types::{SolCall, SolValue};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
         IValidatorConfigV2, IValidatorConfigV2::IValidatorConfigV2Calls, ValidatorConfigV2Error,
@@ -198,7 +197,7 @@ mod tests {
             msg_data.extend_from_slice(validator_addr.as_slice());
             msg_data.extend_from_slice(b"192.168.1.1:8000");
             msg_data.extend_from_slice(b"192.168.1.1");
-            let message = alloy::primitives::keccak256(&msg_data);
+            let message = alloy_primitives::keccak256(&msg_data);
 
             // Sign with namespace
             let signature = private_key.sign(VALIDATOR_NS_ADD, message.as_slice());

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -4,14 +4,24 @@ use tempo_contracts::precompiles::VALIDATOR_CONFIG_V2_ADDRESS;
 pub use tempo_contracts::precompiles::{IValidatorConfigV2, ValidatorConfigV2Error};
 use tempo_precompiles_macros::{Storable, contract};
 
+#[cfg(feature = "std")]
+use crate::ip_validation::IpWithPortParseError;
 use crate::{
     error::{Result, TempoPrecompileError},
-    ip_validation::{IpWithPortParseError, ensure_address_is_ip, ensure_address_is_ip_port},
+    ip_validation::{ensure_address_is_ip, ensure_address_is_ip_port},
     storage::{Handler, Mapping},
     validator_config::ValidatorConfig,
 };
-use alloy::primitives::{Address, B256, Keccak256, keccak256};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use alloy_primitives::Keccak256;
+use alloy_primitives::{Address, B256, keccak256};
+#[cfg(feature = "std")]
 use commonware_codec::DecodeExt;
+#[cfg(feature = "std")]
 use commonware_cryptography::{
     Verifier,
     ed25519::{PublicKey, Signature},
@@ -240,6 +250,7 @@ impl ValidatorConfigV2 {
 
     /// Parses `ingress` as an `<ip>:<port>` pair and returns the hash of the
     /// binary representation of its IP address.
+    #[cfg(feature = "std")]
     fn ingress_ip_key(ingress: &str) -> Result<B256> {
         let ingress = ingress
             .parse::<std::net::SocketAddr>()
@@ -254,6 +265,11 @@ impl ValidatorConfigV2 {
             std::net::IpAddr::V4(v4) => keccak256(v4.octets()),
             std::net::IpAddr::V6(v6) => keccak256(v6.octets()),
         })
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn ingress_ip_key(ingress: &str) -> Result<B256> {
+        Ok(keccak256(ingress.as_bytes()))
     }
 
     fn require_unique_ingress_ip(&self, ingress: &str) -> Result<B256> {
@@ -345,6 +361,7 @@ impl ValidatorConfigV2 {
     /// **FORMAT**:
     /// - Namespace: [`VALIDATOR_NS_ADD`] or [`VALIDATOR_NS_ROTATE`]
     /// - Message: `keccak256(abi.encodePacked(chainId, contractAddr, validatorAddr, ingress, egress))`
+    #[cfg(feature = "std")]
     fn verify_validator_signature(
         &self,
         namespace: &[u8],
@@ -371,6 +388,19 @@ impl ValidatorConfigV2 {
             Err(ValidatorConfigV2Error::invalid_signature())?
         }
 
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn verify_validator_signature(
+        &self,
+        _namespace: &[u8],
+        _pubkey: &B256,
+        _signature: &[u8],
+        _validator_address: Address,
+        _ingress: &str,
+        _egress: &str,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -582,11 +612,14 @@ impl ValidatorConfigV2 {
         self.require_new_address(v1_val.validatorAddress)?;
         self.require_new_pubkey(v1_val.publicKey)?;
 
+        #[cfg(feature = "std")]
         let egress = v1_val
             .outboundAddress
             .parse::<std::net::SocketAddr>()
             .map(|sa| sa.ip().to_string())
             .unwrap_or(v1_val.outboundAddress);
+        #[cfg(not(feature = "std"))]
+        let egress = v1_val.outboundAddress;
 
         let ingress_hash = self.require_unique_ingress_ip(&v1_val.inboundAddress)?;
 
@@ -638,8 +671,7 @@ fn v1() -> ValidatorConfig {
 mod tests {
     use super::*;
     use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
-    use alloy::primitives::Address;
-    use alloy_primitives::FixedBytes;
+    use alloy_primitives::{Address, FixedBytes};
     use commonware_codec::Encode;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
 

--- a/crates/precompiles/tests/storage_tests/arrays.rs
+++ b/crates/precompiles/tests/storage_tests/arrays.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[test]
 fn test_array_storage() {
-    use alloy::primitives::address;
+    use alloy_primitives::address;
 
     #[contract]
     pub struct Layout {

--- a/crates/precompiles/tests/storage_tests/mod.rs
+++ b/crates/precompiles/tests/storage_tests/mod.rs
@@ -4,7 +4,7 @@ use crate::storage::{
     Handler, LayoutCtx, Slot, Storable, StorageCtx, hashmap::HashMapStorageProvider,
     packing::extract_from_word,
 };
-use alloy::primitives::{Address, U256, keccak256};
+use alloy_primitives::{Address, U256, keccak256};
 use proptest::prelude::*;
 use tempo_precompiles::error;
 use tempo_precompiles_macros::{Storable, contract};

--- a/crates/precompiles/tests/storage_tests/packing.rs
+++ b/crates/precompiles/tests/storage_tests/packing.rs
@@ -3,7 +3,7 @@
 //! This module tests the Storable derive macro's implementation of storage packing,
 //! verifying that fields are correctly packed into slots according to Solidity's rules.
 
-use alloy::primitives::FixedBytes;
+use alloy_primitives::FixedBytes;
 use tempo_precompiles::{
     storage::{FromWord, Layout, StorableType, StorageCtx, packing::insert_into_word},
     test_util::gen_word_from,

--- a/crates/precompiles/tests/storage_tests/sets.rs
+++ b/crates/precompiles/tests/storage_tests/sets.rs
@@ -4,7 +4,7 @@
 //! https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/test/utils/structs/EnumerableSet.behavior.js
 
 use super::*;
-use alloy::primitives::B256;
+use alloy_primitives::B256;
 use tempo_precompiles::storage::{Mapping, Set, StorageCtx};
 
 fn expect_members_match<T>(

--- a/crates/precompiles/tests/storage_tests/solidity/utils.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/utils.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::U256;
+use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, process::Command};
 

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -22,7 +22,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 
 revm.workspace = true
 
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-contracts.workspace = true
 tempo-chainspec.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -17,7 +17,7 @@ tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-primitives = { workspace = true, features = ["serde", "reth-codec"] }
 tempo-revm = { workspace = true, features = ["reth"] }
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -21,7 +21,7 @@ tempo-precompiles.workspace = true
 
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true
-reth-chainspec.workspace = true
+reth-chainspec = { workspace = true, features = ["std"] }
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-provider.workspace = true
@@ -34,7 +34,7 @@ revm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
-alloy-evm.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-sol-types.workspace = true
 
 futures.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,7 +17,7 @@ tempo-primitives.workspace = true
 tempo-commonware-node-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-evm.workspace = true
-tempo-precompiles.workspace = true
+tempo-precompiles = { workspace = true, features = ["std"] }
 tempo-revm.workspace = true
 
 alloy = { workspace = true, features = [


### PR DESCRIPTION
## Summary

Extends no_std support to `tempo-precompiles`, building on the chainspec no_std work in #3019. The crate now compiles with `--no-default-features --target riscv32imac-unknown-none-elf`.

The main challenge was the `alloy` meta-crate which doesn't support no_std. This was solved by replacing it with individual sub-crates (`alloy-primitives`, `alloy-sol-types`, `alloy-consensus`) and updating all imports across the crate and its proc-macro companion.

Changes:
- Replace `alloy` meta-crate with `alloy-primitives`, `alloy-sol-types`, `alloy-consensus`
- Replace `std::` imports with `core::`/`alloc::` equivalents throughout
- Use `hashbrown` for HashMap/HashSet, `once_cell::sync::Lazy` for LazyLock
- Feature-gate `scoped-tls`, `std::net`, `std::time`, `commonware-cryptography`, `commonware-codec` behind `std`
- Provide no_std stubs for thread-local storage, IP validation, and signature verification
- Update proc-macro generated code to reference `alloy_primitives` instead of `alloy::primitives`
- Add `tempo-precompiles` to `check_no_std.sh`