### PR TITLE
feat(consensus): read execution layer at hashes not heights

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -282,6 +282,7 @@ where
                 oracle: self.peer_manager.clone(),
                 epoch_strategy: epoch_strategy.clone(),
                 last_finalized_height,
+                marshal: marshal_mailbox.clone(),
             },
         );
 

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, num::NonZeroU32, task::Poll};
 
 use alloy_consensus::BlockHeader as _;
+use alloy_primitives::Sealable as _;
 use bytes::{Buf, BufMut};
 use commonware_codec::{Encode as _, EncodeSize, Read, ReadExt as _, Write};
 use commonware_consensus::{
@@ -32,14 +33,15 @@ use futures::{
 };
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use rand_core::CryptoRngCore;
-use reth_provider::{BlockNumReader, HeaderProvider};
+use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
+use reth_provider::{BlockIdReader as _, HeaderProvider as _};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::TempoFullNode;
 use tracing::{Level, Span, debug, info, info_span, instrument, warn, warn_span};
 
 use crate::{
     consensus::{Digest, block::Block},
-    validators::read_validator_config_with_retry,
+    validators::{read_from_contract_at_hash, read_validator_config_with_retry},
 };
 
 mod state;
@@ -698,13 +700,7 @@ where
         let all_validators = read_validator_config_with_retry(
             &self.context,
             &self.config.execution_node,
-            crate::validators::ReadTarget::Exact {
-                height: self
-                    .config
-                    .epoch_strategy
-                    .last(round.epoch())
-                    .expect("epoch strategy is valid for all epochs"),
-            },
+            BlockNumHash::new(block.number(), block.hash()),
             &self.metrics.attempts_to_read_validator_contract,
         )
         .await;
@@ -857,13 +853,7 @@ where
         let all_validators = read_validator_config_with_retry(
             &self.context,
             &self.config.execution_node,
-            crate::validators::ReadTarget::Exact {
-                height: self
-                    .config
-                    .epoch_strategy
-                    .last(round.epoch())
-                    .expect("epoch strategy is valid for all epochs"),
-            },
+            BlockNumHash::new(block.number(), block.hash()),
             &self.metrics.attempts_to_read_validator_contract,
         )
         .await;
@@ -1171,7 +1161,7 @@ where
         // Read from pre-last block of the epoch, but never ahead of the current request.
         let next_epoch = state.epoch.next();
         let is_next_full_dkg =
-            validators::read_next_full_dkg_ceremony(&self.config.execution_node, request.height)
+            validators::read_next_full_dkg_ceremony(&self.config.execution_node, request.digest.0)
                 // in theory it should never fail, but if it does, just stick to reshare.
                 .is_ok_and(|epoch| epoch == next_epoch.get());
         if is_next_full_dkg {
@@ -1227,18 +1217,18 @@ async fn read_initial_state_and_set_floor<TContext>(
 where
     TContext: CryptoRngCore,
 {
-    let newest_height = node
+    let latest_finalized = node
         .provider
-        .best_block_number()
-        .map(Height::new)
-        .wrap_err("failed reading newest block number from database")?;
+        .finalized_block_num_hash()
+        .wrap_err("unable to read highest finalized block from execution layer")?
+        .unwrap_or_else(|| BlockNumHash::new(0, node.chain_spec().genesis_hash()));
 
     let epoch_info = epoch_strategy
-        .containing(newest_height)
+        .containing(Height::new(latest_finalized.number))
         .expect("epoch strategy is for all heights");
 
-    let last_boundary = if epoch_info.last() == newest_height {
-        newest_height
+    let last_boundary = if epoch_info.last().get() == latest_finalized.number {
+        epoch_info.last()
     } else {
         epoch_info
             .epoch()
@@ -1250,13 +1240,14 @@ where
             })
     };
     info!(
-        %newest_height,
+        %latest_finalized.number,
+        %latest_finalized.hash,
         %last_boundary,
         "execution layer reported newest available block, reading on-chain \
         DKG outcome from last boundary height, and validator state from newest \
         block"
     );
-    let header = node
+    let boundary_header = node
         .provider
         .header_by_number(last_boundary.get())
         .map_or_else(
@@ -1265,21 +1256,20 @@ where
         )
         .wrap_err_with(|| {
             format!("failed to read header for last boundary block number `{last_boundary}`")
-        })?;
+        })?
+        .seal_slow();
 
-    // XXX: Reads the contract from the latest available block (newest_height),
-    // not from the boundary. The reason is that we cannot be sure that the
-    // boundary block is available. But we know that the on-chain state is
-    // immutable - validators never change their identity and never update their
-    // IP addresses (the latter would actually probably be fine; what matters is
-    // that identities don't change).
-    let onchain_outcome =
-        tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
-            .wrap_err("the boundary header did not contain the on-chain DKG outcome")?;
+    let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
+        &mut boundary_header.extra_data().as_ref(),
+    )
+    .wrap_err("the boundary header did not contain the on-chain DKG outcome")?;
 
-    let all_validators = validators::read_from_contract_at_height(0, node, newest_height)
+    let all_validators = read_from_contract_at_hash(0, node, boundary_header.hash())
         .wrap_err_with(|| {
-            format!("failed reading validator config from block height `{newest_height}`")
+            format!(
+                "failed reading validator config from block hash `{}` at height `{last_boundary}`",
+                boundary_header.hash(),
+            )
         })?;
 
     let share = state::ShareState::Plaintext('verify_initial_share: {
@@ -1303,8 +1293,8 @@ where
         Some(share)
     });
 
-    info!(%newest_height, "setting sync floor");
-    marshal.set_floor(newest_height).await;
+    info!(%last_boundary, "setting sync floor");
+    marshal.set_floor(last_boundary).await;
 
     Ok(State {
         epoch: onchain_outcome.epoch,

--- a/crates/commonware-node/src/dkg/manager/validators.rs
+++ b/crates/commonware-node/src/dkg/manager/validators.rs
@@ -1,6 +1,4 @@
-pub(super) use crate::validators::read_from_contract_at_height;
-
-use commonware_consensus::types::Height;
+use alloy_primitives::B256;
 use eyre::WrapErr as _;
 use tempo_node::TempoFullNode;
 use tracing::{Level, instrument};
@@ -12,16 +10,16 @@ use tracing::{Level, instrument};
 #[instrument(
     skip_all,
     fields(
-        at_height,
+        %at_hash,
     ),
     err,
     ret(level = Level::INFO)
 )]
 pub(super) fn read_next_full_dkg_ceremony(
     node: &TempoFullNode,
-    at_height: Height,
+    at_hash: B256,
 ) -> eyre::Result<u64> {
-    crate::validators::read_validator_config_at_height(node, at_height, |config| {
+    crate::validators::read_validator_config_at_hash(node, at_hash, |config| {
         config
             .get_next_full_dkg_ceremony()
             .wrap_err("failed to query contract for next full dkg ceremony")

--- a/crates/commonware-node/src/peer_manager/actor.rs
+++ b/crates/commonware-node/src/peer_manager/actor.rs
@@ -14,7 +14,7 @@ use commonware_utils::{Acknowledgement, acknowledgement::Exact};
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::{StreamExt as _, channel::mpsc};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use reth_ethereum::network::NetworkInfo;
+use reth_ethereum::{network::NetworkInfo, rpc::eth::primitives::BlockNumHash};
 use reth_provider::{BlockNumReader as _, HeaderProvider};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::TempoFullNode;
@@ -38,6 +38,7 @@ where
     epoch_strategy: FixedEpocher,
     last_finalized_height: Height,
     mailbox: mpsc::UnboundedReceiver<MessageWithCause>,
+    marshal: crate::alias::marshal::Mailbox,
 
     contract_read_attempts: Counter,
     peers: Gauge,
@@ -55,6 +56,7 @@ where
             execution_node,
             epoch_strategy,
             last_finalized_height,
+            marshal,
         }: super::Config<TPeerManager>,
         mailbox: mpsc::UnboundedReceiver<MessageWithCause>,
     ) -> Self {
@@ -77,6 +79,7 @@ where
             epoch_strategy,
             last_finalized_height,
             mailbox,
+            marshal,
             contract_read_attempts,
             peers,
         }
@@ -144,7 +147,7 @@ where
 
         // If we're exactly on a boundary, use it; otherwise use the previous
         // epoch's last block (or genesis).
-        let last_boundary = if epoch_info.last() == self.last_finalized_height {
+        let latest_boundary_height = if epoch_info.last() == self.last_finalized_height {
             self.last_finalized_height
         } else {
             epoch_info
@@ -156,26 +159,38 @@ where
                         .expect("epoch strategy covers all epochs")
                 })
         };
+        let Some((_, latest_boundary_digest)) = self.marshal.get_info(latest_boundary_height).await
+        else {
+            eyre::bail!(
+                "marshal actor does not have digest for the latest boundary height `{latest_boundary_height}`",
+            );
+        };
         let header = self
             .execution_node
             .provider
-            .header_by_number(last_boundary.get())
+            .header(latest_boundary_digest.0)
             .map_err(eyre::Report::new)
             .and_then(|h| h.ok_or_eyre("empty header"))
             .wrap_err_with(|| {
-                format!("header not yet available at boundary height {last_boundary}")
+                format!(
+                    "execution layer does not have header for boundary block, hash \
+                    `{latest_boundary_digest}`, height `{latest_boundary_height}`",
+                )
             })?;
 
         let onchain_outcome = match OnchainDkgOutcome::read(&mut header.extra_data().as_ref()) {
             Err(error) => panic!(
-                "boundary block at `{last_boundary}` did not contain a valid DKG outcome; {error}"
+                "boundary block at `{latest_boundary_height}` did not contain a valid DKG outcome; {error}"
             ),
             Ok(outcome) => outcome,
         };
 
-        let validators =
-            validators::read_from_contract_at_height(attempt, &self.execution_node, last_boundary)
-                .wrap_err_with(|| format!("failed reading contract at `{last_boundary}`"))?;
+        let validators = validators::read_from_contract_at_hash(
+            attempt,
+            &self.execution_node,
+            latest_boundary_digest.0,
+        )
+        .wrap_err_with(|| format!("failed reading contract at hash `{latest_boundary_digest}`, height `{latest_boundary_height}`"))?;
 
         let peers = construct_peer_set(&onchain_outcome, &validators);
         self.peers.set(peers.len() as i64);
@@ -249,9 +264,7 @@ where
             let all_validators = read_validator_config_with_retry(
                 &self.context,
                 &self.execution_node,
-                validators::ReadTarget::AtLeast {
-                    height: block.height(),
-                },
+                BlockNumHash::new(block.number(), block.hash()),
                 &self.contract_read_attempts,
             )
             .await;

--- a/crates/commonware-node/src/peer_manager/actor.rs
+++ b/crates/commonware-node/src/peer_manager/actor.rs
@@ -11,17 +11,19 @@ use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::{AddressableManager, Provider};
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
-use eyre::{OptionExt as _, WrapErr as _};
+use eyre::{OptionExt as _, WrapErr as _, eyre};
 use futures::{StreamExt as _, channel::mpsc};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use reth_ethereum::{network::NetworkInfo, rpc::eth::primitives::BlockNumHash};
+use reth_ethereum::{
+    chainspec::EthChainSpec as _, network::NetworkInfo as _, rpc::eth::primitives::BlockNumHash,
+};
 use reth_provider::{BlockNumReader as _, HeaderProvider};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::TempoFullNode;
 use tracing::{Span, error, info, info_span, instrument, warn};
 
 use crate::{
-    consensus::block::Block,
+    consensus::{Digest, block::Block},
     validators::{self, DecodedValidator, read_validator_config_with_retry},
 };
 
@@ -159,11 +161,12 @@ where
                         .expect("epoch strategy covers all epochs")
                 })
         };
-        let Some((_, latest_boundary_digest)) = self.marshal.get_info(latest_boundary_height).await
-        else {
-            eyre::bail!(
+        let latest_boundary_digest = if latest_boundary_height == Height::zero() {
+            Digest(self.execution_node.chain_spec().genesis_hash())
+        } else {
+            self.marshal.get_info(latest_boundary_height).await.ok_or_else(|| eyre!(
                 "marshal actor does not have digest for the latest boundary height `{latest_boundary_height}`",
-            );
+            ))?.1
         };
         let header = self
             .execution_node

--- a/crates/commonware-node/src/peer_manager/mod.rs
+++ b/crates/commonware-node/src/peer_manager/mod.rs
@@ -39,6 +39,8 @@ mod ingress;
 pub(crate) use actor::Actor;
 pub(crate) use ingress::Mailbox;
 
+use crate::alias::marshal;
+
 /// Configuration of the peer manager actor.
 pub(crate) struct Config<TOracle> {
     /// The mailbox to the P2P network to register the peer sets.
@@ -52,6 +54,9 @@ pub(crate) struct Config<TOracle> {
     /// Used during start to determine the correct boundary block, since
     /// the execution layer may be behind.
     pub(crate) last_finalized_height: Height,
+    /// The mailbox of the marshal actor. Used during bootstrapping to read
+    /// the hash of its latest finalized height.
+    pub(crate) marshal: marshal::Mailbox,
 }
 
 /// Initializes a peer manager actor from a `config` with runtime `context`.

--- a/crates/commonware-node/src/validators.rs
+++ b/crates/commonware-node/src/validators.rs
@@ -1,6 +1,5 @@
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use commonware_codec::DecodeExt as _;
-use commonware_consensus::types::Height;
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_utils::ordered;
 use eyre::{OptionExt as _, WrapErr as _};
@@ -9,11 +8,12 @@ use prometheus_client::metrics::counter::Counter;
 use reth_ethereum::{
     evm::revm::{State, database::StateProviderDatabase},
     network::NetworkInfo,
+    rpc::eth::primitives::BlockNumHash,
 };
-use reth_node_builder::{Block as _, ConfigureEvm as _};
+use reth_node_builder::ConfigureEvm as _;
 use reth_provider::{
-    BlockHashReader as _, BlockIdReader as _, BlockNumReader as _, BlockReader as _, BlockSource,
-    CanonStateSubscriptions as _, StateProviderFactory as _,
+    BlockNumReader as _, CanonStateSubscriptions as _, HeaderProvider as _,
+    StateProviderFactory as _,
 };
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
 use tempo_node::TempoFullNode;
@@ -24,17 +24,12 @@ use tempo_precompiles::{
 
 use tracing::{Level, debug, info, instrument, warn};
 
-pub(crate) enum ReadTarget {
-    AtLeast { height: Height },
-    Exact { height: Height },
-}
-
 /// Attempts to read the validator config from the smart contract, retrying
 /// until the required block height is available.
 pub(crate) async fn read_validator_config_with_retry(
     context: &impl commonware_runtime::Clock,
     node: &TempoFullNode,
-    target: ReadTarget,
+    target: BlockNumHash,
     total_attempts: &Counter,
 ) -> ordered::Map<PublicKey, DecodedValidator> {
     let mut attempts = 0;
@@ -47,18 +42,7 @@ pub(crate) async fn read_validator_config_with_retry(
         total_attempts.inc();
         attempts += 1;
 
-        let target_height = match target {
-            ReadTarget::Exact { height } => height,
-            ReadTarget::AtLeast { height } => node
-                .provider
-                .best_block_number()
-                .ok()
-                .map(Height::new)
-                .filter(|best| best >= &height)
-                .unwrap_or(height),
-        };
-
-        if let Ok(validators) = read_from_contract_at_height(attempts, node, target_height) {
+        if let Ok(validators) = read_from_contract_at_hash(attempts, node, target.hash) {
             break 'read_contract validators;
         }
 
@@ -68,14 +52,15 @@ pub(crate) async fn read_validator_config_with_retry(
         let blocks_behind = best_block
             .as_ref()
             .ok()
-            .map(|best| target_height.get().saturating_sub(*best));
+            .map(|best| target.number.saturating_sub(*best));
         tracing::warn_span!("read_validator_config_with_retry").in_scope(|| {
             warn!(
                 attempts,
                 retry_after = %tempo_telemetry_util::display_duration(retry_after),
                 is_syncing,
                 best_block = %tempo_telemetry_util::display_result(&best_block),
-                %target_height,
+                target.number,
+                %target.hash,
                 blocks_behind = %tempo_telemetry_util::display_option(&blocks_behind),
                 "reading validator config from contract failed; will retry",
             );
@@ -94,56 +79,33 @@ pub(crate) async fn read_validator_config_with_retry(
         }
     }
 }
-
 /// Reads state from the ValidatorConfig precompile at a given block height.
-pub(crate) fn read_validator_config_at_height<T>(
+pub(crate) fn read_validator_config_at_hash<T>(
     node: &TempoFullNode,
-    height: Height,
+    hash: B256,
     read_fn: impl FnOnce(&ValidatorConfig) -> eyre::Result<T>,
 ) -> eyre::Result<T> {
-    // Try mapping the block height to a hash tracked by reth.
-    //
-    // First check the canonical chain, then fallback to pending block state.
-    //
-    // Necessary because the DKG and application actors process finalized block concurrently.
-    let block_hash = if let Some(hash) = node
+    let header = node
         .provider
-        .block_hash(height.get())
-        .wrap_err_with(|| format!("failed reading block hash at height `{height}`"))?
-    {
-        hash
-    } else if let Some(pending) = node
-        .provider
-        .pending_block_num_hash()
-        .wrap_err("failed reading pending block state")?
-        && pending.number == height.get()
-    {
-        pending.hash
-    } else {
-        return Err(eyre::eyre!("block not found at height `{height}`"));
-    };
-
-    let block = node
-        .provider
-        .find_block_by_hash(block_hash, BlockSource::Any)
+        .header(hash)
         .map_err(Into::<eyre::Report>::into)
-        .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty block"))
-        .wrap_err_with(|| format!("failed reading block with hash `{block_hash}`"))?;
+        .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty header"))
+        .wrap_err_with(|| {
+            format!("failed getting header for hash `{hash}` from execution layer")
+        })?;
 
     let db = State::builder()
         .with_database(StateProviderDatabase::new(
-            node.provider
-                .state_by_block_hash(block_hash)
-                .wrap_err_with(|| {
-                    format!("failed to get state from node provider for hash `{block_hash}`")
-                })?,
+            node.provider.state_by_block_hash(hash).wrap_err_with(|| {
+                format!("failed to construct EVM state for execution layer at hash `{hash}`")
+            })?,
         ))
         .build();
 
     let mut evm = node
         .evm_config
-        .evm_for_block(db, block.header())
-        .wrap_err("failed instantiating evm for block")?;
+        .evm_for_block(db, &header)
+        .wrap_err("failed instantiating EVM for block")?;
 
     let ctx = evm.ctx_mut();
     StorageCtx::enter_evm(
@@ -164,16 +126,16 @@ pub(crate) fn read_validator_config_at_height<T>(
     skip_all,
     fields(
         attempt = _attempt,
-        %height,
+        %hash,
     ),
     err
 )]
-pub(crate) fn read_from_contract_at_height(
+pub(crate) fn read_from_contract_at_hash(
     _attempt: u32,
     node: &TempoFullNode,
-    height: Height,
+    hash: B256,
 ) -> eyre::Result<ordered::Map<PublicKey, DecodedValidator>> {
-    let raw_validators = read_validator_config_at_height(node, height, |config| {
+    let raw_validators = read_validator_config_at_hash(node, hash, |config| {
         config
             .get_validators()
             .wrap_err("failed to query contract for validator config")


### PR DESCRIPTION
The consensus layer was reading execution layer state at heights instead of preferring specific block hashes. This means that in certain edge cases peer and validator information could be taken from forks instead of the canonical chain.

Closes #1295 