### PR TITLE
fix(ext): skip reth tracing init for extension management commands

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -186,7 +186,15 @@ fn main() -> eyre::Result<()> {
         .try_get_matches_from(std::env::args_os())
         .and_then(|matches| TempoCli::from_arg_matches(&matches))
     {
-        Ok(cli) => cli,
+        Ok(cli) => {
+            // Fast path: extension management commands don't need reth's tracing or runtime.
+            if let Commands::Ext(subcmd) = &cli.command {
+                if let Some(ext) = subcmd.as_ext() {
+                    return ext.run();
+                }
+            }
+            cli
+        }
         Err(err) => {
             if err.kind() == clap::error::ErrorKind::InvalidSubcommand {
                 // Unknown subcommand — try the extension launcher.

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -188,10 +188,10 @@ fn main() -> eyre::Result<()> {
     {
         Ok(cli) => {
             // Fast path: extension management commands don't need reth's tracing or runtime.
-            if let Commands::Ext(subcmd) = &cli.command {
-                if let Some(ext) = subcmd.as_ext() {
-                    return ext.run();
-                }
+            if let Commands::Ext(subcmd) = &cli.command
+                && let Some(ext) = subcmd.as_ext()
+            {
+                return ext.run();
             }
             cli
         }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -37,6 +37,17 @@ pub(crate) struct ExtArgs {
     args: Vec<String>,
 }
 
+impl ExtArgs {
+    /// Runs the extension command by delegating to [`tempo_ext::run`].
+    pub(crate) fn run(&self) -> eyre::Result<()> {
+        let code = tempo_ext::run(std::env::args_os()).map_err(|e| eyre!("{e}"))?;
+        if code != 0 {
+            std::process::exit(code);
+        }
+        Ok(())
+    }
+}
+
 /// Tempo-specific subcommands that extend the reth CLI.
 #[derive(Debug, Subcommand)]
 pub(crate) enum TempoSubcommand {
@@ -76,6 +87,19 @@ pub(crate) enum TempoSubcommand {
     List(ExtArgs),
 }
 
+impl TempoSubcommand {
+    /// Returns the inner [`ExtArgs`] if this is an extension management command
+    /// (`add`, `update`, `remove`, `list`).
+    pub(crate) fn as_ext(&self) -> Option<&ExtArgs> {
+        match self {
+            Self::Add(args) | Self::Update(args) | Self::Remove(args) | Self::List(args) => {
+                Some(args)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl ExtendedCommand for TempoSubcommand {
     fn execute(self, runner: CliRunner) -> eyre::Result<()> {
         match self {
@@ -87,13 +111,7 @@ impl ExtendedCommand for TempoSubcommand {
                 )?;
                 Ok(())
             }
-            Self::Add(_) | Self::Update(_) | Self::Remove(_) | Self::List(_) => {
-                let code = tempo_ext::run(std::env::args_os()).map_err(|e| eyre!("{e}"))?;
-                if code != 0 {
-                    std::process::exit(code);
-                }
-                Ok(())
-            }
+            Self::Add(ext) | Self::Update(ext) | Self::Remove(ext) | Self::List(ext) => ext.run(),
         }
     }
 }


### PR DESCRIPTION
Extension commands like `tempo add`, `tempo update`, `tempo remove`, and `tempo list` were going through reth's full `run_with_components` path which unconditionally initializes tracing before dispatching to the subcommand handler. This produced misleading output like:

```
$ tempo add tempo-docs
2026-03-14T02:28:38.170397Z  INFO Initialized tracing, debug log directory: ...
Error: execution node failed
```

Now these commands are intercepted in the `Ok(cli)` match arm before `run_with_components` is called, matching the existing pattern used for unknown subcommands (extensions like `tempo wallet`) which already bypass reth's runtime via the `InvalidSubcommand` error path.