### PR TITLE
chore(cli): init tracing in init-from-binary-dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11945,6 +11945,7 @@ dependencies = [
  "reth-provider",
  "reth-rpc-server-types",
  "reth-storage-api",
+ "reth-tracing",
  "rustls",
  "serde",
  "serde_json",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -60,6 +60,7 @@ reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-rpc-server-types.workspace = true
 reth-storage-api.workspace = true
+reth-tracing.workspace = true
 clap.workspace = true
 eyre.workspace = true
 jiff.workspace = true

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -16,6 +16,7 @@ use commonware_math::algebra::Random as _;
 use commonware_utils::NZU64;
 use eyre::{OptionExt as _, Report, WrapErr as _, eyre};
 use reth_cli_runner::CliRunner;
+use reth_tracing::Tracer;
 use reth_ethereum_cli::ExtendedCommand;
 use serde::Serialize;
 use tempo_alloy::TempoNetwork;
@@ -81,6 +82,7 @@ impl ExtendedCommand for TempoSubcommand {
         match self {
             Self::Consensus(cmd) => cmd.run(),
             Self::InitFromBinaryDump(cmd) => {
+                reth_tracing::RethTracer::new().init()?;
                 runner.run_blocking_until_ctrl_c(cmd.execute::<tempo_node::node::TempoNode>())?;
                 Ok(())
             }


### PR DESCRIPTION
This command uses `info!` / tracing logs, but tracing was never initialized, this initializes tracing so we see the logs