### PR TITLE
feat(alloy): add account keychain provider helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11846,6 +11846,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
+ "async-trait",
  "dashmap",
  "derive_more",
  "eyre",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -37,6 +37,7 @@ reth-rpc-eth-types = { workspace = true, optional = true }
 dashmap.workspace = true
 derive_more.workspace = true
 futures.workspace = true
+async-trait.workspace = true
 serde.workspace = true
 tracing.workspace = true
 

--- a/crates/alloy/README.md
+++ b/crates/alloy/README.md
@@ -35,7 +35,7 @@ async fn build_provider() -> Result<impl Provider<TempoNetwork>, TransportError>
 
 This crate also exposes bindings for all Tempo precompiles, such as [TIP20](https://docs.tempo.xyz/protocol/tip20/overview):
 
-```rust
+```rust,no_run
 use alloy::{
     primitives::{U256, address},
     providers::ProviderBuilder,
@@ -68,3 +68,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 See the [examples directory](https://github.com/tempoxyz/tempo/tree/main/crates/alloy/examples) for additional runnable code samples.
+
+## Provider Extensions
+
+`tempo-alloy` also exposes Tempo-specific provider helpers for fixed-address precompiles:
+
+```rust,no_run
+use alloy::{
+    primitives::address,
+    providers::ProviderBuilder,
+};
+use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt};
+
+async fn keychain_example() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect("https://rpc.testnet.tempo.xyz")
+        .await?;
+
+    let account = address!("0x1111111111111111111111111111111111111111");
+    let key_id = address!("0x2222222222222222222222222222222222222222");
+
+    let key = provider.get_keychain_key(account, key_id).await?;
+    let same_key = provider.account_keychain().getKey(account, key_id).call().await?;
+
+    assert_eq!(key, same_key);
+    Ok(())
+}
+```

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -1,12 +1,67 @@
+use alloy_contract::Result as ContractResult;
+use alloy_primitives::{Address, U256};
 use alloy_provider::{
-    Identity, ProviderBuilder,
+    Identity, Provider, ProviderBuilder,
     fillers::{JoinFill, RecommendedFillers},
+};
+use tempo_contracts::precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS,
+    IAccountKeychain::{IAccountKeychainInstance, KeyInfo},
 };
 
 use crate::{
     TempoFillers, TempoNetwork,
     fillers::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller},
 };
+
+/// Extension trait for [`Provider`] with Tempo-specific functionality.
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+pub trait TempoProviderExt: Provider<TempoNetwork> {
+    /// Returns a typed instance for the Account Keychain precompile.
+    fn account_keychain(&self) -> IAccountKeychainInstance<&Self, TempoNetwork>
+    where
+        Self: Sized,
+    {
+        IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, self)
+    }
+
+    /// Returns information about a key authorized for an account.
+    async fn get_keychain_key(&self, account: Address, key_id: Address) -> ContractResult<KeyInfo>
+    where
+        Self: Sized,
+    {
+        self.account_keychain().getKey(account, key_id).call().await
+    }
+
+    /// Returns the remaining spending limit for an account/key/token tuple.
+    async fn get_keychain_remaining_limit(
+        &self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+    ) -> ContractResult<U256>
+    where
+        Self: Sized,
+    {
+        self.account_keychain()
+            .getRemainingLimit(account, key_id, token)
+            .call()
+            .await
+    }
+
+    /// Returns the key ID used in the current transaction context.
+    async fn get_keychain_transaction_key(&self) -> ContractResult<Address>
+    where
+        Self: Sized,
+    {
+        self.account_keychain().getTransactionKey().call().await
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+impl<P> TempoProviderExt for P where P: Provider<TempoNetwork> {}
 
 /// Extension trait for [`ProviderBuilder`] with Tempo-specific functionality.
 pub trait TempoProviderBuilderExt {
@@ -82,13 +137,22 @@ impl TempoProviderBuilderExt
 
 #[cfg(test)]
 mod tests {
-    use alloy_provider::{Identity, ProviderBuilder, fillers::JoinFill};
+    use alloy::sol_types::SolCall;
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_provider::{Identity, ProviderBuilder, fillers::JoinFill, mock::Asserter};
+    use tempo_contracts::precompiles::IAccountKeychain::{
+        KeyInfo, SignatureType, getKeyCall, getRemainingLimitCall, getTransactionKeyCall,
+    };
 
     use crate::{
         TempoFillers, TempoNetwork,
         fillers::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller},
-        provider::ext::TempoProviderBuilderExt,
+        provider::ext::{TempoProviderBuilderExt, TempoProviderExt},
     };
+
+    fn mock_provider(asserter: Asserter) -> impl alloy_provider::Provider<TempoNetwork> {
+        ProviderBuilder::<_, _, TempoNetwork>::default().connect_mocked_client(asserter)
+    }
 
     #[test]
     fn test_with_random_nonces() {
@@ -106,5 +170,110 @@ mod tests {
     fn test_with_nonce_key_filler() {
         let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
             ProviderBuilder::new_with_network::<TempoNetwork>().with_nonce_key_filler();
+    }
+
+    #[tokio::test]
+    async fn test_get_keychain_key() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let account = Address::repeat_byte(0x11);
+        let key_id = Address::repeat_byte(0x22);
+        let expected = KeyInfo {
+            signatureType: SignatureType::P256,
+            keyId: key_id,
+            expiry: 1_234_567_890,
+            enforceLimits: true,
+            isRevoked: false,
+        };
+
+        asserter.push_success(&Bytes::from(getKeyCall::abi_encode_returns(&expected)));
+
+        let actual = provider
+            .get_keychain_key(account, key_id)
+            .await
+            .expect("key info call succeeds");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_get_keychain_remaining_limit() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let account = Address::repeat_byte(0x11);
+        let key_id = Address::repeat_byte(0x22);
+        let token = Address::repeat_byte(0x33);
+        let expected = U256::from(42_u64);
+
+        asserter.push_success(&Bytes::from(getRemainingLimitCall::abi_encode_returns(
+            &expected,
+        )));
+
+        let actual = provider
+            .get_keychain_remaining_limit(account, key_id, token)
+            .await
+            .expect("remaining limit call succeeds");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_get_keychain_transaction_key() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let expected = Address::repeat_byte(0x44);
+
+        asserter.push_success(&Bytes::from(getTransactionKeyCall::abi_encode_returns(
+            &expected,
+        )));
+
+        let actual = provider
+            .get_keychain_transaction_key()
+            .await
+            .expect("transaction key call succeeds");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_account_keychain_accessor() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let account = Address::repeat_byte(0x11);
+        let key_id = Address::repeat_byte(0x22);
+        let expected = KeyInfo {
+            signatureType: SignatureType::Secp256k1,
+            keyId: key_id,
+            expiry: u64::MAX,
+            enforceLimits: false,
+            isRevoked: true,
+        };
+
+        asserter.push_success(&Bytes::from(getKeyCall::abi_encode_returns(&expected)));
+
+        let actual = provider
+            .account_keychain()
+            .getKey(account, key_id)
+            .call()
+            .await
+            .expect("typed instance call succeeds");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_get_keychain_key_propagates_errors() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+
+        asserter.push_failure_msg("boom");
+
+        let err = provider
+            .get_keychain_key(Address::repeat_byte(0x11), Address::repeat_byte(0x22))
+            .await
+            .expect_err("errors should propagate");
+
+        assert!(matches!(err, alloy_contract::Error::TransportError(_)));
+        assert!(err.to_string().contains("boom"));
     }
 }

--- a/crates/alloy/src/provider/mod.rs
+++ b/crates/alloy/src/provider/mod.rs
@@ -2,3 +2,6 @@
 ///
 /// These traits extend existing [`Provider`](alloy_provider::Provider)s with new methods specific to Tempo.
 pub mod ext;
+
+#[doc(inline)]
+pub use ext::{TempoProviderBuilderExt, TempoProviderExt};


### PR DESCRIPTION
Adds TempoProviderExt for Account Keychain read calls, including a typed account_keychain accessor and direct helper methods for key info, remaining limits, and transaction key reads.

This removes manual fixed-address eth_call boilerplate and adds mocked-provider coverage plus README examples.