### PR TITLE
refactor(payload): introduce PoolDecision enum to separate policy from execution

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -62,40 +62,44 @@ use tempo_transaction_pool::{
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
-/// Pre-execution policy decision for a pool transaction.
-///
-/// Separates admission policy from EVM execution: `decide_pool_tx` returns one of these
-/// based on gas budget, block size, and cancellation state, so the main loop reads as
-/// pure domain logic.
-enum PoolDecision {
-    /// Transaction passes all admission checks — execute it.
-    Execute(PoolCandidate),
-    /// Transaction should be skipped for the given reason.
-    Skip(PoolSkipReason),
-    /// Building should stop (interrupted or cancelled).
-    Stop,
-}
-
-/// A pool transaction that passed admission checks and is ready for EVM execution.
-struct PoolCandidate {
-    /// Whether this is a TIP-20 payment transaction.
-    is_payment: bool,
-    /// RLP-encoded byte length of the transaction.
-    rlp_len: usize,
-    /// Effective gas price given the current base fee.
-    effective_gas_price: u128,
-    /// The pool transaction handle (needed for `mark_invalid` on execution failure).
-    pool_tx: Arc<ValidPoolTransaction<TempoPooledTransaction>>,
-}
-
-/// Reason a pool transaction was skipped during pre-execution admission.
+/// Why a pool transaction was rejected during admission checks.
 enum PoolSkipReason {
-    /// Transaction exceeds the non-shared gas limit reserved for proposer txs.
-    ExceedsNonSharedGasLimit,
-    /// Non-payment transaction exceeds the general gas limit.
+    ExceedsNonSharedGasLimit { tx_gas: u64, remaining: u64 },
     ExceedsNonPaymentGasLimit,
-    /// Including this transaction would exceed the max RLP block size (Osaka).
-    OversizedBlock,
+    OversizedBlock { projected_size: usize },
+}
+
+impl PoolSkipReason {
+    fn to_pool_error(&self) -> InvalidPoolTransactionError {
+        match self {
+            Self::ExceedsNonSharedGasLimit { tx_gas, remaining } => {
+                InvalidPoolTransactionError::ExceedsGasLimit(*tx_gas, *remaining)
+            }
+            Self::ExceedsNonPaymentGasLimit => InvalidPoolTransactionError::Other(Box::new(
+                TempoPoolTransactionError::ExceedsNonPaymentLimit,
+            )),
+            Self::OversizedBlock { projected_size } => {
+                InvalidPoolTransactionError::OversizedData {
+                    size: *projected_size,
+                    limit: MAX_RLP_BLOCK_SIZE,
+                }
+            }
+        }
+    }
+
+    fn record_metric(&self, metrics: &TempoPayloadBuilderMetrics) {
+        match self {
+            Self::ExceedsNonSharedGasLimit { .. } => {
+                metrics.pool_transactions_skipped_exceeds_non_shared_gas_limit.increment(1);
+            }
+            Self::ExceedsNonPaymentGasLimit => {
+                metrics.pool_transactions_skipped_exceeds_non_payment_gas_limit.increment(1);
+            }
+            Self::OversizedBlock { .. } => {
+                metrics.pool_transactions_skipped_oversized_block.increment(1);
+            }
+        }
+    }
 }
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
@@ -106,53 +110,38 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
     })
 }
 
-/// Evaluates a pool transaction against admission policy and returns a [`PoolDecision`].
-///
-/// Checks (in order):
-/// 1. Interrupt — payload builder was asked to stop
-/// 2. Non-shared gas limit — proposer's pool txs must not exceed the non-shared portion
-/// 3. General gas limit — non-payment txs have a tighter cap
-/// 4. Block size (Osaka) — RLP-encoded block must not exceed `MAX_RLP_BLOCK_SIZE`
-///
-/// If all checks pass, returns `Execute` with pre-computed facts so the caller doesn't
-/// need to re-derive them.
-fn decide_pool_tx(
+/// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
+fn check_pool_tx_admission(
     pool_tx: &Arc<ValidPoolTransaction<TempoPooledTransaction>>,
-    attributes: &TempoPayloadBuilderAttributes,
     cumulative_gas_used: u64,
     non_shared_gas_limit: u64,
     non_payment_gas_used: u64,
     general_gas_limit: u64,
     block_size_used: usize,
     is_osaka: bool,
-    base_fee: u64,
-) -> PoolDecision {
-    if attributes.is_interrupted() {
-        return PoolDecision::Stop;
+) -> Option<PoolSkipReason> {
+    let remaining = non_shared_gas_limit.saturating_sub(cumulative_gas_used);
+    if pool_tx.gas_limit() > remaining {
+        return Some(PoolSkipReason::ExceedsNonSharedGasLimit {
+            tx_gas: pool_tx.gas_limit(),
+            remaining,
+        });
     }
 
-    if cumulative_gas_used + pool_tx.gas_limit() > non_shared_gas_limit {
-        return PoolDecision::Skip(PoolSkipReason::ExceedsNonSharedGasLimit);
+    if !pool_tx.transaction.is_payment()
+        && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
+    {
+        return Some(PoolSkipReason::ExceedsNonPaymentGasLimit);
     }
 
-    let is_payment = pool_tx.transaction.is_payment();
-
-    if !is_payment && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit {
-        return PoolDecision::Skip(PoolSkipReason::ExceedsNonPaymentGasLimit);
+    if is_osaka {
+        let projected = block_size_used + pool_tx.transaction.inner().length();
+        if projected > MAX_RLP_BLOCK_SIZE {
+            return Some(PoolSkipReason::OversizedBlock { projected_size: projected });
+        }
     }
 
-    let rlp_len = pool_tx.transaction.inner().length();
-
-    if is_osaka && block_size_used + rlp_len > MAX_RLP_BLOCK_SIZE {
-        return PoolDecision::Skip(PoolSkipReason::OversizedBlock);
-    }
-
-    PoolDecision::Execute(PoolCandidate {
-        is_payment,
-        rlp_len,
-        effective_gas_price: pool_tx.transaction.effective_gas_price(Some(base_fee)),
-        pool_tx: Arc::clone(pool_tx),
-    })
+    None
 }
 
 #[derive(Debug, Clone)]
@@ -527,7 +516,9 @@ where
         let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
         loop {
-            // check if the job was cancelled, if so we can exit early
+            if attributes.is_interrupted() {
+                break;
+            }
             if cancel.is_cancelled() {
                 record_pool_selection_metrics(
                     &self.metrics,
@@ -547,125 +538,79 @@ where
                 .record(selection_start.elapsed());
             pool_transactions_considered += 1;
 
-            let decision = decide_pool_tx(
+            // Admission check — skip or execute
+            if let Some(reason) = check_pool_tx_admission(
                 &pool_tx,
-                &attributes,
                 cumulative_gas_used,
                 non_shared_gas_limit,
                 non_payment_gas_used,
                 general_gas_limit,
                 block_size_used,
                 is_osaka,
-                base_fee,
-            );
+            ) {
+                best_txs.mark_invalid(&pool_tx, &reason.to_pool_error());
+                reason.record_metric(&self.metrics);
+                pool_transactions_skipped += 1;
+                continue;
+            }
 
-            match decision {
-                PoolDecision::Execute(candidate) => {
-                    if candidate.is_payment {
-                        payment_transactions += 1;
-                    }
+            // Execute
+            let is_payment = pool_tx.transaction.is_payment();
+            if is_payment {
+                payment_transactions += 1;
+            }
 
-                    let tx_debug_repr = tracing::enabled!(Level::TRACE)
-                        .then(|| format!("{:?}", candidate.pool_tx.transaction))
-                        .unwrap_or_default();
+            let tx_rlp_len = pool_tx.transaction.inner().length();
+            let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
 
-                    let tx_with_env =
-                        candidate.pool_tx.transaction.clone().into_with_tx_env();
-                    let tx_execution_start = Instant::now();
-                    let gas_used = match builder.execute_transaction(tx_with_env) {
-                        Ok(gas_used) => gas_used,
-                        Err(BlockExecutionError::Validation(
-                            BlockValidationError::InvalidTx { error, .. },
-                        )) => {
-                            if error.is_nonce_too_low() {
-                                trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                                self.metrics
-                                    .pool_transactions_skipped_nonce_too_low
-                                    .increment(1);
-                            } else {
-                                trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
-                                best_txs.mark_invalid(
-                                    &candidate.pool_tx,
-                                    &InvalidPoolTransactionError::Consensus(
-                                        InvalidTransactionError::TxTypeNotSupported,
-                                    ),
-                                );
-                                self.metrics
-                                    .pool_transactions_skipped_invalid_tx
-                                    .increment(1);
-                            }
-                            pool_transactions_skipped += 1;
-                            continue;
-                        }
-                        // this is an error that we should treat as fatal for this attempt
-                        Err(err) => {
-                            record_pool_selection_metrics(
-                                &self.metrics,
-                                pool_transactions_considered,
-                                pool_transactions_executed,
-                                pool_transactions_skipped,
-                            );
-                            return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
-                        }
-                    };
-                    pool_transactions_executed += 1;
-                    let elapsed = tx_execution_start.elapsed();
-                    self.metrics
-                        .transaction_execution_duration_seconds
-                        .record(elapsed);
-                    trace!(?elapsed, "Transaction executed");
+            let tx_debug_repr = tracing::enabled!(Level::TRACE)
+                .then(|| format!("{:?}", pool_tx.transaction))
+                .unwrap_or_default();
 
-                    total_fees +=
-                        calc_gas_balance_spending(gas_used, candidate.effective_gas_price);
-                    cumulative_gas_used += gas_used;
-                    if !candidate.is_payment {
-                        non_payment_gas_used += gas_used;
-                    }
-                    block_size_used += candidate.rlp_len;
-                }
-                PoolDecision::Skip(reason) => {
-                    match reason {
-                        PoolSkipReason::ExceedsNonSharedGasLimit => {
-                            best_txs.mark_invalid(
-                                &pool_tx,
-                                &InvalidPoolTransactionError::ExceedsGasLimit(
-                                    pool_tx.gas_limit(),
-                                    non_shared_gas_limit - cumulative_gas_used,
-                                ),
-                            );
-                            self.metrics
-                                .pool_transactions_skipped_exceeds_non_shared_gas_limit
-                                .increment(1);
-                        }
-                        PoolSkipReason::ExceedsNonPaymentGasLimit => {
-                            best_txs.mark_invalid(
-                                &pool_tx,
-                                &InvalidPoolTransactionError::Other(Box::new(
-                                    TempoPoolTransactionError::ExceedsNonPaymentLimit,
-                                )),
-                            );
-                            self.metrics
-                                .pool_transactions_skipped_exceeds_non_payment_gas_limit
-                                .increment(1);
-                        }
-                        PoolSkipReason::OversizedBlock => {
-                            best_txs.mark_invalid(
-                                &pool_tx,
-                                &InvalidPoolTransactionError::OversizedData {
-                                    size: block_size_used
-                                        + pool_tx.transaction.inner().length(),
-                                    limit: MAX_RLP_BLOCK_SIZE,
-                                },
-                            );
-                            self.metrics
-                                .pool_transactions_skipped_oversized_block
-                                .increment(1);
-                        }
+            let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
+            let tx_execution_start = Instant::now();
+            let gas_used = match builder.execute_transaction(tx_with_env) {
+                Ok(gas_used) => gas_used,
+                Err(BlockExecutionError::Validation(
+                    BlockValidationError::InvalidTx { error, .. },
+                )) => {
+                    if error.is_nonce_too_low() {
+                        trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
+                        self.metrics.pool_transactions_skipped_nonce_too_low.increment(1);
+                    } else {
+                        trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            &InvalidPoolTransactionError::Consensus(
+                                InvalidTransactionError::TxTypeNotSupported,
+                            ),
+                        );
+                        self.metrics.pool_transactions_skipped_invalid_tx.increment(1);
                     }
                     pool_transactions_skipped += 1;
+                    continue;
                 }
-                PoolDecision::Stop => break,
+                Err(err) => {
+                    record_pool_selection_metrics(
+                        &self.metrics,
+                        pool_transactions_considered,
+                        pool_transactions_executed,
+                        pool_transactions_skipped,
+                    );
+                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
+                }
+            };
+            pool_transactions_executed += 1;
+            let elapsed = tx_execution_start.elapsed();
+            self.metrics.transaction_execution_duration_seconds.record(elapsed);
+            trace!(?elapsed, "Transaction executed");
+
+            total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
+            cumulative_gas_used += gas_used;
+            if !is_payment {
+                non_payment_gas_used += gas_used;
             }
+            block_size_used += tx_rlp_len;
         }
         drop(_pool_tx_span);
         record_pool_selection_metrics(
@@ -918,10 +863,46 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use reth_payload_builder::PayloadId;
     use reth_primitives_traits::SealedBlock;
+    use reth_transaction_pool::{TransactionOrigin, identifier::TransactionId};
     use tempo_primitives::{
         AASigned, Block, SignedSubBlock, SubBlock, SubBlockVersion, TempoSignature,
         TempoTransaction,
     };
+
+    /// Create a pool tx with the given gas limit. Non-payment by default.
+    fn mock_pool_tx(gas_limit: u64) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
+        mock_pool_tx_to(gas_limit, Address::random())
+    }
+
+    /// Create a pool tx with the given gas limit and `to` address.
+    /// Use a TIP-20 prefix address to make it a payment tx.
+    fn mock_pool_tx_to(
+        gas_limit: u64,
+        to: Address,
+    ) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
+        let tx = TempoTxEnvelope::Legacy(alloy_consensus::Signed::new_unhashed(
+            alloy_consensus::TxLegacy {
+                chain_id: Some(1),
+                nonce: 0,
+                gas_price: 1_000_000_000,
+                gas_limit,
+                to: to.into(),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            },
+            Signature::test_signature(),
+        ));
+        let recovered = Recovered::new_unchecked(tx, Address::random());
+        let pooled = TempoPooledTransaction::new(recovered);
+        Arc::new(ValidPoolTransaction {
+            transaction: pooled,
+            transaction_id: TransactionId::new(0u64.into(), 0),
+            propagate: false,
+            timestamp: Instant::now(),
+            origin: TransactionOrigin::Local,
+            authority_ids: None,
+        })
+    }
 
     trait TestExt {
         fn random() -> Self;
@@ -1072,5 +1053,62 @@ mod tests {
         // No valid_before → NOT expired
         let subblock_no_expiry = RecoveredSubBlock::with_valid_before(None);
         assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
+    }
+
+    #[test]
+    fn admission_passes_when_within_all_limits() {
+        let tx = mock_pool_tx(100_000);
+        assert!(check_pool_tx_admission(&tx, 0, 1_000_000, 0, 500_000, 0, false).is_none());
+    }
+
+    #[test]
+    fn admission_rejects_exceeding_non_shared_gas() {
+        let tx = mock_pool_tx(100_000);
+        // only 50k remaining
+        let result = check_pool_tx_admission(&tx, 950_000, 1_000_000, 0, 500_000, 0, false);
+        assert!(matches!(result, Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })));
+    }
+
+    #[test]
+    fn admission_rejects_non_payment_exceeding_general_gas() {
+        let tx = mock_pool_tx(100_000);
+        let result = check_pool_tx_admission(&tx, 0, 1_000_000, 450_000, 500_000, 0, false);
+        assert!(matches!(result, Some(PoolSkipReason::ExceedsNonPaymentGasLimit)));
+    }
+
+    #[test]
+    fn admission_allows_payment_tx_past_general_gas_limit() {
+        // Payment tx: to address with TIP-20 prefix 0x20C0...
+        let mut payment_addr = [0u8; 20];
+        payment_addr[..12]
+            .copy_from_slice(&tempo_primitives::transaction::TIP20_PAYMENT_PREFIX);
+        let tx = mock_pool_tx_to(100_000, Address::from(payment_addr));
+        // non_payment_gas already at limit — but payment txs bypass this check
+        let result = check_pool_tx_admission(&tx, 0, 1_000_000, 500_000, 500_000, 0, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn admission_rejects_oversized_block_osaka() {
+        let tx = mock_pool_tx(21_000);
+        let result =
+            check_pool_tx_admission(&tx, 0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, true);
+        assert!(matches!(result, Some(PoolSkipReason::OversizedBlock { .. })));
+    }
+
+    #[test]
+    fn admission_ignores_block_size_pre_osaka() {
+        let tx = mock_pool_tx(21_000);
+        let result =
+            check_pool_tx_admission(&tx, 0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn admission_boundary_exact_gas_limit_passes() {
+        // tx gas == remaining gas → should pass (check is `>`, not `>=`)
+        let tx = mock_pool_tx(100_000);
+        let result = check_pool_tx_admission(&tx, 900_000, 1_000_000, 0, 500_000, 0, false);
+        assert!(result.is_none());
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -64,43 +64,41 @@ use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
 /// Why a pool transaction was rejected during admission checks.
 enum PoolSkipReason {
-    ExceedsNonSharedGasLimit { tx_gas: u64, remaining: u64 },
+    ExceedsNonSharedGasLimit { remaining: u64 },
     ExceedsNonPaymentGasLimit,
     OversizedBlock { projected_size: usize },
 }
 
 impl PoolSkipReason {
-    fn to_pool_error(&self) -> InvalidPoolTransactionError {
+    /// Converts to the pool error and records the corresponding metric in one pass.
+    fn into_error_and_record(
+        self,
+        tx_gas: u64,
+        metrics: &TempoPayloadBuilderMetrics,
+    ) -> InvalidPoolTransactionError {
         match self {
-            Self::ExceedsNonSharedGasLimit { tx_gas, remaining } => {
-                InvalidPoolTransactionError::ExceedsGasLimit(*tx_gas, *remaining)
-            }
-            Self::ExceedsNonPaymentGasLimit => InvalidPoolTransactionError::Other(Box::new(
-                TempoPoolTransactionError::ExceedsNonPaymentLimit,
-            )),
-            Self::OversizedBlock { projected_size } => InvalidPoolTransactionError::OversizedData {
-                size: *projected_size,
-                limit: MAX_RLP_BLOCK_SIZE,
-            },
-        }
-    }
-
-    fn record_metric(&self, metrics: &TempoPayloadBuilderMetrics) {
-        match self {
-            Self::ExceedsNonSharedGasLimit { .. } => {
+            Self::ExceedsNonSharedGasLimit { remaining } => {
                 metrics
                     .pool_transactions_skipped_exceeds_non_shared_gas_limit
                     .increment(1);
+                InvalidPoolTransactionError::ExceedsGasLimit(tx_gas, remaining)
             }
             Self::ExceedsNonPaymentGasLimit => {
                 metrics
                     .pool_transactions_skipped_exceeds_non_payment_gas_limit
                     .increment(1);
+                InvalidPoolTransactionError::Other(Box::new(
+                    TempoPoolTransactionError::ExceedsNonPaymentLimit,
+                ))
             }
-            Self::OversizedBlock { .. } => {
+            Self::OversizedBlock { projected_size } => {
                 metrics
                     .pool_transactions_skipped_oversized_block
                     .increment(1);
+                InvalidPoolTransactionError::OversizedData {
+                    size: projected_size,
+                    limit: MAX_RLP_BLOCK_SIZE,
+                }
             }
         }
     }
@@ -115,8 +113,13 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
 }
 
 /// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
+///
+/// Pre-computed `is_payment` and `tx_rlp_len` are passed in to avoid duplicate work on the
+/// hot path — the caller needs both values after admission passes.
 fn check_pool_tx_admission(
-    pool_tx: &Arc<ValidPoolTransaction<TempoPooledTransaction>>,
+    tx_gas: u64,
+    is_payment: bool,
+    tx_rlp_len: usize,
     cumulative_gas_used: u64,
     non_shared_gas_limit: u64,
     non_payment_gas_used: u64,
@@ -128,22 +131,16 @@ fn check_pool_tx_admission(
     // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
     // be consumed by proposer's pool transactions.
     let remaining = non_shared_gas_limit.saturating_sub(cumulative_gas_used);
-    if pool_tx.gas_limit() > remaining {
-        return Some(PoolSkipReason::ExceedsNonSharedGasLimit {
-            tx_gas: pool_tx.gas_limit(),
-            remaining,
-        });
+    if tx_gas > remaining {
+        return Some(PoolSkipReason::ExceedsNonSharedGasLimit { remaining });
     }
 
-    // If the tx is not a payment and will exceed the general gas limit, skip it.
-    if !pool_tx.transaction.is_payment()
-        && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
-    {
+    if !is_payment && non_payment_gas_used + tx_gas > general_gas_limit {
         return Some(PoolSkipReason::ExceedsNonPaymentGasLimit);
     }
 
     if is_osaka {
-        let projected = block_size_used + pool_tx.transaction.inner().length();
+        let projected = block_size_used + tx_rlp_len;
         if projected > MAX_RLP_BLOCK_SIZE {
             return Some(PoolSkipReason::OversizedBlock {
                 projected_size: projected,
@@ -550,9 +547,16 @@ where
                 .record(selection_start.elapsed());
             pool_transactions_considered += 1;
 
+            // Pre-compute values needed by both admission and execution.
+            let is_payment = pool_tx.transaction.is_payment();
+            let tx_gas = pool_tx.gas_limit();
+            let tx_rlp_len = pool_tx.transaction.inner().length();
+
             // Admission check — skip or execute
             if let Some(reason) = check_pool_tx_admission(
-                &pool_tx,
+                tx_gas,
+                is_payment,
+                tx_rlp_len,
                 cumulative_gas_used,
                 non_shared_gas_limit,
                 non_payment_gas_used,
@@ -560,19 +564,15 @@ where
                 block_size_used,
                 is_osaka,
             ) {
-                best_txs.mark_invalid(&pool_tx, &reason.to_pool_error());
-                reason.record_metric(&self.metrics);
+                let error = reason.into_error_and_record(tx_gas, &self.metrics);
+                best_txs.mark_invalid(&pool_tx, &error);
                 pool_transactions_skipped += 1;
                 continue;
             }
 
-            // Execute
-            let is_payment = pool_tx.transaction.is_payment();
             if is_payment {
                 payment_transactions += 1;
             }
-
-            let tx_rlp_length = pool_tx.transaction.inner().length();
             let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
 
             let tx_debug_repr = tracing::enabled!(Level::TRACE)
@@ -634,7 +634,7 @@ where
             if !is_payment {
                 non_payment_gas_used += gas_used;
             }
-            block_size_used += tx_rlp_length;
+            block_size_used += tx_rlp_len;
         }
         drop(_pool_tx_span);
         record_pool_selection_metrics(
@@ -887,46 +887,10 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use reth_payload_builder::PayloadId;
     use reth_primitives_traits::SealedBlock;
-    use reth_transaction_pool::{TransactionOrigin, identifier::TransactionId};
     use tempo_primitives::{
         AASigned, Block, SignedSubBlock, SubBlock, SubBlockVersion, TempoSignature,
         TempoTransaction,
     };
-
-    /// Create a pool tx with the given gas limit. Non-payment by default.
-    fn mock_pool_tx(gas_limit: u64) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
-        mock_pool_tx_to(gas_limit, Address::random())
-    }
-
-    /// Create a pool tx with the given gas limit and `to` address.
-    /// Use a TIP-20 prefix address to make it a payment tx.
-    fn mock_pool_tx_to(
-        gas_limit: u64,
-        to: Address,
-    ) -> Arc<ValidPoolTransaction<TempoPooledTransaction>> {
-        let tx = TempoTxEnvelope::Legacy(alloy_consensus::Signed::new_unhashed(
-            alloy_consensus::TxLegacy {
-                chain_id: Some(1),
-                nonce: 0,
-                gas_price: 1_000_000_000,
-                gas_limit,
-                to: to.into(),
-                value: U256::ZERO,
-                input: Bytes::new(),
-            },
-            Signature::test_signature(),
-        ));
-        let recovered = Recovered::new_unchecked(tx, Address::random());
-        let pooled = TempoPooledTransaction::new(recovered);
-        Arc::new(ValidPoolTransaction {
-            transaction: pooled,
-            transaction_id: TransactionId::new(0u64.into(), 0),
-            propagate: false,
-            timestamp: Instant::now(),
-            origin: TransactionOrigin::Local,
-            authority_ids: None,
-        })
-    }
 
     trait TestExt {
         fn random() -> Self;
@@ -1081,15 +1045,19 @@ mod tests {
 
     #[test]
     fn admission_passes_when_within_all_limits() {
-        let tx = mock_pool_tx(100_000);
-        assert!(check_pool_tx_admission(&tx, 0, 1_000_000, 0, 500_000, 0, false).is_none());
+        // tx_gas=100k, is_payment=false, rlp_len=0, cumulative=0, non_shared=1M,
+        // non_payment=0, general=500k, block_size=0, osaka=false
+        assert!(
+            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 0, 500_000, 0, false)
+                .is_none()
+        );
     }
 
     #[test]
     fn admission_rejects_exceeding_non_shared_gas() {
-        let tx = mock_pool_tx(100_000);
-        // only 50k remaining
-        let result = check_pool_tx_admission(&tx, 950_000, 1_000_000, 0, 500_000, 0, false);
+        // only 50k remaining (1M - 950k)
+        let result =
+            check_pool_tx_admission(100_000, false, 0, 950_000, 1_000_000, 0, 500_000, 0, false);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })
@@ -1098,8 +1066,8 @@ mod tests {
 
     #[test]
     fn admission_rejects_non_payment_exceeding_general_gas() {
-        let tx = mock_pool_tx(100_000);
-        let result = check_pool_tx_admission(&tx, 0, 1_000_000, 450_000, 500_000, 0, false);
+        let result =
+            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 450_000, 500_000, 0, false);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonPaymentGasLimit)
@@ -1108,20 +1076,25 @@ mod tests {
 
     #[test]
     fn admission_allows_payment_tx_past_general_gas_limit() {
-        // Payment tx: to address with TIP-20 prefix 0x20C0...
-        let mut payment_addr = [0u8; 20];
-        payment_addr[..12].copy_from_slice(&tempo_primitives::transaction::TIP20_PAYMENT_PREFIX);
-        let tx = mock_pool_tx_to(100_000, Address::from(payment_addr));
-        // non_payment_gas already at limit — but payment txs bypass this check
-        let result = check_pool_tx_admission(&tx, 0, 1_000_000, 500_000, 500_000, 0, false);
+        // non_payment_gas already at limit — but payment txs (is_payment=true) bypass this check
+        let result =
+            check_pool_tx_admission(100_000, true, 0, 0, 1_000_000, 500_000, 500_000, 0, false);
         assert!(result.is_none());
     }
 
     #[test]
     fn admission_rejects_oversized_block_osaka() {
-        let tx = mock_pool_tx(21_000);
-        let result =
-            check_pool_tx_admission(&tx, 0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, true);
+        let result = check_pool_tx_admission(
+            21_000,
+            false,
+            100,
+            0,
+            30_000_000,
+            0,
+            15_000_000,
+            MAX_RLP_BLOCK_SIZE,
+            true,
+        );
         assert!(matches!(
             result,
             Some(PoolSkipReason::OversizedBlock { .. })
@@ -1130,17 +1103,25 @@ mod tests {
 
     #[test]
     fn admission_ignores_block_size_pre_osaka() {
-        let tx = mock_pool_tx(21_000);
-        let result =
-            check_pool_tx_admission(&tx, 0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, false);
+        let result = check_pool_tx_admission(
+            21_000,
+            false,
+            100,
+            0,
+            30_000_000,
+            0,
+            15_000_000,
+            MAX_RLP_BLOCK_SIZE,
+            false,
+        );
         assert!(result.is_none());
     }
 
     #[test]
     fn admission_boundary_exact_gas_limit_passes() {
         // tx gas == remaining gas → should pass (check is `>`, not `>=`)
-        let tx = mock_pool_tx(100_000);
-        let result = check_pool_tx_admission(&tx, 900_000, 1_000_000, 0, 500_000, 0, false);
+        let result =
+            check_pool_tx_admission(100_000, false, 0, 900_000, 1_000_000, 0, 500_000, 0, false);
         assert!(result.is_none());
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -575,9 +575,12 @@ where
                     BlockValidationError::InvalidTx { error, .. },
                 )) => {
                     if error.is_nonce_too_low() {
+                        // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
                         self.metrics.pool_transactions_skipped_nonce_too_low.increment(1);
                     } else {
+                        // if the transaction is invalid, we can skip it and all of its
+                        // descendants
                         trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
                         best_txs.mark_invalid(
                             &pool_tx,
@@ -590,6 +593,7 @@ where
                     pool_transactions_skipped += 1;
                     continue;
                 }
+                // this is an error that we should treat as fatal for this attempt
                 Err(err) => {
                     record_pool_selection_metrics(
                         &self.metrics,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -62,11 +62,96 @@ use tempo_transaction_pool::{
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
+/// Pre-execution policy decision for a pool transaction.
+///
+/// Separates admission policy from EVM execution: `decide_pool_tx` returns one of these
+/// based on gas budget, block size, and cancellation state, so the main loop reads as
+/// pure domain logic.
+enum PoolDecision {
+    /// Transaction passes all admission checks — execute it.
+    Execute(PoolCandidate),
+    /// Transaction should be skipped for the given reason.
+    Skip(PoolSkipReason),
+    /// Building should stop (interrupted or cancelled).
+    Stop,
+}
+
+/// A pool transaction that passed admission checks and is ready for EVM execution.
+struct PoolCandidate {
+    /// Whether this is a TIP-20 payment transaction.
+    is_payment: bool,
+    /// RLP-encoded byte length of the transaction.
+    rlp_len: usize,
+    /// Effective gas price given the current base fee.
+    effective_gas_price: u128,
+    /// The pool transaction handle (needed for `mark_invalid` on execution failure).
+    pool_tx: Arc<ValidPoolTransaction<TempoPooledTransaction>>,
+}
+
+/// Reason a pool transaction was skipped during pre-execution admission.
+enum PoolSkipReason {
+    /// Transaction exceeds the non-shared gas limit reserved for proposer txs.
+    ExceedsNonSharedGasLimit,
+    /// Non-payment transaction exceeds the general gas limit.
+    ExceedsNonPaymentGasLimit,
+    /// Including this transaction would exceed the max RLP block size (Osaka).
+    OversizedBlock,
+}
+
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
     subblock.transactions.iter().any(|tx| {
         tx.as_aa()
             .is_some_and(|tx| tx.tx().valid_before.is_some_and(|valid| valid <= timestamp))
+    })
+}
+
+/// Evaluates a pool transaction against admission policy and returns a [`PoolDecision`].
+///
+/// Checks (in order):
+/// 1. Interrupt — payload builder was asked to stop
+/// 2. Non-shared gas limit — proposer's pool txs must not exceed the non-shared portion
+/// 3. General gas limit — non-payment txs have a tighter cap
+/// 4. Block size (Osaka) — RLP-encoded block must not exceed `MAX_RLP_BLOCK_SIZE`
+///
+/// If all checks pass, returns `Execute` with pre-computed facts so the caller doesn't
+/// need to re-derive them.
+fn decide_pool_tx(
+    pool_tx: &Arc<ValidPoolTransaction<TempoPooledTransaction>>,
+    attributes: &TempoPayloadBuilderAttributes,
+    cumulative_gas_used: u64,
+    non_shared_gas_limit: u64,
+    non_payment_gas_used: u64,
+    general_gas_limit: u64,
+    block_size_used: usize,
+    is_osaka: bool,
+    base_fee: u64,
+) -> PoolDecision {
+    if attributes.is_interrupted() {
+        return PoolDecision::Stop;
+    }
+
+    if cumulative_gas_used + pool_tx.gas_limit() > non_shared_gas_limit {
+        return PoolDecision::Skip(PoolSkipReason::ExceedsNonSharedGasLimit);
+    }
+
+    let is_payment = pool_tx.transaction.is_payment();
+
+    if !is_payment && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit {
+        return PoolDecision::Skip(PoolSkipReason::ExceedsNonPaymentGasLimit);
+    }
+
+    let rlp_len = pool_tx.transaction.inner().length();
+
+    if is_osaka && block_size_used + rlp_len > MAX_RLP_BLOCK_SIZE {
+        return PoolDecision::Skip(PoolSkipReason::OversizedBlock);
+    }
+
+    PoolDecision::Execute(PoolCandidate {
+        is_payment,
+        rlp_len,
+        effective_gas_price: pool_tx.transaction.effective_gas_price(Some(base_fee)),
+        pool_tx: Arc::clone(pool_tx),
     })
 }
 
@@ -442,11 +527,6 @@ where
         let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
         loop {
-            // check if the job was interrupted, if so we can skip remaining transactions
-            if attributes.is_interrupted() {
-                break;
-            }
-
             // check if the job was cancelled, if so we can exit early
             if cancel.is_cancelled() {
                 record_pool_selection_metrics(
@@ -467,129 +547,125 @@ where
                 .record(selection_start.elapsed());
             pool_transactions_considered += 1;
 
-            // Ensure we still have capacity for this transaction within the non-shared gas limit.
-            // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
-            // be consumed by proposer's pool transactions.
-            if cumulative_gas_used + pool_tx.gas_limit() > non_shared_gas_limit {
-                // Mark this transaction as invalid since it doesn't fit
-                // The iterator will handle lane switching internally when appropriate
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::ExceedsGasLimit(
-                        pool_tx.gas_limit(),
-                        non_shared_gas_limit - cumulative_gas_used,
-                    ),
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
-                    .increment(1);
-                continue;
-            }
+            let decision = decide_pool_tx(
+                &pool_tx,
+                &attributes,
+                cumulative_gas_used,
+                non_shared_gas_limit,
+                non_payment_gas_used,
+                general_gas_limit,
+                block_size_used,
+                is_osaka,
+                base_fee,
+            );
 
-            // If the tx is not a payment and will exceed the general gas limit
-            // mark the tx as invalid and continue
-            if !pool_tx.transaction.is_payment()
-                && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
-            {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::Other(Box::new(
-                        TempoPoolTransactionError::ExceedsNonPaymentLimit,
-                    )),
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
-                    .increment(1);
-                continue;
-            }
+            match decision {
+                PoolDecision::Execute(candidate) => {
+                    if candidate.is_payment {
+                        payment_transactions += 1;
+                    }
 
-            let is_payment = pool_tx.transaction.is_payment();
-            if is_payment {
-                payment_transactions += 1;
-            }
+                    let tx_debug_repr = tracing::enabled!(Level::TRACE)
+                        .then(|| format!("{:?}", candidate.pool_tx.transaction))
+                        .unwrap_or_default();
 
-            let tx_rlp_length = pool_tx.transaction.inner().length();
-            let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
+                    let tx_with_env =
+                        candidate.pool_tx.transaction.clone().into_with_tx_env();
+                    let tx_execution_start = Instant::now();
+                    let gas_used = match builder.execute_transaction(tx_with_env) {
+                        Ok(gas_used) => gas_used,
+                        Err(BlockExecutionError::Validation(
+                            BlockValidationError::InvalidTx { error, .. },
+                        )) => {
+                            if error.is_nonce_too_low() {
+                                trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
+                                self.metrics
+                                    .pool_transactions_skipped_nonce_too_low
+                                    .increment(1);
+                            } else {
+                                trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
+                                best_txs.mark_invalid(
+                                    &candidate.pool_tx,
+                                    &InvalidPoolTransactionError::Consensus(
+                                        InvalidTransactionError::TxTypeNotSupported,
+                                    ),
+                                );
+                                self.metrics
+                                    .pool_transactions_skipped_invalid_tx
+                                    .increment(1);
+                            }
+                            pool_transactions_skipped += 1;
+                            continue;
+                        }
+                        // this is an error that we should treat as fatal for this attempt
+                        Err(err) => {
+                            record_pool_selection_metrics(
+                                &self.metrics,
+                                pool_transactions_considered,
+                                pool_transactions_executed,
+                                pool_transactions_skipped,
+                            );
+                            return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
+                        }
+                    };
+                    pool_transactions_executed += 1;
+                    let elapsed = tx_execution_start.elapsed();
+                    self.metrics
+                        .transaction_execution_duration_seconds
+                        .record(elapsed);
+                    trace!(?elapsed, "Transaction executed");
 
-            if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::OversizedData {
-                        size: estimated_block_size_with_tx,
-                        limit: MAX_RLP_BLOCK_SIZE,
-                    },
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_oversized_block
-                    .increment(1);
-                continue;
-            }
-
-            let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
-
-            let tx_debug_repr = tracing::enabled!(Level::TRACE)
-                .then(|| format!("{:?}", pool_tx.transaction))
-                .unwrap_or_default();
-
-            let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
-            let execution_start = Instant::now();
-            let gas_used = match builder.execute_transaction(tx_with_env) {
-                Ok(gas_used) => gas_used,
-                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                    error,
-                    ..
-                })) => {
-                    if error.is_nonce_too_low() {
-                        // if the nonce is too low, we can skip this transaction
-                        trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        self.metrics
-                            .pool_transactions_skipped_nonce_too_low
-                            .increment(1);
-                    } else {
-                        // if the transaction is invalid, we can skip it and all of its
-                        // descendants
-                        trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
-                        best_txs.mark_invalid(
-                            &pool_tx,
-                            &InvalidPoolTransactionError::Consensus(
-                                InvalidTransactionError::TxTypeNotSupported,
-                            ),
-                        );
-                        self.metrics
-                            .pool_transactions_skipped_invalid_tx
-                            .increment(1);
+                    total_fees +=
+                        calc_gas_balance_spending(gas_used, candidate.effective_gas_price);
+                    cumulative_gas_used += gas_used;
+                    if !candidate.is_payment {
+                        non_payment_gas_used += gas_used;
+                    }
+                    block_size_used += candidate.rlp_len;
+                }
+                PoolDecision::Skip(reason) => {
+                    match reason {
+                        PoolSkipReason::ExceedsNonSharedGasLimit => {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::ExceedsGasLimit(
+                                    pool_tx.gas_limit(),
+                                    non_shared_gas_limit - cumulative_gas_used,
+                                ),
+                            );
+                            self.metrics
+                                .pool_transactions_skipped_exceeds_non_shared_gas_limit
+                                .increment(1);
+                        }
+                        PoolSkipReason::ExceedsNonPaymentGasLimit => {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Other(Box::new(
+                                    TempoPoolTransactionError::ExceedsNonPaymentLimit,
+                                )),
+                            );
+                            self.metrics
+                                .pool_transactions_skipped_exceeds_non_payment_gas_limit
+                                .increment(1);
+                        }
+                        PoolSkipReason::OversizedBlock => {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::OversizedData {
+                                    size: block_size_used
+                                        + pool_tx.transaction.inner().length(),
+                                    limit: MAX_RLP_BLOCK_SIZE,
+                                },
+                            );
+                            self.metrics
+                                .pool_transactions_skipped_oversized_block
+                                .increment(1);
+                        }
                     }
                     pool_transactions_skipped += 1;
-                    continue;
                 }
-                // this is an error that we should treat as fatal for this attempt
-                Err(err) => {
-                    record_pool_selection_metrics(
-                        &self.metrics,
-                        pool_transactions_considered,
-                        pool_transactions_executed,
-                        pool_transactions_skipped,
-                    );
-                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
-                }
-            };
-            pool_transactions_executed += 1;
-            let elapsed = execution_start.elapsed();
-            self.metrics
-                .transaction_execution_duration_seconds
-                .record(elapsed);
-            trace!(?elapsed, "Transaction executed");
-
-            // update and add to total fees
-            total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
-            cumulative_gas_used += gas_used;
-            if !is_payment {
-                non_payment_gas_used += gas_used;
+                PoolDecision::Stop => break,
             }
-            block_size_used += tx_rlp_length;
         }
         drop(_pool_tx_span);
         record_pool_selection_metrics(

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -112,6 +112,16 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
     })
 }
 
+/// Snapshot of block-level limits and accumulators used by admission checks.
+struct BlockLimits {
+    cumulative_gas_used: u64,
+    non_shared_gas_limit: u64,
+    non_payment_gas_used: u64,
+    general_gas_limit: u64,
+    block_size_used: usize,
+    is_osaka: bool,
+}
+
 /// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
 ///
 /// Pre-computed `is_payment` and `tx_rlp_len` are passed in to avoid duplicate work on the
@@ -120,27 +130,22 @@ fn check_pool_tx_admission(
     tx_gas: u64,
     is_payment: bool,
     tx_rlp_len: usize,
-    cumulative_gas_used: u64,
-    non_shared_gas_limit: u64,
-    non_payment_gas_used: u64,
-    general_gas_limit: u64,
-    block_size_used: usize,
-    is_osaka: bool,
+    limits: &BlockLimits,
 ) -> Option<PoolSkipReason> {
     // Ensure we still have capacity for this transaction within the non-shared gas limit.
     // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
     // be consumed by proposer's pool transactions.
-    let remaining = non_shared_gas_limit.saturating_sub(cumulative_gas_used);
+    let remaining = limits.non_shared_gas_limit.saturating_sub(limits.cumulative_gas_used);
     if tx_gas > remaining {
         return Some(PoolSkipReason::ExceedsNonSharedGasLimit { remaining });
     }
 
-    if !is_payment && non_payment_gas_used + tx_gas > general_gas_limit {
+    if !is_payment && limits.non_payment_gas_used + tx_gas > limits.general_gas_limit {
         return Some(PoolSkipReason::ExceedsNonPaymentGasLimit);
     }
 
-    if is_osaka {
-        let projected = block_size_used + tx_rlp_len;
+    if limits.is_osaka {
+        let projected = limits.block_size_used + tx_rlp_len;
         if projected > MAX_RLP_BLOCK_SIZE {
             return Some(PoolSkipReason::OversizedBlock {
                 projected_size: projected,
@@ -553,16 +558,19 @@ where
             let tx_rlp_len = pool_tx.transaction.inner().length();
 
             // Admission check — skip or execute
-            if let Some(reason) = check_pool_tx_admission(
-                tx_gas,
-                is_payment,
-                tx_rlp_len,
+            let limits = BlockLimits {
                 cumulative_gas_used,
                 non_shared_gas_limit,
                 non_payment_gas_used,
                 general_gas_limit,
                 block_size_used,
                 is_osaka,
+            };
+            if let Some(reason) = check_pool_tx_admission(
+                tx_gas,
+                is_payment,
+                tx_rlp_len,
+                &limits,
             ) {
                 let error = reason.into_error_and_record(tx_gas, &self.metrics);
                 best_txs.mark_invalid(&pool_tx, &error);
@@ -1043,21 +1051,35 @@ mod tests {
         assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
     }
 
+    fn block_limits(
+        cumulative_gas_used: u64,
+        non_shared_gas_limit: u64,
+        non_payment_gas_used: u64,
+        general_gas_limit: u64,
+        block_size_used: usize,
+        is_osaka: bool,
+    ) -> BlockLimits {
+        BlockLimits {
+            cumulative_gas_used,
+            non_shared_gas_limit,
+            non_payment_gas_used,
+            general_gas_limit,
+            block_size_used,
+            is_osaka,
+        }
+    }
+
     #[test]
     fn admission_passes_when_within_all_limits() {
-        // tx_gas=100k, is_payment=false, rlp_len=0, cumulative=0, non_shared=1M,
-        // non_payment=0, general=500k, block_size=0, osaka=false
-        assert!(
-            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 0, 500_000, 0, false)
-                .is_none()
-        );
+        let limits = block_limits(0, 1_000_000, 0, 500_000, 0, false);
+        assert!(check_pool_tx_admission(100_000, false, 0, &limits).is_none());
     }
 
     #[test]
     fn admission_rejects_exceeding_non_shared_gas() {
         // only 50k remaining (1M - 950k)
-        let result =
-            check_pool_tx_admission(100_000, false, 0, 950_000, 1_000_000, 0, 500_000, 0, false);
+        let limits = block_limits(950_000, 1_000_000, 0, 500_000, 0, false);
+        let result = check_pool_tx_admission(100_000, false, 0, &limits);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })
@@ -1066,8 +1088,8 @@ mod tests {
 
     #[test]
     fn admission_rejects_non_payment_exceeding_general_gas() {
-        let result =
-            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 450_000, 500_000, 0, false);
+        let limits = block_limits(0, 1_000_000, 450_000, 500_000, 0, false);
+        let result = check_pool_tx_admission(100_000, false, 0, &limits);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonPaymentGasLimit)
@@ -1077,24 +1099,14 @@ mod tests {
     #[test]
     fn admission_allows_payment_tx_past_general_gas_limit() {
         // non_payment_gas already at limit — but payment txs (is_payment=true) bypass this check
-        let result =
-            check_pool_tx_admission(100_000, true, 0, 0, 1_000_000, 500_000, 500_000, 0, false);
-        assert!(result.is_none());
+        let limits = block_limits(0, 1_000_000, 500_000, 500_000, 0, false);
+        assert!(check_pool_tx_admission(100_000, true, 0, &limits).is_none());
     }
 
     #[test]
     fn admission_rejects_oversized_block_osaka() {
-        let result = check_pool_tx_admission(
-            21_000,
-            false,
-            100,
-            0,
-            30_000_000,
-            0,
-            15_000_000,
-            MAX_RLP_BLOCK_SIZE,
-            true,
-        );
+        let limits = block_limits(0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, true);
+        let result = check_pool_tx_admission(21_000, false, 100, &limits);
         assert!(matches!(
             result,
             Some(PoolSkipReason::OversizedBlock { .. })
@@ -1103,25 +1115,14 @@ mod tests {
 
     #[test]
     fn admission_ignores_block_size_pre_osaka() {
-        let result = check_pool_tx_admission(
-            21_000,
-            false,
-            100,
-            0,
-            30_000_000,
-            0,
-            15_000_000,
-            MAX_RLP_BLOCK_SIZE,
-            false,
-        );
-        assert!(result.is_none());
+        let limits = block_limits(0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, false);
+        assert!(check_pool_tx_admission(21_000, false, 100, &limits).is_none());
     }
 
     #[test]
     fn admission_boundary_exact_gas_limit_passes() {
         // tx gas == remaining gas → should pass (check is `>`, not `>=`)
-        let result =
-            check_pool_tx_admission(100_000, false, 0, 900_000, 1_000_000, 0, 500_000, 0, false);
-        assert!(result.is_none());
+        let limits = block_limits(900_000, 1_000_000, 0, 500_000, 0, false);
+        assert!(check_pool_tx_admission(100_000, false, 0, &limits).is_none());
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1042,8 +1042,10 @@ mod tests {
 
     #[test]
     fn admission_passes_when_within_all_limits() {
-        assert!(check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 0, 500_000, 0, false)
-            .is_none());
+        assert!(
+            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 0, 500_000, 0, false)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1097,18 +1099,20 @@ mod tests {
 
     #[test]
     fn admission_ignores_block_size_pre_osaka() {
-        assert!(check_pool_tx_admission(
-            21_000,
-            false,
-            100,
-            0,
-            30_000_000,
-            0,
-            15_000_000,
-            MAX_RLP_BLOCK_SIZE,
-            false
-        )
-        .is_none());
+        assert!(
+            check_pool_tx_admission(
+                21_000,
+                false,
+                100,
+                0,
+                30_000_000,
+                0,
+                15_000_000,
+                MAX_RLP_BLOCK_SIZE,
+                false
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -135,7 +135,9 @@ fn check_pool_tx_admission(
     // Ensure we still have capacity for this transaction within the non-shared gas limit.
     // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
     // be consumed by proposer's pool transactions.
-    let remaining = limits.non_shared_gas_limit.saturating_sub(limits.cumulative_gas_used);
+    let remaining = limits
+        .non_shared_gas_limit
+        .saturating_sub(limits.cumulative_gas_used);
     if tx_gas > remaining {
         return Some(PoolSkipReason::ExceedsNonSharedGasLimit { remaining });
     }
@@ -566,12 +568,7 @@ where
                 block_size_used,
                 is_osaka,
             };
-            if let Some(reason) = check_pool_tx_admission(
-                tx_gas,
-                is_payment,
-                tx_rlp_len,
-                &limits,
-            ) {
+            if let Some(reason) = check_pool_tx_admission(tx_gas, is_payment, tx_rlp_len, &limits) {
                 let error = reason.into_error_and_record(tx_gas, &self.metrics);
                 best_txs.mark_invalid(&pool_tx, &error);
                 pool_transactions_skipped += 1;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -572,7 +572,7 @@ where
                 payment_transactions += 1;
             }
 
-            let tx_rlp_len = pool_tx.transaction.inner().length();
+            let tx_rlp_length = pool_tx.transaction.inner().length();
             let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
 
             let tx_debug_repr = tracing::enabled!(Level::TRACE)
@@ -634,7 +634,7 @@ where
             if !is_payment {
                 non_payment_gas_used += gas_used;
             }
-            block_size_used += tx_rlp_len;
+            block_size_used += tx_rlp_length;
         }
         drop(_pool_tx_span);
         record_pool_selection_metrics(

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -113,6 +113,7 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
 }
 
 /// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
+#[allow(clippy::too_many_arguments)]
 fn check_pool_tx_admission(
     tx_gas: u64,
     is_payment: bool,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -78,25 +78,29 @@ impl PoolSkipReason {
             Self::ExceedsNonPaymentGasLimit => InvalidPoolTransactionError::Other(Box::new(
                 TempoPoolTransactionError::ExceedsNonPaymentLimit,
             )),
-            Self::OversizedBlock { projected_size } => {
-                InvalidPoolTransactionError::OversizedData {
-                    size: *projected_size,
-                    limit: MAX_RLP_BLOCK_SIZE,
-                }
-            }
+            Self::OversizedBlock { projected_size } => InvalidPoolTransactionError::OversizedData {
+                size: *projected_size,
+                limit: MAX_RLP_BLOCK_SIZE,
+            },
         }
     }
 
     fn record_metric(&self, metrics: &TempoPayloadBuilderMetrics) {
         match self {
             Self::ExceedsNonSharedGasLimit { .. } => {
-                metrics.pool_transactions_skipped_exceeds_non_shared_gas_limit.increment(1);
+                metrics
+                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
+                    .increment(1);
             }
             Self::ExceedsNonPaymentGasLimit => {
-                metrics.pool_transactions_skipped_exceeds_non_payment_gas_limit.increment(1);
+                metrics
+                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
+                    .increment(1);
             }
             Self::OversizedBlock { .. } => {
-                metrics.pool_transactions_skipped_oversized_block.increment(1);
+                metrics
+                    .pool_transactions_skipped_oversized_block
+                    .increment(1);
             }
         }
     }
@@ -141,7 +145,9 @@ fn check_pool_tx_admission(
     if is_osaka {
         let projected = block_size_used + pool_tx.transaction.inner().length();
         if projected > MAX_RLP_BLOCK_SIZE {
-            return Some(PoolSkipReason::OversizedBlock { projected_size: projected });
+            return Some(PoolSkipReason::OversizedBlock {
+                projected_size: projected,
+            });
         }
     }
 
@@ -577,13 +583,16 @@ where
             let tx_execution_start = Instant::now();
             let gas_used = match builder.execute_transaction(tx_with_env) {
                 Ok(gas_used) => gas_used,
-                Err(BlockExecutionError::Validation(
-                    BlockValidationError::InvalidTx { error, .. },
-                )) => {
+                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    error,
+                    ..
+                })) => {
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        self.metrics.pool_transactions_skipped_nonce_too_low.increment(1);
+                        self.metrics
+                            .pool_transactions_skipped_nonce_too_low
+                            .increment(1);
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -594,7 +603,9 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
-                        self.metrics.pool_transactions_skipped_invalid_tx.increment(1);
+                        self.metrics
+                            .pool_transactions_skipped_invalid_tx
+                            .increment(1);
                     }
                     pool_transactions_skipped += 1;
                     continue;
@@ -612,7 +623,9 @@ where
             };
             pool_transactions_executed += 1;
             let elapsed = tx_execution_start.elapsed();
-            self.metrics.transaction_execution_duration_seconds.record(elapsed);
+            self.metrics
+                .transaction_execution_duration_seconds
+                .record(elapsed);
             trace!(?elapsed, "Transaction executed");
 
             // update and add to total fees
@@ -1077,22 +1090,27 @@ mod tests {
         let tx = mock_pool_tx(100_000);
         // only 50k remaining
         let result = check_pool_tx_admission(&tx, 950_000, 1_000_000, 0, 500_000, 0, false);
-        assert!(matches!(result, Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })));
+        assert!(matches!(
+            result,
+            Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })
+        ));
     }
 
     #[test]
     fn admission_rejects_non_payment_exceeding_general_gas() {
         let tx = mock_pool_tx(100_000);
         let result = check_pool_tx_admission(&tx, 0, 1_000_000, 450_000, 500_000, 0, false);
-        assert!(matches!(result, Some(PoolSkipReason::ExceedsNonPaymentGasLimit)));
+        assert!(matches!(
+            result,
+            Some(PoolSkipReason::ExceedsNonPaymentGasLimit)
+        ));
     }
 
     #[test]
     fn admission_allows_payment_tx_past_general_gas_limit() {
         // Payment tx: to address with TIP-20 prefix 0x20C0...
         let mut payment_addr = [0u8; 20];
-        payment_addr[..12]
-            .copy_from_slice(&tempo_primitives::transaction::TIP20_PAYMENT_PREFIX);
+        payment_addr[..12].copy_from_slice(&tempo_primitives::transaction::TIP20_PAYMENT_PREFIX);
         let tx = mock_pool_tx_to(100_000, Address::from(payment_addr));
         // non_payment_gas already at limit — but payment txs bypass this check
         let result = check_pool_tx_admission(&tx, 0, 1_000_000, 500_000, 500_000, 0, false);
@@ -1104,7 +1122,10 @@ mod tests {
         let tx = mock_pool_tx(21_000);
         let result =
             check_pool_tx_admission(&tx, 0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, true);
-        assert!(matches!(result, Some(PoolSkipReason::OversizedBlock { .. })));
+        assert!(matches!(
+            result,
+            Some(PoolSkipReason::OversizedBlock { .. })
+        ));
     }
 
     #[test]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -120,6 +120,9 @@ fn check_pool_tx_admission(
     block_size_used: usize,
     is_osaka: bool,
 ) -> Option<PoolSkipReason> {
+    // Ensure we still have capacity for this transaction within the non-shared gas limit.
+    // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
+    // be consumed by proposer's pool transactions.
     let remaining = non_shared_gas_limit.saturating_sub(cumulative_gas_used);
     if pool_tx.gas_limit() > remaining {
         return Some(PoolSkipReason::ExceedsNonSharedGasLimit {
@@ -128,6 +131,7 @@ fn check_pool_tx_admission(
         });
     }
 
+    // If the tx is not a payment and will exceed the general gas limit, skip it.
     if !pool_tx.transaction.is_payment()
         && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
     {
@@ -516,9 +520,11 @@ where
         let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
         loop {
+            // check if the job was interrupted, if so we can skip remaining transactions
             if attributes.is_interrupted() {
                 break;
             }
+            // check if the job was cancelled, if so we can exit early
             if cancel.is_cancelled() {
                 record_pool_selection_metrics(
                     &self.metrics,
@@ -609,6 +615,7 @@ where
             self.metrics.transaction_execution_duration_seconds.record(elapsed);
             trace!(?elapsed, "Transaction executed");
 
+            // update and add to total fees
             total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
             cumulative_gas_used += gas_used;
             if !is_payment {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -112,42 +112,32 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
     })
 }
 
-/// Snapshot of block-level limits and accumulators used by admission checks.
-struct BlockLimits {
+/// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
+fn check_pool_tx_admission(
+    tx_gas: u64,
+    is_payment: bool,
+    tx_rlp_len: usize,
     cumulative_gas_used: u64,
     non_shared_gas_limit: u64,
     non_payment_gas_used: u64,
     general_gas_limit: u64,
     block_size_used: usize,
     is_osaka: bool,
-}
-
-/// Returns `Some(reason)` if the transaction should be skipped, `None` if it can execute.
-///
-/// Pre-computed `is_payment` and `tx_rlp_len` are passed in to avoid duplicate work on the
-/// hot path — the caller needs both values after admission passes.
-fn check_pool_tx_admission(
-    tx_gas: u64,
-    is_payment: bool,
-    tx_rlp_len: usize,
-    limits: &BlockLimits,
 ) -> Option<PoolSkipReason> {
     // Ensure we still have capacity for this transaction within the non-shared gas limit.
     // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
     // be consumed by proposer's pool transactions.
-    let remaining = limits
-        .non_shared_gas_limit
-        .saturating_sub(limits.cumulative_gas_used);
+    let remaining = non_shared_gas_limit.saturating_sub(cumulative_gas_used);
     if tx_gas > remaining {
         return Some(PoolSkipReason::ExceedsNonSharedGasLimit { remaining });
     }
 
-    if !is_payment && limits.non_payment_gas_used + tx_gas > limits.general_gas_limit {
+    if !is_payment && non_payment_gas_used + tx_gas > general_gas_limit {
         return Some(PoolSkipReason::ExceedsNonPaymentGasLimit);
     }
 
-    if limits.is_osaka {
-        let projected = limits.block_size_used + tx_rlp_len;
+    if is_osaka {
+        let projected = block_size_used + tx_rlp_len;
         if projected > MAX_RLP_BLOCK_SIZE {
             return Some(PoolSkipReason::OversizedBlock {
                 projected_size: projected,
@@ -560,15 +550,17 @@ where
             let tx_rlp_len = pool_tx.transaction.inner().length();
 
             // Admission check — skip or execute
-            let limits = BlockLimits {
+            if let Some(reason) = check_pool_tx_admission(
+                tx_gas,
+                is_payment,
+                tx_rlp_len,
                 cumulative_gas_used,
                 non_shared_gas_limit,
                 non_payment_gas_used,
                 general_gas_limit,
                 block_size_used,
                 is_osaka,
-            };
-            if let Some(reason) = check_pool_tx_admission(tx_gas, is_payment, tx_rlp_len, &limits) {
+            ) {
                 let error = reason.into_error_and_record(tx_gas, &self.metrics);
                 best_txs.mark_invalid(&pool_tx, &error);
                 pool_transactions_skipped += 1;
@@ -1048,35 +1040,17 @@ mod tests {
         assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
     }
 
-    fn block_limits(
-        cumulative_gas_used: u64,
-        non_shared_gas_limit: u64,
-        non_payment_gas_used: u64,
-        general_gas_limit: u64,
-        block_size_used: usize,
-        is_osaka: bool,
-    ) -> BlockLimits {
-        BlockLimits {
-            cumulative_gas_used,
-            non_shared_gas_limit,
-            non_payment_gas_used,
-            general_gas_limit,
-            block_size_used,
-            is_osaka,
-        }
-    }
-
     #[test]
     fn admission_passes_when_within_all_limits() {
-        let limits = block_limits(0, 1_000_000, 0, 500_000, 0, false);
-        assert!(check_pool_tx_admission(100_000, false, 0, &limits).is_none());
+        assert!(check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 0, 500_000, 0, false)
+            .is_none());
     }
 
     #[test]
     fn admission_rejects_exceeding_non_shared_gas() {
         // only 50k remaining (1M - 950k)
-        let limits = block_limits(950_000, 1_000_000, 0, 500_000, 0, false);
-        let result = check_pool_tx_admission(100_000, false, 0, &limits);
+        let result =
+            check_pool_tx_admission(100_000, false, 0, 950_000, 1_000_000, 0, 500_000, 0, false);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonSharedGasLimit { .. })
@@ -1085,8 +1059,8 @@ mod tests {
 
     #[test]
     fn admission_rejects_non_payment_exceeding_general_gas() {
-        let limits = block_limits(0, 1_000_000, 450_000, 500_000, 0, false);
-        let result = check_pool_tx_admission(100_000, false, 0, &limits);
+        let result =
+            check_pool_tx_admission(100_000, false, 0, 0, 1_000_000, 450_000, 500_000, 0, false);
         assert!(matches!(
             result,
             Some(PoolSkipReason::ExceedsNonPaymentGasLimit)
@@ -1096,14 +1070,25 @@ mod tests {
     #[test]
     fn admission_allows_payment_tx_past_general_gas_limit() {
         // non_payment_gas already at limit — but payment txs (is_payment=true) bypass this check
-        let limits = block_limits(0, 1_000_000, 500_000, 500_000, 0, false);
-        assert!(check_pool_tx_admission(100_000, true, 0, &limits).is_none());
+        assert!(
+            check_pool_tx_admission(100_000, true, 0, 0, 1_000_000, 500_000, 500_000, 0, false)
+                .is_none()
+        );
     }
 
     #[test]
     fn admission_rejects_oversized_block_osaka() {
-        let limits = block_limits(0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, true);
-        let result = check_pool_tx_admission(21_000, false, 100, &limits);
+        let result = check_pool_tx_admission(
+            21_000,
+            false,
+            100,
+            0,
+            30_000_000,
+            0,
+            15_000_000,
+            MAX_RLP_BLOCK_SIZE,
+            true,
+        );
         assert!(matches!(
             result,
             Some(PoolSkipReason::OversizedBlock { .. })
@@ -1112,14 +1097,26 @@ mod tests {
 
     #[test]
     fn admission_ignores_block_size_pre_osaka() {
-        let limits = block_limits(0, 30_000_000, 0, 15_000_000, MAX_RLP_BLOCK_SIZE, false);
-        assert!(check_pool_tx_admission(21_000, false, 100, &limits).is_none());
+        assert!(check_pool_tx_admission(
+            21_000,
+            false,
+            100,
+            0,
+            30_000_000,
+            0,
+            15_000_000,
+            MAX_RLP_BLOCK_SIZE,
+            false
+        )
+        .is_none());
     }
 
     #[test]
     fn admission_boundary_exact_gas_limit_passes() {
         // tx gas == remaining gas → should pass (check is `>`, not `>=`)
-        let limits = block_limits(900_000, 1_000_000, 0, 500_000, 0, false);
-        assert!(check_pool_tx_admission(100_000, false, 0, &limits).is_none());
+        assert!(
+            check_pool_tx_admission(100_000, false, 0, 900_000, 1_000_000, 0, 500_000, 0, false)
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
Reduce duplicated code, simplify code logic and allow us to test `check_pool_tx_admission`. 

changes: 
- Extracts pool transaction admission checks into a `decide_pool_tx` function that returns `PoolDecision::{Execute, Skip, Stop}`. The pool loop now reads as domain logic:



## Testing
`cargo test -p tempo-payload-builder` — all 3 tests pass.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk