### PR TITLE
feat(builder): add slow build/tx warnings and gas utilization metrics

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -62,11 +62,14 @@ use tempo_transaction_pool::{
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
 
-/// Threshold above which a single transaction execution emits a warning.
+/// Threshold above which a single transaction execution is counted as slow.
 const SLOW_TX_THRESHOLD: Duration = Duration::from_millis(50);
 
 /// Threshold above which the entire payload build emits a detailed warning.
 const SLOW_BUILD_THRESHOLD: Duration = Duration::from_millis(500);
+
+/// Maximum number of individual slow transactions to log per payload build.
+const MAX_SLOW_TX_LOGS: usize = 3;
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -383,6 +386,8 @@ where
         ));
 
         let execution_start = Instant::now();
+        let mut slow_tx_count: usize = 0;
+        let mut slowest_tx_elapsed = Duration::ZERO;
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
@@ -489,12 +494,18 @@ where
                 .transaction_execution_duration_seconds
                 .record(elapsed);
             if elapsed > SLOW_TX_THRESHOLD {
-                warn!(
-                    tx_hash = %pool_tx.hash(),
-                    gas_used,
-                    ?elapsed,
-                    "slow transaction execution"
-                );
+                slow_tx_count += 1;
+                if elapsed > slowest_tx_elapsed {
+                    slowest_tx_elapsed = elapsed;
+                }
+                if slow_tx_count <= MAX_SLOW_TX_LOGS {
+                    warn!(
+                        tx_hash = %pool_tx.hash(),
+                        gas_used,
+                        ?elapsed,
+                        "slow transaction execution"
+                    );
+                }
             }
             trace!(?elapsed, "Transaction executed");
 
@@ -507,6 +518,14 @@ where
             block_size_used += tx_rlp_length;
         }
         drop(_block_fill_span);
+        if slow_tx_count > MAX_SLOW_TX_LOGS {
+            warn!(
+                slow_tx_count,
+                suppressed = slow_tx_count - MAX_SLOW_TX_LOGS,
+                ?slowest_tx_elapsed,
+                "additional slow transactions suppressed"
+            );
+        }
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -42,7 +42,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
@@ -61,6 +61,12 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
+
+/// Threshold above which a single transaction execution emits a warning.
+const SLOW_TX_THRESHOLD: Duration = Duration::from_millis(50);
+
+/// Threshold above which the entire payload build emits a detailed warning.
+const SLOW_BUILD_THRESHOLD: Duration = Duration::from_millis(500);
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -258,9 +264,10 @@ where
             .with_bundle_update()
             .build();
         drop(_state_setup_span);
+        let state_setup_elapsed = state_setup_start.elapsed();
         self.metrics
             .state_setup_duration_seconds
-            .record(state_setup_start.elapsed());
+            .record(state_setup_elapsed);
 
         let chain_spec = self.provider.chain_spec();
         let is_osaka = self
@@ -481,6 +488,14 @@ where
             self.metrics
                 .transaction_execution_duration_seconds
                 .record(elapsed);
+            if elapsed > SLOW_TX_THRESHOLD {
+                warn!(
+                    tx_hash = %pool_tx.hash(),
+                    gas_used,
+                    ?elapsed,
+                    "slow transaction execution"
+                );
+            }
             trace!(?elapsed, "Transaction executed");
 
             // update and add to total fees
@@ -644,6 +659,35 @@ where
         self.metrics
             .rlp_block_size_bytes_last
             .set(rlp_length as f64);
+
+        // Gas utilization breakdown
+        let gas_utilization = gas_used as f64 / block_gas_limit as f64;
+        self.metrics.gas_utilization_ratio.set(gas_utilization);
+        self.metrics
+            .non_shared_gas_used
+            .set(cumulative_gas_used as f64);
+        // Subblock gas is the portion of total gas consumed by validator subblock transactions.
+        // cumulative_gas_used only tracks proposer pool txs, so the difference is subblock gas.
+        let shared_gas_used_amount = gas_used.saturating_sub(cumulative_gas_used);
+        self.metrics
+            .shared_gas_used
+            .set(shared_gas_used_amount as f64);
+
+        if elapsed > SLOW_BUILD_THRESHOLD {
+            warn!(
+                ?elapsed,
+                ?state_setup_elapsed,
+                ?total_normal_transaction_execution_elapsed,
+                ?total_subblock_transaction_execution_elapsed,
+                ?system_txs_execution_elapsed,
+                ?builder_finish_elapsed,
+                gas_used,
+                gas_utilization = format_args!("{:.1}%", gas_utilization * 100.0),
+                subblocks_count,
+                total_transactions,
+                "Slow payload build"
+            );
+        }
 
         info!(
             parent_hash = ?sealed_block.parent_hash(),

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -68,9 +68,6 @@ const SLOW_TX_THRESHOLD: Duration = Duration::from_millis(50);
 /// Threshold above which the entire payload build emits a detailed warning.
 const SLOW_BUILD_THRESHOLD: Duration = Duration::from_millis(500);
 
-/// Maximum number of individual slow transactions to log per payload build.
-const MAX_SLOW_TX_LOGS: usize = 3;
-
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
     subblock.transactions.iter().any(|tx| {
@@ -386,8 +383,6 @@ where
         ));
 
         let execution_start = Instant::now();
-        let mut slow_tx_count: usize = 0;
-        let mut slowest_tx_elapsed = Duration::ZERO;
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
@@ -494,18 +489,12 @@ where
                 .transaction_execution_duration_seconds
                 .record(elapsed);
             if elapsed > SLOW_TX_THRESHOLD {
-                slow_tx_count += 1;
-                if elapsed > slowest_tx_elapsed {
-                    slowest_tx_elapsed = elapsed;
-                }
-                if slow_tx_count <= MAX_SLOW_TX_LOGS {
-                    warn!(
-                        tx_hash = %pool_tx.hash(),
-                        gas_used,
-                        ?elapsed,
-                        "slow transaction execution"
-                    );
-                }
+                warn!(
+                    tx_hash = %pool_tx.hash(),
+                    gas_used,
+                    ?elapsed,
+                    "slow transaction execution"
+                );
             }
             trace!(?elapsed, "Transaction executed");
 
@@ -518,14 +507,6 @@ where
             block_size_used += tx_rlp_length;
         }
         drop(_block_fill_span);
-        if slow_tx_count > MAX_SLOW_TX_LOGS {
-            warn!(
-                slow_tx_count,
-                suppressed = slow_tx_count - MAX_SLOW_TX_LOGS,
-                ?slowest_tx_elapsed,
-                "additional slow transactions suppressed"
-            );
-        }
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds
@@ -679,18 +660,8 @@ where
             .rlp_block_size_bytes_last
             .set(rlp_length as f64);
 
-        // Gas utilization breakdown
         let gas_utilization = gas_used as f64 / block_gas_limit as f64;
         self.metrics.gas_utilization_ratio.set(gas_utilization);
-        self.metrics
-            .non_shared_gas_used
-            .set(cumulative_gas_used as f64);
-        // Subblock gas is the portion of total gas consumed by validator subblock transactions.
-        // cumulative_gas_used only tracks proposer pool txs, so the difference is subblock gas.
-        let shared_gas_used_amount = gas_used.saturating_sub(cumulative_gas_used);
-        self.metrics
-            .shared_gas_used
-            .set(shared_gas_used_amount as f64);
 
         if elapsed > SLOW_BUILD_THRESHOLD {
             warn!(

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -77,10 +77,6 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
     /// Block gas utilization ratio (gas_used / gas_limit).
     pub(crate) gas_utilization_ratio: Gauge,
-    /// Gas used by proposer pool transactions (non-shared).
-    pub(crate) non_shared_gas_used: Gauge,
-    /// Gas used by validator subblock transactions (shared).
-    pub(crate) shared_gas_used: Gauge,
 }
 
 impl TempoPayloadBuilderMetrics {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -75,6 +75,12 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) hashed_post_state_duration_seconds: Histogram,
     /// Time to compute the state root and trie updates via `state_root_with_updates`.
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
+    /// Block gas utilization ratio (gas_used / gas_limit).
+    pub(crate) gas_utilization_ratio: Gauge,
+    /// Gas used by proposer pool transactions (non-shared).
+    pub(crate) non_shared_gas_used: Gauge,
+    /// Gas used by validator subblock transactions (shared).
+    pub(crate) shared_gas_used: Gauge,
 }
 
 impl TempoPayloadBuilderMetrics {


### PR DESCRIPTION
Adds three builder performance observability features:

**1. Slow build warning** — when `payload_build_duration_seconds` exceeds 500ms, emits a structured `warn!` with per-phase breakdown (state setup, normal tx exec, subblock tx exec, system tx exec, finalization, gas utilization). All timers already existed — this just adds conditional logging.

**2. Slow transaction warning** — when a single tx execution exceeds 50ms, emits a `warn!` with tx hash and gas used so problematic contracts are identified immediately.

**3. Gas utilization metrics**:

| Metric | Type | What |
|--------|------|------|
| `tempo_payload_builder_gas_utilization_ratio` | Gauge | `gas_used / gas_limit` — block fullness |
| `tempo_payload_builder_non_shared_gas_used` | Gauge | Gas consumed by proposer pool transactions |
| `tempo_payload_builder_shared_gas_used` | Gauge | Gas consumed by validator subblock + system transactions |

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk