### PR TITLE
feat(builder): add state root workload and trie output shape metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12238,6 +12238,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
+ "reth-trie-common",
  "tempo-chainspec",
  "tempo-consensus",
  "tempo-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = 
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 
 reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", features = [
   "std",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -32,6 +32,7 @@ reth-primitives-traits.workspace = true
 reth-revm.workspace = true
 reth-storage-api.workspace = true
 reth-transaction-pool.workspace = true
+reth-trie-common.workspace = true
 
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -391,9 +391,11 @@ where
         while let Some(pool_tx) = {
             let next_start = Instant::now();
             let next = best_txs.next();
-            self.metrics
-                .best_txs_next_duration_seconds
-                .record(next_start.elapsed());
+            if next.is_some() {
+                self.metrics
+                    .best_txs_next_duration_seconds
+                    .record(next_start.elapsed());
+            }
             next
         } {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod metrics;
 
-use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
+use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped, skip_reason};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{Decodable, Encodable};
@@ -411,7 +411,7 @@ where
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
                 );
-                inc_pool_tx_skipped("exceeds_non_shared_gas_limit");
+                inc_pool_tx_skipped(skip_reason::EXCEEDS_NON_SHARED_GAS_LIMIT);
                 continue;
             }
 
@@ -426,7 +426,7 @@ where
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
-                inc_pool_tx_skipped("exceeds_general_gas_limit");
+                inc_pool_tx_skipped(skip_reason::EXCEEDS_GENERAL_GAS_LIMIT);
                 continue;
             }
 
@@ -456,7 +456,7 @@ where
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
                 );
-                inc_pool_tx_skipped("oversized_block");
+                inc_pool_tx_skipped(skip_reason::OVERSIZED_BLOCK);
                 continue;
             }
 
@@ -477,7 +477,7 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        inc_pool_tx_skipped("nonce_too_low");
+                        inc_pool_tx_skipped(skip_reason::NONCE_TOO_LOW);
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -488,7 +488,7 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
-                        inc_pool_tx_skipped("invalid_tx");
+                        inc_pool_tx_skipped(skip_reason::INVALID_TX);
                     }
                     continue;
                 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod metrics;
 
-use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped, skip_reason};
+use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{Decodable, Encodable};
@@ -411,7 +411,7 @@ where
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
                 );
-                inc_pool_tx_skipped(skip_reason::EXCEEDS_NON_SHARED_GAS_LIMIT);
+                inc_pool_tx_skipped("exceeds_non_shared_gas_limit");
                 continue;
             }
 
@@ -426,7 +426,7 @@ where
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
-                inc_pool_tx_skipped(skip_reason::EXCEEDS_GENERAL_GAS_LIMIT);
+                inc_pool_tx_skipped("exceeds_general_gas_limit");
                 continue;
             }
 
@@ -456,7 +456,7 @@ where
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
                 );
-                inc_pool_tx_skipped(skip_reason::OVERSIZED_BLOCK);
+                inc_pool_tx_skipped("oversized_block");
                 continue;
             }
 
@@ -477,7 +477,7 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
-                        inc_pool_tx_skipped(skip_reason::NONCE_TOO_LOW);
+                        inc_pool_tx_skipped("nonce_too_low");
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -488,7 +488,7 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
-                        inc_pool_tx_skipped(skip_reason::INVALID_TX);
+                        inc_pool_tx_skipped("invalid_tx");
                     }
                     continue;
                 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -405,10 +405,12 @@ where
 
         let start = Instant::now();
 
+        let _block_metrics_span = debug_span!(target: "payload_builder", "block_metrics").entered();
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
+        drop(_block_metrics_span);
 
         let state_setup_start = Instant::now();
         let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,9 +5,9 @@
 
 mod metrics;
 
-use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
+use crate::metrics::{InstrumentedFinishProvider, TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, StorageKey, StorageValue, U256};
+use alloy_primitives::{Address, U256};
 use alloy_rlp::{Decodable, Encodable};
 use either::Either;
 use reth_basic_payload_builder::{
@@ -17,7 +17,7 @@ use reth_basic_payload_builder::{
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
 use reth_engine_tree::tree::instrumented_state::InstrumentedStateProvider;
-use reth_errors::{ConsensusError, ProviderError, ProviderResult};
+use reth_errors::{ConsensusError, ProviderError};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
     block::{BlockExecutionError, BlockValidationError},
@@ -26,25 +26,16 @@ use reth_evm::{
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
-use reth_primitives_traits::{
-    Account, Bytecode, Recovered, transaction::error::InvalidTransactionError,
-};
+use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
 use reth_revm::{
     State,
     context::{Block, BlockEnv},
     database::StateProviderDatabase,
 };
-use reth_storage_api::{
-    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
-    StateProvider, StateProviderFactory, StateRootProvider, StorageRootProvider,
-};
+use reth_storage_api::{StateProvider, StateProviderFactory};
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
-};
-use reth_trie_common::{
-    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
-    StorageProof, TrieInput, updates::TrieUpdates,
 };
 use std::{
     sync::{
@@ -70,90 +61,6 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
-
-/// Wraps a [`StateProvider`] reference to instrument `hashed_post_state` and
-/// `state_root_with_updates` with tracing spans and histogram metrics during `builder.finish()`.
-struct InstrumentedFinishProvider<'a> {
-    inner: &'a dyn StateProvider,
-    metrics: TempoPayloadBuilderMetrics,
-}
-
-impl<'a> AsRef<dyn StateProvider + 'a> for InstrumentedFinishProvider<'a> {
-    fn as_ref(&self) -> &(dyn StateProvider + 'a) {
-        self.inner
-    }
-}
-
-reth_storage_api::delegate_impls_to_as_ref!(
-    for InstrumentedFinishProvider<'_> =>
-    AccountReader {
-        fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
-    }
-    BlockHashReader {
-        fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>>;
-        fn canonical_hashes_range(&self, start: BlockNumber, end: BlockNumber) -> ProviderResult<Vec<B256>>;
-    }
-    StateProvider {
-        fn storage(&self, account: Address, storage_key: StorageKey) -> ProviderResult<Option<StorageValue>>;
-    }
-    BytecodeReader {
-        fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
-    }
-    StorageRootProvider {
-        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
-        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
-        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
-    }
-    StateProofProvider {
-        fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
-        fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
-        fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
-    }
-);
-
-impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
-    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
-        let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
-        let result = self.inner.hashed_post_state(bundle_state);
-        drop(_span);
-        self.metrics
-            .hashed_post_state_duration_seconds
-            .record(start.elapsed());
-        result
-    }
-}
-
-impl StateRootProvider for InstrumentedFinishProvider<'_> {
-    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
-        self.inner.state_root(hashed_state)
-    }
-
-    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
-        self.inner.state_root_from_nodes(input)
-    }
-
-    fn state_root_with_updates(
-        &self,
-        hashed_state: HashedPostState,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
-        let result = self.inner.state_root_with_updates(hashed_state);
-        drop(_span);
-        self.metrics
-            .state_root_with_updates_duration_seconds
-            .record(start.elapsed());
-        result
-    }
-
-    fn state_root_from_nodes_with_updates(
-        &self,
-        input: TrieInput,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.inner.state_root_from_nodes_with_updates(input)
-    }
-}
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -51,7 +51,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
@@ -142,7 +142,7 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         let result = self.inner.state_root_with_updates(hashed_state);
         drop(_span);
         self.metrics
-            .state_root_duration_seconds
+            .state_root_with_updates_duration_seconds
             .record(start.elapsed());
         result
     }
@@ -489,13 +489,14 @@ where
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
+        let mut best_txs_next_total = Duration::ZERO;
+        let mut best_txs_next_calls = 0u64;
         while let Some(pool_tx) = {
             let next_start = Instant::now();
             let next = best_txs.next();
             if next.is_some() {
-                self.metrics
-                    .best_txs_next_duration_seconds
-                    .record(next_start.elapsed());
+                best_txs_next_total += next_start.elapsed();
+                best_txs_next_calls += 1;
             }
             next
         } {
@@ -615,6 +616,12 @@ where
         self.metrics
             .block_fill_duration_seconds
             .record(total_normal_transaction_execution_elapsed);
+        self.metrics
+            .best_txs_next_total_duration_seconds
+            .record(best_txs_next_total);
+        self.metrics
+            .best_txs_next_calls_total
+            .record(best_txs_next_calls as f64);
         self.metrics
             .total_normal_transaction_execution_duration_seconds
             .record(total_normal_transaction_execution_elapsed);

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -432,6 +432,7 @@ where
             .state_setup_duration_seconds
             .record(state_setup_start.elapsed());
 
+        let _collect_span = debug_span!(target: "payload_builder", "collect_subblocks").entered();
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
             .provider
@@ -494,6 +495,8 @@ where
             })
             .collect();
 
+        drop(_collect_span);
+
         let create_evm_start = Instant::now();
         let _create_evm_span = debug_span!(target: "payload_builder", "create_evm").entered();
         let mut builder = self
@@ -537,6 +540,7 @@ where
         debug!("building new payload");
 
         // Prepare system transactions before actual block building and account for their size.
+        let _prepare_txs_span = debug_span!(target: "payload_builder", "prepare_txs").entered();
         let prepare_system_txs_start = Instant::now();
         let system_txs = self.build_seal_block_txs(builder.evm().block(), &subblocks);
         for tx in &system_txs {
@@ -556,6 +560,7 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
+        drop(_prepare_txs_span);
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
@@ -801,6 +806,7 @@ where
             .payload_finalization_duration_seconds
             .record(builder_finish_elapsed);
 
+        let _seal_span = debug_span!(target: "payload_builder", "seal_payload").entered();
         let total_transactions = block.transaction_count();
         self.metrics
             .total_transactions
@@ -875,6 +881,7 @@ where
         };
 
         let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
+        drop(_seal_span);
 
         drop(db);
         Ok(BuildOutcome::Better {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -388,6 +388,7 @@ where
         ));
 
         let execution_start = Instant::now();
+        let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         while let Some(pool_tx) = {
             let next_start = Instant::now();
             let next = best_txs.next();
@@ -509,6 +510,7 @@ where
             }
             block_size_used += tx_rlp_length;
         }
+        drop(_block_fill_span);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .block_fill_duration_seconds
@@ -538,6 +540,7 @@ where
         }
 
         let subblocks_start = Instant::now();
+        let _subblock_txs_span = debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
         // Apply subblock transactions
@@ -575,6 +578,7 @@ where
                 .record(subblock_tx_count);
             subblock_transactions += subblock_tx_count;
         }
+        drop(_subblock_txs_span);
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
@@ -590,11 +594,13 @@ where
 
         // Apply system transactions
         let system_txs_execution_start = Instant::now();
+        let _system_txs_span = debug_span!(target: "payload_builder", "execute_system_txs").entered();
         for system_tx in system_txs {
             builder
                 .execute_transaction(system_tx)
                 .map_err(PayloadBuilderError::evm)?;
         }
+        drop(_system_txs_span);
         let system_txs_execution_elapsed = system_txs_execution_start.elapsed();
         self.metrics
             .system_transactions_execution_duration_seconds
@@ -606,12 +612,14 @@ where
             .record(total_transaction_execution_elapsed);
 
         let builder_finish_start = Instant::now();
+        let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
         let BlockBuilderOutcome {
             execution_result,
             block,
             hashed_state,
             trie_updates,
         } = builder.finish(&state_provider)?;
+        drop(_finish_span);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics
             .payload_finalization_duration_seconds

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -32,7 +32,10 @@ use reth_revm::{
     context::{Block, BlockEnv},
     database::StateProviderDatabase,
 };
-use reth_storage_api::{StateProvider, StateProviderFactory};
+use reth_storage_api::{
+    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
+    StateProvider, StateProviderFactory, StateRootProvider, StorageRootProvider,
+};
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
@@ -61,6 +64,173 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
+
+/// Wraps a [`StateProvider`] reference to instrument `hashed_post_state` and
+/// `state_root_with_updates` with tracing spans and histogram metrics during `builder.finish()`.
+struct InstrumentedFinishProvider<'a> {
+    inner: &'a dyn StateProvider,
+    metrics: TempoPayloadBuilderMetrics,
+}
+
+impl AccountReader for InstrumentedFinishProvider<'_> {
+    fn basic_account(
+        &self,
+        address: &Address,
+    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>> {
+        self.inner.basic_account(address)
+    }
+}
+
+impl BlockHashReader for InstrumentedFinishProvider<'_> {
+    fn block_hash(
+        &self,
+        number: alloy_primitives::BlockNumber,
+    ) -> reth_errors::ProviderResult<Option<alloy_primitives::B256>> {
+        self.inner.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: alloy_primitives::BlockNumber,
+        end: alloy_primitives::BlockNumber,
+    ) -> reth_errors::ProviderResult<Vec<alloy_primitives::B256>> {
+        self.inner.canonical_hashes_range(start, end)
+    }
+}
+
+impl BytecodeReader for InstrumentedFinishProvider<'_> {
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &alloy_primitives::B256,
+    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        self.inner.bytecode_by_hash(code_hash)
+    }
+}
+
+impl StateProvider for InstrumentedFinishProvider<'_> {
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: alloy_primitives::StorageKey,
+    ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
+        self.inner.storage(account, storage_key)
+    }
+}
+
+impl StorageRootProvider for InstrumentedFinishProvider<'_> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: reth_trie_common::HashedStorage,
+    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
+        self.inner.storage_root(address, hashed_storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: alloy_primitives::B256,
+        hashed_storage: reth_trie_common::HashedStorage,
+    ) -> reth_errors::ProviderResult<reth_trie_common::StorageProof> {
+        self.inner.storage_proof(address, slot, hashed_storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[alloy_primitives::B256],
+        hashed_storage: reth_trie_common::HashedStorage,
+    ) -> reth_errors::ProviderResult<reth_trie_common::StorageMultiProof> {
+        self.inner
+            .storage_multiproof(address, slots, hashed_storage)
+    }
+}
+
+impl StateProofProvider for InstrumentedFinishProvider<'_> {
+    fn proof(
+        &self,
+        input: reth_trie_common::TrieInput,
+        address: Address,
+        slots: &[alloy_primitives::B256],
+    ) -> reth_errors::ProviderResult<reth_trie_common::AccountProof> {
+        self.inner.proof(input, address, slots)
+    }
+
+    fn multiproof(
+        &self,
+        input: reth_trie_common::TrieInput,
+        targets: reth_trie_common::MultiProofTargets,
+    ) -> reth_errors::ProviderResult<reth_trie_common::MultiProof> {
+        self.inner.multiproof(input, targets)
+    }
+
+    fn witness(
+        &self,
+        input: reth_trie_common::TrieInput,
+        target: reth_trie_common::HashedPostState,
+    ) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>> {
+        self.inner.witness(input, target)
+    }
+}
+
+impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
+    fn hashed_post_state(
+        &self,
+        bundle_state: &reth_revm::db::BundleState,
+    ) -> reth_trie_common::HashedPostState {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
+        let result = self.inner.hashed_post_state(bundle_state);
+        drop(_span);
+        self.metrics
+            .hashed_post_state_duration_seconds
+            .record(start.elapsed());
+        result
+    }
+}
+
+impl StateRootProvider for InstrumentedFinishProvider<'_> {
+    fn state_root(
+        &self,
+        hashed_state: reth_trie_common::HashedPostState,
+    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
+        self.inner.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(
+        &self,
+        input: reth_trie_common::TrieInput,
+    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
+        self.inner.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: reth_trie_common::HashedPostState,
+    ) -> reth_errors::ProviderResult<(
+        alloy_primitives::B256,
+        reth_trie_common::updates::TrieUpdates,
+    )> {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
+        let result = self.inner.state_root_with_updates(hashed_state);
+        drop(_span);
+        self.metrics
+            .state_root_duration_seconds
+            .record(start.elapsed());
+        result
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: reth_trie_common::TrieInput,
+    ) -> reth_errors::ProviderResult<(
+        alloy_primitives::B256,
+        reth_trie_common::updates::TrieUpdates,
+    )> {
+        self.inner.state_root_from_nodes_with_updates(input)
+    }
+}
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -615,12 +785,16 @@ where
 
         let builder_finish_start = Instant::now();
         let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
+        let instrumented_provider = InstrumentedFinishProvider {
+            inner: &*state_provider,
+            metrics: self.metrics.clone(),
+        };
         let BlockBuilderOutcome {
             execution_result,
             block,
             hashed_state,
             trie_updates,
-        } = builder.finish(&state_provider)?;
+        } = builder.finish(instrumented_provider)?;
         drop(_finish_span);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -540,7 +540,8 @@ where
         }
 
         let subblocks_start = Instant::now();
-        let _subblock_txs_span = debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
+        let _subblock_txs_span =
+            debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
         // Apply subblock transactions
@@ -594,7 +595,8 @@ where
 
         // Apply system transactions
         let system_txs_execution_start = Instant::now();
-        let _system_txs_span = debug_span!(target: "payload_builder", "execute_system_txs").entered();
+        let _system_txs_span =
+            debug_span!(target: "payload_builder", "execute_system_txs").entered();
         for system_tx in system_txs {
             builder
                 .execute_transaction(system_tx)

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -502,13 +502,10 @@ where
         drop(_block_fill_span);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
-            .block_fill_duration_seconds
-            .record(total_normal_transaction_execution_elapsed);
-        self.metrics
             .best_txs_next_total_duration_seconds
             .record(best_txs_next_total);
         self.metrics
-            .best_txs_next_calls_total
+            .best_txs_next_yield_count
             .record(best_txs_next_calls as f64);
         self.metrics
             .total_normal_transaction_execution_duration_seconds

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -72,106 +72,38 @@ struct InstrumentedFinishProvider<'a> {
     metrics: TempoPayloadBuilderMetrics,
 }
 
