### PR TITLE
docs(tip-1016): set execution gas floor to pre-TIP-1000 costs

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -23,10 +23,11 @@ TIP-1000 increased storage creation costs to 250,000 gas per operation and 1,000
    - Keep general gas limit at 30M (would prefer lower)
    - Limit contract code to 1,000 gas/byte (would prefer 2,500)
 
-2. **New account throughput penalty**: TIP-20 transfer to new address costs 271,000 gas total (41k execution + 230k storage) vs 24,000 gas to existing. At 500M payment lane gas limit:
-    - With storage creation gas: only 1,847 new account transfers/block = 3,694 TPS
-    - Without storage creation gas: ~12,000 new account transfers/block = ~24,000 TPS
-    - ~6x throughput improvement by exempting storage creation gas from limits
+2. **New account throughput penalty**: TIP-20 transfer to new address costs ~300,000 gas total (~70k execution + 230k storage) vs ~50,000 gas to existing. At 500M payment lane gas limit:
+    - With storage creation gas counting: only ~1,700 new account transfers/block = ~3,400 TPS
+    - Without storage creation gas counting: ~7,100 new account transfers/block = ~14,200 TPS
+    - Existing account transfers: ~10,000 transfers/block = ~20,000 TPS
+    - ~4x throughput improvement for new accounts by exempting storage creation gas from limits
 
 The root cause: storage creation gas counts against limits designed for execution time constraints. Storage creation is permanent (disk) not ephemeral (CPU), and shouldn't be bounded by per-block execution limits.
 
@@ -108,26 +109,26 @@ Example for 24KB contract:
 ## Examples
 
 ### TIP-20 Transfer to New Address
-- Transfer logic: ~21,000 execution gas
+- Transfer logic: ~50,000 execution gas
 - New balance slot: 20,000 execution gas + 230,000 storage creation gas
-- **Total**: 41,000 execution gas + 230,000 storage creation gas = 271,000 gas
-- User must authorize: `gas_limit >= 271,000`
-- Counts toward block limit: 41,000 execution gas
-- Total cost: 271,000 gas
+- **Total**: ~70,000 execution gas + 230,000 storage creation gas = ~300,000 gas
+- User must authorize: `gas_limit >= 300,000`
+- Counts toward block limit: ~70,000 execution gas
+- Total cost: ~300,000 gas
 
 ### TIP-20 Transfer to Existing Address
-- Transfer logic: ~21,000 execution gas
-- Update existing slot: ~2,900 execution gas (hot SSTORE)
-- **Total**: ~24,000 execution gas
-- User must authorize: `gas_limit >= 24,000`
-- Counts toward block limit: ~24,000 execution gas
-- Total cost: ~24,000 gas
+- Transfer logic: ~50,000 execution gas
+- Update existing slot: included in transfer logic
+- **Total**: ~50,000 execution gas
+- User must authorize: `gas_limit >= 50,000`
+- Counts toward block limit: ~50,000 execution gas
+- Total cost: ~50,000 gas
 
 ### Block Throughput
 At 500M payment lane execution gas limit:
-- New account transfers: ~41k execution gas each → ~12,000 transfers/block
-- Existing account transfers: ~24k execution gas each → ~21,000 transfers/block
-- ~16,000 TPS on average (vs 3,334 TPS in TIP-1000)
+- New account transfers: ~70k execution gas each → ~7,100 transfers/block
+- Existing account transfers: ~50k execution gas each → ~10,000 transfers/block
+- ~8,500 TPS on average (vs ~3,400 TPS without exemption)
 - Storage creation gas doesn't reduce block capacity
 
 ---
@@ -169,7 +170,7 @@ At 500M payment lane execution gas limit:
 
 1. **Higher contract code pricing**: 2,500 gas/byte (vs 1,000) provides better state growth protection ($50M for 1TB vs $20M)
 2. **Lower protocol transaction limit**: Can use 16M max_transaction_gas_limit while deploying 24KB contracts (~7M execution gas counts)
-3. **Better throughput for new accounts**: ~12,000 new account transfers/block vs 1,847 in TIP-1000 (~6x improvement)
+3. **Better throughput for new accounts**: ~7,100 new account transfers/block vs ~1,700 without exemption (~4x improvement)
 4. **Accounts for computational cost**: Storage operations still charge execution gas for writing/hashing (not completely free)
 5. **No surprise costs**: User's `gas_limit` still bounds total cost (no griefing)
 6. **No complexity**: Single gas unit, one basefee, existing transaction format works
@@ -178,8 +179,8 @@ At 500M payment lane execution gas limit:
 
 | Operation | TIP-1000 Cost | TIP-1016 Cost |
 |-----------|---------------|---------------|
-| TIP-20 transfer (existing) | ~50k gas = 0.1 cent (1,000 microdollars) | ~24k gas = 0.05 cent (500 microdollars) |
-| TIP-20 transfer (new) | ~300k gas = 0.6 cent (6,000 microdollars) | ~271k gas = 0.54 cent (5,420 microdollars) |
+| TIP-20 transfer (existing) | ~50k gas = 0.1 cent (1,000 microdollars) | ~50k gas = 0.1 cent (1,000 microdollars) |
+| TIP-20 transfer (new) | ~300k gas = 0.6 cent (6,000 microdollars) | ~300k gas = 0.6 cent (6,000 microdollars) |
 | 1KB contract | ~1.75M gas = 3.5 cents (35,000 microdollars) | ~3.25M gas = 6.5 cents (65,000 microdollars) |
 | 24KB contract | ~30M gas = 60 cents (600,000 microdollars) | ~64M gas = 128 cents (1,280,000 microdollars) |
 


### PR DESCRIPTION
Execution gas for storage creation operations in TIP-1016 was set to arbitrary low values (5,000). This bumps them to at least the pre-TIP-1000 standard EVM costs so that exempting storage gas from protocol limits never makes an operation cheaper against limits than it was before TIP-1000.

| Operation | Old Exec | New Exec | Storage | Total |
|-----------|----------|----------|---------|-------|
| Cold SSTORE | 5,000 | 20,000 | 230,000 | 250,000 |
| Account creation | 5,000 | 25,000 | 225,000 | 250,000 |
| Contract metadata | 5,000 | 32,000 | 468,000 | 500,000 |
| Code per byte | 200 | 200 | 2,300 | 2,500 |

Adds invariant 9 (Execution Gas Floor) and updates all derived numbers (throughput, examples, motivation).

Prompted by: dankrad