### PR TITLE
revert(payload): revert #3008 and #3034

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -60,7 +60,7 @@ use tempo_transaction_pool::{
     TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
-use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
+use tracing::{Level, debug, error, info, instrument, trace, warn};
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -234,59 +234,27 @@ where
         } = config;
 
         let start = Instant::now();
-        let record_build_attempt_duration = || {
-            self.metrics
-                .payload_build_duration_seconds
-                .record(start.elapsed())
-        };
-        // Early-return helper: records `payload_build_duration_seconds` before exiting,
-        // so the metric is emitted on every code path (error, cancel, abort, success).
-        macro_rules! return_with_build_duration {
-            ($value:expr) => {{
-                record_build_attempt_duration();
-                return $value;
-            }};
-        }
 
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
 
-        let state_provider = {
-            let start = Instant::now();
-            let _span = debug_span!(target: "payload_builder", "state_provider").entered();
-            let res = self.provider.state_by_block_hash(parent_header.hash());
-            self.metrics
-                .state_provider_duration_seconds
-                .record(start.elapsed());
-            match res {
-                Ok(provider) => provider,
-                Err(err) => return_with_build_duration!(Err(err.into())),
-            }
-        };
+        let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
         let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
         } else {
             state_provider
         };
-        let mut db = {
-            let start = Instant::now();
-            let _span = debug_span!(target: "payload_builder", "build_state_db").entered();
-            let state = StateProviderDatabase::new(&state_provider);
-            let db = State::builder()
-                .with_database(if self.disable_state_cache {
-                    Box::new(state) as Box<dyn Database<Error = ProviderError>>
-                } else {
-                    Box::new(cached_reads.as_db_mut(state))
-                })
-                .with_bundle_update()
-                .build();
-            self.metrics
-                .build_state_db_duration_seconds
-                .record(start.elapsed());
-            db
-        };
+        let state = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder()
+            .with_database(if self.disable_state_cache {
+                Box::new(state) as Box<dyn Database<Error = ProviderError>>
+            } else {
+                Box::new(cached_reads.as_db_mut(state))
+            })
+            .with_bundle_update()
+            .build();
 
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
@@ -350,54 +318,33 @@ where
             })
             .collect();
 
-        let mut builder = {
-            let start = Instant::now();
-            let _span = debug_span!(target: "payload_builder", "create_evm").entered();
-            let res = self
-                .evm_config
-                .builder_for_next_block(
-                    &mut db,
-                    &parent_header,
-                    TempoNextBlockEnvAttributes {
-                        inner: NextBlockEnvAttributes {
-                            timestamp: attributes.timestamp(),
-                            suggested_fee_recipient: attributes.suggested_fee_recipient(),
-                            prev_randao: attributes.prev_randao(),
-                            gas_limit: block_gas_limit,
-                            parent_beacon_block_root: attributes.parent_beacon_block_root(),
-                            withdrawals: Some(attributes.withdrawals().clone()),
-                            extra_data: attributes.extra_data().clone(),
-                        },
-                        general_gas_limit,
-                        shared_gas_limit,
-                        timestamp_millis_part: attributes.timestamp_millis_part(),
-                        subblock_fee_recipients,
+        let mut builder = self
+            .evm_config
+            .builder_for_next_block(
+                &mut db,
+                &parent_header,
+                TempoNextBlockEnvAttributes {
+                    inner: NextBlockEnvAttributes {
+                        timestamp: attributes.timestamp(),
+                        suggested_fee_recipient: attributes.suggested_fee_recipient(),
+                        prev_randao: attributes.prev_randao(),
+                        gas_limit: block_gas_limit,
+                        parent_beacon_block_root: attributes.parent_beacon_block_root(),
+                        withdrawals: Some(attributes.withdrawals().clone()),
+                        extra_data: attributes.extra_data().clone(),
                     },
-                )
-                .map_err(PayloadBuilderError::other);
-            self.metrics
-                .create_evm_duration_seconds
-                .record(start.elapsed());
-            match res {
-                Ok(builder) => builder,
-                Err(err) => return_with_build_duration!(Err(err)),
-            }
-        };
+                    general_gas_limit,
+                    shared_gas_limit,
+                    timestamp_millis_part: attributes.timestamp_millis_part(),
+                    subblock_fee_recipients,
+                },
+            )
+            .map_err(PayloadBuilderError::other)?;
 
-        {
-            let start = Instant::now();
-            let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
-            let res = builder.apply_pre_execution_changes().map_err(|err| {
-                warn!(%err, "failed to apply pre-execution changes");
-                PayloadBuilderError::Internal(err.into())
-            });
-            self.metrics
-                .pre_execution_duration_seconds
-                .record(start.elapsed());
-            if let Err(err) = res {
-                return_with_build_duration!(Err(err));
-            }
-        }
+        builder.apply_pre_execution_changes().map_err(|err| {
+            warn!(%err, "failed to apply pre-execution changes");
+            PayloadBuilderError::Internal(err.into())
+        })?;
 
         debug!("building new payload");
 
@@ -422,51 +369,8 @@ where
                 .map(|gasprice| gasprice as u64),
         ));
 
-        let mut pool_transactions_considered = 0u64;
-        let mut pool_transactions_executed = 0u64;
-        let mut pool_transactions_skipped = 0u64;
-        let record_pool_selection_metrics =
-            |metrics: &TempoPayloadBuilderMetrics, considered: u64, executed: u64, skipped: u64| {
-                metrics
-                    .pool_transactions_considered
-                    .record(considered as f64);
-                metrics
-                    .pool_transactions_considered_last
-                    .set(considered as f64);
-                metrics.pool_transactions_executed.record(executed as f64);
-                metrics.pool_transactions_executed_last.set(executed as f64);
-                metrics.pool_transactions_skipped.record(skipped as f64);
-                metrics.pool_transactions_skipped_last.set(skipped as f64);
-            };
-
-        let _pool_tx_span = debug_span!(target: "payload_builder", "execute_pool_txs").entered();
         let execution_start = Instant::now();
-        loop {
-            // check if the job was interrupted, if so we can skip remaining transactions
-            if attributes.is_interrupted() {
-                break;
-            }
-
-            // check if the job was cancelled, if so we can exit early
-            if cancel.is_cancelled() {
-                record_pool_selection_metrics(
-                    &self.metrics,
-                    pool_transactions_considered,
-                    pool_transactions_executed,
-                    pool_transactions_skipped,
-                );
-                return_with_build_duration!(Ok(BuildOutcome::Cancelled));
-            }
-
-            let selection_start = Instant::now();
-            let Some(pool_tx) = best_txs.next() else {
-                break;
-            };
-            self.metrics
-                .transaction_selection_duration_seconds
-                .record(selection_start.elapsed());
-            pool_transactions_considered += 1;
-
+        while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
             // be consumed by proposer's pool transactions.
@@ -480,10 +384,6 @@ where
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
                 );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_shared_gas_limit
-                    .increment(1);
                 continue;
             }
 
@@ -498,11 +398,17 @@ where
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_exceeds_non_payment_gas_limit
-                    .increment(1);
                 continue;
+            }
+
+            // check if the job was interrupted, if so we can skip remaining transactions
+            if attributes.is_interrupted() {
+                break;
+            }
+
+            // check if the job was cancelled, if so we can exit early
+            if cancel.is_cancelled() {
+                return Ok(BuildOutcome::Cancelled);
             }
 
             let is_payment = pool_tx.transaction.is_payment();
@@ -521,10 +427,6 @@ where
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
                 );
-                pool_transactions_skipped += 1;
-                self.metrics
-                    .pool_transactions_skipped_oversized_block
-                    .increment(1);
                 continue;
             }
 
@@ -545,9 +447,6 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        self.metrics
-                            .pool_transactions_skipped_nonce_too_low
-                            .increment(1);
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -558,25 +457,12 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
-                        self.metrics
-                            .pool_transactions_skipped_invalid_tx
-                            .increment(1);
                     }
-                    pool_transactions_skipped += 1;
                     continue;
                 }
                 // this is an error that we should treat as fatal for this attempt
-                Err(err) => {
-                    record_pool_selection_metrics(
-                        &self.metrics,
-                        pool_transactions_considered,
-                        pool_transactions_executed,
-                        pool_transactions_skipped,
-                    );
-                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
-                }
+                Err(err) => return Err(PayloadBuilderError::evm(err)),
             };
-            pool_transactions_executed += 1;
             let elapsed = execution_start.elapsed();
             self.metrics
                 .transaction_execution_duration_seconds
@@ -591,13 +477,6 @@ where
             }
             block_size_used += tx_rlp_length;
         }
-        drop(_pool_tx_span);
-        record_pool_selection_metrics(
-            &self.metrics,
-            pool_transactions_considered,
-            pool_transactions_executed,
-            pool_transactions_skipped,
-        );
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds
@@ -617,29 +496,15 @@ where
             drop(builder);
             drop(db);
             // can skip building the block
-            return_with_build_duration!(Ok(BuildOutcome::Aborted {
+            return Ok(BuildOutcome::Aborted {
                 fees: total_fees,
                 cached_reads,
-            }));
+            });
         }
 
-        let _subblock_span =
-            debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
         let subblocks_start = Instant::now();
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
-        let record_subblock_metrics = |metrics: &TempoPayloadBuilderMetrics,
-                                       elapsed: std::time::Duration,
-                                       count: f64,
-                                       txs: f64| {
-            metrics
-                .total_subblock_transaction_execution_duration_seconds
-                .record(elapsed);
-            metrics.subblocks.record(count);
-            metrics.subblocks_last.set(count);
-            metrics.subblock_transactions.record(txs);
-            metrics.subblock_transactions_last.set(txs);
-        };
         // Apply subblock transactions
         for subblock in &subblocks {
             for tx in subblock.transactions_recovered() {
@@ -654,43 +519,37 @@ where
                         );
                         self.highest_invalid_subblock
                             .store(builder.evm().block().number.to(), Ordering::Relaxed);
+
+                        return Err(PayloadBuilderError::evm(err));
+                    } else {
+                        return Err(PayloadBuilderError::evm(err));
                     }
-                    record_subblock_metrics(
-                        &self.metrics,
-                        subblocks_start.elapsed(),
-                        subblocks_count,
-                        subblock_transactions,
-                    );
-                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
                 }
 
                 subblock_transactions += 1.0;
             }
         }
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
-        drop(_subblock_span);
-        record_subblock_metrics(
-            &self.metrics,
-            total_subblock_transaction_execution_elapsed,
-            subblocks_count,
-            subblock_transactions,
-        );
+        self.metrics
+            .total_subblock_transaction_execution_duration_seconds
+            .record(total_subblock_transaction_execution_elapsed);
+        self.metrics.subblocks.record(subblocks_count);
+        self.metrics.subblocks_last.set(subblocks_count);
+        self.metrics
+            .subblock_transactions
+            .record(subblock_transactions);
+        self.metrics
+            .subblock_transactions_last
+            .set(subblock_transactions);
 
         // Apply system transactions
-        let system_txs_execution_elapsed = {
-            let _span = debug_span!(target: "payload_builder", "execute_system_txs").entered();
-            let system_txs_execution_start = Instant::now();
-            for system_tx in system_txs {
-                if let Err(err) = builder.execute_transaction(system_tx) {
-                    let elapsed = system_txs_execution_start.elapsed();
-                    self.metrics
-                        .system_transactions_execution_duration_seconds
-                        .record(elapsed);
-                    return_with_build_duration!(Err(PayloadBuilderError::evm(err)));
-                }
-            }
-            system_txs_execution_start.elapsed()
-        };
+        let system_txs_execution_start = Instant::now();
+        for system_tx in system_txs {
+            builder
+                .execute_transaction(system_tx)
+                .map_err(PayloadBuilderError::evm)?;
+        }
+        let system_txs_execution_elapsed = system_txs_execution_start.elapsed();
         self.metrics
             .system_transactions_execution_duration_seconds
             .record(system_txs_execution_elapsed);
@@ -700,31 +559,17 @@ where
             .total_transaction_execution_duration_seconds
             .record(total_transaction_execution_elapsed);
 
-        let (builder_finish_elapsed, execution_result, block, hashed_state, trie_updates) = {
-            let _span = debug_span!(target: "payload_builder", "finish_block").entered();
-            let builder_finish_start = Instant::now();
-            let res = builder.finish(&state_provider);
-            let builder_finish_elapsed = builder_finish_start.elapsed();
-            self.metrics
-                .payload_finalization_duration_seconds
-                .record(builder_finish_elapsed);
-            let BlockBuilderOutcome {
-                execution_result,
-                block,
-                hashed_state,
-                trie_updates,
-            } = match res {
-                Ok(outcome) => outcome,
-                Err(err) => return_with_build_duration!(Err(err.into())),
-            };
-            (
-                builder_finish_elapsed,
-                execution_result,
-                block,
-                hashed_state,
-                trie_updates,
-            )
-        };
+        let builder_finish_start = Instant::now();
+        let BlockBuilderOutcome {
+            execution_result,
+            block,
+            hashed_state,
+            trie_updates,
+        } = builder.finish(&state_provider)?;
+        let builder_finish_elapsed = builder_finish_start.elapsed();
+        self.metrics
+            .payload_finalization_duration_seconds
+            .record(builder_finish_elapsed);
 
         let total_transactions = block.transaction_count();
         self.metrics
@@ -746,22 +591,17 @@ where
         let rlp_length = sealed_block.rlp_length();
 
         if is_osaka && rlp_length > MAX_RLP_BLOCK_SIZE {
-            return_with_build_duration!(Err(PayloadBuilderError::other(
-                ConsensusError::BlockTooLarge {
-                    rlp_length,
-                    max_rlp_length: MAX_RLP_BLOCK_SIZE,
-                }
-            )));
+            return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
+                rlp_length,
+                max_rlp_length: MAX_RLP_BLOCK_SIZE,
+            }));
         }
 
         let elapsed = start.elapsed();
         self.metrics.payload_build_duration_seconds.record(elapsed);
-        let secs = elapsed.as_secs_f64();
-        if secs > 0.0 {
-            let gas_per_second = sealed_block.gas_used() as f64 / secs;
-            self.metrics.gas_per_second.record(gas_per_second);
-            self.metrics.gas_per_second_last.set(gas_per_second);
-        }
+        let gas_per_second = sealed_block.gas_used() as f64 / elapsed.as_secs_f64();
+        self.metrics.gas_per_second.record(gas_per_second);
+        self.metrics.gas_per_second_last.set(gas_per_second);
         self.metrics.rlp_block_size_bytes.record(rlp_length as f64);
         self.metrics
             .rlp_block_size_bytes_last

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,8 +1,5 @@
 use metrics::Gauge;
-use reth_metrics::{
-    Metrics,
-    metrics::{Counter, Histogram},
-};
+use reth_metrics::{Metrics, metrics::Histogram};
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_payload_builder")]
@@ -31,42 +28,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used: Histogram,
     /// Amount of gas used in the payload.
     pub(crate) gas_used_last: Gauge,
-    /// Time spent fetching the parent state provider.
-    pub(crate) state_provider_duration_seconds: Histogram,
-    /// Time spent constructing the state DB wrapper.
-    pub(crate) build_state_db_duration_seconds: Histogram,
-    /// Time spent creating the EVM/block builder.
-    pub(crate) create_evm_duration_seconds: Histogram,
-    /// Time spent applying pre-execution changes.
-    pub(crate) pre_execution_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
-    /// The time it took to select the next candidate transaction from the pool.
-    pub(crate) transaction_selection_duration_seconds: Histogram,
-    /// Number of candidate pool transactions considered per payload attempt.
-    pub(crate) pool_transactions_considered: Histogram,
-    /// Number of candidate pool transactions considered for the latest payload attempt.
-    pub(crate) pool_transactions_considered_last: Gauge,
-    /// Number of pool transactions successfully executed per payload attempt.
-    pub(crate) pool_transactions_executed: Histogram,
-    /// Number of pool transactions successfully executed for the latest payload attempt.
-    pub(crate) pool_transactions_executed_last: Gauge,
-    /// Number of pool transactions skipped per payload attempt.
-    pub(crate) pool_transactions_skipped: Histogram,
-    /// Number of pool transactions skipped for the latest payload attempt.
-    pub(crate) pool_transactions_skipped_last: Gauge,
-    /// Number of pool transactions skipped because they exceed the non-shared gas limit.
-    pub(crate) pool_transactions_skipped_exceeds_non_shared_gas_limit: Counter,
-    /// Number of pool transactions skipped because they exceed the non-payment gas limit.
-    pub(crate) pool_transactions_skipped_exceeds_non_payment_gas_limit: Counter,
-    /// Number of pool transactions skipped because they would exceed the max block RLP size.
-    pub(crate) pool_transactions_skipped_oversized_block: Counter,
-    /// Number of pool transactions skipped because the nonce is too low.
-    pub(crate) pool_transactions_skipped_nonce_too_low: Counter,
-    /// Number of pool transactions skipped because of other validation failures.
-    pub(crate) pool_transactions_skipped_invalid_tx: Counter,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.


### PR DESCRIPTION
Reverts #3008 (builder phase spans, per-phase timings, tx selection metrics) and #3034 (BuildGuard RAII duration macro).

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey