### PR TITLE
docs(tip-1029): fee recipient from validator config v2

### DIFF
--- a/tips/tip-1029.md
+++ b/tips/tip-1029.md
@@ -85,7 +85,7 @@ like so, with the contract value taking priority if set:
 
 # Invariants
 
-The invariants listed here are only local to a given node and consistute an
+The invariants listed here are only local to a given node and constitute an
 implementation detail. They are not expected to be enforced by validators.
 
 - The fee recipient used in payload building MUST equal the on-chain

--- a/tips/tip-1029.md
+++ b/tips/tip-1029.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-XXXX
+id: TIP-1029
 title: Fee Recipient from Validator Config V2
 description: Validators declare a fee recipient address in ValidatorConfigV2; the node reads it and passes it to the payload builder.
 authors: @superfluffy
@@ -8,26 +8,13 @@ related: TIP-1017
 protocolVersion: TBD
 ---
 
-# TIP-XXXX: Fee Recipient from Validator Config V2
+# TIP-1029: Fee Recipient from Validator Config V2
 
 ## Abstract
 
 Proposers use the `feeRecipient` field added to validator entries in [TIP-1017](./tip-1017.md).
 When a validator proposes a block, the node reads this on-chain field and uses it as the fee recipient in the payload builder.
 The command line flag `--consensus.fee-recipient` is removed.
-
-## Proposal
-
-1. Nodes, when building blocks to be proposed, use the
-  `ValidatorConfigV2.Validator.feeRecipient` field of their `Validator` entry
-   at the chain state of the notarized parent block.
-2. The state of the notarized (not finalized) block is used because:
-    + the state must be available to propose a block.
-    + because Tempo consensus uses a VRF to determine the next leader, a node
-      can be elected leader several blocks in a row. Waiting for the fee receipient
-      rotation to be actived by a finalized block would make it non-deterministic.
-3. Remove the `--consensus.fee-recipient` command line argument to provide a
-   single source of truth and make compliance easier.
 
 ## Motivation
 
@@ -38,9 +25,24 @@ contract call. Regular node operations include all other calls.
 
 Currently, an infrastructure engineer has complete control over where fees are
 sent by using `--consensus.fee-recipient` command line argument on the tempo binary.
-With this TIP, treasury management can instead be gated behind higher priviledge
+With this TIP, treasury management can instead be gated behind higher privilege
 requirements (for example, requiring a higher multisig threshold), while keeping
 every day ops more manageable (by requiring a lower multisig threshold).
+
+---
+
+# Specification
+
+1. Nodes, when building blocks to be proposed, use the
+   `ValidatorConfigV2.Validator.feeRecipient` field of their `Validator` entry
+   at the chain state of the notarized parent block.
+2. The state of the notarized (not finalized) block is used because:
+    + the state must be available to propose a block.
+    + because Tempo consensus uses a VRF to determine the next leader, a node
+      can be elected leader several blocks in a row. Waiting for the fee recipient
+      rotation to be activated by a finalized block would make it non-deterministic.
+3. Remove the `--consensus.fee-recipient` command line argument to provide a
+   single source of truth and make compliance easier.
 
 ## Node Behaviour
 
@@ -66,3 +68,9 @@ like so, with the contract value taking priority if set.
 1. Use `v.feeRecipient` if set to a value that is *not* the zero address `0x0`.
 2. If `v.feeRecipient` is set to the zero address `0x0`, use `--consensus.fee-recipient`.
 3. `--consensus.fee-recipient` will retain a default value of `0x0`.
+
+# Invariants
+
+- The fee recipient used in payload building MUST equal the on-chain `ValidatorConfigV2.Validator.feeRecipient` value read at the notarized parent block's state.
+- If `feeRecipient` is the zero address (`0x0`), the node MUST fall back to `--consensus.fee-recipient` during the migration period.
+- A validator whose public key is not found in ValidatorConfigV2 MUST NOT propose a block (pre-existing invariant, unchanged by this TIP).

--- a/tips/tip-1029.md
+++ b/tips/tip-1029.md
@@ -1,7 +1,9 @@
 ---
 id: TIP-1029
 title: Fee Recipient from Validator Config V2
-description: Validators declare a fee recipient address in ValidatorConfigV2; the node reads it and passes it to the payload builder.
+description: |
+   Validators declare a fee recipient address in ValidatorConfigV2; the node
+   reads it and passes it to the payload builder.
 authors: @superfluffy
 status: Draft
 related: TIP-1017
@@ -12,22 +14,26 @@ protocolVersion: TBD
 
 ## Abstract
 
-Proposers use the `feeRecipient` field added to validator entries in [TIP-1017](./tip-1017.md).
-When a validator proposes a block, the node reads this on-chain field and uses it as the fee recipient in the payload builder.
-The command line flag `--consensus.fee-recipient` is removed.
+Proposers use the `feeRecipient` field added to validator entries in
+[TIP-1017](./tip-1017.md). When a validator proposes a block, the node reads
+this on-chain field and uses it as the fee recipient in the payload builder.
+The command line flag `--consensus.fee-recipient` is deprecated and eventually
+removed.
 
 ## Motivation
 
-For compliance reasons, operators wish to separate every day node ops from treasury
-management. In the context of running a validator, treasury management includes
-the `feeRecipient` field of entries in the smart contract, and the `ValidatorConfigV2.setFeeRecipient`
-contract call. Regular node operations include all other calls.
+For compliance reasons, operators wish to separate every day node ops from
+treasury management. In the context of running a validator, treasury management
+includes the `feeRecipient` field of entries in the smart contract, and the
+`ValidatorConfigV2.setFeeRecipient` contract call. Regular node operations
+include all other calls.
 
 Currently, an infrastructure engineer has complete control over where fees are
-sent by using `--consensus.fee-recipient` command line argument on the tempo binary.
-With this TIP, treasury management can instead be gated behind higher privilege
-requirements (for example, requiring a higher multisig threshold), while keeping
-every day ops more manageable (by requiring a lower multisig threshold).
+sent by using `--consensus.fee-recipient` command line argument on the tempo
+binary. With this TIP, treasury management can instead be gated behind higher
+privilege requirements (for example, requiring a higher multisig threshold),
+while keeping every day ops more manageable (by requiring a lower multisig
+threshold).
 
 ---
 
@@ -39,20 +45,25 @@ every day ops more manageable (by requiring a lower multisig threshold).
 2. The state of the notarized (not finalized) block is used because:
     + the state must be available to propose a block.
     + because Tempo consensus uses a VRF to determine the next leader, a node
-      can be elected leader several blocks in a row. Waiting for the fee recipient
-      rotation to be activated by a finalized block would make it non-deterministic.
+      can be elected leader several blocks in a row. Waiting for the fee
+      recipient rotation to be activated by a finalized block would make it
+      non-deterministic.
 3. Remove the `--consensus.fee-recipient` command line argument to provide a
    single source of truth and make compliance easier.
 
 ## Node Behaviour
 
-When proposing a block, the node determines its fee recipient as follows:
+When proposing a block, the node sets its fee recipient as follows:
 
-1. Read its entry `v` from the ValidatorConfigV2 using `ValidatorConfig2.validatorByPublicKey`
-   at the chain state of the proposal's parent block.
-2. The public key is determined from the ed25519 signing key passed to the node
-   at startup.
-3. Use `v.feeRecipient` of its entry in `TempoPayloadBuilderAttributes`.
+1. Determines the consensus ed25519 public key from its ed25519 signing key. The
+   signing key is read at startup from the path passed in via the
+   `--consensus.signing-share` command line argument.
+2. Read the entry `v` corresponding to the ed25519 public key from the
+   `ValidatorConfigV2` smart contract using the
+   `ValidatorConfigV2.validatorByPublicKey` call at the chain state at the
+   parent block the proposal will be constructed on top of.
+3. Construct a `TempoPayloadBuilderAttributes` setting `suggested_fee_recipient`
+   to `v.feeRecipient`
 
 ## Relationship with subblock building?
 
@@ -63,14 +74,19 @@ TBD.
 This TIP will be activated in a future hardfork (TBD). The command line option
 `--consensus.fee-recipient` will be deprecated but still be present during this
 hardfork period and removed in a subsequent hardfork (TBD). The node will behave
-like so, with the contract value taking priority if set.
+like so, with the contract value taking priority if set:
 
 1. Use `v.feeRecipient` if set to a value that is *not* the zero address `0x0`.
-2. If `v.feeRecipient` is set to the zero address `0x0`, use `--consensus.fee-recipient`.
+2. If `v.feeRecipient` is set to the zero address `0x0`, use
+   `--consensus.fee-recipient`.
 3. `--consensus.fee-recipient` will retain a default value of `0x0`.
 
 # Invariants
 
-- The fee recipient used in payload building MUST equal the on-chain `ValidatorConfigV2.Validator.feeRecipient` value read at the notarized parent block's state.
-- If `feeRecipient` is the zero address (`0x0`), the node MUST fall back to `--consensus.fee-recipient` during the migration period.
-- A validator whose public key is not found in ValidatorConfigV2 MUST NOT propose a block (pre-existing invariant, unchanged by this TIP).
+- The fee recipient used in payload building MUST equal the on-chain
+  `ValidatorConfigV2.Validator.feeRecipient` value read at the notarized parent
+  block's state when `feeRecipient` is not the zero address `0x0`.
+- If `feeRecipient` is the zero address (`0x0`), the node MUST fall back to
+  `--consensus.fee-recipient` during the migration period.
+- A validator whose public key is not found in ValidatorConfigV2 MUST NOT
+  propose a block (pre-existing invariant, unchanged by this TIP).

--- a/tips/tip-1029.md
+++ b/tips/tip-1029.md
@@ -41,7 +41,9 @@ threshold).
 
 1. Nodes, when building blocks to be proposed, use the
    `ValidatorConfigV2.Validator.feeRecipient` field of their `Validator` entry
-   at the chain state of the notarized parent block.
+   at the chain state of the notarized parent block. For back-to-back leader
+   slots, the node MAY use the post-state of its own proposed parent block
+   before notarization.
 2. The state of the notarized (not finalized) block is used because:
     + the state must be available to propose a block.
     + because Tempo consensus uses a VRF to determine the next leader, a node
@@ -82,6 +84,9 @@ like so, with the contract value taking priority if set:
 3. `--consensus.fee-recipient` will retain a default value of `0x0`.
 
 # Invariants
+
+The invariants listed here are only local to a given node and consistute an
+implementation detail. They are not expected to be enforced by validators.
 
 - The fee recipient used in payload building MUST equal the on-chain
   `ValidatorConfigV2.Validator.feeRecipient` value read at the notarized parent

--- a/tips/tip-xxxx.md
+++ b/tips/tip-xxxx.md
@@ -1,0 +1,68 @@
+---
+id: TIP-XXXX
+title: Fee Recipient from Validator Config V2
+description: Validators declare a fee recipient address in ValidatorConfigV2; the node reads it and passes it to the payload builder.
+authors: @superfluffy
+status: Draft
+related: TIP-1017
+protocolVersion: TBD
+---
+
+# TIP-XXXX: Fee Recipient from Validator Config V2
+
+## Abstract
+
+Proposers use the `feeRecipient` field added to validator entries in [TIP-1017](./tip-1017.md).
+When a validator proposes a block, the node reads this on-chain field and uses it as the fee recipient in the payload builder.
+The command line flag `--consensus.fee-recipient` is removed.
+
+## Proposal
+
+1. Nodes, when building blocks to be proposed, use the
+  `ValidatorConfigV2.Validator.feeRecipient` field of their `Validator` entry
+   at the chain state of the notarized parent block.
+2. The state of the notarized (not finalized) block is used because:
+    + the state must be available to propose a block.
+    + because Tempo consensus uses a VRF to determine the next leader, a node
+      can be elected leader several blocks in a row. Waiting for the fee receipient
+      rotation to be actived by a finalized block would make it non-deterministic.
+3. Remove the `--consensus.fee-recipient` command line argument to provide a
+   single source of truth and make compliance easier.
+
+## Motivation
+
+For compliance reasons, operators wish to separate every day node ops from treasury
+management. In the context of running a validator, treasury management includes
+the `feeRecipient` field of entries in the smart contract, and the `ValidatorConfigV2.setFeeRecipient`
+contract call. Regular node operations include all other calls.
+
+Currently, an infrastructure engineer has complete control over where fees are
+sent by using `--consensus.fee-recipient` command line argument on the tempo binary.
+With this TIP, treasury management can instead be gated behind higher priviledge
+requirements (for example, requiring a higher multisig threshold), while keeping
+every day ops more manageable (by requiring a lower multisig threshold).
+
+## Node Behaviour
+
+When proposing a block, the node determines its fee recipient as follows:
+
+1. Read its entry `v` from the ValidatorConfigV2 using `ValidatorConfig2.validatorByPublicKey`
+   at the chain state of the proposal's parent block.
+2. The public key is determined from the ed25519 signing key passed to the node
+   at startup.
+3. Use `v.feeRecipient` of its entry in `TempoPayloadBuilderAttributes`.
+
+## Relationship with subblock building?
+
+TBD.
+
+## Migration
+
+This TIP will be activated in a future hardfork (TBD). The command line option
+`--consensus.fee-recipient` will be deprecated but still be present during this
+hardfork period and removed in a subsequent hardfork (TBD). The node will behave
+like so, with the contract value taking priority if set.
+
+1. Use `v.feeRecipient` if set to a value that is *not* the zero address `0x0`.
+2. If `v.feeRecipient` is set to the zero address `0x0`, use `--consensus.fee-recipient`.
+3. `--consensus.fee-recipient` will retain a default value of `0x0`.


### PR DESCRIPTION
Proposes to use `ValidatorConfigV2.Validator.feeRecipient` as the `suggestedFeeRecipient` when proposing blocks.