### PR TITLE
ci: run flaky e2e tests exclusively to reduce contention

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,7 +4,8 @@ retries = 2
 test-threads = "num-cpus"
 
 # Heavy e2e tests that flake under resource contention — run exclusively.
-# threads-required = "num-test-threads" means "use all slots", so no other test runs concurrently.
+# threads-required = "num-test-threads" reserves all slots, so no other test runs concurrently.
+# Scheduled last to avoid blocking the rest of the suite.
 [[profile.ci.overrides]]
 filter = """
   package(tempo-e2e) & (
@@ -15,6 +16,7 @@ filter = """
 """
 failure-output = "immediate"
 threads-required = "num-test-threads"
+priority = -100
 
 # tempo-e2e tests spawn multiple execution nodes, each creating 4 rayon thread
 # pools (cpu, rpc, trie, storage) via reth's Runtime. Even with test_with_handle()
@@ -42,6 +44,7 @@ filter = """
   )
 """
 threads-required = "num-test-threads"
+priority = -100
 
 [[profile.default.overrides]]
 filter = "package(tempo-e2e)"


### PR DESCRIPTION
Several e2e tests flake consistently under resource contention on CI (32-vCPU runner):

- `validator_can_fast_sync_after_full_dkg` fails in ~50% of runs, needing all 3 retries in some cases
- `subblocks_are_included` and `can_restart_after_joining_from_snapshot` flake occasionally

These tests were running concurrently with up to 3 other e2e tests (each reserving 8 of 32 slots) plus integration tests.

This adds a nextest override that reserves all test slots (`threads-required = "num-test-threads"`) for these tests so they run exclusively. Also sets `failure-output = "immediate"` for the CI profile so failures produce debuggable output instead of being suppressed by the existing `failure-output = "never"`.

ref https://github.com/tempoxyz/tempo/actions/runs/22798126108/job/66135699771?pr=3023