### PR TITLE
fix: make `fn is_payment` hardfork-aware via `PaymentRules` enum

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -27,6 +27,7 @@ use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
 use alloy_evm::revm::primitives::hardfork::SpecId;
 use alloy_hardforks::hardfork;
 use reth_chainspec::{EthereumHardforks, ForkCondition};
+use tempo_primitives::PaymentRules;
 
 /// Single-source hardfork definition macro. Append a new variant and everything else is generated:
 ///
@@ -245,6 +246,16 @@ impl TempoHardfork {
                 crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
             }
             Self::T2 => crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS,
+        }
+    }
+
+    /// Returns the payment classification rules for this hardfork.
+    pub const fn payment_rules(&self) -> PaymentRules {
+        match self {
+            Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
+                PaymentRules::Genesis
+            }
+            Self::T2 => PaymentRules::T2,
         }
     }
 }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -331,8 +331,12 @@ where
         } else {
             match self.section {
                 BlockSection::StartOfBlock | BlockSection::NonShared => {
+                    let is_t2 = self
+                        .inner
+                        .spec
+                        .is_t2_active_at_timestamp(self.evm().block().timestamp.to::<u64>());
                     if gas_used > self.non_shared_gas_left
-                        || (!tx.is_payment() && gas_used > self.non_payment_gas_left)
+                        || (!tx.is_payment(is_t2) && gas_used > self.non_payment_gas_left)
                     {
                         // Assume that this transaction wants to make use of gas incentive section
                         //
@@ -425,10 +429,14 @@ where
         let inner = result?;
 
         let next_section = self.validate_tx(recovered.tx(), inner.result.result.gas_used())?;
+        let is_t2 = self
+            .inner
+            .spec
+            .is_t2_active_at_timestamp(self.evm().block().timestamp.to::<u64>());
         Ok(TempoTxResult {
             inner,
             next_section,
-            is_payment: recovered.tx().is_payment(),
+            is_payment: recovered.tx().is_payment(is_t2),
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
         })

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -331,12 +331,13 @@ where
         } else {
             match self.section {
                 BlockSection::StartOfBlock | BlockSection::NonShared => {
-                    let is_t2 = self
+                    let payment_rules = self
                         .inner
                         .spec
-                        .is_t2_active_at_timestamp(self.evm().block().timestamp.to::<u64>());
+                        .tempo_hardfork_at(self.evm().block().timestamp.to::<u64>())
+                        .payment_rules();
                     if gas_used > self.non_shared_gas_left
-                        || (!tx.is_payment(is_t2) && gas_used > self.non_payment_gas_left)
+                        || (!tx.is_payment(payment_rules) && gas_used > self.non_payment_gas_left)
                     {
                         // Assume that this transaction wants to make use of gas incentive section
                         //
@@ -429,14 +430,15 @@ where
         let inner = result?;
 
         let next_section = self.validate_tx(recovered.tx(), inner.result.result.gas_used())?;
-        let is_t2 = self
+        let payment_rules = self
             .inner
             .spec
-            .is_t2_active_at_timestamp(self.evm().block().timestamp.to::<u64>());
+            .tempo_hardfork_at(self.evm().block().timestamp.to::<u64>())
+            .payment_rules();
         Ok(TempoTxResult {
             inner,
             next_section,
-            is_payment: recovered.tx().is_payment(is_t2),
+            is_payment: recovered.tx().is_payment(payment_rules),
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
         })

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -15,7 +15,7 @@ use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{IRolesAuth, ITIP20, ITIP20Factory};
 use tempo_node::node::TempoNode;
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::ISSUER_ROLE};
-use tempo_primitives::TempoTxEnvelope;
+use tempo_primitives::{PaymentRules, TempoTxEnvelope};
 
 /// Helper to setup a test token by manually injecting transactions and advancing blocks
 async fn setup_token_manual<P>(
@@ -170,10 +170,13 @@ where
 
 /// Helper to count payment and non-payment transactions
 fn count_transaction_types(transactions: &[TempoTxEnvelope]) -> (usize, usize) {
-    let payment_count = transactions.iter().filter(|tx| tx.is_payment(true)).count();
+    let payment_count = transactions
+        .iter()
+        .filter(|tx| tx.is_payment(PaymentRules::T2))
+        .count();
     let non_payment_count = transactions
         .iter()
-        .filter(|tx| !tx.is_payment(true))
+        .filter(|tx| !tx.is_payment(PaymentRules::T2))
         .count();
     (payment_count, non_payment_count)
 }
@@ -323,7 +326,7 @@ async fn test_block_building_only_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            tx.is_payment(true),
+            tx.is_payment(PaymentRules::T2),
             "All transactions should be payment transactions"
         );
     }
@@ -393,7 +396,7 @@ async fn test_block_building_only_non_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            !tx.is_payment(true),
+            !tx.is_payment(PaymentRules::T2),
             "All transactions should be non-payment transactions"
         );
     }

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -170,8 +170,11 @@ where
 
 /// Helper to count payment and non-payment transactions
 fn count_transaction_types(transactions: &[TempoTxEnvelope]) -> (usize, usize) {
-    let payment_count = transactions.iter().filter(|tx| tx.is_payment()).count();
-    let non_payment_count = transactions.iter().filter(|tx| !tx.is_payment()).count();
+    let payment_count = transactions.iter().filter(|tx| tx.is_payment(true)).count();
+    let non_payment_count = transactions
+        .iter()
+        .filter(|tx| !tx.is_payment(true))
+        .count();
     (payment_count, non_payment_count)
 }
 
@@ -320,7 +323,7 @@ async fn test_block_building_only_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            tx.is_payment(),
+            tx.is_payment(true),
             "All transactions should be payment transactions"
         );
     }
@@ -390,7 +393,7 @@ async fn test_block_building_only_non_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            !tx.is_payment(),
+            !tx.is_payment(true),
             "All transactions should be non-payment transactions"
         );
     }

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -172,11 +172,11 @@ where
 fn count_transaction_types(transactions: &[TempoTxEnvelope]) -> (usize, usize) {
     let payment_count = transactions
         .iter()
-        .filter(|tx| tx.is_payment(PaymentRules::T2))
+        .filter(|tx| tx.is_payment(PaymentRules::LATEST))
         .count();
     let non_payment_count = transactions
         .iter()
-        .filter(|tx| !tx.is_payment(PaymentRules::T2))
+        .filter(|tx| !tx.is_payment(PaymentRules::LATEST))
         .count();
     (payment_count, non_payment_count)
 }
