### PR TITLE
docs(tip-1030): allow same-tick flip orders

### DIFF
--- a/tips/tip-1030.md
+++ b/tips/tip-1030.md
@@ -41,7 +41,7 @@ No new errors.
 # Implications
 
 - **Locked books**: Same-tick flip orders can result in `best_bid_tick == best_ask_tick`. This forecloses any future upgrade that would forbid bids and asks from resting at the same tick, since same-tick flip orders legitimately create that state.
-- **MEV**: Tighter flip orders (where `flipTick` is closer to or equal to `tick`) increase the likelihood of certain kinds of MEV, such as backrunning, since the price at which the new opposite-side order will appear is more predictable.
+- **MEV**: Tighter flip orders (where `flipTick` is closer to or equal to `tick`) increase the likelihood of certain kinds of MEV, such as backrunning, since the new opposite-side order appears at a better price for the backrunner.
 
 # Invariants
 

--- a/tips/tip-1030.md
+++ b/tips/tip-1030.md
@@ -5,17 +5,19 @@ description: Relaxes the placeFlip validation to allow flipTick to equal tick, e
 authors: Dan Robinson
 status: Draft
 related: TIP-1002
+protocolVersion: T5
+supersedes: TIP-1002
 ---
 
 # TIP-1030: Allow same-tick flip orders
 
 ## Abstract
 
-Relaxes the `placeFlip` validation to allow `flipTick == tick`, enabling flip orders that flip to the same price. This is the "allow same-tick flip orders" portion of TIP-1002, without the "prevent crossed orders" change.
+Relaxes the `placeFlip` validation to allow `flipTick == tick`, enabling flip orders that flip to the same price. This supersedes TIP-1002, extracting the "allow same-tick flip orders" portion without the "prevent crossed orders" change.
 
 ## Motivation
 
-Currently, `placeFlip` requires `flipTick` to be strictly on the opposite side of `tick` (e.g., for a bid, `flipTick > tick`). This prevents use cases like instant token convertibility, where an issuer wants to place flip orders on both sides at the same tick to create a stable two-sided market that automatically replenishes when orders are filled.
+Currently, `placeFlip` requires `flipTick` to be strictly on the opposite side of `tick` (e.g., for a bid, `flipTick > tick`). This prevents use cases like instant token convertibility, where someone wants to place flip orders on both sides at the same tick to create a stable two-sided market that automatically replenishes when orders are filled.
 
 ---
 
@@ -35,6 +37,11 @@ No new events.
 ## New errors
 
 No new errors.
+
+# Implications
+
+- **Locked books**: Same-tick flip orders can result in `best_bid_tick == best_ask_tick`. This forecloses any future upgrade that would forbid bids and asks from resting at the same tick, since same-tick flip orders legitimately create that state.
+- **MEV**: Tighter flip orders (where `flipTick` is closer to or equal to `tick`) increase the likelihood of certain kinds of MEV, such as backrunning, since the price at which the new opposite-side order will appear is more predictable.
 
 # Invariants
 

--- a/tips/tip-1030.md
+++ b/tips/tip-1030.md
@@ -28,8 +28,6 @@ The `placeFlip` validation is relaxed to allow `flipTick == tick`:
 - **Current behavior**: For bids, `flipTick > tick` required; for asks, `flipTick < tick` required
 - **New behavior**: For bids, `flipTick >= tick` required; for asks, `flipTick <= tick` required
 
-This applies to both the precompile implementation and the Solidity reference implementation.
-
 ## Events
 
 No new events.

--- a/tips/tip-1030.md
+++ b/tips/tip-1030.md
@@ -1,0 +1,44 @@
+---
+id: TIP-1030
+title: Allow same-tick flip orders
+description: Relaxes the placeFlip validation to allow flipTick to equal tick, enabling flip orders that flip to the same price.
+authors: Dan Robinson
+status: Draft
+related: TIP-1002
+---
+
+# TIP-1030: Allow same-tick flip orders
+
+## Abstract
+
+Relaxes the `placeFlip` validation to allow `flipTick == tick`, enabling flip orders that flip to the same price. This is the "allow same-tick flip orders" portion of TIP-1002, without the "prevent crossed orders" change.
+
+## Motivation
+
+Currently, `placeFlip` requires `flipTick` to be strictly on the opposite side of `tick` (e.g., for a bid, `flipTick > tick`). This prevents use cases like instant token convertibility, where an issuer wants to place flip orders on both sides at the same tick to create a stable two-sided market that automatically replenishes when orders are filled.
+
+---
+
+# Specification
+
+## Modified behavior
+
+The `placeFlip` validation is relaxed to allow `flipTick == tick`:
+
+- **Current behavior**: For bids, `flipTick > tick` required; for asks, `flipTick < tick` required
+- **New behavior**: For bids, `flipTick >= tick` required; for asks, `flipTick <= tick` required
+
+This applies to both the precompile implementation and the Solidity reference implementation.
+
+## Events
+
+No new events.
+
+## New errors
+
+No new errors.
+
+# Invariants
+
+- Flip orders with `flipTick == tick` are accepted and behave like any other flip order
+- Flip orders with `flipTick` strictly on the wrong side of `tick` are still rejected


### PR DESCRIPTION
Adds TIP-1030, which is the "allow same-tick flip orders" portion of TIP-1002 without the "prevent crossed orders" change.

Relaxes `placeFlip` validation so `flipTick == tick` is allowed, enabling use cases like instant token convertibility where an issuer places flip orders on both sides at the same tick.

Prompted by: Dan