### PR TITLE
chore: bump reth to latest tempo/v1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -469,7 +469,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -968,14 +968,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "arrayvec",
  "derive_arbitrary",
  "derive_more",
  "nybbles",
@@ -1016,9 +1015,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1037,9 +1036,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1496,9 +1495,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1507,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -2063,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2290,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2300,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2312,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "0e78417baa3b3114dc0e95e7357389a249c4da97c3c2b540700079db6171bfd7"
 
 [[package]]
 name = "cmac"
@@ -2825,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4313,20 +4312,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -4808,7 +4807,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5065,9 +5064,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -5157,9 +5156,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -5229,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -5242,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5285,9 +5284,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5548,9 +5547,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libflate"
@@ -5642,13 +5641,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.2",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -5665,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -6058,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -6380,9 +6380,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -6819,18 +6819,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6839,9 +6839,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -6864,6 +6864,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -7086,11 +7092,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -7362,7 +7368,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7371,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -7400,16 +7406,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -7419,6 +7425,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -7609,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7800,7 +7812,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7824,7 +7836,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7855,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7875,7 +7887,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7889,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7967,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7977,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7997,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8017,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8027,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8043,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8056,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8068,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8094,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8120,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8148,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8178,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8193,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8218,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8242,7 +8254,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8266,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8301,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8359,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8387,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8410,7 +8422,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8435,7 +8447,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "futures",
  "pin-project",
@@ -8457,7 +8469,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8514,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8542,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8557,7 +8569,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8573,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8595,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8606,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8634,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8655,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8696,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "clap",
  "eyre",
@@ -8718,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8734,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8752,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8765,7 +8777,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8794,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8814,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8824,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8848,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8870,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8883,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8901,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8939,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8953,7 +8965,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "serde",
  "serde_json",
@@ -8963,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8991,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "bytes",
  "futures",
@@ -9011,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9027,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9036,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "futures",
  "metrics",
@@ -9048,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9057,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9071,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9128,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9153,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9176,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9191,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9205,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9222,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9246,7 +9258,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9314,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9370,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9408,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9432,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9456,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "bytes",
  "eyre",
@@ -9485,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9497,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9512,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9533,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9545,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9568,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9578,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -9591,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9624,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9667,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9695,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9710,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9723,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9805,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9836,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9877,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9898,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9928,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9972,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10020,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10034,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10050,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10099,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10126,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10140,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10160,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10173,7 +10185,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10197,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10214,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10232,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10248,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10258,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "clap",
  "eyre",
@@ -10277,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "clap",
  "eyre",
@@ -10295,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10339,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10365,7 +10377,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10392,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10407,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10432,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10451,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10469,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#1c2c3362778ff120320bd9dbe4f0111b51ba9c15"
 dependencies = [
  "zstd",
 ]
@@ -10638,9 +10650,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10662,9 +10674,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11090,9 +11102,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -11594,9 +11606,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -11641,12 +11653,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11898,12 +11910,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -12797,9 +12809,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -12807,16 +12819,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12923,6 +12935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12938,12 +12959,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -13500,11 +13521,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -13634,9 +13655,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13647,9 +13668,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -13661,9 +13682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13671,9 +13692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -13684,9 +13705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -13754,9 +13775,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14402,9 +14423,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -14637,18 +14658,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Run `cargo update` to pick up [paradigmxyz/reth#22998](https://github.com/paradigmxyz/reth/pull/22998) (fix(provider): heal finalized/safe block numbers ahead of highest header).

## Changes

- `Cargo.lock` updated (245 insertions, 224 deletions)
- Notable bumps: reth branch deps (`f9788d50` → `1c2c3362`), revm-precompile, tokio, zerocopy, wasm-bindgen

## Testing

CI will validate the build.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie