### PR TITLE
chore(ci): remove tons of Setting user token logs in bloat bench

### DIFF
--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -801,8 +801,11 @@ fn initialize_fee_manager(
             fee_manager
                 .initialize()
                 .expect("Could not init fee manager");
+            println!(
+                "Setting user fee token {user_fee_token_address} for {} accounts",
+                initial_accounts.len()
+            );
             for address in initial_accounts.iter().progress() {
-                println!("Setting user token for {user_fee_token_address}");
                 fee_manager
                     .set_user_token(
                         *address,


### PR DESCRIPTION
https://github.com/tempoxyz/tempo/actions/runs/22911326605/job/66484303423

there are tons of "setting user token" logs:
```
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
Setting user token for 0x20C0000000000000000000000000000000000001
```

I think the logs were bugged in the first place since they should have used the actual user address that they were setting the user token for, rather than the user token being set. But even then I think they would be too noisy.