### PR TITLE
chore: DRY fn is_payment and rename to v1

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -332,7 +332,7 @@ where
             match self.section {
                 BlockSection::StartOfBlock | BlockSection::NonShared => {
                     if gas_used > self.non_shared_gas_left
-                        || (!tx.is_payment() && gas_used > self.non_payment_gas_left)
+                        || (!tx.is_payment_v1() && gas_used > self.non_payment_gas_left)
                     {
                         // Assume that this transaction wants to make use of gas incentive section
                         //
@@ -428,7 +428,7 @@ where
         Ok(TempoTxResult {
             inner,
             next_section,
-            is_payment: recovered.tx().is_payment(),
+            is_payment: recovered.tx().is_payment_v1(),
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
         })

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -165,35 +165,19 @@ impl TempoTxEnvelope {
     /// See [`is_payment_v2`](Self::is_payment_v2) for the stricter builder-level variant.
     ///
     /// [TIP-20 payment]: <https://docs.tempo.xyz/protocol/tip20/overview#get-predictable-payment-fees>
-    pub fn is_payment(&self) -> bool {
+    pub fn is_payment_v1(&self) -> bool {
         match self {
-            Self::Legacy(tx) => tx
-                .tx()
-                .to
-                .to()
-                .is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX)),
-            Self::Eip2930(tx) => tx
-                .tx()
-                .to
-                .to()
-                .is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX)),
-            Self::Eip1559(tx) => tx
-                .tx()
-                .to
-                .to()
-                .is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX)),
-            Self::Eip7702(tx) => tx.tx().to.starts_with(&TIP20_PAYMENT_PREFIX),
-            Self::AA(tx) => tx.tx().calls.iter().all(|call| {
-                call.to
-                    .to()
-                    .is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
-            }),
+            Self::Legacy(tx) => is_tip20_call(tx.tx().to.to()),
+            Self::Eip2930(tx) => is_tip20_call(tx.tx().to.to()),
+            Self::Eip1559(tx) => is_tip20_call(tx.tx().to.to()),
+            Self::Eip7702(tx) => is_tip20_call(Some(&tx.tx().to)),
+            Self::AA(tx) => tx.tx().calls.iter().all(|call| is_tip20_call(call.to.to())),
         }
     }
 
     /// Strict [TIP-20 payment] classification: `0x20c0` prefix AND recognized calldata.
     ///
-    /// Like [`is_payment`](Self::is_payment), but additionally requires calldata to match a
+    /// Like [`is_payment_v1`](Self::is_payment_v1), but additionally requires calldata to match a
     /// recognized payment selector with exact ABI-encoded length.
     ///
     /// # NOTE
@@ -720,7 +704,7 @@ mod tests {
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
 
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
     }
 
     #[test]
@@ -734,7 +718,7 @@ mod tests {
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
 
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
     }
 
     fn create_aa_envelope(call: Call) -> TempoTxEnvelope {
@@ -755,7 +739,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
     }
 
     #[test]
@@ -767,7 +751,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
     }
 
     #[test]
@@ -778,7 +762,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
     }
 
     #[test]
@@ -791,7 +775,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
     }
 
     #[test]
@@ -804,7 +788,7 @@ mod tests {
             input: Bytes::new(),
         };
         let envelope = create_aa_envelope(call);
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
     }
 
     #[test]
@@ -818,7 +802,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
 
         // Eip2930 non-payment
         let tx = TxEip2930 {
@@ -827,7 +811,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip2930(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
 
         // Eip1559 payment
         let tx = TxEip1559 {
@@ -836,7 +820,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
 
         // Eip1559 non-payment
         let tx = TxEip1559 {
@@ -845,7 +829,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip1559(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
 
         // Eip7702 payment (note: Eip7702 has direct `to` address, not TxKind)
         let tx = TxEip7702 {
@@ -854,7 +838,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(envelope.is_payment());
+        assert!(envelope.is_payment_v1());
 
         // Eip7702 non-payment
         let tx = TxEip7702 {
@@ -863,7 +847,7 @@ mod tests {
         };
         let envelope =
             TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
-        assert!(!envelope.is_payment());
+        assert!(!envelope.is_payment_v1());
     }
 
     #[test]
@@ -878,7 +862,7 @@ mod tests {
             let signed = Signed::new_unhashed(tx, Signature::test_signature());
             let envelope = TempoTxEnvelope::Legacy(signed);
             assert!(
-                envelope.is_payment(),
+                envelope.is_payment_v1(),
                 "is_payment should accept valid calldata"
             );
             assert!(
@@ -898,7 +882,7 @@ mod tests {
         let signed = Signed::new_unhashed(tx, Signature::test_signature());
         let envelope = TempoTxEnvelope::Legacy(signed);
         assert!(
-            envelope.is_payment(),
+            envelope.is_payment_v1(),
             "is_payment should accept (prefix-only)"
         );
         assert!(
@@ -920,7 +904,7 @@ mod tests {
             };
             let signed = Signed::new_unhashed(tx, Signature::test_signature());
             let envelope = TempoTxEnvelope::Legacy(signed);
-            assert!(envelope.is_payment(), "v1 should accept (prefix-only)");
+            assert!(envelope.is_payment_v1(), "v1 should accept (prefix-only)");
             assert!(
                 !envelope.is_payment_v2(),
                 "v2 should reject excess calldata: {calldata}"
@@ -941,7 +925,7 @@ mod tests {
             };
             let signed = Signed::new_unhashed(tx, Signature::test_signature());
             let envelope = TempoTxEnvelope::Legacy(signed);
-            assert!(envelope.is_payment(), "v1 should accept (prefix-only)");
+            assert!(envelope.is_payment_v1(), "v1 should accept (prefix-only)");
             assert!(
                 !envelope.is_payment_v2(),
                 "v2 should reject unknown selector: {calldata}"


### PR DESCRIPTION
purely cosmetic cleanup, no behavior change

turns `fn is_tip20_call` as the common helper for both `is_payment_v1` and `is_payment_v2`