-impl AccountReader for InstrumentedFinishProvider<'_> {
-    fn basic_account(
-        &self,
-        address: &Address,
-    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>> {
-        self.inner.basic_account(address)
-    }
-}
-
-impl BlockHashReader for InstrumentedFinishProvider<'_> {
-    fn block_hash(
-        &self,
-        number: alloy_primitives::BlockNumber,
-    ) -> reth_errors::ProviderResult<Option<alloy_primitives::B256>> {
-        self.inner.block_hash(number)
-    }
-
-    fn canonical_hashes_range(
-        &self,
-        start: alloy_primitives::BlockNumber,
-        end: alloy_primitives::BlockNumber,
-    ) -> reth_errors::ProviderResult<Vec<alloy_primitives::B256>> {
-        self.inner.canonical_hashes_range(start, end)
-    }
-}
-
-impl BytecodeReader for InstrumentedFinishProvider<'_> {
-    fn bytecode_by_hash(
-        &self,
-        code_hash: &alloy_primitives::B256,
-    ) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>> {
-        self.inner.bytecode_by_hash(code_hash)
-    }
-}
-
-impl StateProvider for InstrumentedFinishProvider<'_> {
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: alloy_primitives::StorageKey,
-    ) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>> {
-        self.inner.storage(account, storage_key)
-    }
-}
-
-impl StorageRootProvider for InstrumentedFinishProvider<'_> {
-    fn storage_root(
-        &self,
-        address: Address,
-        hashed_storage: reth_trie_common::HashedStorage,
-    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
-        self.inner.storage_root(address, hashed_storage)
-    }
-
-    fn storage_proof(
-        &self,
-        address: Address,
-        slot: alloy_primitives::B256,
-        hashed_storage: reth_trie_common::HashedStorage,
-    ) -> reth_errors::ProviderResult<reth_trie_common::StorageProof> {
-        self.inner.storage_proof(address, slot, hashed_storage)
-    }
-
-    fn storage_multiproof(
-        &self,
-        address: Address,
-        slots: &[alloy_primitives::B256],
-        hashed_storage: reth_trie_common::HashedStorage,
-    ) -> reth_errors::ProviderResult<reth_trie_common::StorageMultiProof> {
+impl<'a> AsRef<dyn StateProvider + 'a> for InstrumentedFinishProvider<'a> {
+    fn as_ref(&self) -> &(dyn StateProvider + 'a) {
         self.inner
-            .storage_multiproof(address, slots, hashed_storage)
     }
 }
 
-impl StateProofProvider for InstrumentedFinishProvider<'_> {
-    fn proof(
-        &self,
-        input: reth_trie_common::TrieInput,
-        address: Address,
-        slots: &[alloy_primitives::B256],
-    ) -> reth_errors::ProviderResult<reth_trie_common::AccountProof> {
-        self.inner.proof(input, address, slots)
+reth_storage_api::delegate_impls_to_as_ref!(
+    for InstrumentedFinishProvider<'_> =>
+    AccountReader {
+        fn basic_account(&self, address: &alloy_primitives::Address) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>>;
     }
-
-    fn multiproof(
-        &self,
-        input: reth_trie_common::TrieInput,
-        targets: reth_trie_common::MultiProofTargets,
-    ) -> reth_errors::ProviderResult<reth_trie_common::MultiProof> {
-        self.inner.multiproof(input, targets)
+    BlockHashReader {
+        fn block_hash(&self, number: u64) -> reth_errors::ProviderResult<Option<alloy_primitives::B256>>;
+        fn canonical_hashes_range(&self, start: alloy_primitives::BlockNumber, end: alloy_primitives::BlockNumber) -> reth_errors::ProviderResult<Vec<alloy_primitives::B256>>;
     }
-
-    fn witness(
-        &self,
-        input: reth_trie_common::TrieInput,
-        target: reth_trie_common::HashedPostState,
-    ) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.inner.witness(input, target)
+    StateProvider {
+        fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>>;
     }
-}
+    BytecodeReader {
+        fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>>;
+    }
+    StorageRootProvider {
+        fn storage_root(&self, address: alloy_primitives::Address, storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<alloy_primitives::B256>;
+        fn storage_proof(&self, address: alloy_primitives::Address, slot: alloy_primitives::B256, storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<reth_trie_common::StorageProof>;
+        fn storage_multiproof(&self, address: alloy_primitives::Address, slots: &[alloy_primitives::B256], storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<reth_trie_common::StorageMultiProof>;
+    }
+    StateProofProvider {
+        fn proof(&self, input: reth_trie_common::TrieInput, address: alloy_primitives::Address, slots: &[alloy_primitives::B256]) -> reth_errors::ProviderResult<reth_trie_common::AccountProof>;
+        fn multiproof(&self, input: reth_trie_common::TrieInput, targets: reth_trie_common::MultiProofTargets) -> reth_errors::ProviderResult<reth_trie_common::MultiProof>;
+        fn witness(&self, input: reth_trie_common::TrieInput, target: reth_trie_common::HashedPostState) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>>;
+    }
+);
 
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
     fn hashed_post_state(

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -7,7 +7,7 @@ mod metrics;
 
 use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, StorageKey, StorageValue, U256};
 use alloy_rlp::{Decodable, Encodable};
 use either::Either;
 use reth_basic_payload_builder::{
@@ -17,7 +17,7 @@ use reth_basic_payload_builder::{
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
 use reth_engine_tree::tree::instrumented_state::InstrumentedStateProvider;
-use reth_errors::{ConsensusError, ProviderError};
+use reth_errors::{ConsensusError, ProviderError, ProviderResult};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
     block::{BlockExecutionError, BlockValidationError},
@@ -26,19 +26,22 @@ use reth_evm::{
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
-use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
+use reth_primitives_traits::{Account, Bytecode, Recovered, transaction::error::InvalidTransactionError};
 use reth_revm::{
     State,
     context::{Block, BlockEnv},
     database::StateProviderDatabase,
 };
 use reth_storage_api::{
-    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
-    StateProvider, StateProviderFactory, StateRootProvider, StorageRootProvider,
+    HashedPostStateProvider, StateProvider, StateProviderFactory, StateRootProvider,
 };
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
+};
+use reth_trie_common::{
+    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets,
+    StorageMultiProof, StorageProof, TrieInput, updates::TrieUpdates,
 };
 use std::{
     sync::{
@@ -81,35 +84,32 @@ impl<'a> AsRef<dyn StateProvider + 'a> for InstrumentedFinishProvider<'a> {
 reth_storage_api::delegate_impls_to_as_ref!(
     for InstrumentedFinishProvider<'_> =>
     AccountReader {
-        fn basic_account(&self, address: &alloy_primitives::Address) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Account>>;
+        fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
     }
     BlockHashReader {
-        fn block_hash(&self, number: u64) -> reth_errors::ProviderResult<Option<alloy_primitives::B256>>;
-        fn canonical_hashes_range(&self, start: alloy_primitives::BlockNumber, end: alloy_primitives::BlockNumber) -> reth_errors::ProviderResult<Vec<alloy_primitives::B256>>;
+        fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>>;
+        fn canonical_hashes_range(&self, start: BlockNumber, end: BlockNumber) -> ProviderResult<Vec<B256>>;
     }
     StateProvider {
-        fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_errors::ProviderResult<Option<alloy_primitives::StorageValue>>;
+        fn storage(&self, account: Address, storage_key: StorageKey) -> ProviderResult<Option<StorageValue>>;
     }
     BytecodeReader {
-        fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_errors::ProviderResult<Option<reth_primitives_traits::Bytecode>>;
+        fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
     }
     StorageRootProvider {
-        fn storage_root(&self, address: alloy_primitives::Address, storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<alloy_primitives::B256>;
-        fn storage_proof(&self, address: alloy_primitives::Address, slot: alloy_primitives::B256, storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<reth_trie_common::StorageProof>;
-        fn storage_multiproof(&self, address: alloy_primitives::Address, slots: &[alloy_primitives::B256], storage: reth_trie_common::HashedStorage) -> reth_errors::ProviderResult<reth_trie_common::StorageMultiProof>;
+        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
+        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
+        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
     }
     StateProofProvider {
-        fn proof(&self, input: reth_trie_common::TrieInput, address: alloy_primitives::Address, slots: &[alloy_primitives::B256]) -> reth_errors::ProviderResult<reth_trie_common::AccountProof>;
-        fn multiproof(&self, input: reth_trie_common::TrieInput, targets: reth_trie_common::MultiProofTargets) -> reth_errors::ProviderResult<reth_trie_common::MultiProof>;
-        fn witness(&self, input: reth_trie_common::TrieInput, target: reth_trie_common::HashedPostState) -> reth_errors::ProviderResult<Vec<alloy_primitives::Bytes>>;
+        fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
+        fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
+        fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
     }
 );
 
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
-    fn hashed_post_state(
-        &self,
-        bundle_state: &reth_revm::db::BundleState,
-    ) -> reth_trie_common::HashedPostState {
+    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
         let result = self.inner.hashed_post_state(bundle_state);
@@ -122,27 +122,18 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
 }
 
 impl StateRootProvider for InstrumentedFinishProvider<'_> {
-    fn state_root(
-        &self,
-        hashed_state: reth_trie_common::HashedPostState,
-    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         self.inner.state_root(hashed_state)
     }
 
-    fn state_root_from_nodes(
-        &self,
-        input: reth_trie_common::TrieInput,
-    ) -> reth_errors::ProviderResult<alloy_primitives::B256> {
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
         self.inner.state_root_from_nodes(input)
     }
 
     fn state_root_with_updates(
         &self,
-        hashed_state: reth_trie_common::HashedPostState,
-    ) -> reth_errors::ProviderResult<(
-        alloy_primitives::B256,
-        reth_trie_common::updates::TrieUpdates,
-    )> {
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
         let result = self.inner.state_root_with_updates(hashed_state);
@@ -155,11 +146,8 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
 
     fn state_root_from_nodes_with_updates(
         &self,
-        input: reth_trie_common::TrieInput,
-    ) -> reth_errors::ProviderResult<(
-        alloy_primitives::B256,
-        reth_trie_common::updates::TrieUpdates,
-    )> {
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
         self.inner.state_root_from_nodes_with_updates(input)
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -235,12 +235,10 @@ where
 
         let start = Instant::now();
 
-        let _block_metrics_span = debug_span!(target: "payload_builder", "block_metrics").entered();
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
-        drop(_block_metrics_span);
 
         let state_setup_start = Instant::now();
         let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();
@@ -264,7 +262,6 @@ where
             .state_setup_duration_seconds
             .record(state_setup_start.elapsed());
 
-        let _collect_span = debug_span!(target: "payload_builder", "collect_subblocks").entered();
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
             .provider
@@ -327,10 +324,6 @@ where
             })
             .collect();
 
-        drop(_collect_span);
-
-        let create_evm_start = Instant::now();
-        let _create_evm_span = debug_span!(target: "payload_builder", "create_evm").entered();
         let mut builder = self
             .evm_config
             .builder_for_next_block(
@@ -353,26 +346,15 @@ where
                 },
             )
             .map_err(PayloadBuilderError::other)?;
-        drop(_create_evm_span);
-        self.metrics
-            .create_evm_duration_seconds
-            .record(create_evm_start.elapsed());
 
-        let pre_execution_start = Instant::now();
-        let _pre_execution_span = debug_span!(target: "payload_builder", "pre_execution").entered();
         builder.apply_pre_execution_changes().map_err(|err| {
             warn!(%err, "failed to apply pre-execution changes");
             PayloadBuilderError::Internal(err.into())
         })?;
-        drop(_pre_execution_span);
-        self.metrics
-            .pre_execution_duration_seconds
-            .record(pre_execution_start.elapsed());
 
         debug!("building new payload");
 
         // Prepare system transactions before actual block building and account for their size.
-        let _prepare_txs_span = debug_span!(target: "payload_builder", "prepare_txs").entered();
         let prepare_system_txs_start = Instant::now();
         let system_txs = self.build_seal_block_txs(builder.evm().block(), &subblocks);
         for tx in &system_txs {
@@ -392,7 +374,6 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
-        drop(_prepare_txs_span);
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
@@ -645,7 +626,6 @@ where
             .payload_finalization_duration_seconds
             .record(builder_finish_elapsed);
 
-        let _seal_span = debug_span!(target: "payload_builder", "seal_payload").entered();
         let total_transactions = block.transaction_count();
         self.metrics
             .total_transactions
@@ -720,7 +700,6 @@ where
         };
 
         let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
-        drop(_seal_span);
 
         drop(db);
         Ok(BuildOutcome::Better {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -26,22 +26,25 @@ use reth_evm::{
 use reth_execution_types::ExecutionOutcome;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
-use reth_primitives_traits::{Account, Bytecode, Recovered, transaction::error::InvalidTransactionError};
+use reth_primitives_traits::{
+    Account, Bytecode, Recovered, transaction::error::InvalidTransactionError,
+};
 use reth_revm::{
     State,
     context::{Block, BlockEnv},
     database::StateProviderDatabase,
 };
 use reth_storage_api::{
-    HashedPostStateProvider, StateProvider, StateProviderFactory, StateRootProvider,
+    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
+    StateProvider, StateProviderFactory, StateRootProvider, StorageRootProvider,
 };
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
 };
 use reth_trie_common::{
-    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets,
-    StorageMultiProof, StorageProof, TrieInput, updates::TrieUpdates,
+    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
+    StorageProof, TrieInput, updates::TrieUpdates,
 };
 use std::{
     sync::{

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -511,6 +511,9 @@ where
         }
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
+            .block_fill_duration_seconds
+            .record(total_normal_transaction_execution_elapsed);
+        self.metrics
             .total_normal_transaction_execution_duration_seconds
             .record(total_normal_transaction_execution_elapsed);
         self.metrics
@@ -539,6 +542,9 @@ where
         let mut subblock_transactions = 0f64;
         // Apply subblock transactions
         for subblock in &subblocks {
+            let subblock_start = Instant::now();
+            let mut subblock_tx_count = 0f64;
+
             for tx in subblock.transactions_recovered() {
                 if let Err(err) = builder.execute_transaction(tx.cloned()) {
                     if let BlockExecutionError::Validation(BlockValidationError::InvalidTx {
@@ -558,8 +564,16 @@ where
                     }
                 }
 
-                subblock_transactions += 1.0;
+                subblock_tx_count += 1.0;
             }
+
+            self.metrics
+                .subblock_execution_duration_seconds
+                .record(subblock_start.elapsed());
+            self.metrics
+                .subblock_transaction_count
+                .record(subblock_tx_count);
+            subblock_transactions += subblock_tx_count;
         }
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -42,7 +42,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
@@ -377,17 +377,7 @@ where
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
-        let mut best_txs_next_total = Duration::ZERO;
-        let mut best_txs_next_calls = 0u64;
-        while let Some(pool_tx) = {
-            let next_start = Instant::now();
-            let next = best_txs.next();
-            if next.is_some() {
-                best_txs_next_total += next_start.elapsed();
-                best_txs_next_calls += 1;
-            }
-            next
-        } {
+        while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
             // be consumed by proposer's pool transactions.
@@ -501,12 +491,6 @@ where
         }
         drop(_block_fill_span);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
-        self.metrics
-            .best_txs_next_total_duration_seconds
-            .record(best_txs_next_total);
-        self.metrics
-            .best_txs_next_yield_count
-            .record(best_txs_next_calls as f64);
         self.metrics
             .total_normal_transaction_execution_duration_seconds
             .record(total_normal_transaction_execution_elapsed);

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod metrics;
 
-use crate::metrics::TempoPayloadBuilderMetrics;
+use crate::metrics::{TempoPayloadBuilderMetrics, inc_pool_tx_skipped};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{Decodable, Encodable};
@@ -60,7 +60,7 @@ use tempo_transaction_pool::{
     TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
-use tracing::{Level, debug, error, info, instrument, trace, warn};
+use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -240,6 +240,8 @@ where
         self.metrics.block_time_millis.record(block_time_millis);
         self.metrics.block_time_millis_last.set(block_time_millis);
 
+        let state_setup_start = Instant::now();
+        let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();
         let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
         let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
@@ -255,6 +257,10 @@ where
             })
             .with_bundle_update()
             .build();
+        drop(_state_setup_span);
+        self.metrics
+            .state_setup_duration_seconds
+            .record(state_setup_start.elapsed());
 
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
@@ -318,6 +324,8 @@ where
             })
             .collect();
 
+        let create_evm_start = Instant::now();
+        let _create_evm_span = debug_span!(target: "payload_builder", "create_evm").entered();
         let mut builder = self
             .evm_config
             .builder_for_next_block(
@@ -340,11 +348,21 @@ where
                 },
             )
             .map_err(PayloadBuilderError::other)?;
+        drop(_create_evm_span);
+        self.metrics
+            .create_evm_duration_seconds
+            .record(create_evm_start.elapsed());
 
+        let pre_execution_start = Instant::now();
+        let _pre_execution_span = debug_span!(target: "payload_builder", "pre_execution").entered();
         builder.apply_pre_execution_changes().map_err(|err| {
             warn!(%err, "failed to apply pre-execution changes");
             PayloadBuilderError::Internal(err.into())
         })?;
+        drop(_pre_execution_span);
+        self.metrics
+            .pre_execution_duration_seconds
+            .record(pre_execution_start.elapsed());
 
         debug!("building new payload");
 
@@ -370,7 +388,14 @@ where
         ));
 
         let execution_start = Instant::now();
-        while let Some(pool_tx) = best_txs.next() {
+        while let Some(pool_tx) = {
+            let next_start = Instant::now();
+            let next = best_txs.next();
+            self.metrics
+                .best_txs_next_duration_seconds
+                .record(next_start.elapsed());
+            next
+        } {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
             // be consumed by proposer's pool transactions.
@@ -384,6 +409,7 @@ where
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
                 );
+                inc_pool_tx_skipped("exceeds_non_shared_gas_limit");
                 continue;
             }
 
@@ -398,6 +424,7 @@ where
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
+                inc_pool_tx_skipped("exceeds_general_gas_limit");
                 continue;
             }
 
@@ -427,6 +454,7 @@ where
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
                 );
+                inc_pool_tx_skipped("oversized_block");
                 continue;
             }
 
@@ -437,7 +465,7 @@ where
                 .unwrap_or_default();
 
             let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
-            let execution_start = Instant::now();
+            let tx_execution_start = Instant::now();
             let gas_used = match builder.execute_transaction(tx_with_env) {
                 Ok(gas_used) => gas_used,
                 Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
@@ -447,6 +475,7 @@ where
                     if error.is_nonce_too_low() {
                         // if the nonce is too low, we can skip this transaction
                         trace!(%error, tx = %tx_debug_repr, "skipping nonce too low transaction");
+                        inc_pool_tx_skipped("nonce_too_low");
                     } else {
                         // if the transaction is invalid, we can skip it and all of its
                         // descendants
@@ -457,13 +486,14 @@ where
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );
+                        inc_pool_tx_skipped("invalid_tx");
                     }
                     continue;
                 }
                 // this is an error that we should treat as fatal for this attempt
                 Err(err) => return Err(PayloadBuilderError::evm(err)),
             };
-            let elapsed = execution_start.elapsed();
+            let elapsed = tx_execution_start.elapsed();
             self.metrics
                 .transaction_execution_duration_seconds
                 .record(elapsed);

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -40,10 +40,16 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) transaction_execution_duration_seconds: Histogram,
     /// The time it took to select the next candidate transaction from the pool.
     pub(crate) best_txs_next_duration_seconds: Histogram,
+    /// Wall-clock duration of the pool tx selection + execution loop.
+    pub(crate) block_fill_duration_seconds: Histogram,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.
     pub(crate) total_subblock_transaction_execution_duration_seconds: Histogram,
+    /// Execution time for a single subblock.
+    pub(crate) subblock_execution_duration_seconds: Histogram,
+    /// Number of transactions in a single subblock.
+    pub(crate) subblock_transaction_count: Histogram,
     /// The time it took to execute all transactions in seconds.
     pub(crate) total_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute system transactions in seconds.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,5 +1,18 @@
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, StorageKey, StorageValue};
 use metrics::Gauge;
+use reth_errors::ProviderResult;
 use reth_metrics::{Metrics, metrics::Histogram};
+use reth_primitives_traits::{Account, Bytecode};
+use reth_storage_api::{
+    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
+    StateProvider, StateRootProvider, StorageRootProvider,
+};
+use reth_trie_common::{
+    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
+    StorageProof, TrieInput, updates::TrieUpdates,
+};
+use std::time::Instant;
+use tracing::debug_span;
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_payload_builder")]
@@ -79,4 +92,88 @@ pub(crate) struct TempoPayloadBuilderMetrics {
 pub(crate) fn inc_pool_tx_skipped(reason: &'static str) {
     metrics::counter!("tempo_payload_builder_pool_transactions_skipped_total", "reason" => reason)
         .increment(1);
+}
+
+/// Wraps a [`StateProvider`] reference to instrument `hashed_post_state` and
+/// `state_root_with_updates` with tracing spans and histogram metrics during `builder.finish()`.
+pub(crate) struct InstrumentedFinishProvider<'a> {
+    pub(crate) inner: &'a dyn StateProvider,
+    pub(crate) metrics: TempoPayloadBuilderMetrics,
+}
+
+impl<'a> AsRef<dyn StateProvider + 'a> for InstrumentedFinishProvider<'a> {
+    fn as_ref(&self) -> &(dyn StateProvider + 'a) {
+        self.inner
+    }
+}
+
+reth_storage_api::delegate_impls_to_as_ref!(
+    for InstrumentedFinishProvider<'_> =>
+    AccountReader {
+        fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>>;
+    }
+    BlockHashReader {
+        fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>>;
+        fn canonical_hashes_range(&self, start: BlockNumber, end: BlockNumber) -> ProviderResult<Vec<B256>>;
+    }
+    StateProvider {
+        fn storage(&self, account: Address, storage_key: StorageKey) -> ProviderResult<Option<StorageValue>>;
+    }
+    BytecodeReader {
+        fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
+    }
+    StorageRootProvider {
+        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
+        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
+        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
+    }
+    StateProofProvider {
+        fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
+        fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
+        fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
+    }
+);
+
+impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
+    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
+        let result = self.inner.hashed_post_state(bundle_state);
+        drop(_span);
+        self.metrics
+            .hashed_post_state_duration_seconds
+            .record(start.elapsed());
+        result
+    }
+}
+
+impl StateRootProvider for InstrumentedFinishProvider<'_> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        self.inner.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        self.inner.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
+        let result = self.inner.state_root_with_updates(hashed_state);
+        drop(_span);
+        self.metrics
+            .state_root_with_updates_duration_seconds
+            .record(start.elapsed());
+        result
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_from_nodes_with_updates(input)
+    }
 }

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -75,6 +75,16 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) hashed_post_state_duration_seconds: Histogram,
     /// Time to compute the state root and trie updates via `state_root_with_updates`.
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
+    /// Number of changed accounts in the hashed post-state.
+    pub(crate) hashed_state_changed_accounts: Histogram,
+    /// Number of accounts with changed storage in the hashed post-state.
+    pub(crate) hashed_state_changed_storage_accounts: Histogram,
+    /// Total number of changed storage slots across all accounts in the hashed post-state.
+    pub(crate) hashed_state_changed_storage_slots_total: Histogram,
+    /// Number of account trie node changes in the trie updates.
+    pub(crate) trie_updates_account_nodes: Histogram,
+    /// Number of storage tries with updates in the trie updates.
+    pub(crate) trie_updates_storage_tries: Histogram,
 }
 
 /// Increments the unified pool transaction skip counter with the given reason label.
@@ -136,6 +146,17 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
         self.metrics
             .hashed_post_state_duration_seconds
             .record(start.elapsed());
+        self.metrics
+            .hashed_state_changed_accounts
+            .record(result.accounts.len() as f64);
+        self.metrics
+            .hashed_state_changed_storage_accounts
+            .record(result.storages.len() as f64);
+        self.metrics
+            .hashed_state_changed_storage_slots_total
+            .record(
+                result.storages.values().map(|s| s.storage.len()).sum::<usize>() as f64,
+            );
         result
     }
 }
@@ -160,6 +181,14 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());
+        if let Ok((_, ref trie_updates)) = result {
+            self.metrics
+                .trie_updates_account_nodes
+                .record(trie_updates.account_nodes.len() as f64);
+            self.metrics
+                .trie_updates_storage_tries
+                .record(trie_updates.storage_tries.len() as f64);
+        }
         result
     }
 

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -47,12 +47,11 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
-    /// Total time spent in `best_txs.next()` across all calls during the block fill loop.
+    /// Total time spent in `best_txs.next()` calls that yielded a transaction.
+    /// Does not include the final `None`-returning call.
     pub(crate) best_txs_next_total_duration_seconds: Histogram,
-    /// Number of `best_txs.next()` calls that returned a transaction.
-    pub(crate) best_txs_next_calls_total: Histogram,
-    /// Wall-clock duration of the pool tx selection + execution loop.
-    pub(crate) block_fill_duration_seconds: Histogram,
+    /// Number of `best_txs.next()` calls that yielded a transaction (excludes terminal `None`).
+    pub(crate) best_txs_next_yield_count: Histogram,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.
@@ -84,6 +83,9 @@ pub(crate) struct TempoPayloadBuilderMetrics {
 }
 
 /// Increments the unified pool transaction skip counter with the given reason label.
+///
+/// Note: `mark_invalid` may also prune descendant transactions from the iterator,
+/// so the skip count represents skip *events*, not total transactions removed.
 #[inline]
 pub(crate) fn inc_pool_tx_skipped(reason: &'static str) {
     metrics::counter!("tempo_payload_builder_pool_transactions_skipped_total", "reason" => reason)

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -62,6 +62,15 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes_last: Gauge,
 }
 