@@ -326,7 +326,7 @@ async fn test_block_building_only_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            tx.is_payment(PaymentRules::T2),
+            tx.is_payment(PaymentRules::LATEST),
             "All transactions should be payment transactions"
         );
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -277,7 +277,9 @@ where
             .provider
             .chain_spec()
             .is_osaka_active_at_timestamp(attributes.timestamp());
-        let is_t2 = chain_spec.is_t2_active_at_timestamp(attributes.timestamp());
+        let payment_rules = chain_spec
+            .tempo_hardfork_at(attributes.timestamp())
+            .payment_rules();
 
         let block_gas_limit: u64 = parent_header.gas_limit();
         let shared_gas_limit = block_gas_limit / TEMPO_SHARED_GAS_DIVISOR;
@@ -469,7 +471,7 @@ where
 
             // If the tx is not a payment and will exceed the general gas limit
             // mark the tx as invalid and continue
-            if !pool_tx.transaction.inner().is_payment(is_t2)
+            if !pool_tx.transaction.inner().is_payment(payment_rules)
                 && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
             {
                 best_txs.mark_invalid(
@@ -485,7 +487,7 @@ where
                 continue;
             }
 
-            let is_payment = pool_tx.transaction.inner().is_payment(is_t2);
+            let is_payment = pool_tx.transaction.inner().is_payment(payment_rules);
             if is_payment {
                 payment_transactions += 1;
             }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -277,6 +277,7 @@ where
             .provider
             .chain_spec()
             .is_osaka_active_at_timestamp(attributes.timestamp());
+        let is_t2 = chain_spec.is_t2_active_at_timestamp(attributes.timestamp());
 
         let block_gas_limit: u64 = parent_header.gas_limit();
         let shared_gas_limit = block_gas_limit / TEMPO_SHARED_GAS_DIVISOR;
@@ -468,7 +469,7 @@ where
 
             // If the tx is not a payment and will exceed the general gas limit
             // mark the tx as invalid and continue
-            if !pool_tx.transaction.is_payment()
+            if !pool_tx.transaction.inner().is_payment(is_t2)
                 && non_payment_gas_used + pool_tx.gas_limit() > general_gas_limit
             {
                 best_txs.mark_invalid(
@@ -484,7 +485,7 @@ where
                 continue;
             }
 
-            let is_payment = pool_tx.transaction.is_payment();
+            let is_payment = pool_tx.transaction.inner().is_payment(is_t2);
             if is_payment {
                 payment_transactions += 1;
             }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -8,9 +8,9 @@ pub use alloy_consensus::Header;
 
 pub mod transaction;
 pub use transaction::{
-    AASigned, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,
-    SignatureType, TEMPO_GAS_PRICE_SCALING_FACTOR, TEMPO_TX_TYPE_ID, TempoSignature,
-    TempoTransaction, TempoTxEnvelope, TempoTxType, derive_p256_address,
+    AASigned, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, PaymentRules,
+    SECP256K1_SIGNATURE_LENGTH, SignatureType, TEMPO_GAS_PRICE_SCALING_FACTOR, TEMPO_TX_TYPE_ID,
+    TempoSignature, TempoTransaction, TempoTxEnvelope, TempoTxType, derive_p256_address,
 };
 
 mod header;

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -32,9 +32,14 @@ fn is_valid_payment_calldata(input: &[u8]) -> bool {
     })
 }
 
+/// Returns `true` if `to` has the TIP-20 payment prefix.
+fn has_tip20_prefix(to: Option<&Address>) -> bool {
+    to.is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
+}
+
 /// Returns `true` if `to` has the TIP-20 payment prefix and `input` is valid payment calldata.
-fn is_tip20_payment(to: Option<&Address>, input: &[u8]) -> bool {
-    to.is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX)) && is_valid_payment_calldata(input)
+fn is_tip20_payment_strict(to: Option<&Address>, input: &[u8]) -> bool {
+    has_tip20_prefix(to) && is_valid_payment_calldata(input)
 }
 
 /// Fake signature for Tempo system transactions.
@@ -179,22 +184,39 @@ impl TempoTxEnvelope {
 
     /// Classify a transaction as payment or non-payment.
     ///
-    /// A transaction is a payment if:
-    /// 1. The `to` address has the TIP20 prefix, AND
-    /// 2. The calldata has a recognized payment selector with exact ABI-encoded length.
-    pub fn is_payment(&self) -> bool {
-        match self {
-            Self::Legacy(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
-            Self::Eip2930(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
-            Self::Eip1559(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
-            Self::Eip7702(tx) => is_tip20_payment(Some(&tx.tx().to), &tx.tx().input),
-            Self::AA(tx) => {
-                !tx.tx().calls.is_empty()
-                    && tx
-                        .tx()
-                        .calls
-                        .iter()
-                        .all(|call| is_tip20_payment(call.to.to(), &call.input))
+    /// Pre-T2 (strict = false): a transaction is a payment if the `to` address has the TIP20
+    /// prefix.
+    ///
+    /// Post-T2 (strict = true): additionally requires the calldata to have a recognized payment
+    /// selector with exact ABI-encoded length, and AA transactions must have a non-empty calls
+    /// list.
+    pub fn is_payment(&self, strict: bool) -> bool {
+        if strict {
+            match self {
+                Self::Legacy(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
+                Self::Eip2930(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
+                Self::Eip1559(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
+                Self::Eip7702(tx) => is_tip20_payment_strict(Some(&tx.tx().to), &tx.tx().input),
+                Self::AA(tx) => {
+                    !tx.tx().calls.is_empty()
+                        && tx
+                            .tx()
+                            .calls
+                            .iter()
+                            .all(|call| is_tip20_payment_strict(call.to.to(), &call.input))
+                }
+            }
+        } else {
+            match self {
+                Self::Legacy(tx) => has_tip20_prefix(tx.tx().to.to()),
+                Self::Eip2930(tx) => has_tip20_prefix(tx.tx().to.to()),
+                Self::Eip1559(tx) => has_tip20_prefix(tx.tx().to.to()),
+                Self::Eip7702(tx) => has_tip20_prefix(Some(&tx.tx().to)),
+                Self::AA(tx) => tx
+                    .tx()
+                    .calls
+                    .iter()
+                    .all(|call| has_tip20_prefix(call.to.to())),
             }
         }
     }
@@ -693,7 +715,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment(true));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -703,7 +725,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment(true));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -713,7 +735,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment(true));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -723,7 +745,35 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment(true));
+    }
+
+    #[test]
+    fn test_payment_pre_t2_prefix_only() {
+        // Pre-T2: address prefix alone is sufficient, calldata is ignored
+        let tx = TxLegacy {
+            to: TxKind::Call(PAYMENT_TKN),
+            gas_limit: 21000,
+            ..Default::default()
+        };
+        let signed = Signed::new_unhashed(tx, Signature::test_signature());
+        let envelope = TempoTxEnvelope::Legacy(signed);
+        assert!(
+            envelope.is_payment(false),
+            "pre-T2: empty calldata should still be payment"
+        );
+
+        // AA with empty calls is vacuously true pre-T2
+        let tx = TempoTransaction {
+            fee_token: Some(PAYMENT_TKN),
+            calls: vec![],
+            ..Default::default()
+        };
+        let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
+        assert!(
+            envelope.is_payment(false),
+            "pre-T2: empty AA calls is vacuously true"
+        );
     }
 
     #[test]
@@ -735,7 +785,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -750,7 +800,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -765,7 +815,7 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -779,7 +829,7 @@ mod tests {
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
 
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     fn create_aa_envelope(call: Call) -> TempoTxEnvelope {
@@ -799,7 +849,7 @@ mod tests {
             ..Default::default()
         };
         let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -813,7 +863,7 @@ mod tests {
             };
             let envelope = create_aa_envelope(call);
             assert!(
-                envelope.is_payment(),
+                envelope.is_payment(true),
                 "PAYMENT_CALLDATA[{i}] should be classified as payment"
             );
         }
@@ -828,7 +878,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -839,7 +889,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -853,7 +903,7 @@ mod tests {
             };
             let envelope = create_aa_envelope(call);
             assert!(
-                envelope.is_payment(),
+                envelope.is_payment(true),
                 "PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix"
             );
         }
@@ -869,7 +919,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]
@@ -887,7 +937,7 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(), "Eip2930 PAYMENT_CALLDATA[{i}]");
+            assert!(envelope.is_payment(true), "Eip2930 PAYMENT_CALLDATA[{i}]");
 
             // Eip1559 payment
             let tx = TxEip1559 {
@@ -897,7 +947,7 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(), "Eip1559 PAYMENT_CALLDATA[{i}]");
+            assert!(envelope.is_payment(true), "Eip1559 PAYMENT_CALLDATA[{i}]");
 
             // Eip7702 payment
             let tx = TxEip7702 {
@@ -907,7 +957,7 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(), "Eip7702 PAYMENT_CALLDATA[{i}]");
+            assert!(envelope.is_payment(true), "Eip7702 PAYMENT_CALLDATA[{i}]");
         }
 
         // Non-payment addresses
@@ -917,7 +967,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
 
         let tx = TxEip1559 {
             to: TxKind::Call(address!("1234567890123456789012345678901234567890")),
@@ -925,7 +975,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
 
         let tx = TxEip7702 {
             to: address!("1234567890123456789012345678901234567890"),
@@ -933,7 +983,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment(true));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -14,6 +14,24 @@ use core::fmt;
 /// Same as TIP20_TOKEN_PREFIX
 pub const TIP20_PAYMENT_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
 
+/// Payment classification rules that vary by hardfork.
+///
+/// Named after the hardfork that introduced each set of rules. Multiple hardforks may share the
+/// same variant when the payment rules don't change between them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaymentRules {
+    /// Pre-T2: a transaction is a payment if the `to` address has the TIP-20 prefix.
+    Genesis,
+    /// T2+: additionally, requires recognized payment selector with exact ABI-encoded length,
+    /// and AA transactions must have a non-empty calls list.
+    T2,
+}
+
+impl PaymentRules {
+    /// The latest payment rules. Must be updated when a new hardfork changes payment semantics.
+    pub const LATEST: Self = Self::T2;
+}
+
 /// Valid TIP-20 payment selectors with their expected calldata lengths.
 const PAYMENT_CALLDATA: &[([u8; 4], usize)] = &[
     (hex!("a9059cbb"), 68),  // transfer(address,uint256)
@@ -184,15 +202,14 @@ impl TempoTxEnvelope {
 
     /// Classify a transaction as payment or non-payment.
     ///
-    /// Pre-T2 (strict = false): a transaction is a payment if the `to` address has the TIP20
-    /// prefix.
+    /// The classification rules depend on the active hardfork, encoded via [`PaymentRules`]:
     ///
-    /// Post-T2 (strict = true): additionally requires the calldata to have a recognized payment
-    /// selector with exact ABI-encoded length, and AA transactions must have a non-empty calls
-    /// list.
-    pub fn is_payment(&self, strict: bool) -> bool {
-        if strict {
-            match self {
+    /// - [`PaymentRules::Genesis`]: a tx is a payment if the `to` address has the TIP-20 prefix.
+    /// - [`PaymentRules::T2`]: additionally, requires the calldata to have a recognized payment
+    ///   selector with exact ABI-encoded length + AA transactions must have a non-empty calls list.
+    pub fn is_payment(&self, rules: PaymentRules) -> bool {
+        match rules {
+            PaymentRules::T2 => match self {
                 Self::Legacy(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
                 Self::Eip2930(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
                 Self::Eip1559(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
@@ -205,9 +222,8 @@ impl TempoTxEnvelope {
                             .iter()
                             .all(|call| is_tip20_payment_strict(call.to.to(), &call.input))
                 }
-            }
-        } else {
-            match self {
+            },
+            PaymentRules::Genesis => match self {
                 Self::Legacy(tx) => has_tip20_prefix(tx.tx().to.to()),
                 Self::Eip2930(tx) => has_tip20_prefix(tx.tx().to.to()),
                 Self::Eip1559(tx) => has_tip20_prefix(tx.tx().to.to()),
@@ -217,7 +233,7 @@ impl TempoTxEnvelope {
                     .calls
                     .iter()
                     .all(|call| has_tip20_prefix(call.to.to())),
-            }
+            },
         }
     }
 
@@ -715,7 +731,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(envelope.is_payment(PaymentRules::T2));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -725,7 +742,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(envelope.is_payment(PaymentRules::T2));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -735,7 +753,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(envelope.is_payment(PaymentRules::T2));
 
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
@@ -745,12 +764,13 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
-    fn test_payment_pre_t2_prefix_only() {
-        // Pre-T2: address prefix alone is sufficient, calldata is ignored
+    fn test_payment_rules_differ_across_forks() {
+        // TIP-20 prefix but no valid selector — payment under Genesis, not under T2
         let tx = TxLegacy {
             to: TxKind::Call(PAYMENT_TKN),
             gas_limit: 21000,
@@ -758,22 +778,18 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(
-            envelope.is_payment(false),
-            "pre-T2: empty calldata should still be payment"
-        );
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
 
-        // AA with empty calls is vacuously true pre-T2
+        // AA with empty calls — vacuously true under Genesis, rejected under T2
         let tx = TempoTransaction {
             fee_token: Some(PAYMENT_TKN),
             calls: vec![],
             ..Default::default()
         };
         let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
-        assert!(
-            envelope.is_payment(false),
-            "pre-T2: empty AA calls is vacuously true"
-        );
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -785,7 +801,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -800,7 +817,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -815,7 +833,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-        assert!(!envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -828,8 +847,8 @@ mod tests {
         };
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
-
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     fn create_aa_envelope(call: Call) -> TempoTxEnvelope {
@@ -849,7 +868,8 @@ mod tests {
             ..Default::default()
         };
         let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
-        assert!(!envelope.is_payment(true));
+        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -863,8 +883,12 @@ mod tests {
             };
             let envelope = create_aa_envelope(call);
             assert!(
-                envelope.is_payment(true),
-                "PAYMENT_CALLDATA[{i}] should be classified as payment"
+                envelope.is_payment(PaymentRules::Genesis),
+                "Genesis: PAYMENT_CALLDATA[{i}] should be classified as payment"
+            );
+            assert!(
+                envelope.is_payment(PaymentRules::T2),
+                "T2: PAYMENT_CALLDATA[{i}] should be classified as payment"
             );
         }
     }
@@ -878,7 +902,8 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -889,7 +914,8 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -903,8 +929,12 @@ mod tests {
             };
             let envelope = create_aa_envelope(call);
             assert!(
-                envelope.is_payment(true),
-                "PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix"
+                envelope.is_payment(PaymentRules::Genesis),
+                "Genesis: PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix"
+            );
+            assert!(
+                envelope.is_payment(PaymentRules::T2),
+                "T2: PAYMENT_CALLDATA[{i}] should match partial TIP20 prefix"
             );
         }
     }
@@ -919,7 +949,8 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -937,7 +968,14 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(true), "Eip2930 PAYMENT_CALLDATA[{i}]");
+            assert!(
+                envelope.is_payment(PaymentRules::Genesis),
+                "Genesis: Eip2930 PAYMENT_CALLDATA[{i}]"
+            );
+            assert!(
+                envelope.is_payment(PaymentRules::T2),
+                "T2: Eip2930 PAYMENT_CALLDATA[{i}]"
+            );
 
             // Eip1559 payment
             let tx = TxEip1559 {
@@ -947,7 +985,14 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(true), "Eip1559 PAYMENT_CALLDATA[{i}]");
+            assert!(
+                envelope.is_payment(PaymentRules::Genesis),
+                "Genesis: Eip1559 PAYMENT_CALLDATA[{i}]"
+            );
+            assert!(
+                envelope.is_payment(PaymentRules::T2),
+                "T2: Eip1559 PAYMENT_CALLDATA[{i}]"
+            );
 
             // Eip7702 payment
             let tx = TxEip7702 {
@@ -957,7 +1002,14 @@ mod tests {
             };
             let envelope =
                 TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-            assert!(envelope.is_payment(true), "Eip7702 PAYMENT_CALLDATA[{i}]");
+            assert!(
+                envelope.is_payment(PaymentRules::Genesis),
+                "Genesis: Eip7702 PAYMENT_CALLDATA[{i}]"
+            );
+            assert!(
+                envelope.is_payment(PaymentRules::T2),
+                "T2: Eip7702 PAYMENT_CALLDATA[{i}]"
+            );
         }
 
         // Non-payment addresses
@@ -967,7 +1019,8 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
 
         let tx = TxEip1559 {
             to: TxKind::Call(address!("1234567890123456789012345678901234567890")),
@@ -975,7 +1028,8 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
 
         let tx = TxEip7702 {
             to: address!("1234567890123456789012345678901234567890"),
@@ -983,7 +1037,8 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment(true));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -50,16 +50,6 @@ fn is_valid_payment_calldata(input: &[u8]) -> bool {
     })
 }
 
-/// Returns `true` if `to` has the TIP-20 payment prefix.
-fn has_tip20_prefix(to: Option<&Address>) -> bool {
-    to.is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
-}
-
-/// Returns `true` if `to` has the TIP-20 payment prefix and `input` is valid payment calldata.
-fn is_tip20_payment_strict(to: Option<&Address>, input: &[u8]) -> bool {
-    has_tip20_prefix(to) && is_valid_payment_calldata(input)
-}
-
 /// Fake signature for Tempo system transactions.
 pub const TEMPO_SYSTEM_TX_SIGNATURE: Signature = Signature::new(U256::ZERO, U256::ZERO, false);
 
@@ -208,32 +198,29 @@ impl TempoTxEnvelope {
     /// - [`PaymentRules::T2`]: additionally, requires the calldata to have a recognized payment
     ///   selector with exact ABI-encoded length + AA transactions must have a non-empty calls list.
     pub fn is_payment(&self, rules: PaymentRules) -> bool {
-        match rules {
-            PaymentRules::T2 => match self {
-                Self::Legacy(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
-                Self::Eip2930(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
-                Self::Eip1559(tx) => is_tip20_payment_strict(tx.tx().to.to(), &tx.tx().input),
-                Self::Eip7702(tx) => is_tip20_payment_strict(Some(&tx.tx().to), &tx.tx().input),
-                Self::AA(tx) => {
-                    !tx.tx().calls.is_empty()
-                        && tx
-                            .tx()
-                            .calls
-                            .iter()
-                            .all(|call| is_tip20_payment_strict(call.to.to(), &call.input))
+        let is_tip20_payment = |to: Option<&Address>, input: &[u8]| -> bool {
+            // must always start with TIP20 prefix
+            to.is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
+            // custom hardfork logic
+                && match rules {
+                    PaymentRules::Genesis => true,
+                    PaymentRules::T2 => is_valid_payment_calldata(input),
                 }
-            },
-            PaymentRules::Genesis => match self {
-                Self::Legacy(tx) => has_tip20_prefix(tx.tx().to.to()),
-                Self::Eip2930(tx) => has_tip20_prefix(tx.tx().to.to()),
-                Self::Eip1559(tx) => has_tip20_prefix(tx.tx().to.to()),
-                Self::Eip7702(tx) => has_tip20_prefix(Some(&tx.tx().to)),
-                Self::AA(tx) => tx
-                    .tx()
-                    .calls
-                    .iter()
-                    .all(|call| has_tip20_prefix(call.to.to())),
-            },
+        };
+
+        match self {
+            Self::Legacy(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip2930(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip1559(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip7702(tx) => is_tip20_payment(Some(&tx.tx().to), &tx.tx().input),
+            Self::AA(tx) => {
+                !tx.tx().calls.is_empty()
+                    && tx
+                        .tx()
+                        .calls
+                        .iter()
+                        .all(|call| is_tip20_payment(call.to.to(), &call.input))
+            }
         }
     }
 
@@ -780,16 +767,6 @@ mod tests {
         let envelope = TempoTxEnvelope::Legacy(signed);
         assert!(envelope.is_payment(PaymentRules::Genesis));
         assert!(!envelope.is_payment(PaymentRules::T2));
-
-        // AA with empty calls — vacuously true under Genesis, rejected under T2
-        let tx = TempoTransaction {
-            fee_token: Some(PAYMENT_TKN),
-            calls: vec![],
-            ..Default::default()
-        };
-        let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
-        assert!(envelope.is_payment(PaymentRules::Genesis));
-        assert!(!envelope.is_payment(PaymentRules::T2));
     }
 
     #[test]
@@ -868,7 +845,7 @@ mod tests {
             ..Default::default()
         };
         let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
-        assert!(envelope.is_payment(PaymentRules::Genesis));
+        assert!(!envelope.is_payment(PaymentRules::Genesis));
         assert!(!envelope.is_payment(PaymentRules::T2));
     }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -13,7 +13,9 @@ pub use tt_signature::{
 };
 
 pub use alloy_eips::eip7702::Authorization;
-pub use envelope::{TIP20_PAYMENT_PREFIX, TempoTxEnvelope, TempoTxType, TempoTypedTransaction};
+pub use envelope::{
+    PaymentRules, TIP20_PAYMENT_PREFIX, TempoTxEnvelope, TempoTxType, TempoTypedTransaction,
+};
 pub use key_authorization::{
     KeyAuthorization, KeyAuthorizationChainIdError, SignedKeyAuthorization, TokenLimit,
 };

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -30,7 +30,7 @@ use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
     tip20::is_tip20_prefix,
 };
-use tempo_primitives::{AASigned, TempoPrimitives};
+use tempo_primitives::{AASigned, PaymentRules, TempoPrimitives};
 use tracing::{debug, error};
 
 /// Evict transactions this many seconds before they expire to reduce propagation
@@ -506,8 +506,13 @@ where
                 let new = match event {
                     CanonStateNotification::Reorg { old, new } => {
                         // Handle reorg: identify orphaned AA 2D txs and affected nonce slots
+                        let reorg_payment_rules = pool
+                            .client()
+                            .chain_spec()
+                            .tempo_hardfork_at(new.tip().header().timestamp())
+                            .payment_rules();
                         let (orphaned_txs, affected_seq_ids) =
-                            handle_reorg(old, new.clone(), |hash| pool.contains(hash));
+                            handle_reorg(old, new.clone(), |hash| pool.contains(hash), reorg_payment_rules);
 
                         // Reset nonce state for affected 2D nonce slots from the new tip's state.
                         // Necessary because state diffs only contain slots that changed in the new chain.
@@ -898,6 +903,7 @@ pub fn handle_reorg<F>(
     old_chain: Arc<Chain<TempoPrimitives>>,
     new_chain: Arc<Chain<TempoPrimitives>>,
     is_in_pool: F,
+    payment_rules: PaymentRules,
 ) -> (Vec<TempoPooledTransaction>, HashSet<AASequenceId>)
 where
     F: Fn(&TxHash) -> bool,
@@ -934,7 +940,7 @@ where
         // because tx presence in the new chain doesn't guarantee the nonce slot was modified.
         affected_seq_ids.insert(seq_id);
 
-        let pooled_tx = TempoPooledTransaction::new(tx);
+        let pooled_tx = TempoPooledTransaction::new(tx, payment_rules);
         if is_in_pool(pooled_tx.hash()) {
             continue;
         }
@@ -1311,8 +1317,12 @@ mod tests {
         let pool_hashes: HashSet<TxHash> = [hash_2d_in_pool].into_iter().collect();
 
         // Execute handle_reorg
-        let (orphaned, affected_seq_ids) =
-            handle_reorg(old_chain, new_chain, |hash| pool_hashes.contains(hash));
+        let (orphaned, affected_seq_ids) = handle_reorg(
+            old_chain,
+            new_chain,
+            |hash| pool_hashes.contains(hash),
+            PaymentRules::LATEST,
+        );
 
         // Verify: Only the orphaned AA 2D tx should be returned (not in-pool, not re-included)
         assert_eq!(

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -13,7 +13,7 @@ use reth_transaction_pool::{TransactionOrigin, ValidPoolTransaction};
 use std::time::Instant;
 use tempo_chainspec::{TempoChainSpec, spec::DEV};
 use tempo_primitives::{
-    TempoTxEnvelope,
+    PaymentRules, TempoTxEnvelope,
     transaction::{
         TempoSignedAuthorization, TempoTransaction,
         tempo_transaction::Call,
@@ -211,7 +211,7 @@ impl TxBuilder {
         let envelope: TempoTxEnvelope = aa_signed.into();
 
         let recovered = Recovered::new_unchecked(envelope, self.sender);
-        TempoPooledTransaction::new(recovered)
+        TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
     }
 
     /// Build an AA transaction with a V2 keychain signature.
@@ -304,7 +304,7 @@ impl TxBuilder {
             use reth_primitives_traits::SignerRecoverable;
             envelope.try_into_recovered().unwrap()
         };
-        TempoPooledTransaction::new(recovered)
+        TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
     }
 
     /// Build an EIP-1559 transaction.
@@ -326,7 +326,7 @@ impl TxBuilder {
         ));
 
         let recovered = Recovered::new_unchecked(envelope, self.sender);
-        TempoPooledTransaction::new(recovered)
+        TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
     }
 }
 

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -21,7 +21,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 use tempo_precompiles::{DEFAULT_FEE_TOKEN, nonce::NonceManager};
-use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
+use tempo_primitives::{PaymentRules, TempoTxEnvelope, transaction::calc_gas_balance_spending};
 use tempo_revm::TempoTxEnv;
 use thiserror::Error;
 
@@ -48,8 +48,8 @@ pub struct TempoPooledTransaction {
 
 impl TempoPooledTransaction {
     /// Create new instance of [Self] from the given consensus transactions and the encoded size.
-    pub fn new(transaction: Recovered<TempoTxEnvelope>) -> Self {
-        let is_payment = transaction.is_payment(true);
+    pub fn new(transaction: Recovered<TempoTxEnvelope>, payment_rules: PaymentRules) -> Self {
+        let is_payment = transaction.is_payment(payment_rules);
         let is_expiring_nonce = transaction
             .as_aa()
             .map(|tx| tx.tx().is_expiring_nonce_tx())
@@ -481,7 +481,7 @@ impl PoolTransaction for TempoPooledTransaction {
     }
 
     fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
-        Self::new(tx)
+        Self::new(tx, PaymentRules::LATEST)
     }
 
     fn hash(&self) -> &TxHash {
@@ -655,7 +655,7 @@ mod tests {
             address!("0000000000000000000000000000000000000001"),
         );
 
-        let pooled_tx = TempoPooledTransaction::new(recovered);
+        let pooled_tx = TempoPooledTransaction::new(recovered, PaymentRules::T2);
         assert!(pooled_tx.is_payment());
     }
 

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -49,7 +49,7 @@ pub struct TempoPooledTransaction {
 impl TempoPooledTransaction {
     /// Create new instance of [Self] from the given consensus transactions and the encoded size.
     pub fn new(transaction: Recovered<TempoTxEnvelope>) -> Self {
-        let is_payment = transaction.is_payment();
+        let is_payment = transaction.is_payment(true);
         let is_expiring_nonce = transaction
             .as_aa()
             .map(|tx| tx.tx().is_expiring_nonce_tx())

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1612,7 +1612,7 @@ mod tests {
     use std::collections::HashSet;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_primitives::{
-        TempoTxEnvelope,
+        PaymentRules, TempoTxEnvelope,
         transaction::{
             TempoTransaction,
             tempo_transaction::Call,
@@ -5132,7 +5132,7 @@ mod tests {
             let aa_signed = AASigned::new_unhashed(tx, signature);
             let envelope: TempoTxEnvelope = aa_signed.into();
             let recovered = Recovered::new_unchecked(envelope, sender);
-            TempoPooledTransaction::new(recovered)
+            TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
         };
 
         let tx1 = build_tx(Signature::new(U256::from(1), U256::from(2), false));
@@ -5217,7 +5217,7 @@ mod tests {
         let aa_signed = AASigned::new_unhashed(tx, signature);
         let envelope: TempoTxEnvelope = aa_signed.into();
         let recovered = Recovered::new_unchecked(envelope, sender);
-        let pooled = TempoPooledTransaction::new(recovered);
+        let pooled = TempoPooledTransaction::new(recovered, PaymentRules::LATEST);
 
         let tx_hash = *pooled.hash();
         pool.add_transaction(

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1095,7 +1095,7 @@ mod tests {
         tip403_registry::{ITIP403Registry, PolicyData, TIP403Registry},
     };
     use tempo_primitives::{
-        Block, TempoHeader, TempoPrimitives, TempoTxEnvelope,
+        Block, PaymentRules, TempoHeader, TempoPrimitives, TempoTxEnvelope,
         transaction::{
             TempoTransaction,
             envelope::TEMPO_SYSTEM_TX_SIGNATURE,
@@ -1249,6 +1249,7 @@ mod tests {
         let envelope = TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, TEMPO_SYSTEM_TX_SIGNATURE));
         let transaction = TempoPooledTransaction::new(
             reth_primitives_traits::Recovered::new_unchecked(envelope, Address::ZERO),
+            PaymentRules::LATEST,
         );
         let validator = setup_validator(&transaction, 0);
 
@@ -1296,6 +1297,7 @@ mod tests {
         );
         let transaction = TempoPooledTransaction::new(
             TempoTxEnvelope::from(signed).try_into_recovered().unwrap(),
+            PaymentRules::LATEST,
         );
         let validator = setup_validator(&transaction, 0);
 
@@ -1560,7 +1562,10 @@ mod tests {
                     Signature::test_signature(),
                 )),
             );
-            TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
+            TempoPooledTransaction::new(
+                TempoTxEnvelope::from(signed).try_into_recovered().unwrap(),
+                PaymentRules::LATEST,
+            )
         };
 
         // Intrinsic gas for 10 calls: 21k base + 10*2600 cold access + 10*100*4 calldata = ~51k
@@ -1663,7 +1668,10 @@ mod tests {
                     Signature::test_signature(),
                 )),
             );
-            TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
+            TempoPooledTransaction::new(
+                TempoTxEnvelope::from(signed).try_into_recovered().unwrap(),
+                PaymentRules::LATEST,
+            )
         };
 
         // Test 1: Verify 1D nonce (nonce_key=0) with low gas fails intrinsic gas check
@@ -1786,7 +1794,10 @@ mod tests {
                     Signature::test_signature(),
                 )),
             );
-            TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
+            TempoPooledTransaction::new(
+                TempoTxEnvelope::from(signed).try_into_recovered().unwrap(),
+                PaymentRules::LATEST,
+            )
         };
 
         // Expiring nonce tx should only need ~35k gas (base + EXPIRING_NONCE_GAS of 13k)
@@ -1860,7 +1871,10 @@ mod tests {
                     Signature::test_signature(),
                 )),
             );
-            TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
+            TempoPooledTransaction::new(
+                TempoTxEnvelope::from(signed).try_into_recovered().unwrap(),
+                PaymentRules::LATEST,
+            )
         };
 
         // Test 1: 1D nonce (nonce_key=0) with nonce > 0 has no extra 2D nonce charge.
@@ -2324,7 +2338,7 @@ mod tests {
             let signed_tx = AASigned::new_unhashed(tx_aa, keychain_sig);
             let envelope: TempoTxEnvelope = signed_tx.into();
             let recovered = envelope.try_into_recovered().unwrap();
-            TempoPooledTransaction::new(recovered)
+            TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
         }
 
         /// Setup validator with keychain storage for a specific user and key_id.
@@ -2975,7 +2989,7 @@ mod tests {
             let signed_tx = AASigned::new_unhashed(tx_aa, keychain_sig);
             let envelope: TempoTxEnvelope = signed_tx.into();
             let recovered = envelope.try_into_recovered().unwrap();
-            let transaction = TempoPooledTransaction::new(recovered);
+            let transaction = TempoPooledTransaction::new(recovered, PaymentRules::LATEST);
 
             // The transaction.sender() == real_user (from keychain sig's user_address)
             // So this validation path checks sig.user_address == transaction.sender()
@@ -3931,7 +3945,7 @@ mod tests {
         );
         let envelope: TempoTxEnvelope = signed_tx.into();
         let recovered = envelope.try_into_recovered().unwrap();
-        TempoPooledTransaction::new(recovered)
+        TempoPooledTransaction::new(recovered, PaymentRules::LATEST)
     }
 
     #[tokio::test]


### PR DESCRIPTION
makes `TempoTxEnvelope::is_payment()` hardfork-aware by introducing a `PaymentRules` enum.
the active `TempoHardfork` determines which classification rules apply.

> NOTE: this approach is required to prevent circular deps

- `PaymentRules::Genesis` (pre-T2): address prefix only
- `PaymentRules::T2`: prefix + recognized selector + exact ABI-encoded length
- `PaymentRules::LATEST`: alias for the newest rules, used by context-free callsites

Adding a future hardfork that changes payment semantics requires adding a variant, a match arm, and updating `LATEST`.