### PR TITLE
feat(feed): trace individual consensus votes for observability

### DIFF
--- a/crates/commonware-node/src/feed/actor.rs
+++ b/crates/commonware-node/src/feed/actor.rs
@@ -169,6 +169,14 @@ impl<TContext: Spawner> Actor<TContext> {
         let (round, payload) = match &activity {
             Activity::Notarization(n) => (n.proposal.round, n.proposal.payload),
             Activity::Finalization(f) => (f.proposal.round, f.proposal.payload),
+            Activity::Notarize(_)
+            | Activity::Finalize(_)
+            | Activity::Nullify(_)
+            | Activity::Certification(_)
+            | Activity::Nullification(_) => {
+                info_span!("handle_activity", activity = ?activity).in_scope(|| {});
+                return;
+            }
             _ => return,
         };
 


### PR DESCRIPTION
## Summary

Emit `handle_activity` spans for individual Notarize/Finalize/Nullify votes so valscope can show per-validator vote flow timing.

## Motivation

Valscope [#127](https://github.com/tempoxyz/valscope/pull/127) added vote flow visibility, but joshie pointed out that `from_participant` is always `None` because the feed actor only traced certificate activities (Notarization/Finalization), not individual votes. Certificates are aggregated quorum proofs without individual sender attribution.

Individual votes carry an `attestation.signer: Participant(N)` which identifies the voting validator — exactly what we need for vote flow observability.

## Changes

- `crates/commonware-node/src/feed/actor.rs`: emit an `info_span!("handle_activity", activity = ?activity)` for individual vote activities before dropping them (the feed actor still only processes certificates for block resolution)

## How it works

The simplex engine's batcher reports every peer vote (`Activity::Notarize`, `Activity::Finalize`, `Activity::Nullify`) to the feed actor. Previously these were silently dropped. Now they emit a tracing span with the same `handle_activity` name and `activity` attribute, making them discoverable by valscope's TraceQL query.

The debug output includes `Participant(N)` which valscope's existing regex (`Participant\\(\\d+\\)`) already parses.

## Testing

- `cargo check -p tempo-commonware-node` passes

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk