### PR TITLE
fix(txpool): strict payment calldata validation in pool and builder (…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12438,6 +12438,7 @@ dependencies = [
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "arbitrary",
  "base64 0.22.1",
  "derive_more",
@@ -12456,6 +12457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempo-contracts",
  "tracing-subscriber 0.3.22",
 ]
 

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -17,6 +17,7 @@ alloy-primitives.workspace = true
 alloy-sol-types = { workspace = true, features = ["json"] }
 
 [dev-dependencies]
+alloy-primitives = { workspace = true, features = ["rand"] }
 alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -24,4 +24,3 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 [features]
 default = ["rpc"]
 rpc = ["dep:alloy-contract"]
-serde = ["alloy-primitives/serde", "alloy-sol-types/serde"]

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -24,3 +24,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 [features]
 default = ["rpc"]
 rpc = ["dep:alloy-contract"]
+serde = ["alloy-primitives/serde", "alloy-sol-types/serde"]

--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -1,6 +1,7 @@
 pub use IRolesAuth::{IRolesAuthErrors as RolesAuthError, IRolesAuthEvents as RolesAuthEvent};
 pub use ITIP20::{ITIP20Errors as TIP20Error, ITIP20Events as TIP20Event};
 use alloy_primitives::{Address, U256};
+use alloy_sol_types::{SolCall, SolType};
 
 /// USD currency string constant.
 pub const USD_CURRENCY: &str = "USD";
@@ -171,6 +172,37 @@ crate::sol! {
     }
 }
 
+impl ITIP20::ITIP20Calls {
+    /// Returns `true` if `input` matches one of the recognized [TIP-20 payment] selectors:
+    /// - `transfer` / `transferWithMemo`
+    /// - `transferFrom` / `transferFromWithMemo`
+    /// - `mint` / `mintWithMemo`
+    /// - `burn` / `burnWithMemo`
+    ///
+    /// # NOTES
+    /// - Only validates calldata; the caller must check the TIP-20 address prefix on `to`.
+    /// - Only selector and exact ABI-encoded length match, no decoding (better performance).
+    ///
+    /// [TIP-20 payment]: <https://docs.tempo.xyz/protocol/tip20/overview#get-predictable-payment-fees>
+    pub fn is_payment(input: &[u8]) -> bool {
+        fn is_call<C: SolCall>(input: &[u8]) -> bool {
+            input.first_chunk::<4>() == Some(&C::SELECTOR)
+                && input.len()
+                    == 4 + <C::Parameters<'_> as SolType>::ENCODED_SIZE.unwrap_or_default()
+        }
+
+        is_call::<ITIP20::transferCall>(input)
+            || is_call::<ITIP20::transferWithMemoCall>(input)
+            || is_call::<ITIP20::transferFromCall>(input)
+            || is_call::<ITIP20::transferFromWithMemoCall>(input)
+            || is_call::<ITIP20::approveCall>(input)
+            || is_call::<ITIP20::mintCall>(input)
+            || is_call::<ITIP20::mintWithMemoCall>(input)
+            || is_call::<ITIP20::burnCall>(input)
+            || is_call::<ITIP20::burnWithMemoCall>(input)
+    }
+}
+
 impl RolesAuthError {
     /// Creates an error for unauthorized access.
     pub const fn unauthorized() -> Self {
@@ -286,5 +318,58 @@ impl TIP20Error {
     /// Error when permit signature is invalid
     pub const fn invalid_signature() -> Self {
         Self::InvalidSignature(ITIP20::InvalidSignature {})
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::vec::Vec;
+    use alloy_primitives::{Address, B256, U256};
+
+    #[rustfmt::skip]
+    /// Returns valid ABI-encoded calldata for every recognized TIP-20 payment selector.
+    fn payment_calldatas() -> [Vec<u8>; 9] {
+        let (to, from, amount, memo) = (Address::random(), Address::random(), U256::random(), B256::random());
+
+        [
+            ITIP20::transferCall { to, amount }.abi_encode(),
+            ITIP20::transferWithMemoCall { to, amount, memo }.abi_encode(),
+            ITIP20::transferFromCall { from, to, amount }.abi_encode(),
+            ITIP20::transferFromWithMemoCall { from, to, amount, memo }.abi_encode(),
+            ITIP20::approveCall { spender: to, amount }.abi_encode(),
+            ITIP20::mintCall { to, amount }.abi_encode(),
+            ITIP20::mintWithMemoCall { to, amount, memo }.abi_encode(),
+            ITIP20::burnCall { amount }.abi_encode(),
+            ITIP20::burnWithMemoCall { amount, memo }.abi_encode(),
+        ]
+    }
+
+    #[rustfmt::skip]
+    /// Returns ABI-encoded calldata for TIP-20 selectors NOT recognized as payments.
+    fn non_payment_calldatas() -> [Vec<u8>; 3] {
+        let mut data = ITIP20::transferCall { to: Address::random(), amount: U256::random() }.abi_encode();
+        data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        [
+            // non-payment TIP20 calls with known selectors
+            ITIP20::claimRewardsCall {}.abi_encode(),
+            ITIP20::permitCall {
+                owner: Address::random(), spender: Address::random(), value: U256::random(), deadline: U256::random(),
+                v: u8::MAX, r: B256::random(), s: B256::random() }.abi_encode(),
+            // non-payment TIP20 calls with unknown selectors
+            data,
+        ]
+    }
+
+    #[test]
+    fn test_is_payment() {
+        for calldata in payment_calldatas() {
+            assert!(ITIP20::ITIP20Calls::is_payment(&calldata))
+        }
+
+        for calldata in non_payment_calldatas() {
+            assert!(!ITIP20::ITIP20Calls::is_payment(&calldata))
+        }
     }
 }

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -170,9 +170,8 @@ where
 
 /// Helper to count payment and non-payment transactions
 fn count_transaction_types(transactions: &[TempoTxEnvelope]) -> (usize, usize) {
-    let payment_count = transactions.iter().filter(|tx| tx.is_payment()).count();
-    let non_payment_count = transactions.iter().filter(|tx| !tx.is_payment()).count();
-    (payment_count, non_payment_count)
+    let payment_count = transactions.iter().filter(|tx| tx.is_payment_v2()).count();
+    (payment_count, transactions.len() - payment_count)
 }
 
 /// Test with only a few mixed payment and non-payment transactions
@@ -320,7 +319,7 @@ async fn test_block_building_only_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            tx.is_payment(),
+            tx.is_payment_v2(),
             "All transactions should be payment transactions"
         );
     }
@@ -390,7 +389,7 @@ async fn test_block_building_only_non_payment_txs() -> eyre::Result<()> {
 
     for tx in &user_txs {
         assert!(
-            !tx.is_payment(),
+            !tx.is_payment_v2(),
             "All transactions should be non-payment transactions"
         );
     }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,6 +11,8 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+tempo-contracts.workspace = true
+
 # Reth
 reth-db-api = { workspace = true, optional = true }
 reth-ethereum-primitives = { workspace = true, optional = true }
@@ -55,6 +57,7 @@ alloy-primitives = { workspace = true, features = [
 	"rand",
 ] }
 alloy-signer.workspace = true
+alloy-sol-types.workspace = true
 alloy-signer-local.workspace = true
 rand.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
@@ -77,7 +80,8 @@ std = [
 	"revm/std",
 	"serde/std",
 	"serde_json/std",
-	"sha2/std"
+	"sha2/std",
+	"alloy-sol-types/std",
 ]
 reth = ["dep:reth-ethereum-primitives", "dep:reth-primitives-traits"]
 serde = [
@@ -92,6 +96,7 @@ serde = [
 	"p256/serde",
 	"tracing-subscriber/serde",
 	"revm/serde",
+	"tempo-contracts/serde"
 ]
 reth-codec = [
 	"reth",
@@ -126,6 +131,7 @@ arbitrary = [
 	"alloy-rpc-types-eth?/arbitrary",
 	"reth-db-api?/arbitrary",
 	"revm/arbitrary",
+	"alloy-sol-types/arbitrary",
 ]
 rpc = [
 	"reth",

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -9,6 +9,7 @@ use alloy_consensus::{
 };
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, hex};
 use core::fmt;
+use tempo_contracts::precompiles::ITIP20;
 
 /// TIP20 payment address prefix (12 bytes for payment classification)
 /// Same as TIP20_TOKEN_PREFIX
@@ -154,9 +155,16 @@ impl TempoTxEnvelope {
             && self.nonce() == 0
     }
 
-    /// Classify a transaction as payment or non-payment.
+    /// [TIP-20 payment] classification: `to` address has the `0x20c0` prefix.
     ///
-    /// Currently uses classifier v1: transaction is a payment if the `to` address has the TIP20 prefix.
+    /// A transaction is considered a payment if its `to` address carries the TIP-20 prefix.
+    /// For AA transactions, every call must target a TIP-20 address.
+    ///
+    /// # NOTE
+    /// Consensus-level classifier, used during block validation, against `general_gas_limit`.
+    /// See [`is_payment_v2`](Self::is_payment_v2) for the stricter builder-level variant.
+    ///
+    /// [TIP-20 payment]: <https://docs.tempo.xyz/protocol/tip20/overview#get-predictable-payment-fees>
     pub fn is_payment(&self) -> bool {
         match self {
             Self::Legacy(tx) => tx
@@ -180,6 +188,34 @@ impl TempoTxEnvelope {
                     .to()
                     .is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
             }),
+        }
+    }
+
+    /// Strict [TIP-20 payment] classification: `0x20c0` prefix AND recognized calldata.
+    ///
+    /// Like [`is_payment`](Self::is_payment), but additionally requires calldata to match a
+    /// recognized payment selector with exact ABI-encoded length.
+    ///
+    /// # NOTE
+    /// Builder-level classifier, used by the transaction pool and payload builder to prevent DoS of
+    /// the payment lane. NOT enforced during block validation — a future TIP will enshrine this
+    /// stricter classification at the protocol level.
+    ///
+    /// [TIP-20 payment]: <https://docs.tempo.xyz/protocol/tip20/overview#get-predictable-payment-fees>
+    pub fn is_payment_v2(&self) -> bool {
+        match self {
+            Self::Legacy(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip2930(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip1559(tx) => is_tip20_payment(tx.tx().to.to(), &tx.tx().input),
+            Self::Eip7702(tx) => is_tip20_payment(Some(&tx.tx().to), &tx.tx().input),
+            Self::AA(tx) => {
+                !tx.tx().calls.is_empty()
+                    && tx
+                        .tx()
+                        .calls
+                        .iter()
+                        .all(|call| is_tip20_payment(call.to.to(), &call.input))
+            }
         }
     }
 
@@ -413,6 +449,17 @@ impl From<TempoTransaction> for TempoTypedTransaction {
     }
 }
 
+/// Returns `true` if `to` has the TIP-20 payment prefix.
+fn is_tip20_call(to: Option<&Address>) -> bool {
+    to.is_some_and(|to| to.starts_with(&TIP20_PAYMENT_PREFIX))
+}
+
+/// Returns `true` if `to` has the TIP-20 payment prefix and `input` is recognized payment
+/// calldata (selector + exact ABI-encoded length).
+fn is_tip20_payment(to: Option<&Address>, input: &[u8]) -> bool {
+    is_tip20_call(to) && ITIP20::ITIP20Calls::is_payment(input)
+}
+
 #[cfg(feature = "rpc")]
 impl reth_rpc_convert::SignableTxRequest<TempoTxEnvelope>
     for alloy_rpc_types_eth::TransactionRequest
@@ -624,8 +671,26 @@ mod tests {
     use super::*;
     use crate::transaction::{Call, TempoTransaction};
     use alloy_primitives::{Bytes, Signature, TxKind, U256, address};
+    use alloy_sol_types::SolCall;
 
     const PAYMENT_TKN: Address = address!("20c0000000000000000000000000000000000001");
+
+    #[rustfmt::skip]
+    /// Returns valid ABI-encoded calldata for every recognized TIP-20 payment selector.
+    fn payment_calldatas() -> [Bytes; 9] {
+        let (to, from, amount, memo) = (Address::random(), Address::random(), U256::random(), B256::random());
+        [
+            ITIP20::transferCall { to, amount }.abi_encode().into(),
+            ITIP20::transferWithMemoCall { to, amount, memo }.abi_encode().into(),
+            ITIP20::transferFromCall { from, to, amount }.abi_encode().into(),
+            ITIP20::transferFromWithMemoCall { from, to, amount, memo }.abi_encode().into(),
+            ITIP20::approveCall { spender: to, amount }.abi_encode().into(),
+            ITIP20::mintCall { to, amount }.abi_encode().into(),
+            ITIP20::mintWithMemoCall { to, amount, memo }.abi_encode().into(),
+            ITIP20::burnCall { amount }.abi_encode().into(),
+            ITIP20::burnWithMemoCall { amount, memo }.abi_encode().into(),
+        ]
+    }
 
     #[test]
     fn test_non_fee_token_access() {
@@ -799,6 +864,116 @@ mod tests {
         let envelope =
             TempoTxEnvelope::Eip7702(Signed::new_unhashed(tx, Signature::test_signature()));
         assert!(!envelope.is_payment());
+    }
+
+    #[test]
+    fn test_strict_payment_accepts_valid_calldata() {
+        for calldata in payment_calldatas() {
+            let tx = TxLegacy {
+                to: TxKind::Call(PAYMENT_TKN),
+                gas_limit: 21000,
+                input: calldata.clone(),
+                ..Default::default()
+            };
+            let signed = Signed::new_unhashed(tx, Signature::test_signature());
+            let envelope = TempoTxEnvelope::Legacy(signed);
+            assert!(
+                envelope.is_payment(),
+                "is_payment should accept valid calldata"
+            );
+            assert!(
+                envelope.is_payment_v2(),
+                "is_strict_payment should accept valid calldata: {calldata}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_payment_rejects_empty_calldata() {
+        let tx = TxLegacy {
+            to: TxKind::Call(PAYMENT_TKN),
+            gas_limit: 21000,
+            ..Default::default()
+        };
+        let signed = Signed::new_unhashed(tx, Signature::test_signature());
+        let envelope = TempoTxEnvelope::Legacy(signed);
+        assert!(
+            envelope.is_payment(),
+            "is_payment should accept (prefix-only)"
+        );
+        assert!(
+            !envelope.is_payment_v2(),
+            "is_strict_payment should reject empty calldata"
+        );
+    }
+
+    #[test]
+    fn test_strict_payment_rejects_excess_calldata() {
+        for calldata in payment_calldatas() {
+            let mut data = calldata.to_vec();
+            data.extend_from_slice(&[0u8; 32]);
+            let tx = TxLegacy {
+                to: TxKind::Call(PAYMENT_TKN),
+                gas_limit: 21000,
+                input: Bytes::from(data),
+                ..Default::default()
+            };
+            let signed = Signed::new_unhashed(tx, Signature::test_signature());
+            let envelope = TempoTxEnvelope::Legacy(signed);
+            assert!(envelope.is_payment(), "v1 should accept (prefix-only)");
+            assert!(
+                !envelope.is_payment_v2(),
+                "v2 should reject excess calldata: {calldata}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_payment_rejects_unknown_selector() {
+        for calldata in payment_calldatas() {
+            let mut data = calldata.to_vec();
+            data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+            let tx = TxLegacy {
+                to: TxKind::Call(PAYMENT_TKN),
+                gas_limit: 21000,
+                input: Bytes::from(data),
+                ..Default::default()
+            };
+            let signed = Signed::new_unhashed(tx, Signature::test_signature());
+            let envelope = TempoTxEnvelope::Legacy(signed);
+            assert!(envelope.is_payment(), "v1 should accept (prefix-only)");
+            assert!(
+                !envelope.is_payment_v2(),
+                "v2 should reject unknown selector: {calldata}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_payment_aa_empty_calls() {
+        let tx = TempoTransaction {
+            fee_token: Some(PAYMENT_TKN),
+            calls: vec![],
+            ..Default::default()
+        };
+        let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
+        assert!(
+            !envelope.is_payment_v2(),
+            "AA with empty calls should not be strict payment"
+        );
+    }
+
+    #[test]
+    fn test_strict_payment_aa_valid_calldata() {
+        for calldata in payment_calldatas() {
+            let call = Call {
+                to: TxKind::Call(PAYMENT_TKN),
+                value: U256::ZERO,
+                input: calldata,
+            };
+            let envelope = create_aa_envelope(call);
+            assert!(envelope.is_payment_v2());
+        }
     }
 
     #[test]

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -54,7 +54,7 @@ pub struct TempoPooledTransaction {
 impl TempoPooledTransaction {
     /// Create new instance of [Self] from the given consensus transactions and the encoded size.
     pub fn new(transaction: Recovered<TempoTxEnvelope>) -> Self {
-        let is_payment = transaction.is_payment();
+        let is_payment = transaction.is_payment_v2();
         let is_expiring_nonce = transaction
             .as_aa()
             .map(|tx| tx.tx().is_expiring_nonce_tx())
@@ -111,7 +111,7 @@ impl TempoPooledTransaction {
 
     /// Returns whether this is a payment transaction.
     ///
-    /// Based on classifier v1: payment if tx.to has TIP20 reserved prefix.
+    /// Uses strict classification: TIP-20 prefix AND recognized calldata.
     pub fn is_payment(&self) -> bool {
         self.is_payment
     }
@@ -637,7 +637,9 @@ mod tests {
     use crate::test_utils::TxBuilder;
     use alloy_consensus::TxEip1559;
     use alloy_primitives::{Address, Signature, TxKind, address};
-    use tempo_precompiles::nonce::NonceManager;
+    use alloy_sol_types::SolCall;
+    use tempo_contracts::precompiles::ITIP20;
+    use tempo_precompiles::{PATH_USD_ADDRESS, nonce::NonceManager};
     use tempo_primitives::transaction::{
         TempoTransaction,
         tempo_transaction::Call,
@@ -647,7 +649,38 @@ mod tests {
 
     #[test]
     fn test_payment_classification_positive() {
-        // Test that TIP20 address prefix is correctly classified as payment
+        // Test that TIP20 address prefix with valid calldata is classified as payment
+        let calldata = ITIP20::transferCall {
+            to: Address::random(),
+            amount: U256::random(),
+        }
+        .abi_encode();
+
+        let tx = TxEip1559 {
+            to: TxKind::Call(PATH_USD_ADDRESS),
+            gas_limit: 21000,
+            input: Bytes::from(calldata),
+            ..Default::default()
+        };
+
+        let envelope = TempoTxEnvelope::Eip1559(alloy_consensus::Signed::new_unchecked(
+            tx,
+            Signature::test_signature(),
+            B256::ZERO,
+        ));
+
+        let recovered = Recovered::new_unchecked(
+            envelope,
+            address!("0000000000000000000000000000000000000001"),
+        );
+
+        let pooled_tx = TempoPooledTransaction::new(recovered);
+        assert!(pooled_tx.is_payment());
+    }
+
+    #[test]
+    fn test_payment_classification_tip20_prefix_without_valid_calldata() {
+        // TIP20 prefix but no valid calldata should NOT be classified as payment in the pool
         let payment_addr = address!("20c0000000000000000000000000000000000001");
         let tx = TxEip1559 {
             to: TxKind::Call(payment_addr),
@@ -667,7 +700,7 @@ mod tests {
         );
 
         let pooled_tx = TempoPooledTransaction::new(recovered);
-        assert!(pooled_tx.is_payment());
+        assert!(!pooled_tx.is_payment());
     }
 
     #[test]


### PR DESCRIPTION
…#3099)

## Motivation

Payment lane classification currently only checks the TIP-20 address prefix. Transactions with unrecognized or oversized calldata can be classified as payments, bypassing the 30M general gas limit and accessing the full 450M+ payment lane budget.

## Solution

Adds `ITIP20Calls::is_payment()` for type-safe calldata matching using `SolCall::SELECTOR` and `SolType::ENCODED_SIZE`, and introduces `is_payment_v2()` on `TempoTxEnvelope` which requires both TIP-20 prefix and recognized calldata. The existing prefix-only check is preserved as `is_payment()` for the block executor (consensus). The tx pool and payload builder use `is_payment_v2()`, so no hardfork gate is needed.

Recognized selectors: `transfer`, `transferWithMemo`, `transferFrom`, `transferFromWithMemo`, `mint`, `mintWithMemo`, `burn`, `burnWithMemo`.

Closes #1379. Supersedes #2575, #2601, #3040, #3097, #3103.

Prompted by: dan

---------