### PR TITLE
feat(payload): add pool fetch duration metric

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -366,6 +366,7 @@ where
             .record(prepare_system_txs_elapsed);
 
         let base_fee = builder.evm_mut().block().basefee;
+        let pool_fetch_start = Instant::now();
         let mut best_txs = best_txs(BestTransactionsAttributes::new(
             base_fee,
             builder
@@ -374,6 +375,9 @@ where
                 .blob_gasprice()
                 .map(|gasprice| gasprice as u64),
         ));
+        self.metrics
+            .pool_fetch_duration_seconds
+            .record(pool_fetch_start.elapsed());
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -41,6 +41,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) gas_used: Histogram,
     /// Amount of gas used in the payload.
     pub(crate) gas_used_last: Gauge,
+    /// Time to create the pool's `BestTransactions` iterator, including lock acquisition and snapshot.
+    pub(crate) pool_fetch_duration_seconds: Histogram,
     /// Time to acquire the state provider and initialize the state DB.
     pub(crate) state_setup_duration_seconds: Histogram,
     /// The time it took to prepare system transactions in seconds.


### PR DESCRIPTION
Closes RETH-578

Adds `tempo_payload_builder_pool_fetch_duration_seconds` histogram.

| What it measures | Why we need it |
| -- | -- |
| Time the builder spends calling `best_transactions()` — read lock on `aa_2d_pool` + protocol pool BTreeMap clone + `MergeBestTransactions` setup | When a block builds slow, we can't tell if the pool caused it. This is the only pool cost on the builder's critical path that isn't instrumented. |

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk