### PR TITLE
fix: never propose blocks with timestamp before the parent

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -543,6 +543,9 @@ impl Inner<Init> {
         };
 
         // Use current timestamp but make sure that if parent's timestamp is in the future, we account for that.
+        //
+        // We don't expect this being hit in practice because we validate the
+        // timestamp is not in the future during EL validation.
         let current_timestamp = context.current().epoch_millis();
         let timestamp_millis = if current_timestamp <= parent.timestamp_millis() {
             self.metrics.parent_ahead_of_local_time.inc();

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -23,6 +23,11 @@ use tempo_primitives::{
 };
 
 /// How far in the future the block timestamp can be.
+///
+/// We are setting this to 0 to not allow any drift of the block time in the future.
+/// We are considering this safe because with the way CL works currently block time would
+/// be consistent and thus an honest proposer should never produce a block that appears
+/// to be in the future even assuming 50-100ms clock drift.
 pub const ALLOWED_FUTURE_BLOCK_TIME_MILLIS: u64 = 0;
 
 /// Divisor for calculating shared gas limit (payment lane capacity).


### PR DESCRIPTION
## Summary

If a malicious proposer builds a block with a timestamp in the future, honest proposers will continue setting timestamp to the current time, which results in their blocks being invalid.

This PR ensures parent timestamp is taken into account when choosing the timestamp for the next block.

## Changes

- Use `parent.timestamp_millis() + 1` when local time is behind the parent (`crates/commonware-node/src/consensus/application/actor.rs`)
- Reduce allowed future block time from 3s to 500ms (`crates/consensus/src/lib.rs`)
- Switch timestamp validation to millisecond precision
- Add `parent_ahead_of_local_time` counter metric

## Testing

Cherry-picked from [tempo-private-fork#26](https://github.com/tempoxyz/tempo-private-fork/pull/26) — 5 commits by @klkvr.

Prompted by: klkvr