### PR TITLE
fix(test): handle pool rejection in testnet 

### DIFF
--- a/crates/node/tests/it/tempo_transaction/testnet.rs
+++ b/crates/node/tests/it/tempo_transaction/testnet.rs
@@ -121,10 +121,21 @@ impl super::types::TestEnv for Testnet {
         encoded: Vec<u8>,
         tx_hash: B256,
     ) -> eyre::Result<()> {
-        let _ = self
+        // Pool validation may now reject txs that were previously only excluded
+        // by the builder (e.g. duplicate key_authorization). A pool rejection is
+        // a stricter form of exclusion, so treat it as success.
+        let send_result = self
             .provider
             .raw_request::<_, B256>("eth_sendRawTransaction".into(), [encoded])
-            .await?;
+            .await;
+        if let Err(e) = send_result {
+            let err = e.to_string();
+            assert!(
+                err.contains("already exists") || err.contains("spending limit exceeded"),
+                "Expected pool validation rejection, got: {e}"
+            );
+            return Ok(());
+        }
 
         // Verify the tx is known to the RPC (confirms it entered the mempool).
         let tx_obj: Option<serde_json::Value> = self


### PR DESCRIPTION
Pool validation now catches duplicate key_authorization at RPC time instead of letting the tx enter the pool and be excluded by the builder. A pool rejection is a stricter form of exclusion, so treat it as a passing outcome after verifying the error is a validation rejection.

Amp-Thread-ID: https://ampcode.com/threads/T-019ce316-195e-7549-9ee2-c9c289cd33a7