### PR TITLE
fix: make --follow conflict with --telemetry-url

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -67,7 +67,7 @@ type TempoCli =
 struct TempoArgs {
     /// Follow this specific RPC node for block hashes.
     /// If provided without a value, defaults to the RPC URL for the selected chain.
-    #[arg(long, value_name = "URL", default_missing_value = "auto", num_args(0..=1), env = "TEMPO_FOLLOW")]
+    #[arg(long, value_name = "URL", default_missing_value = "auto", num_args(0..=1), env = "TEMPO_FOLLOW", conflicts_with = "telemetry_url")]
     pub follow: Option<String>,
 
     #[command(flatten)]


### PR DESCRIPTION
Follow nodes don't run consensus so they shouldn't send telemetry to the partner VM stack — they'd produce duplicate logs/metrics alongside the actual validator.

Adds `conflicts_with = "telemetry_url"` to the `--follow` arg so clap rejects the combination at startup.

Prompted by: joshie