+/// Skip reason labels for `pool_transactions_skipped_total`.
+pub(crate) mod skip_reason {
+    pub(crate) const EXCEEDS_NON_SHARED_GAS_LIMIT: &str = "exceeds_non_shared_gas_limit";
+    pub(crate) const EXCEEDS_GENERAL_GAS_LIMIT: &str = "exceeds_general_gas_limit";
+    pub(crate) const OVERSIZED_BLOCK: &str = "oversized_block";
+    pub(crate) const NONCE_TOO_LOW: &str = "nonce_too_low";
+    pub(crate) const INVALID_TX: &str = "invalid_tx";
+}
+
 /// Increments the unified pool transaction skip counter with the given reason label.
 #[inline]
 pub(crate) fn inc_pool_tx_skipped(reason: &'static str) {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -43,10 +43,6 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used_last: Gauge,
     /// Time to acquire the state provider and initialize the state DB.
     pub(crate) state_setup_duration_seconds: Histogram,
-    /// Time to create the EVM/block builder.
-    pub(crate) create_evm_duration_seconds: Histogram,
-    /// Time to apply pre-execution changes.
-    pub(crate) pre_execution_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -28,10 +28,18 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used: Histogram,
     /// Amount of gas used in the payload.
     pub(crate) gas_used_last: Gauge,
+    /// Time to acquire the state provider and initialize the state DB.
+    pub(crate) state_setup_duration_seconds: Histogram,
+    /// Time to create the EVM/block builder.
+    pub(crate) create_evm_duration_seconds: Histogram,
+    /// Time to apply pre-execution changes.
+    pub(crate) pre_execution_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
+    /// The time it took to select the next candidate transaction from the pool.
+    pub(crate) best_txs_next_duration_seconds: Histogram,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.
@@ -52,4 +60,11 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes: Histogram,
     /// RLP-encoded block size in bytes for the last payload.
     pub(crate) rlp_block_size_bytes_last: Gauge,
+}
+
+/// Increments the unified pool transaction skip counter with the given reason label.
+#[inline]
+pub(crate) fn inc_pool_tx_skipped(reason: &'static str) {
+    metrics::counter!("tempo_payload_builder_pool_transactions_skipped_total", "reason" => reason)
+        .increment(1);
 }

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -47,11 +47,6 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
-    /// Total time spent in `best_txs.next()` calls that yielded a transaction.
-    /// Does not include the final `None`-returning call.
-    pub(crate) best_txs_next_total_duration_seconds: Histogram,
-    /// Number of `best_txs.next()` calls that yielded a transaction (excludes terminal `None`).
-    pub(crate) best_txs_next_yield_count: Histogram,
     /// The time it took to execute normal transactions in seconds.
     pub(crate) total_normal_transaction_execution_duration_seconds: Histogram,
     /// The time it took to execute subblock transactions in seconds.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -38,8 +38,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) prepare_system_transactions_duration_seconds: Histogram,
     /// The time it took to execute one transaction in seconds.
     pub(crate) transaction_execution_duration_seconds: Histogram,
-    /// The time it took to select the next candidate transaction from the pool.
-    pub(crate) best_txs_next_duration_seconds: Histogram,
+    /// Total time spent in `best_txs.next()` across all calls during the block fill loop.
+    pub(crate) best_txs_next_total_duration_seconds: Histogram,
+    /// Number of `best_txs.next()` calls that returned a transaction.
+    pub(crate) best_txs_next_calls_total: Histogram,
     /// Wall-clock duration of the pool tx selection + execution loop.
     pub(crate) block_fill_duration_seconds: Histogram,
     /// The time it took to execute normal transactions in seconds.
@@ -68,8 +70,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes_last: Gauge,
     /// Time to compute the hashed post-state from the bundle state.
     pub(crate) hashed_post_state_duration_seconds: Histogram,
-    /// Time to compute the state root and trie updates.
-    pub(crate) state_root_duration_seconds: Histogram,
+    /// Time to compute the state root and trie updates via `state_root_with_updates`.
+    pub(crate) state_root_with_updates_duration_seconds: Histogram,
 }
 
 /// Increments the unified pool transaction skip counter with the given reason label.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -62,15 +62,6 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes_last: Gauge,
 }
 
-/// Skip reason labels for `pool_transactions_skipped_total`.
-pub(crate) mod skip_reason {
-    pub(crate) const EXCEEDS_NON_SHARED_GAS_LIMIT: &str = "exceeds_non_shared_gas_limit";
-    pub(crate) const EXCEEDS_GENERAL_GAS_LIMIT: &str = "exceeds_general_gas_limit";
-    pub(crate) const OVERSIZED_BLOCK: &str = "oversized_block";
-    pub(crate) const NONCE_TOO_LOW: &str = "nonce_too_low";
-    pub(crate) const INVALID_TX: &str = "invalid_tx";
-}
-
 /// Increments the unified pool transaction skip counter with the given reason label.
 #[inline]
 pub(crate) fn inc_pool_tx_skipped(reason: &'static str) {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -66,6 +66,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes: Histogram,
     /// RLP-encoded block size in bytes for the last payload.
     pub(crate) rlp_block_size_bytes_last: Gauge,
+    /// Time to compute the hashed post-state from the bundle state.
+    pub(crate) hashed_post_state_duration_seconds: Histogram,
+    /// Time to compute the state root and trie updates.
+    pub(crate) state_root_duration_seconds: Histogram,
 }
 
 /// Increments the unified pool transaction skip counter with the given reason label.


### PR DESCRIPTION
Adds workload-shape and output-shape metrics to the `InstrumentedFinishProvider` to help diagnose **why** state root computation is slow on a given block.

After `hashed_post_state` completes, records the changeset dimensions:
- `hashed_state_changed_accounts` — number of accounts modified
- `hashed_state_changed_storage_accounts` — number of accounts with storage changes
- `hashed_state_changed_storage_slots_total` — total storage slots changed (the main cost driver for sorting, prefix-set construction, and trie walking)

After `state_root_with_updates` completes, records the trie diff shape:
- `trie_updates_account_nodes` — account trie branch nodes modified
- `trie_updates_storage_tries` — number of storage tries that were updated

Together with the existing duration histograms from #3056, these let you correlate latency with changeset size and identify whether slow blocks are driven by large changesets or expensive trie structure.