### PR TITLE
fix(telemetry): include process metrics in push export

### DIFF
--- a/crates/node/src/telemetry.rs
+++ b/crates/node/src/telemetry.rs
@@ -2,7 +2,7 @@
 //!
 //! This module pushes Prometheus-format metrics directly to Victoria Metrics by polling:
 //! - Commonware's runtime context (`context.encode()`)
-//! - Reth's prometheus recorder (`handle.render()`)
+//! - Reth's prometheus recorder (`collect_and_render()`)
 
 use commonware_runtime::{Metrics as _, Spawner as _, tokio::Context};
 use eyre::WrapErr as _;
@@ -52,7 +52,7 @@ pub fn install_prometheus_metrics(
 
             // Collect metrics from both sources
             let consensus_metrics = context.encode();
-            let reth_metrics = reth_recorder.handle().render();
+            let reth_metrics = reth_recorder.collect_and_render();
             let body = format!("{consensus_metrics}\n{reth_metrics}");
 
             // Push to Victoria Metrics


### PR DESCRIPTION
Use `collect_and_render()` instead of `handle().render()` so that `process_start_time_seconds`, IO counters, and jemalloc stats are collected before pushing.

Validators using only `--telemetry-url` (without `--metrics`) were missing all `reth_process_*` and `reth_io_*` metrics because the collection hooks only fired on HTTP scrape, not on the push path. This was the case for validationcloud.

Depends on https://github.com/paradigmxyz/reth/pull/22897.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>
Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: alexey