### PR TITLE
TIP-1028: Address-Level Receive Policies

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -495,7 +495,7 @@ DEX swaps (`swapExactAmountIn`, `swapExactAmountOut`) transfer the output token 
 
 Order fills (`partial_fill_order`, `fill_order`) credit tokens to the maker's *DEX internal balance* via `increment_balance`, which does not trigger TIP-20 transfers. Address-level controls are NOT checked on internal balance credits. Controls are checked when the maker later calls `withdraw` to move tokens out of the DEX to their wallet (see below).
 
-> **DEX Internal Balance Bypass**: This is an intentional design choice, not a loophole. The DEX's internal accounting is an escrow mechanism — tokens are locked in the DEX contract, not delivered to the maker's wallet. Address-level controls govern what enters an address's wallet, and the `withdraw` path enforces this. Attempting to enforce controls on internal balance credits would break order matching (the maker is not the caller during fills) and would be redundant with the `withdraw` check.
+> **DEX Internal Balance Bypass**: This is an intentional design choice, not a loophole. The DEX's internal accounting is an escrow mechanism — tokens are locked in the DEX contract, not delivered to the maker's wallet. Address-level controls govern what enters an address's wallet, and the `withdraw` path enforces this. Attempting to enforce controls on internal balance credits would break order matching.
 
 ### Order Placement
 


### PR DESCRIPTION
Extends TIP-403 with token sets and address-level receive policies.