### PR TITLE
fix(ci): remove issue_comment: edited from bench trigger

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,7 +7,7 @@
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
   workflow_dispatch:
     inputs:
       preset:


### PR DESCRIPTION
Previously benches would "run" on every edited comment (even those made by the bench run itself): 
<img width="1319" height="789" alt="Screenshot 2026-03-10 at 11 32 44 AM" src="https://github.com/user-attachments/assets/79b3b37e-01db-4484-967c-3416e8cb596a" />
<img width="1646" height="683" alt="Screenshot 2026-03-10 at 11 40 36 AM" src="https://github.com/user-attachments/assets/e8cce296-11df-4cfa-8090-f672d5e7914d" />


