### PR TITLE
wip: refactor(payload): move pool-fill budgeting into builder

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -553,14 +553,13 @@ impl Inner<Init> {
             self.fee_recipient,
             context.current().epoch_millis(),
             extra_data,
+            Some(self.new_payload_wait_time),
             move || {
                 self.subblocks
                     .get_subblocks(parent.block_hash())
                     .unwrap_or_default()
             },
         );
-
-        let interrupt_handle = attrs.interrupt_handle().clone();
 
         let payload_id = self
             .execution_node
@@ -571,14 +570,6 @@ impl Inner<Init> {
             .map_err(|_| eyre!("channel was closed before a response was returned"))
             .and_then(|ret| ret.wrap_err("execution layer rejected request"))
             .wrap_err("failed requesting new payload from the execution layer")?;
-
-        debug!(
-            timeout_ms = self.new_payload_wait_time.as_millis(),
-            "sleeping for payload builder timeout"
-        );
-        context.sleep(self.new_payload_wait_time).await;
-
-        interrupt_handle.interrupt();
 
         let payload = self
             .execution_node

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -447,6 +447,7 @@ where
         let execution_start = Instant::now();
         if !stop_pool_fill {
             loop {
+                // check if the pool-fill budget was reached, if so we can skip remaining transactions
                 if pool_fill_budget_reached_at("pool_tx_selection") {
                     break;
                 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -42,7 +42,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
@@ -68,6 +68,10 @@ fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> boo
         tx.as_aa()
             .is_some_and(|tx| tx.tx().valid_before.is_some_and(|valid| valid <= timestamp))
     })
+}
+
+fn pool_fill_budget_reached(elapsed: Duration, pool_fill_budget: Option<Duration>) -> bool {
+    pool_fill_budget.is_some_and(|budget| elapsed >= budget)
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +238,21 @@ where
         } = config;
 
         let guard = BuildGuard::new(&self.metrics);
+        let pool_fill_budget_reached_at = |stage: &'static str| {
+            let pool_fill_budget = attributes.pool_fill_budget();
+            let elapsed = guard.elapsed();
+            if !pool_fill_budget_reached(elapsed, pool_fill_budget) {
+                return false;
+            }
+
+            debug!(
+                ?elapsed,
+                ?pool_fill_budget,
+                stage,
+                "payload pool-fill budget reached"
+            );
+            true
+        };
 
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
@@ -247,7 +266,10 @@ where
             self.metrics
                 .state_provider_duration_seconds
                 .record(start.elapsed());
-            res?
+            match res {
+                Ok(provider) => provider,
+                Err(err) => return Err(err.into()),
+            }
         };
         let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
@@ -271,7 +293,6 @@ where
                 .record(start.elapsed());
             db
         };
-
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
             .provider
@@ -362,9 +383,11 @@ where
             self.metrics
                 .create_evm_duration_seconds
                 .record(start.elapsed());
-            res?
+            match res {
+                Ok(builder) => builder,
+                Err(err) => return Err(err),
+            }
         };
-
         {
             let start = Instant::now();
             let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
@@ -375,9 +398,10 @@ where
             self.metrics
                 .pre_execution_duration_seconds
                 .record(start.elapsed());
-            res?;
+            if let Err(err) = res {
+                return Err(err);
+            }
         }
-
         debug!("building new payload");
 
         // Prepare system transactions before actual block building and account for their size.
@@ -390,6 +414,7 @@ where
         self.metrics
             .prepare_system_transactions_duration_seconds
             .record(prepare_system_txs_elapsed);
+        let stop_pool_fill = pool_fill_budget_reached_at("before_pool_tx_selection");
 
         let base_fee = builder.evm_mut().block().basefee;
         let mut best_txs = best_txs(BestTransactionsAttributes::new(
@@ -420,155 +445,156 @@ where
 
         let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
-        loop {
-            // check if the job was interrupted, if so we can skip remaining transactions
-            if attributes.is_interrupted() {
-                break;
-            }
-
-            // check if the job was cancelled, if so we can exit early
-            if cancel.is_cancelled() {
-                record_pool_selection_metrics(
-                    &self.metrics,
-                    pool_transactions_considered,
-                    pool_transactions_executed,
-                    pool_transactions_skipped,
-                );
-                return Ok(BuildOutcome::Cancelled);
-            }
-
-            let selection_start = Instant::now();
-            let Some(pool_tx) = best_txs.next() else {
-                break;
-            };
-            self.metrics
-                .transaction_selection_duration_seconds
-                .record(selection_start.elapsed());
-            pool_transactions_considered += 1;
-
-            // Ensure we still have capacity for this transaction within the non-shared gas limit.
-            // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
-            // be consumed by proposer's pool transactions.
-            if cumulative_gas_used + pool_tx.gas_limit() > non_shared_gas_limit {
-                // Mark this transaction as invalid since it doesn't fit
-                // The iterator will handle lane switching internally when appropriate
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::ExceedsGasLimit(
-                        pool_tx.gas_limit(),
-                        non_shared_gas_limit - cumulative_gas_used,
-                    ),
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
-                    .increment(1);
-                continue;
-            }
-
-            // If the tx is not a payment and will exceed the general gas limit
-            // mark the tx as invalid and continue
-            if !pool_tx.transaction.is_payment()
-                && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
-            {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::Other(Box::new(
-                        TempoPoolTransactionError::ExceedsNonPaymentLimit,
-                    )),
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
-                    .increment(1);
-                continue;
-            }
-
-            let is_payment = pool_tx.transaction.is_payment();
-            if is_payment {
-                payment_transactions += 1;
-            }
-
-            let tx_rlp_length = pool_tx.transaction.inner().length();
-            let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
-
-            if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::OversizedData {
-                        size: estimated_block_size_with_tx,
-                        limit: MAX_RLP_BLOCK_SIZE,
-                    },
-                );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_oversized_block
-                    .increment(1);
-                continue;
-            }
-
-            let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
-
-            let tx_debug_repr = tracing::enabled!(Level::TRACE)
-                .then(|| format!("{:?}", pool_tx.transaction))
-                .unwrap_or_default();
-
-            let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
-            let execution_start = Instant::now();
-            let gas_used = match builder.execute_transaction(tx_with_env) {
-                Ok(gas_used) => gas_used,
-                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                    error,
-                    ..
-                })) => {
-                    if error.is_nonce_too_low() {
-                        // if the nonce is too low, we can skip this transaction
-                        trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        self.metrics
-                            .pool_transactions_skipped_nonce_too_low
-                            .increment(1);
-                    } else {
-                        // if the transaction is invalid, we can skip it and all of its
-                        // descendants
-                        trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
-                        best_txs.mark_invalid(
-                            &pool_tx,
-                            &InvalidPoolTransactionError::Consensus(
-                                InvalidTransactionError::TxTypeNotSupported,
-                            ),
-                        );
-                        self.metrics
-                            .pool_transactions_skipped_invalid_tx
-                            .increment(1);
-                    }
-                    pool_transactions_skipped += 1;
-                    continue;
+        if !stop_pool_fill {
+            loop {
+                if pool_fill_budget_reached_at("pool_tx_selection") {
+                    break;
                 }
-                // this is an error that we should treat as fatal for this attempt
-                Err(err) => {
+
+                // check if the job was cancelled, if so we can exit early
+                if cancel.is_cancelled() {
                     record_pool_selection_metrics(
                         &self.metrics,
                         pool_transactions_considered,
                         pool_transactions_executed,
                         pool_transactions_skipped,
                     );
-                    return Err(PayloadBuilderError::evm(err));
+                    return Ok(BuildOutcome::Cancelled);
                 }
-            };
-            pool_transactions_executed += 1;
-            let elapsed = execution_start.elapsed();
-            self.metrics
-                .transaction_execution_duration_seconds
-                .record(elapsed);
-            trace!(?elapsed, "Transaction executed");
 
-            // update and add to total fees
-            total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
-            cumulative_gas_used += gas_used;
-            if !is_payment {
-                non_payment_gas_used += gas_used;
+                let selection_start = Instant::now();
+                let Some(pool_tx) = best_txs.next() else {
+                    break;
+                };
+                self.metrics
+                    .transaction_selection_duration_seconds
+                    .record(selection_start.elapsed());
+                pool_transactions_considered += 1;
+
+                // Ensure we still have capacity for this transaction within the non-shared gas limit.
+                // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
+                // be consumed by proposer's pool transactions.
+                if cumulative_gas_used + pool_tx.gas_limit() > non_shared_gas_limit {
+                    // Mark this transaction as invalid since it doesn't fit
+                    // The iterator will handle lane switching internally when appropriate
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        &InvalidPoolTransactionError::ExceedsGasLimit(
+                            pool_tx.gas_limit(),
+                            non_shared_gas_limit - cumulative_gas_used,
+                        ),
+                    );
+                    pool_transactions_skipped += 1;
+                    self.metrics
+                        .pool_transactions_skipped_exceeds_non_shared_gas_limit
+                        .increment(1);
+                    continue;
+                }
+
+                // If the tx is not a payment and will exceed the general gas limit
+                // mark the tx as invalid and continue
+                if !pool_tx.transaction.is_payment()
+                    && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
+                {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        &InvalidPoolTransactionError::Other(Box::new(
+                            TempoPoolTransactionError::ExceedsNonPaymentLimit,
+                        )),
+                    );
+                    pool_transactions_skipped += 1;
+                    self.metrics
+                        .pool_transactions_skipped_exceeds_non_payment_gas_limit
+                        .increment(1);
+                    continue;
+                }
+
+                let is_payment = pool_tx.transaction.is_payment();
+                if is_payment {
+                    payment_transactions += 1;
+                }
+
+                let tx_rlp_length = pool_tx.transaction.inner().length();
+                let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
+
+                if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        &InvalidPoolTransactionError::OversizedData {
+                            size: estimated_block_size_with_tx,
+                            limit: MAX_RLP_BLOCK_SIZE,
+                        },
+                    );
+                    pool_transactions_skipped += 1;
+                    self.metrics
+                        .pool_transactions_skipped_oversized_block
+                        .increment(1);
+                    continue;
+                }
+
+                let effective_gas_price = pool_tx.transaction.effective_gas_price(Some(base_fee));
+
+                let tx_debug_repr = tracing::enabled!(Level::TRACE)
+                    .then(|| format!("{:?}", pool_tx.transaction))
+                    .unwrap_or_default();
+
+                let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
+                let execution_start = Instant::now();
+                let gas_used = match builder.execute_transaction(tx_with_env) {
+                    Ok(gas_used) => gas_used,
+                    Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                        error,
+                        ..
+                    })) => {
+                        if error.is_nonce_too_low() {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
+                            self.metrics
+                                .pool_transactions_skipped_nonce_too_low
+                                .increment(1);
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Consensus(
+                                    InvalidTransactionError::TxTypeNotSupported,
+                                ),
+                            );
+                            self.metrics
+                                .pool_transactions_skipped_invalid_tx
+                                .increment(1);
+                        }
+                        pool_transactions_skipped += 1;
+                        continue;
+                    }
+                    // this is an error that we should treat as fatal for this attempt
+                    Err(err) => {
+                        record_pool_selection_metrics(
+                            &self.metrics,
+                            pool_transactions_considered,
+                            pool_transactions_executed,
+                            pool_transactions_skipped,
+                        );
+                        return Err(PayloadBuilderError::evm(err));
+                    }
+                };
+                pool_transactions_executed += 1;
+                let elapsed = execution_start.elapsed();
+                self.metrics
+                    .transaction_execution_duration_seconds
+                    .record(elapsed);
+                trace!(?elapsed, "Transaction executed");
+
+                // update and add to total fees
+                total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
+                cumulative_gas_used += gas_used;
+                if !is_payment {
+                    non_payment_gas_used += gas_used;
+                }
+                block_size_used += tx_rlp_length;
             }
