### PR TITLE
feat(observability): add pool_fetch_duration_seconds to builder

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -366,6 +366,7 @@ where
             .record(prepare_system_txs_elapsed);
 
         let base_fee = builder.evm_mut().block().basefee;
+        let pool_fetch_start = Instant::now();
         let mut best_txs = best_txs(BestTransactionsAttributes::new(
             base_fee,
             builder
@@ -374,6 +375,9 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
+        self.metrics
+            .pool_fetch_duration_seconds
+            .record(pool_fetch_start.elapsed());
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -75,6 +75,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) hashed_post_state_duration_seconds: Histogram,
     /// Time to compute the state root and trie updates via `state_root_with_updates`.
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
+    /// Time to fetch the best transactions iterator from the pool.
+    pub(crate) pool_fetch_duration_seconds: Histogram,
 }
 
 impl TempoPayloadBuilderMetrics {

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -111,3 +111,20 @@ pub struct TempoPoolMaintenanceMetrics {
     /// Number of paused transactions evicted due to the global cap.
     pub paused_pool_cap_evicted: Counter,
 }
+
+/// Metrics for the Tempo transaction pool validator.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "transaction_pool.validator")]
+pub struct TempoValidatorMetrics {
+    /// Total time spent validating a single transaction in seconds.
+    pub validation_duration_seconds: Histogram,
+}
+
+impl TempoValidatorMetrics {
+    /// Increments the rejection counter with the given reason label.
+    #[inline]
+    pub fn inc_rejected(&self, reason: &'static str) {
+        metrics::counter!("transaction_pool_validator_rejected_total", "reason" => reason)
+            .increment(1);
+    }
+}

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1,5 +1,6 @@
 use crate::{
     amm::AmmLiquidityCache,
+    metrics::TempoValidatorMetrics,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use alloy_consensus::Transaction;
@@ -83,6 +84,8 @@ pub struct TempoTransactionValidator<Client> {
     pub(crate) max_tempo_authorizations: usize,
     /// Cache of AMM liquidity for validator tokens.
     pub(crate) amm_liquidity_cache: AmmLiquidityCache,
+    /// Validator metrics for observability.
+    pub(crate) metrics: TempoValidatorMetrics,
 }
 
 impl<Client> TempoTransactionValidator<Client>
@@ -100,6 +103,7 @@ where
             aa_valid_after_max_secs,
             max_tempo_authorizations,
             amm_liquidity_cache,
+            metrics: TempoValidatorMetrics::default(),
         }
     }
 
@@ -660,6 +664,24 @@ where
         &self,
         origin: TransactionOrigin,
         transaction: TempoPooledTransaction,
+        state_provider: impl StateProvider,
+    ) -> TransactionValidationOutcome<TempoPooledTransaction> {
+        let start = std::time::Instant::now();
+        let outcome = self.validate_one_inner(origin, transaction, state_provider);
+        self.metrics.validation_duration_seconds.record(start.elapsed());
+
+        if let TransactionValidationOutcome::Invalid(_, ref err) = outcome {
+            let reason = classify_rejection_reason(err);
+            self.metrics.inc_rejected(reason);
+        }
+
+        outcome
+    }
+
+    fn validate_one_inner(
+        &self,
+        origin: TransactionOrigin,
+        transaction: TempoPooledTransaction,
         mut state_provider: impl StateProvider,
     ) -> TransactionValidationOutcome<TempoPooledTransaction> {
         // Get the current hardfork based on tip timestamp
@@ -1016,6 +1038,66 @@ where
             }
             outcome => outcome,
         }
+    }
+}
+
+/// Classifies a pool transaction rejection error into a static reason string for metrics.
+fn classify_rejection_reason(err: &InvalidPoolTransactionError) -> &'static str {
+    match err {
+        InvalidPoolTransactionError::Consensus(inner) => match inner {
+            InvalidTransactionError::TxTypeNotSupported => "system_tx",
+            InvalidTransactionError::NonceNotConsistent { .. } => "nonce_too_low",
+            InvalidTransactionError::InsufficientFunds(_) => "insufficient_funds",
+            _ => "consensus_other",
+        },
+        InvalidPoolTransactionError::OversizedData { .. } => "oversized",
+        InvalidPoolTransactionError::Other(boxed) => {
+            match boxed.as_any().downcast_ref::<TempoPoolTransactionError>() {
+                Some(tempo_err) => match tempo_err {
+                    TempoPoolTransactionError::FeeCapBelowMinBaseFee { .. } => "fee_too_low",
+                    TempoPoolTransactionError::InvalidFeeToken(_) => "invalid_fee_token",
+                    TempoPoolTransactionError::PausedFeeToken(_) => "paused_fee_token",
+                    TempoPoolTransactionError::MissingFeeToken => "invalid_fee_token",
+                    TempoPoolTransactionError::BlackListedFeePayer { .. } => "blacklisted",
+                    TempoPoolTransactionError::InsufficientLiquidity(_) => {
+                        "insufficient_liquidity"
+                    }
+                    TempoPoolTransactionError::InsufficientGasForAAIntrinsicCost { .. } => {
+                        "insufficient_gas"
+                    }
+                    TempoPoolTransactionError::NonZeroValue => "non_zero_value",
+                    TempoPoolTransactionError::InvalidValidBefore { .. }
+                    | TempoPoolTransactionError::InvalidValidAfter { .. }
+                    | TempoPoolTransactionError::ExpiringNonceReplay
+                    | TempoPoolTransactionError::ExpiringNonceMissingValidBefore
+                    | TempoPoolTransactionError::ExpiringNonceNonceNotZero
+                    | TempoPoolTransactionError::ExpiringNonceValidBeforeTooFar { .. } => {
+                        "temporal_conditional"
+                    }
+                    TempoPoolTransactionError::Keychain(_)
+                    | TempoPoolTransactionError::AccessKeyExpired { .. }
+                    | TempoPoolTransactionError::KeyAuthorizationExpired { .. }
+                    | TempoPoolTransactionError::SpendingLimitExceeded { .. } => "keychain",
+                    TempoPoolTransactionError::LegacyKeychainPostT1C
+                    | TempoPoolTransactionError::V2KeychainPreT1C => "keychain_version",
+                    TempoPoolTransactionError::InvalidFeePayerSignature => "invalid_fee_payer",
+                    TempoPoolTransactionError::SubblockNonceKey => "subblock_nonce_key",
+                    TempoPoolTransactionError::TooManyAuthorizations { .. }
+                    | TempoPoolTransactionError::TooManyCalls { .. }
+                    | TempoPoolTransactionError::NoCalls
+                    | TempoPoolTransactionError::CreateCallNotFirst
+                    | TempoPoolTransactionError::CreateCallWithAuthorizationList
+                    | TempoPoolTransactionError::CallInputTooLarge { .. }
+                    | TempoPoolTransactionError::TooManyAccessListAccounts { .. }
+                    | TempoPoolTransactionError::TooManyStorageKeysPerAccount { .. }
+                    | TempoPoolTransactionError::TooManyTotalStorageKeys { .. }
+                    | TempoPoolTransactionError::TooManyTokenLimits { .. } => "field_limits",
+                    TempoPoolTransactionError::ExceedsNonPaymentLimit => "exceeds_gas_limit",
+                },
+                None => "other",
+            }
+        }
+        _ => "other",
     }
 }
 


### PR DESCRIPTION
Closes [RETH-578](https://linear.app/tempoxyz/issue/RETH-578)

Adds `tempo_payload_builder.pool_fetch_duration_seconds` histogram — measures how long the builder spends calling `best_transactions_with_attributes()` to get the iterator from the pool. This captures both read lock acquisition time and the O(n) BTreeMap clone cost.

Without this, when blockscope shows a slow build, we can't tell if the pool is stalling the builder vs EVM execution being slow.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk