### PR TITLE
docs: add TIP-1032 issuer orders spec

### DIFF
--- a/tips/tip-1032.md
+++ b/tips/tip-1032.md
@@ -1,0 +1,180 @@
+---
+id: TIP-1032
+title: Issuer Orders
+description: Extends the stablecoin DEX with issuer orders that mint on fill and burn on receive, enabling zero-capital market making by token issuers.
+authors: Dan Robinson
+status: Draft
+related: N/A
+protocolVersion: TBD
+---
+
+# TIP-1032: Issuer Orders
+
+## Abstract
+
+This specification extends the stablecoin DEX with **issuer orders**, a special order type that allows token issuers to provide liquidity without locking capital. An issuer order can be placed by the issuer of the base token, the quote token, or both. When an issuer provides their token on an order, it is minted on-demand when filled rather than escrowed upfront. When an issuer receives their token on an order, it is immediately burned rather than credited to their balance. Issuer orders integrate with the existing flip order mechanism, enabling perpetual mint/burn market-making strategies.
+
+## Motivation
+
+Stablecoin issuers often want to provide liquidity for their token without tying up large amounts of capital in resting orders. Traditional orders require the maker to escrow tokens upfront, forcing issuers to pre-mint tokens they may never sell and creating operational complexity in managing reserves across multiple price levels.
+
+Issuer orders solve this by allowing the issuer to commit to mint tokens at specific prices. The tokens only come into existence when someone trades against the order. The symmetric burn-on-receive behavior enables issuers to run perpetual two-sided markets that mint on one side and burn on the other, maintaining price stability without accumulating inventory.
+
+When the maker is the issuer of both the base and quote tokens, they can run a completely capital-free market, minting one token and burning the other on every fill.
+
+# Specification
+
+## Issuer order behavior
+
+An issuer order carries two boolean flags: `isBaseIssuer` and `isQuoteIssuer`. Each flag independently controls the mint/burn behavior for that token based on the order side.
+
+When `isBaseIssuer` is true on an ask order (selling base), no base token escrow is required at placement. When the order is filled, the DEX mints base tokens on-demand and delivers them to the taker using the DEX's normal settlement mechanism (e.g. mint-to-DEX then transfer to the taker). When `isBaseIssuer` is true on a bid order (buying base), the base tokens that would normally be credited to the maker are instead burned.
+
+When `isQuoteIssuer` is true on a bid order (paying with quote), no quote token escrow is required at placement. When the order is filled, the DEX mints quote tokens on-demand and uses them to pay the taker. When `isQuoteIssuer` is true on an ask order (receiving quote), the quote tokens that would normally be credited to the maker are instead burned.
+
+Both flags can be true simultaneously. When both are set, an ask order mints base tokens for the taker and burns the quote tokens received, while a bid order burns the base tokens received and mints quote tokens for the taker. This enables zero-capital market making where the issuer never holds inventory of either token.
+
+If minting would exceed a token's supply cap, the order partially fills up to the remaining mintable amount.
+
+## Escrow behavior
+
+The escrow requirement depends on the combination of flags and order side. For ask orders, base tokens are escrowed unless `isBaseIssuer` is true. For bid orders, quote tokens are escrowed unless `isQuoteIssuer` is true. When both conditions align (base issuer ask or quote issuer bid), no escrow is required at all.
+
+Cancellation refunds any escrowed tokens. For orders with no escrow, cancellation simply removes the order from the book.
+
+## Settlement and accounting
+
+Issuer orders MUST integrate with the DEX's existing settlement model.
+
+- **Minting**: to deliver output tokens to the taker, implementations SHOULD mint to the DEX contract address and then use the DEX's normal payout mechanism to the taker.
+- **Burning**: when an issuer order burns tokens "received" by the issuer, the DEX MUST burn the tokens that would otherwise have been credited to the maker. Concretely, under a typical settlement model where the DEX contract custody holds trade proceeds, this means burning from the DEX contract's own balance rather than crediting the maker.
+
+## Authorization
+
+The DEX verifies that the maker has the appropriate `ISSUER_ROLE` at placement time. If `isBaseIssuer` is true, the maker must have `ISSUER_ROLE` on the base token. If `isQuoteIssuer` is true, the maker must have `ISSUER_ROLE` on the quote token. If both flags are true, both roles are required.
+
+Issuer role status is also enforced at fill time (including at flip time). If a fill would require minting or burning as an issuer for a token, then at the time of the fill the maker MUST still hold `ISSUER_ROLE` for that token.
+
+If the required role check fails at fill time, the issuer order fill MUST revert (i.e. issuer orders can fail at fill time due to role revocation).
+
+To handle issuer role transitions, anyone may cancel an issuer order whose maker no longer holds the required `ISSUER_ROLE`(s). The `cancelStaleIssuerOrder` function checks the maker's current role status for each applicable token and, if any required role has been revoked, cancels the order and refunds any escrowed tokens.
+
+## Order representation
+
+The `Order` struct gains two new boolean fields:
+
+```solidity
+struct Order {
+    uint128 orderId;
+    address maker;
+    bytes32 bookKey;
+    bool isBid;
+    int16 tick;
+    uint128 amount;
+    uint128 remaining;
+    uint128 prev;
+    uint128 next;
+    bool isFlip;
+    int16 flipTick;
+    bool isBaseIssuer;
+    bool isQuoteIssuer;
+}
+```
+
+## Flip order integration
+
+Issuer orders fully support the flip mechanism. When an issuer flip order is fully filled, the newly created order on the opposite side preserves both `isBaseIssuer` and `isQuoteIssuer` flags. This enables perpetual mint/burn cycles where the issuer order behavior is consistent across all flips.
+
+If flipping would create an invalid issuer order (e.g. the maker no longer holds the required `ISSUER_ROLE`(s) for the issuer flags), the flip MUST silently fail and no new order is created.
+
+## Quoting
+
+Issuer orders appear as regular liquidity in the orderbook. The `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` functions do not distinguish between regular and issuer orders; they sum available liquidity at each tick regardless of order type.
+
+Because issuer orders depend on external token state (issuer roles, transfer policy checks, and supply caps), quotes MAY be inaccurate. In particular, quotes do not account for:
+
+- role revocations that cause issuer orders to revert at fill time,
+- transfer policy changes that block mint recipients, or
+- supply caps that limit mintable output.
+
+## Interface
+
+### Issuer order placement
+
+```solidity
+function placeIssuer(address token, uint128 amount, bool isBid, int16 tick, bool isBaseIssuer, bool isQuoteIssuer) external returns (uint128 orderId);
+```
+
+Places an issuer limit order against the pair of `token` and its quote. At least one of `isBaseIssuer` or `isQuoteIssuer` must be true. The caller must have `ISSUER_ROLE` on the base token if `isBaseIssuer` is true, and on the quote token if `isQuoteIssuer` is true. Escrow is taken only for tokens where the caller is not acting as issuer.
+
+```solidity
+function placeIssuerFlip(address token, uint128 amount, bool isBid, int16 tick, int16 flipTick, bool isBaseIssuer, bool isQuoteIssuer) external returns (uint128 orderId);
+```
+
+Like `placeIssuer`, but marks the order as a flip order. When fully filled, a new issuer order is placed on the opposite side at `flipTick` with the same issuer flags. The flip tick constraints match regular flip orders.
+
+### Stale order cancellation
+
+```solidity
+function cancelStaleIssuerOrder(uint128 orderId) external;
+```
+
+Cancels an issuer order whose maker no longer has the required `ISSUER_ROLE`(s). Can be called by anyone. Reverts if the order has no issuer flags set or if the maker still holds all required roles.
+
+### Events
+
+The existing `OrderPlaced` and `FlipOrderPlaced` events gain `isBaseIssuer` and `isQuoteIssuer` fields:
+
+```solidity
+event OrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, bool isBaseIssuer, bool isQuoteIssuer);
+event FlipOrderPlaced(uint128 indexed orderId, address indexed maker, address indexed token, uint128 amount, bool isBid, int16 tick, int16 flipTick, bool isBaseIssuer, bool isQuoteIssuer);
+```
+
+The `OrderFilled` and `OrderCancelled` events remain unchanged.
+
+### Errors
+
+```solidity
+error NotTokenIssuer();
+error IssuerOrderNotStale();
+error NotIssuerOrder();
+```
+
+`NotTokenIssuer` is returned when attempting to place an issuer order without the required `ISSUER_ROLE`(s). `IssuerOrderNotStale` is returned when attempting to cancel an issuer order whose maker still has all required roles. `NotIssuerOrder` is returned when calling `cancelStaleIssuerOrder` on an order with neither issuer flag set.
+
+## Implementation notes
+
+Issuer order mint/burn MUST be authorized as the specific maker address (the issuer), not as the DEX itself.
+
+To support this safely without granting the DEX blanket issuer privileges, TIP-20 tokens used with issuer orders SHOULD expose DEX-only entrypoints that accept an explicit `issuer` argument:
+
+```solidity
+function mintByExchange(address issuer, address to, uint256 amount) external;
+function burnByExchange(address issuer, address from, uint256 amount) external;
+```
+
+These functions MUST:
+
+- only be callable by the Stablecoin DEX contract, and
+- enforce that `issuer` has `ISSUER_ROLE` for the token.
+
+When filling an order with `isBaseIssuer` true, the DEX either mints base tokens (for asks) or burns base tokens (for bids) using these DEX-only entrypoints with `issuer = order.maker`. The same logic applies symmetrically for `isQuoteIssuer` and quote tokens.
+
+Minted tokens are subject to the token's transfer policy and supply cap. If the recipient is blocked by the transfer policy, the fill fails. If minting would exceed the supply cap, the order partially fills up to the remaining mintable amount (i.e. the DEX clamps the fill to a mintable amount rather than attempting a mint that would revert).
+
+# Invariants
+
+## Trade-offs and broken invariants
+
+Issuer orders intentionally break a prior invariant that **fills cannot fail at fill time**. Specifically, issuer order fills may revert due to:
+
+- the maker's issuer privileges being revoked between placement and fill time, and/or
+- external token state that affects mint/burn outcomes (e.g. supply cap exhaustion or transfer-policy checks).
+
+As a result, it may not be possible to compute a strict upper bound on gas usage for a DEX swap purely from the swap size and number of hops: walking the book may encounter issuer orders that revert at fill time, causing the swap to fail after consuming additional gas.
+
+## Example
+
+An issuer controls both baseUSD and quoteUSD tokens. They want to run a capital-free spread. They call `placeIssuerFlip(baseUSD, 1_000_000, false, -10, 10, true, true)` to place an issuer ask at tick -10 with a flip tick of +10. No escrow is taken since both issuer flags are true.
+
+When a taker buys 1M baseUSD against this order, the DEX mints 1M baseUSD (typically to the DEX itself and then settles it to the taker) and burns the quoteUSD received as payment (typically from the DEX's custody balance rather than crediting the maker). The order flips to an issuer bid at tick +10. When a different taker sells baseUSD against this bid, the DEX burns the received baseUSD and mints quoteUSD to pay the seller. The order flips back to an ask at tick -10, and the cycle continues indefinitely with no capital requirements.

--- a/tips/tip-1032.md
+++ b/tips/tip-1032.md
@@ -53,11 +53,9 @@ Issuer orders MUST integrate with the DEX's existing settlement model.
 
 The DEX verifies that the maker has the appropriate `ISSUER_ROLE` at placement time. If `isBaseIssuer` is true, the maker must have `ISSUER_ROLE` on the base token. If `isQuoteIssuer` is true, the maker must have `ISSUER_ROLE` on the quote token. If both flags are true, both roles are required.
 
-Issuer role status is also enforced at fill time (including at flip time). If a fill would require minting or burning as an issuer for a token, then at the time of the fill the maker MUST still hold `ISSUER_ROLE` for that token.
+Issuer role status is also checked at fill time (including at flip time). If a fill would require minting or burning as an issuer for a token, but the maker no longer holds `ISSUER_ROLE` for that token, the DEX MUST skip the order: it is cancelled in-place (with any escrowed tokens refunded to the maker) and the swap continues walking the book to the next order. The fill MUST NOT revert.
 
-If the required role check fails at fill time, the issuer order fill MUST revert (i.e. issuer orders can fail at fill time due to role revocation).
-
-To handle issuer role transitions, anyone may cancel an issuer order whose maker no longer holds the required `ISSUER_ROLE`(s). The `cancelStaleIssuerOrder` function checks the maker's current role status for each applicable token and, if any required role has been revoked, cancels the order and refunds any escrowed tokens.
+The existing `cancelStaleOrder` function is extended to also check issuer role validity. For issuer orders, the order is considered stale if the maker no longer holds the required `ISSUER_ROLE`(s) for any token where an issuer flag is set. Anyone may call `cancelStaleOrder` on such an order to cancel it and refund any escrowed tokens.
 
 ## Order representation
 
@@ -85,15 +83,15 @@ struct Order {
 
 Issuer orders fully support the flip mechanism. When an issuer flip order is fully filled, the newly created order on the opposite side preserves both `isBaseIssuer` and `isQuoteIssuer` flags. This enables perpetual mint/burn cycles where the issuer order behavior is consistent across all flips.
 
-If flipping would create an invalid issuer order (e.g. the maker no longer holds the required `ISSUER_ROLE`(s) for the issuer flags), the flip MUST silently fail and no new order is created.
+If the maker no longer holds the required `ISSUER_ROLE`(s) at flip time, the flip MUST silently fail and no new order is created.
 
 ## Quoting
 
 Issuer orders appear as regular liquidity in the orderbook. The `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` functions do not distinguish between regular and issuer orders; they sum available liquidity at each tick regardless of order type.
 
-Because issuer orders depend on external token state (issuer roles, transfer policy checks, and supply caps), quotes MAY be inaccurate. In particular, quotes do not account for:
+Because issuer orders depend on external token state (issuer roles, transfer policy checks, and supply caps), quotes MAY overestimate available liquidity. In particular, quotes do not account for:
 
-- role revocations that cause issuer orders to revert at fill time,
+- role revocations that cause issuer orders to be skipped at fill time,
 - transfer policy changes that block mint recipients, or
 - supply caps that limit mintable output.
 
@@ -113,14 +111,6 @@ function placeIssuerFlip(address token, uint128 amount, bool isBid, int16 tick, 
 
 Like `placeIssuer`, but marks the order as a flip order. When fully filled, a new issuer order is placed on the opposite side at `flipTick` with the same issuer flags. The flip tick constraints match regular flip orders.
 
-### Stale order cancellation
-
-```solidity
-function cancelStaleIssuerOrder(uint128 orderId) external;
-```
-
-Cancels an issuer order whose maker no longer has the required `ISSUER_ROLE`(s). Can be called by anyone. Reverts if the order has no issuer flags set or if the maker still holds all required roles.
-
 ### Events
 
 The existing `OrderPlaced` and `FlipOrderPlaced` events gain `isBaseIssuer` and `isQuoteIssuer` fields:
@@ -136,11 +126,9 @@ The `OrderFilled` and `OrderCancelled` events remain unchanged.
 
 ```solidity
 error NotTokenIssuer();
-error IssuerOrderNotStale();
-error NotIssuerOrder();
 ```
 
-`NotTokenIssuer` is returned when attempting to place an issuer order without the required `ISSUER_ROLE`(s). `IssuerOrderNotStale` is returned when attempting to cancel an issuer order whose maker still has all required roles. `NotIssuerOrder` is returned when calling `cancelStaleIssuerOrder` on an order with neither issuer flag set.
+`NotTokenIssuer` is returned when attempting to place an issuer order without the required `ISSUER_ROLE`(s).
 
 ## Implementation notes
 
@@ -160,18 +148,15 @@ These functions MUST:
 
 When filling an order with `isBaseIssuer` true, the DEX either mints base tokens (for asks) or burns base tokens (for bids) using these DEX-only entrypoints with `issuer = order.maker`. The same logic applies symmetrically for `isQuoteIssuer` and quote tokens.
 
-Minted tokens are subject to the token's transfer policy and supply cap. If the recipient is blocked by the transfer policy, the fill fails. If minting would exceed the supply cap, the order partially fills up to the remaining mintable amount (i.e. the DEX clamps the fill to a mintable amount rather than attempting a mint that would revert).
+Minted tokens are subject to the token's transfer policy and supply cap. If minting would exceed the supply cap, the order partially fills up to the remaining mintable amount. If the remaining mintable amount is zero, or if the recipient is blocked by the transfer policy, the order is skipped (cancelled in-place) and the swap continues to the next order.
 
 # Invariants
 
-## Trade-offs and broken invariants
+## Preserved invariants
 
-Issuer orders intentionally break a prior invariant that **fills cannot fail at fill time**. Specifically, issuer order fills may revert due to:
+Issuer orders preserve the invariant that **fills never revert**. When the DEX encounters an issuer order that cannot be filled (due to role revocation, supply cap exhaustion, or transfer policy restrictions), it skips the order by cancelling it in-place and continues walking the book. Swaps may receive less output than quoted if issuer orders are skipped, but the swap itself always succeeds.
 
-- the maker's issuer privileges being revoked between placement and fill time, and/or
-- external token state that affects mint/burn outcomes (e.g. supply cap exhaustion or transfer-policy checks).
-
-As a result, it may not be possible to compute a strict upper bound on gas usage for a DEX swap purely from the swap size and number of hops: walking the book may encounter issuer orders that revert at fill time, causing the swap to fail after consuming additional gas.
+Gas usage remains bounded: skipped orders consume gas for the role check and cancellation but do not cause the overall swap to revert.
 
 ## Example
 

--- a/tips/tip-1032.md
+++ b/tips/tip-1032.md
@@ -34,7 +34,7 @@ When `isQuoteIssuer` is true on a bid order (paying with quote), no quote token 
 
 Both flags can be true simultaneously. When both are set, an ask order mints base tokens for the taker and burns the quote tokens received, while a bid order burns the base tokens received and mints quote tokens for the taker. This enables zero-capital market making where the issuer never holds inventory of either token.
 
-If minting would exceed a token's supply cap, the order partially fills up to the remaining mintable amount.
+If minting would exceed a token's supply cap or otherwise fail, the order is skipped at fill time (see Authorization).
 
 ## Escrow behavior
 
@@ -53,9 +53,17 @@ Issuer orders MUST integrate with the DEX's existing settlement model.
 
 The DEX verifies that the maker has the appropriate `ISSUER_ROLE` at placement time. If `isBaseIssuer` is true, the maker must have `ISSUER_ROLE` on the base token. If `isQuoteIssuer` is true, the maker must have `ISSUER_ROLE` on the quote token. If both flags are true, both roles are required.
 
-Issuer role status is also checked at fill time (including at flip time). If a fill would require minting or burning as an issuer for a token, but the maker no longer holds `ISSUER_ROLE` for that token, the DEX MUST skip the order: it is cancelled in-place (with any escrowed tokens refunded to the maker) and the swap continues walking the book to the next order. The fill MUST NOT revert.
+Issuer role status is also checked at fill time (including at flip time). If the maker no longer holds the required `ISSUER_ROLE` for a token, the DEX MUST cancel the order in-place (refunding any escrowed tokens) and continue walking the book to the next order. Role revocation is a permanent condition, so the order is removed from the book.
+
+If the maker still holds the required role(s) but the mint or burn fails for other reasons (e.g. supply cap exhaustion or transfer policy restrictions), the DEX MUST skip the order without cancelling it. The order remains on the book and may become fillable again when conditions change (e.g. after burns free up supply cap room). The swap continues to the next order.
+
+In both cases, the fill MUST NOT revert.
 
 The existing `cancelStaleOrder` function is extended to also check issuer role validity. For issuer orders, the order is considered stale if the maker no longer holds the required `ISSUER_ROLE`(s) for any token where an issuer flag is set. Anyone may call `cancelStaleOrder` on such an order to cancel it and refund any escrowed tokens.
+
+## Issuer order limits
+
+To bound the cost of walking past unfillable issuer orders, the DEX enforces a limit of **one issuer order per side per tick per issuer**. At any given tick, an issuer address may have at most one issuer bid and one issuer ask. Placement MUST revert if it would violate this limit.
 
 ## Order representation
 
@@ -83,7 +91,7 @@ struct Order {
 
 Issuer orders fully support the flip mechanism. When an issuer flip order is fully filled, the newly created order on the opposite side preserves both `isBaseIssuer` and `isQuoteIssuer` flags. This enables perpetual mint/burn cycles where the issuer order behavior is consistent across all flips.
 
-If the maker no longer holds the required `ISSUER_ROLE`(s) at flip time, the flip MUST silently fail and no new order is created.
+If the maker no longer holds the required `ISSUER_ROLE`(s) at flip time, the flip MUST silently fail and no new order is created. Similarly, if the flip would place an issuer order at a tick where the maker already has an issuer order on the same side, the flip MUST silently fail.
 
 ## Quoting
 
@@ -126,9 +134,10 @@ The `OrderFilled` and `OrderCancelled` events remain unchanged.
 
 ```solidity
 error NotTokenIssuer();
+error IssuerOrderLimitExceeded();
 ```
 
-`NotTokenIssuer` is returned when attempting to place an issuer order without the required `ISSUER_ROLE`(s).
+`NotTokenIssuer` is returned when attempting to place an issuer order without the required `ISSUER_ROLE`(s). `IssuerOrderLimitExceeded` is returned when attempting to place an issuer order at a tick where the maker already has an issuer order on the same side.
 
 ## Implementation notes
 
@@ -148,15 +157,15 @@ These functions MUST:
 
 When filling an order with `isBaseIssuer` true, the DEX either mints base tokens (for asks) or burns base tokens (for bids) using these DEX-only entrypoints with `issuer = order.maker`. The same logic applies symmetrically for `isQuoteIssuer` and quote tokens.
 
-Minted tokens are subject to the token's transfer policy and supply cap. If minting would exceed the supply cap, the order partially fills up to the remaining mintable amount. If the remaining mintable amount is zero, or if the recipient is blocked by the transfer policy, the order is skipped (cancelled in-place) and the swap continues to the next order.
+Minted tokens are subject to the token's transfer policy and supply cap. If `mintByExchange` or `burnByExchange` reverts (due to supply cap exhaustion, transfer policy restrictions, or any other reason), the DEX MUST skip the order without cancelling it and continue to the next order. The order remains on the book and may become fillable when conditions change. If the revert is due to role revocation specifically, the order is cancelled in-place as described in the Authorization section.
 
 # Invariants
 
 ## Preserved invariants
 
-Issuer orders preserve the invariant that **fills never revert**. When the DEX encounters an issuer order that cannot be filled (due to role revocation, supply cap exhaustion, or transfer policy restrictions), it skips the order by cancelling it in-place and continues walking the book. Swaps may receive less output than quoted if issuer orders are skipped, but the swap itself always succeeds.
+Issuer orders preserve the invariant that **fills never revert**. When the DEX encounters an issuer order that cannot be filled, it either cancels it (role revocation) or skips it (mint/burn failure) and continues walking the book. Swaps may receive less output than quoted if issuer orders are skipped or cancelled, but the swap itself always succeeds.
 
-Gas usage remains bounded: skipped orders consume gas for the role check and cancellation but do not cause the overall swap to revert.
+Gas usage remains bounded: the per-tick issuer order limit (one bid + one ask per issuer) bounds the number of unfillable issuer orders the DEX may encounter at each tick. Skipped orders consume gas for the role check and failed mint/burn attempt but do not cause the overall swap to revert.
 
 ## Example
 


### PR DESCRIPTION
Moves the issuer orders spec from `dr/issuer-orders-spec-v2` into `tips/tip-1032.md`. Content is unchanged — reformatted with TIP frontmatter.

Prompted by: Dan