### PR TITLE
fix(rpc): AA roundtrip conversion

### DIFF
--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -313,9 +313,9 @@ impl From<TempoTransaction> for TempoTransactionRequest {
             fee_token: tx.fee_token,
             inner: TransactionRequest {
                 from: None,
-                // AA calls are stored in the `calls` field below — leave `to`, `value`,
-                // and `input` unset so that `build_aa()` / `try_into_tx_env()` don't
-                // append a duplicate call from the envelope fields.
+                // AA transactions store their calls in `calls` below.
+                // `to`, `value`, `input` must stay unset to avoid the builder
+                // creating a duplicate call from the envelope fields.
                 to: None,
                 gas: Some(tx.gas_limit()),
                 gas_price: tx.gas_price(),
@@ -659,6 +659,49 @@ mod tests {
         assert_eq!(
             roundtrip.calls, batch,
             "multi-call AA must not gain phantom calls on round-trip"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tempo-compat")]
+    fn test_aa_roundtrip_via_tx_env() {
+        use reth_rpc_convert::TryIntoTxEnv;
+
+        let calls = vec![
+            Call {
+                to: address!("0x1111111111111111111111111111111111111111").into(),
+                value: U256::ZERO,
+                input: Bytes::from(vec![0xaa]),
+            },
+            Call {
+                to: address!("0x2222222222222222222222222222222222222222").into(),
+                value: U256::ZERO,
+                input: Bytes::from(vec![0xbb]),
+            },
+        ];
+
+        let tx = TempoTransaction {
+            chain_id: 4217,
+            nonce: 1,
+            gas_limit: 100_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000,
+            calls: calls.clone(),
+            ..Default::default()
+        };
+
+        let req = TempoTransactionRequest::from(tx);
+
+        let evm_env = reth_evm::EvmEnv::<
+            reth_evm::revm::primitives::hardfork::SpecId,
+            tempo_evm::TempoBlockEnv,
+        >::default();
+        let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
+        let aa_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
+
+        assert_eq!(
+            aa_calls, calls,
+            "roundtrip via try_into_tx_env must preserve exact call list"
         );
     }
 }


### PR DESCRIPTION
ref: `AUD-38`

this PR ensures consistent conversion between `TempoTransaction` and `TempoTransactionRequest` so that roundtrip conversions are idempotent