-            block_size_used += tx_rlp_length;
         }
         drop(_pool_tx_span);
         record_pool_selection_metrics(
@@ -692,7 +718,10 @@ where
                 block,
                 hashed_state,
                 trie_updates,
-            } = res?;
+            } = match res {
+                Ok(outcome) => outcome,
+                Err(err) => return Err(err.into()),
+            };
             (
                 builder_finish_elapsed,
                 execution_result,
@@ -815,6 +844,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use reth_payload_builder::PayloadId;
     use reth_primitives_traits::SealedBlock;
+    use std::time::Duration;
     use tempo_primitives::{
         AASigned, Block, SignedSubBlock, SubBlock, SubBlockVersion, TempoSignature,
         TempoTransaction,
@@ -943,6 +973,7 @@ mod tests {
             Address::default(),
             1000,
             extra_data.clone(),
+            None,
             Vec::new,
         );
 
@@ -969,5 +1000,27 @@ mod tests {
         // No valid_before → NOT expired
         let subblock_no_expiry = RecoveredSubBlock::with_valid_before(None);
         assert!(!has_expired_transactions(&subblock_no_expiry, 1000));
+    }
+
+    #[test]
+    fn test_pool_fill_budget_guard_skips_when_elapsed() {
+        let elapsed = Duration::from_millis(5);
+
+        assert!(pool_fill_budget_reached(elapsed, Some(Duration::ZERO)));
+        assert!(pool_fill_budget_reached(
+            elapsed,
+            Some(Duration::from_millis(1))
+        ));
+    }
+
+    #[test]
+    fn test_pool_fill_budget_guard_allows_when_not_elapsed_or_unset() {
+        let elapsed = Duration::ZERO;
+
+        assert!(!pool_fill_budget_reached(elapsed, None));
+        assert!(!pool_fill_budget_reached(
+            elapsed,
+            Some(Duration::from_secs(1))
+        ));
     }
 }

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -4,40 +4,17 @@ use alloy_rpc_types_eth::Withdrawals;
 use reth_ethereum_engine_primitives::{EthPayloadAttributes, EthPayloadBuilderAttributes};
 use reth_node_api::{PayloadAttributes, PayloadBuilderAttributes};
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::Infallible,
-    sync::{Arc, atomic, atomic::Ordering},
-};
+use std::{convert::Infallible, sync::Arc, time::Duration};
 use tempo_primitives::RecoveredSubBlock;
 
-/// A handle for a payload interrupt flag.
-///
-/// Can be fired using [`InterruptHandle::interrupt`].
-#[derive(Debug, Clone, Default)]
-pub struct InterruptHandle(Arc<atomic::AtomicBool>);
-
-impl InterruptHandle {
-    /// Turns on the interrupt flag on the associated payload.
-    pub fn interrupt(&self) {
-        self.0.store(true, Ordering::Relaxed);
-    }
-
-    /// Returns whether the interrupt flag is set.
-    pub fn is_interrupted(&self) -> bool {
-        self.0.load(Ordering::Relaxed)
-    }
-}
-
 /// Container type for all components required to build a payload.
-///
-/// The `TempoPayloadBuilderAttributes` has an additional feature of interrupting payload.
 ///
 /// It also carries DKG data to be included in the block's extra_data field.
 #[derive(derive_more::Debug, Clone)]
 pub struct TempoPayloadBuilderAttributes {
     inner: EthPayloadBuilderAttributes,
-    interrupt: InterruptHandle,
     timestamp_millis_part: u64,
+    pool_fill_budget: Option<Duration>,
     /// DKG ceremony data to include in the block's extra_data header field.
     ///
     /// This is empty when no DKG data is available (e.g., when the DKG manager
@@ -55,6 +32,7 @@ impl TempoPayloadBuilderAttributes {
         suggested_fee_recipient: Address,
         timestamp_millis: u64,
         extra_data: Bytes,
+        pool_fill_budget: Option<Duration>,
         subblocks: impl Fn() -> Vec<RecoveredSubBlock> + Send + Sync + 'static,
     ) -> Self {
         let (seconds, millis) = (timestamp_millis / 1000, timestamp_millis % 1000);
@@ -68,8 +46,8 @@ impl TempoPayloadBuilderAttributes {
                 withdrawals: Withdrawals::default(),
                 parent_beacon_block_root: Some(B256::ZERO),
             },
-            interrupt: InterruptHandle::default(),
             timestamp_millis_part: millis,
+            pool_fill_budget,
             extra_data,
             subblocks: Arc::new(subblocks),
         }
@@ -80,15 +58,9 @@ impl TempoPayloadBuilderAttributes {
         &self.extra_data
     }
 
-    /// Returns the `interrupt` flag. If true, it marks that a payload is requested to stop
-    /// processing any more transactions.
-    pub fn is_interrupted(&self) -> bool {
-        self.interrupt.0.load(Ordering::Relaxed)
-    }
-
-    /// Returns a cloneable [`InterruptHandle`] for turning on the `interrupt` flag.
-    pub fn interrupt_handle(&self) -> &InterruptHandle {
-        &self.interrupt
+    /// Returns the pool-fill budget for this payload, if one is set.
+    pub const fn pool_fill_budget(&self) -> Option<Duration> {
+        self.pool_fill_budget
     }
 
     /// Returns the milliseconds portion of the timestamp.
@@ -117,8 +89,8 @@ impl From<EthPayloadBuilderAttributes> for TempoPayloadBuilderAttributes {
     fn from(inner: EthPayloadBuilderAttributes) -> Self {
         Self {
             inner,
-            interrupt: InterruptHandle::default(),
             timestamp_millis_part: 0,
+            pool_fill_budget: None,
             extra_data: Bytes::default(),
             subblocks: Arc::new(Vec::new),
         }
@@ -143,8 +115,8 @@ impl PayloadBuilderAttributes for TempoPayloadBuilderAttributes {
         } = rpc_payload_attributes;
         Ok(Self {
             inner: EthPayloadBuilderAttributes::try_new(parent, inner, version)?,
-            interrupt: InterruptHandle::default(),
             timestamp_millis_part,
+            pool_fill_budget: None,
             extra_data: Bytes::default(),
             subblocks: Arc::new(Vec::new),
         })
@@ -212,10 +184,12 @@ impl PayloadAttributes for TempoPayloadAttributes {
 mod tests {
     use super::*;
     use alloy_rpc_types_eth::Withdrawal;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     trait TestExt: Sized {
         fn random() -> Self;
         fn with_timestamp(self, millis: u64) -> Self;
+        fn with_pool_fill_budget(self, pool_fill_budget: Option<Duration>) -> Self;
         fn with_subblocks(
             self,
             f: impl Fn() -> Vec<RecoveredSubBlock> + Send + Sync + 'static,
@@ -230,6 +204,7 @@ mod tests {
                 Address::random(),
                 1000,
                 Bytes::default(),
+                None,
                 Vec::new,
             )
         }
@@ -237,6 +212,11 @@ mod tests {
         fn with_timestamp(mut self, millis: u64) -> Self {
             self.inner.timestamp = millis / 1000;
             self.timestamp_millis_part = millis % 1000;
+            self
+        }
+
+        fn with_pool_fill_budget(mut self, pool_fill_budget: Option<Duration>) -> Self {
+            self.pool_fill_budget = pool_fill_budget;
             self
         }
 
@@ -250,30 +230,13 @@ mod tests {
     }
 
     #[test]
-    fn test_interrupt_handle() {
-        // Default state
-        let handle = InterruptHandle::default();
-        assert!(!handle.is_interrupted());
+    fn test_pool_fill_budget_accessors() {
+        let attrs = TempoPayloadBuilderAttributes::random();
+        assert_eq!(attrs.pool_fill_budget(), None);
 
-        // Interrupt sets flag
-        handle.interrupt();
-        assert!(handle.is_interrupted());
-
-        // Clone shares state
-        let handle2 = handle.clone();
-        assert!(handle2.is_interrupted());
-
-        // New handle via clone before interrupt
-        let fresh = InterruptHandle::default();
-        let cloned = fresh.clone();
-        assert!(!cloned.is_interrupted());
-        fresh.interrupt();
-        assert!(cloned.is_interrupted()); // shared atomic
-
-        // Multiple interrupts are idempotent
-        handle.interrupt();
-        handle.interrupt();
-        assert!(handle.is_interrupted());
+        let budget = Some(Duration::from_millis(250));
+        let attrs = attrs.with_pool_fill_budget(budget);
+        assert_eq!(attrs.pool_fill_budget(), budget);
     }
 
     #[test]
@@ -291,6 +254,7 @@ mod tests {
             recipient,
             timestamp_millis,
             extra_data.clone(),
+            Some(Duration::from_millis(250)),
             Vec::new,
         );
         assert_eq!(attrs.extra_data(), &extra_data);
@@ -299,6 +263,7 @@ mod tests {
         assert_eq!(attrs.payload_id(), id);
         assert_eq!(attrs.timestamp(), 1);
         assert_eq!(attrs.timestamp_millis_part(), 500);
+        assert_eq!(attrs.pool_fill_budget(), Some(Duration::from_millis(250)));
 
         // Hardcoded in ::new()
         assert_eq!(attrs.prev_randao(), B256::ZERO);
@@ -312,31 +277,20 @@ mod tests {
             recipient,
             timestamp_millis + 500, // 1.5 seconds + 500ms
             Bytes::default(),
+            None,
             Vec::new,
         );
         assert_eq!(attrs2.extra_data(), &Bytes::default());
         assert_eq!(attrs2.timestamp(), 2);
         assert_eq!(attrs2.timestamp_millis_part(), 0);
+        assert_eq!(attrs2.pool_fill_budget(), None);
     }
 
     #[test]
-    fn test_builder_attributes_interrupt_integration() {
-        let attrs = TempoPayloadBuilderAttributes::random();
-
-        // Initially not interrupted
-        assert!(!attrs.is_interrupted());
-
-        // Get handle and interrupt
-        let handle = attrs.interrupt_handle().clone();
-        handle.interrupt();
-
-        // Both see interrupted state
-        assert!(attrs.is_interrupted());
-        assert!(handle.is_interrupted());
-
-        // Multiple handle accesses return same underlying state
-        let handle2 = attrs.interrupt_handle();
-        assert!(handle2.is_interrupted());
+    fn test_builder_attributes_pool_fill_budget_integration() {
+        let attrs = TempoPayloadBuilderAttributes::random()
+            .with_pool_fill_budget(Some(Duration::from_millis(500)));
+        assert_eq!(attrs.pool_fill_budget(), Some(Duration::from_millis(500)));
     }
 
     #[test]
@@ -368,8 +322,6 @@ mod tests {
 
     #[test]
     fn test_builder_attributes_subblocks() {
-        use std::sync::atomic::AtomicUsize;
-
         let call_count = Arc::new(AtomicUsize::new(0));
         let count_clone = call_count.clone();
 
@@ -423,7 +375,7 @@ mod tests {
         // Tempo-specific defaults
         assert_eq!(tempo_attrs.timestamp_millis_part(), 0);
         assert_eq!(tempo_attrs.extra_data(), &Bytes::default());
-        assert!(!tempo_attrs.is_interrupted());
+        assert_eq!(tempo_attrs.pool_fill_budget(), None);
         assert!(tempo_attrs.subblocks().is_empty());
     }
 
@@ -450,7 +402,7 @@ mod tests {
         assert_eq!(attrs.timestamp_millis_part(), 750);
         assert_eq!(attrs.timestamp_millis(), 100_750);
         assert_eq!(attrs.extra_data(), &Bytes::default());
-        assert!(!attrs.is_interrupted());
+        assert_eq!(attrs.pool_fill_budget(), None);
     }
 
     #[test]

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -6,7 +6,7 @@
 mod attrs;
 
 use alloy_primitives::B256;
-pub use attrs::{InterruptHandle, TempoPayloadAttributes, TempoPayloadBuilderAttributes};
+pub use attrs::{TempoPayloadAttributes, TempoPayloadBuilderAttributes};
 use std::sync::Arc;
 
 use alloy_eips::eip7685::Requests;


### PR DESCRIPTION
Moves Tempo's payload build timing policy into the builder by replacing the actor-side sleep/interrupt flow with `pool_fill_budget` on payload attributes.

This removes the `InterruptHandle` side channel, keeps the current `resolve_kind(..., WaitForPending)` flow intact, and adds direct unit coverage for the builder's budget guard.

The upstream `PayloadBuilderHandle` resolve API cleanup is intentionally deferred to the follow-up Phase 1 work.