### PR TITLE
docs(tip-1034): specify single-slot TIP-20 escrow channels

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -2,7 +2,7 @@
 id: TIP-1034
 title: TIP-20 Channel Escrow Precompile
 description: Enshrines TIP-20 channel escrow as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
-authors: Tanishk Goyal
+authors: Tanishk Goyal, Brendan Ryan
 status: Draft
 related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -42,10 +42,10 @@ address constant TIP20_CHANNEL_ESCROW = 0x4D505000000000000000000000000000000000
 
 ## Implementation Details
 
-This TIP is normative. The current reference implementations are informative and live at:
+This TIP is normative. The current reference Solidity artifacts are informative and live at:
 
-1. [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol)
-2. [`tips/ref-impls/src/TIP20ChannelEscrow.sol`](ref-impls/src/TIP20ChannelEscrow.sol)
+1. [`tips/verify/src/interfaces/ITIP20ChannelEscrow.sol`](verify/src/interfaces/ITIP20ChannelEscrow.sol)
+2. [`tips/verify/src/TIP20ChannelEscrow.sol`](verify/src/TIP20ChannelEscrow.sol)
 
 Implementations SHOULD keep those reference artifacts aligned with the normative interface and execution rules defined below.
 
@@ -124,7 +124,7 @@ channelId = keccak256(
 
 ### Interface
 
-The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol).
+The canonical interface for this TIP is [`tips/verify/src/interfaces/ITIP20ChannelEscrow.sol`](verify/src/interfaces/ITIP20ChannelEscrow.sol).
 
 Implementations MUST expose an external interface that is semantically identical to that file,
 including the `ChannelDescriptor`, `ChannelState`, and `Channel` structs, the descriptor-based

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -51,23 +51,53 @@ Implementations SHOULD keep those reference artifacts aligned with the normative
 
 Channels are unidirectional (`payer -> payee`) and token-specific.
 
-### Channel State Layout
+### Channel Identity And Packed State
 
 ```solidity
-struct Channel {
-    bool finalized;
-    uint64 closeRequestedAt;
+struct ChannelDescriptor {
     address payer;
     address payee;
-    uint64 expiresAt;
     address token;
+    bytes32 salt;
     address authorizedSigner;
-    uint128 deposit;
-    uint128 settled;
+}
+
+struct ChannelState {
+    bool finalized;
+    uint32 closeRequestedAt;
+    uint32 expiresAt;
+    uint96 deposit;
+    uint96 settled;
+}
+
+struct Channel {
+    ChannelDescriptor descriptor;
+    ChannelState state;
 }
 ```
 
-This layout uses 5 storage slots total.
+Implementations MUST store only `ChannelState` on-chain, keyed by `channelId` and packed into a
+single 32-byte storage slot. `ChannelDescriptor` is immutable channel identity and MUST NOT be
+stored on-chain; it MUST instead be supplied in calldata for post-open operations and emitted in
+`ChannelOpened` so indexers and counterparties can recover it.
+
+The packed slot layout is:
+
+```text
+bits   0..95   settled        uint96
+bits  96..191  deposit        uint96
+bits 192..223  expiresAt      uint32
+bits 224..255  closeData      uint32
+```
+
+`closeData` MUST be encoded as:
+
+1. `0` for an active channel with no close request.
+2. `1` for a finalized channel tombstone.
+3. `closeRequestedAt + 2` for an active channel with a close request.
+
+Implementations MUST decode `closeRequestedAt` as `0` when `closeData < 2`, otherwise as
+`closeData - 2`.
 
 `channelId` MUST use the following deterministic domain-separated construction:
 
@@ -89,14 +119,16 @@ channelId = keccak256(
 
 The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol).
 
-Implementations MUST expose an external interface that is semantically identical to that file, including the `Channel` state layout, events, errors, and function signatures.
+Implementations MUST expose an external interface that is semantically identical to that file,
+including the `ChannelDescriptor`, `ChannelState`, and `Channel` view structs, the descriptor-based
+post-open methods, the events, the errors, and the function signatures.
 
 ### Execution Semantics
 
 Voucher signatures use the following EIP-712 type:
 
 ```solidity
-Voucher(bytes32 channelId,uint128 cumulativeAmount)
+Voucher(bytes32 channelId,uint96 cumulativeAmount)
 ```
 
 Voucher signatures MUST be verified via the TIP-1020 Signature Verification Precompile at
@@ -117,19 +149,21 @@ strict predicate `timestamp > block.timestamp`, and expiry checks MUST use the s
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, invalid payee address, and any `expiresAt` value where `expiresAt <= block.timestamp`.
-2. `open` MUST persist `expiresAt`.
-3. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy both `newExpiresAt > block.timestamp` and `newExpiresAt > current expiresAt`.
-4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it and emit `CloseRequestCancelled`.
-5. `requestClose` MUST set `closeRequestedAt = block.timestamp` on the first successful call and leave it unchanged on later successful calls.
-6. `settle` MUST reject when `block.timestamp >= expiresAt`.
-7. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
-8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
-9. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
-10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
-11. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
-12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
-13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-14. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
+2. `open` MUST persist only the packed `ChannelState` slot and MUST emit the full immutable descriptor in `ChannelOpened`.
+3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
+4. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy both `newExpiresAt > block.timestamp` and `newExpiresAt > current expiresAt`.
+5. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it and emit `CloseRequestCancelled`.
+6. `requestClose` MUST encode `closeRequestedAt = block.timestamp` into the packed slot on the first successful call and leave it unchanged on later successful calls.
+7. `settle` MUST reject when `block.timestamp >= expiresAt`.
+8. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
+9. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
+10. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
+11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
+12. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
+13. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
+14. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+15. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
+16. Terminal `close` and `withdraw` MUST leave a non-zero finalized tombstone in the packed slot. Implementations MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
 
 ## Native Escrow Movement
 
@@ -187,13 +221,15 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
 5. Only payee can `settle` and `close`.
-6. Once finalized, all state-changing methods MUST revert for that channel.
-7. Fund conservation MUST hold at all terminal states.
-8. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
-9. `open` and `topUp` MUST not require a prior user `approve` transaction.
-10. No capture-increasing operation may succeed past `expiresAt`.
-11. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
-12. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+6. A channel MUST consume exactly one storage slot of mutable on-chain state.
+7. Once finalized, all state-changing methods MUST revert for that channel.
+8. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
+9. Fund conservation MUST hold at all terminal states.
+10. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+11. `open` and `topUp` MUST not require a prior user `approve` transaction.
+12. No capture-increasing operation may succeed past `expiresAt`.
+13. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
+14. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
 
 ## References
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP enshrines MPP payment channels in Tempo as a native precompile. The implementation baseline follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow.
+This TIP enshrines MPP payment channels in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
 
 The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
 
@@ -40,14 +40,18 @@ address constant MPP_CHANNEL_PRECOMPILE = 0x4D5050000000000000000000000000000000
 
 `MPP_CHANNEL_PRECOMPILE` MUST refer to this address throughout this specification.
 
-## Baseline Implementation
+## Implementation Details
 
-Unless explicitly changed in `Changes Proposed`, the precompile MUST match the reference implementation behavior and interface in:
+This precompile MUST follow the current reference implementation in:
 
 1. `tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`
 2. `tips/ref-impls/src/TempoStreamChannel.sol`
 
+with updates integrated directly in the sections below (expiry, explicit partial capture, native escrow movement, and payment-lane integration).
+
 Channels are unidirectional (`payer -> payee`) and token-specific.
+
+### Channel State Layout
 
 ```solidity
 struct Channel {
@@ -55,6 +59,7 @@ struct Channel {
     uint64 closeRequestedAt;
     address payer;
     address payee;
+    uint64 expiresAt;
     address token;
     address authorizedSigner;
     uint128 deposit;
@@ -62,7 +67,9 @@ struct Channel {
 }
 ```
 
-`channelId` MUST use the same deterministic domain-separated construction used in the reference implementation:
+Compared to the reference implementation, this adds `expiresAt` and places it after `payee` for tight packing. This layout uses 5 storage slots total.
+
+`channelId` MUST use the deterministic domain-separated construction from the reference implementation:
 
 ```solidity
 channelId = keccak256(
@@ -78,7 +85,7 @@ channelId = keccak256(
 );
 ```
 
-The baseline callable interface is:
+### Interface
 
 ```solidity
 interface IMPPChannel {
@@ -90,9 +97,12 @@ interface IMPPChannel {
     error InvalidPayee();
     error InvalidToken();
     error ZeroDeposit();
+    error InvalidExpiry();
+    error ChannelExpired();
     error InvalidSignature();
     error AmountExceedsDeposit();
     error AmountNotIncreasing();
+    error CaptureAmountInvalid();
     error CloseNotReady();
     error DepositOverflow();
     error TransferFailed();
@@ -104,7 +114,8 @@ interface IMPPChannel {
         address token,
         address authorizedSigner,
         bytes32 salt,
-        uint128 deposit
+        uint128 deposit,
+        uint64 expiresAt
     );
 
     event Settled(
@@ -121,7 +132,8 @@ interface IMPPChannel {
         address indexed payer,
         address indexed payee,
         uint128 additionalDeposit,
-        uint128 newDeposit
+        uint128 newDeposit,
+        uint64 newExpiresAt
     );
 
     event CloseRequested(
@@ -156,7 +168,8 @@ interface IMPPChannel {
         address token,
         uint128 deposit,
         bytes32 salt,
-        address authorizedSigner
+        address authorizedSigner,
+        uint64 expiresAt
     ) external returns (bytes32 channelId);
 
     function settle(
@@ -165,9 +178,18 @@ interface IMPPChannel {
         bytes calldata signature
     ) external;
 
-    function topUp(bytes32 channelId, uint256 additionalDeposit) external;
+    function topUp(
+        bytes32 channelId,
+        uint256 additionalDeposit,
+        uint64 newExpiresAt
+    ) external;
 
-    function close(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external;
+    function close(
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        uint128 captureAmount,
+        bytes calldata signature
+    ) external;
 
     function requestClose(bytes32 channelId) external;
     function withdraw(bytes32 channelId) external;
@@ -175,21 +197,25 @@ interface IMPPChannel {
 }
 ```
 
-## Baseline Channel Semantics
+Compared to the reference interface, this adds `expiresAt` to channel lifecycle (`open`, `topUp`) and adds explicit final `captureAmount` to `close`.
 
-Voucher signatures use the same EIP-712 voucher shape:
+### Execution Semantics
+
+Voucher signatures keep the reference EIP-712 shape:
 
 ```solidity
 Voucher(bytes32 channelId,uint128 cumulativeAmount)
 ```
 
-Baseline execution rules:
+Execution semantics are the same as the reference implementation except:
 
-1. `settle` transfers only the positive delta from prior `settled` to the new signed cumulative amount.
-2. `close` settles any final voucher delta and refunds the remainder to the payer.
-3. `requestClose` starts the close grace timer for payer-driven withdrawal.
-4. `withdraw` succeeds only after the grace timer in baseline behavior.
-5. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+1. `open` MUST validate `expiresAt > block.timestamp` and persist `expiresAt`.
+2. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST be strictly in the future.
+3. `settle` and `close` MUST reject any capture-increasing action after `expiresAt`.
+4. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
+5. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+6. `withdraw` MUST be allowed after close grace OR after expiry.
+7. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
 
 ## Native Escrow Movement
 
@@ -226,40 +252,6 @@ For AA transactions, payment classification MUST require every call to satisfy e
 
 With this integration, channel lifecycle calls consume payment-lane capacity rather than non-payment capacity. Under high congestion, these transactions continue to compete in the same lane as other payment traffic instead of being excluded by non-payment limits.
 
-## Changes Proposed
-
-This section lists behavior changes beyond the baseline reference implementation.
-
-### Change 1: Explicit Authorization Expiry
-
-Add `expiresAt` to channel state and enforce authorization expiry semantics:
-
-1. `open` requires a valid future `expiresAt`.
-2. `settle` and `close` that increase captured amount MUST fail after expiry.
-3. After expiry, payer MAY reclaim remaining funds via `withdraw` without waiting for close grace.
-4. `topUp` MAY extend expiry by setting a new future deadline.
-
-### Change 2: Explicit Final Partial Capture
-
-Extend `close` to make final partial capture explicit:
-
-```solidity
-function close(
-    bytes32 channelId,
-    uint128 cumulativeAmount,
-    uint128 captureAmount,
-    bytes calldata signature
-) external;
-```
-
-Rules:
-
-1. `captureAmount` MUST satisfy `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
-2. Signature still authorizes `cumulativeAmount` (the upper bound).
-3. `captureAmount` determines final payee payout, with `deposit - captureAmount` refunded to payer.
-
-This keeps cumulative vouchers while making “authorize up to X, capture Y” explicit on finalization.
-
 ---
 
 # Invariants
@@ -273,5 +265,5 @@ This keeps cumulative vouchers while making “authorize up to X, capture Y” e
 7. Fund conservation MUST hold at all terminal states.
 8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
-10. If `Changes Proposed` are activated, no capture-increasing operation may succeed past `expiresAt`.
-11. If `Changes Proposed` are activated, `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
+10. No capture-increasing operation may succeed past `expiresAt`.
+11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -8,8 +8,6 @@ related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
-Related: [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec), [TIP-1000](tip-1000.md), [TIP-1020](https://docs.tempo.xyz/protocol/tips/tip-1020), [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html), [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)
-
 # TIP-1034: Enshrined MPP Channels Precompile
 
 ## Abstract
@@ -120,16 +118,18 @@ Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, invalid payee address, and any `expiresAt` value where `expiresAt <= block.timestamp`.
 2. `open` MUST persist `expiresAt`.
-3. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy `newExpiresAt > block.timestamp`.
+3. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy both `newExpiresAt > block.timestamp` and `newExpiresAt > current expiresAt`.
 4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeRequestedAt = block.timestamp` on the first successful call and leave it unchanged on later successful calls.
 6. `settle` MUST reject when `block.timestamp >= expiresAt`.
 7. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
 8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
 9. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
-10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
-11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-12. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
+10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
+11. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
+12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
+13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+14. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
 
 ## Native Escrow Movement
 
@@ -192,4 +192,13 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
 10. No capture-increasing operation may succeed past `expiresAt`.
-11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
+11. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
+12. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+
+## References
+
+- [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec)
+- [TIP-1000](tip-1000.md)
+- [TIP-1020](https://docs.tempo.xyz/protocol/tips/tip-1020)
+- [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
+- [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -182,6 +182,29 @@ Required behavior:
 2. `topUp` escrows `additionalDeposit` the same way.
 3. `settle`, `close`, and `withdraw` payout paths continue to transfer TIP-20 value using protocol-native token movement.
 
+### No Separate Emergency Close
+
+This TIP does not define a separate `emergencyClose` entrypoint for ordinary recipient-specific
+`close` failures.
+
+`close` is the only channel operation that atomically performs both outbound payout legs in one
+call: `escrow -> payee` and `escrow -> payer`. If that combined path fails only because one
+recipient leg cannot receive funds under the token's current transfer policy, the unaffected party
+already has a unilateral single-recipient fallback:
+
+1. If the payer-side refund leg makes `close` unusable, the payee can continue using `settle`
+   before `expiresAt`, subject to the normal `settle` bounds.
+2. If the payee-side payout leg makes `close` unusable, the payer can recover the remaining escrow
+   via `requestClose` + `withdraw`, or directly via `withdraw` once `block.timestamp >= expiresAt`.
+
+This means a recipient-specific `close` failure does not create a new bilateral hostage condition,
+so a dedicated `emergencyClose` is not required for that case.
+
+This reasoning is limited to recipient-specific `close` failures. It does not change the general
+requirement that `settle`, `close`, and `withdraw` all rely on protocol-native TIP-20 payout
+transfers. If the token's pause state or transfer policy later prevents the escrow address from
+sending funds at all, all outbound exit paths can fail.
+
 ## Payment-Lane Integration (Mandatory)
 
 Channel escrow operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -63,11 +63,10 @@ struct ChannelDescriptor {
 }
 
 struct ChannelState {
-    bool finalized;
-    uint32 closeRequestedAt;
-    uint32 expiresAt;
-    uint96 deposit;
     uint96 settled;
+    uint96 deposit;
+    uint32 expiresAt;
+    uint32 closeData;
 }
 
 struct Channel {
@@ -94,10 +93,10 @@ bits 224..255  closeData      uint32
 
 1. `0` for an active channel with no close request.
 2. `1` for a finalized channel tombstone.
-3. `closeRequestedAt + 2` for an active channel with a close request.
+3. Any value `>= 2` for an active channel with a close request, where the stored value is the exact `closeRequestedAt` timestamp.
 
-Implementations MUST decode `closeRequestedAt` as `0` when `closeData < 2`, otherwise as
-`closeData - 2`.
+This means timestamps `0` and `1` are reserved sentinel values and are not representable as
+close-request times.
 
 `channelId` MUST use the following deterministic domain-separated construction:
 
@@ -120,7 +119,7 @@ channelId = keccak256(
 The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol).
 
 Implementations MUST expose an external interface that is semantically identical to that file,
-including the `ChannelDescriptor`, `ChannelState`, and `Channel` view structs, the descriptor-based
+including the `ChannelDescriptor`, `ChannelState`, and `Channel` structs, the descriptor-based
 post-open methods, the events, the errors, and the function signatures.
 
 ### Execution Semantics
@@ -152,8 +151,8 @@ Execution semantics are:
 2. `open` MUST persist only the packed `ChannelState` slot and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy both `newExpiresAt > block.timestamp` and `newExpiresAt > current expiresAt`.
-5. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it and emit `CloseRequestCancelled`.
-6. `requestClose` MUST encode `closeRequestedAt = block.timestamp` into the packed slot on the first successful call and leave it unchanged on later successful calls.
+5. If `closeData >= 2`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
+6. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
 7. `settle` MUST reject when `block.timestamp >= expiresAt`.
 8. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
 9. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
@@ -162,8 +161,8 @@ Execution semantics are:
 12. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
 13. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 14. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-15. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
-16. Terminal `close` and `withdraw` MUST leave a non-zero finalized tombstone in the packed slot. Implementations MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
+15. `withdraw` MUST be allowed when either the close grace period has elapsed from `closeData` or `block.timestamp >= expiresAt`.
+16. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
 
 ## Native Escrow Movement
 
@@ -222,14 +221,17 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
 5. Only payee can `settle` and `close`.
 6. A channel MUST consume exactly one storage slot of mutable on-chain state.
-7. Once finalized, all state-changing methods MUST revert for that channel.
-8. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
-9. Fund conservation MUST hold at all terminal states.
-10. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
-11. `open` and `topUp` MUST not require a prior user `approve` transaction.
-12. No capture-increasing operation may succeed past `expiresAt`.
-13. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
-14. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+7. `closeData == 0` MUST mean active with no close request.
+8. `closeData == 1` MUST mean finalized.
+9. `closeData >= 2` MUST mean active with a close request timestamp equal to `closeData`.
+10. Once finalized, all state-changing methods MUST revert for that channel.
+11. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
+12. Fund conservation MUST hold at all terminal states.
+13. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+14. `open` and `topUp` MUST not require a prior user `approve` transaction.
+15. No capture-increasing operation may succeed past `expiresAt`.
+16. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
+17. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
 
 ## References
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP enshrines TIP-20 channel escrow in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
+This TIP enshrines TIP-20 channel escrow in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with explicit partial-capture updates defined in this spec.
 
 The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
 
@@ -65,7 +65,6 @@ struct ChannelDescriptor {
 struct ChannelState {
     uint96 settled;
     uint96 deposit;
-    uint32 expiresAt;
     uint32 closeData;
 }
 
@@ -85,17 +84,17 @@ The packed slot layout is:
 ```text
 bits   0..95   settled        uint96
 bits  96..191  deposit        uint96
-bits 192..223  expiresAt      uint32
-bits 224..255  closeData      uint32
+bits 192..223  closeData      uint32
+bits 224..255  reserved       zero
 ```
 
 These widths are chosen to keep the entire mutable channel state in one storage slot without
 introducing any practical limit for production usage. `uint96` supports up to
 `2^96 - 1 = 79,228,162,514,264,337,593,543,950,335` base units, which is far above the supply or
 escrow size of any realistic TIP-20 token deployment. `uint32` stores second-resolution unix
-timestamps through February 2106, which is sufficient for channel expiry and close-grace tracking
-because channels are expected to live for minutes, hours, days, or months rather than many
-decades.
+timestamps through February 2106, which is sufficient for close-request tracking because channels
+are expected to live for minutes, hours, days, or months rather than many decades. The reserved
+high 32 bits MUST remain zero.
 
 `closeData` MUST be encoded as:
 
@@ -149,28 +148,25 @@ This means:
 3. TIP-1020 keychain wrapper signatures (`0x03` / `0x04`) MUST be rejected for direct voucher verification.
 4. Delegated voucher signing MUST use `authorizedSigner`, rather than a keychain wrapper around `payer`.
 
-Execution semantics use exact timestamp boundaries. Future-required timestamps MUST use the
-strict predicate `timestamp > block.timestamp`, and expiry checks MUST use the strict predicate
-`block.timestamp >= expiresAt`. Implementations MUST NOT substitute different operators.
+Execution semantics use exact timestamp boundaries. Close-grace completion MUST use the strict
+predicate `block.timestamp >= closeRequestedAt + CLOSE_GRACE_PERIOD`. Implementations MUST NOT
+substitute a different operator.
 
 Execution semantics are:
 
-1. `open` MUST reject zero deposit, invalid token address, invalid payee address, and any `expiresAt` value where `expiresAt <= block.timestamp`.
+1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
 2. `open` MUST persist only the packed `ChannelState` slot and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
-4. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy both `newExpiresAt > block.timestamp` and `newExpiresAt > current expiresAt`.
-5. If `closeData >= 2`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
-6. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
-7. `settle` MUST reject when `block.timestamp >= expiresAt`.
-8. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
-9. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
-10. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
-11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
-12. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
-13. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
-14. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-15. `withdraw` MUST be allowed when either the close grace period has elapsed from `closeData` or `block.timestamp >= expiresAt`.
-16. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
+4. If `closeData >= 2`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
+5. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
+6. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
+7. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
+8. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
+9. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
+10. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
+11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+12. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
+13. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
 
 ## Native Escrow Movement
 
@@ -193,9 +189,9 @@ recipient leg cannot receive funds under the token's current transfer policy, th
 already has a unilateral single-recipient fallback:
 
 1. If the payer-side refund leg makes `close` unusable, the payee can continue using `settle`
-   before `expiresAt`, subject to the normal `settle` bounds.
+   subject to the normal `settle` bounds.
 2. If the payee-side payout leg makes `close` unusable, the payer can recover the remaining escrow
-   via `requestClose` + `withdraw`, or directly via `withdraw` once `block.timestamp >= expiresAt`.
+   via `requestClose` + `withdraw`.
 
 This means a recipient-specific `close` failure does not create a new bilateral hostage condition,
 so a dedicated `emergencyClose` is not required for that case.
@@ -260,9 +256,8 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 12. Fund conservation MUST hold at all terminal states.
 13. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 14. `open` and `topUp` MUST not require a prior user `approve` transaction.
-15. No capture-increasing operation may succeed past `expiresAt`.
-16. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.
-17. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+15. `withdraw` MUST require an active close request whose grace period has elapsed.
+16. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
 
 ## References
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -89,6 +89,14 @@ bits 192..223  expiresAt      uint32
 bits 224..255  closeData      uint32
 ```
 
+These widths are chosen to keep the entire mutable channel state in one storage slot without
+introducing any practical limit for production usage. `uint96` supports up to
+`2^96 - 1 = 79,228,162,514,264,337,593,543,950,335` base units, which is far above the supply or
+escrow size of any realistic TIP-20 token deployment. `uint32` stores second-resolution unix
+timestamps through February 2106, which is sufficient for channel expiry and close-grace tracking
+because channels are expected to live for minutes, hours, days, or months rather than many
+decades.
+
 `closeData` MUST be encoded as:
 
 1. `0` for an active channel with no close request.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -4,11 +4,13 @@ title: Enshrined MPP Channels Precompile
 description: Enshrines MPP payment channels as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal
 status: Draft
-related: TIP-20, TIP-1000, Tempo Session, Tempo Charge
+related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
 # TIP-1034: Enshrined MPP Channels Precompile
+
+Related: [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec), [TIP-1000](tip-1000.md), [TIP-1020](https://docs.tempo.xyz/protocol/tips/tip-1020), [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html), [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)
 
 ## Abstract
 
@@ -25,13 +27,6 @@ MPP channels are currently specified as a Solidity contract reference implementa
 3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow.
 
 This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.
-
-## Related
-
-1. [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec)
-2. [TIP-1000](tip-1000.md)
-3. [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
-4. [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)
 
 ---
 
@@ -106,6 +101,21 @@ Voucher signatures use the following EIP-712 type:
 Voucher(bytes32 channelId,uint128 cumulativeAmount)
 ```
 
+Voucher signatures MUST be verified via the TIP-1020 Signature Verification Precompile at
+`0x5165300000000000000000000000000000000000`, using the same signature encodings and
+verification rules as Tempo transaction signatures.
+
+This means:
+
+1. Implementations MUST compute the EIP-712 voucher digest and validate signatures using TIP-1020 `recover` or `verify`, not raw `ecrecover`.
+2. Voucher signatures MAY use any TIP-1020-supported Tempo signature type.
+3. TIP-1020 keychain wrapper signatures (`0x03` / `0x04`) MUST be rejected for direct voucher verification.
+4. Delegated voucher signing MUST use `authorizedSigner`, rather than a keychain wrapper around `payer`.
+
+Execution semantics use exact timestamp boundaries. Future-required timestamps MUST use the
+strict predicate `timestamp > block.timestamp`, and expiry checks MUST use the strict predicate
+`block.timestamp >= expiresAt`. Implementations MUST NOT substitute different operators.
+
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, invalid payee address, and any `expiresAt` value where `expiresAt <= block.timestamp`.
@@ -115,7 +125,7 @@ Execution semantics are:
 5. `requestClose` MUST set `closeRequestedAt = block.timestamp` on the first successful call and leave it unchanged on later successful calls.
 6. `settle` MUST reject when `block.timestamp >= expiresAt`.
 7. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
-8. `close` MUST validate the voucher signature for any capture-increasing close.
+8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
 9. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
 10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
 11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
@@ -142,18 +152,25 @@ Implementations MUST define a strict classifier `is_mpp_channel_payment(to, inpu
 1. `to == MPP_CHANNEL_PRECOMPILE`.
 2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
 3. Calldata length/encoding is valid for that selector.
+4. For `settle` and `close`, the trailing `signature` bytes use a valid TIP-1020 / Tempo transaction signature encoding.
 
-For AA transactions, payment classification MUST satisfy both:
+Transactions with authorization side effects MUST be classified as non-payment.
+
+For EIP-7702 transactions, payment classification requires `authorization_list.length == 0`.
+
+For AA transactions, payment classification MUST satisfy all of:
 
 1. `calls.length > 0`.
-2. Every call satisfies either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+2. `tempo_authorization_list.length == 0`.
+3. `key_authorization` is absent.
+4. Every call satisfies either TIP-20 strict payment classification or `is_mpp_channel_payment`.
 
 An AA transaction with an empty `calls` array MUST be classified as non-payment.
 
 ### Required Integration Points
 
-1. The consensus-level payment classifier (`is_payment`) MUST include MPP channel calls.
-2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_mpp_channel_payment`.
+1. The consensus-level payment classifier (`is_payment`) MUST include MPP channel calls and MUST enforce the same authorization-side-effect exclusions above.
+2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_mpp_channel_payment` and MUST enforce the same authorization-side-effect exclusions above.
 3. The transaction pool payment flag MUST be computed from the strict classifier, so MPP channel calls are admitted in the payment lane path.
 4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat MPP channel calls as payment, so they are not rejected by the non-payment overflow path.
 
@@ -172,7 +189,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 5. Only payee can `settle` and `close`.
 6. Once finalized, all state-changing methods MUST revert for that channel.
 7. Fund conservation MUST hold at all terminal states.
-8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, and AA payment classification MUST require `calls.length > 0`.
+8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
 10. No capture-increasing operation may succeed past `expiresAt`.
 11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -161,7 +161,12 @@ Implementations MUST define a strict classifier `is_mpp_channel_payment(to, inpu
 2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
 3. Calldata length/encoding is valid for that selector.
 
-For AA transactions, payment classification MUST require every call to satisfy either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+For AA transactions, payment classification MUST satisfy both:
+
+1. `calls.length > 0`.
+2. Every call satisfies either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+
+An AA transaction with an empty `calls` array MUST be classified as non-payment.
 
 ### Required Integration Points
 
@@ -185,7 +190,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 5. Only payee can `settle` and `close`.
 6. Once finalized, all state-changing methods MUST revert for that channel.
 7. Fund conservation MUST hold at all terminal states.
-8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers.
+8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, and AA payment classification MUST require `calls.length > 0`.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
 10. No capture-increasing operation may succeed past `expiresAt`.
 11. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -92,29 +92,31 @@ For unchanged functions, events, and errors, see the reference interface: [`ref-
 This TIP updates only the following interface functions:
 
 ```solidity
-interface IMPPChannel {
-    function open(
-        address payee,
-        address token,
-        uint128 deposit,
-        bytes32 salt,
-        address authorizedSigner,
-        uint64 expiresAt
-    ) external returns (bytes32 channelId);
+function open(
+    address payee,
+    address token,
+    uint128 deposit,
+    bytes32 salt,
+    address authorizedSigner,
+    uint64 expiresAt
+) external returns (bytes32 channelId);
+```
 
-    function topUp(
-        bytes32 channelId,
-        uint256 additionalDeposit,
-        uint64 newExpiresAt
-    ) external;
+```solidity
+function topUp(
+    bytes32 channelId,
+    uint256 additionalDeposit,
+    uint64 newExpiresAt
+) external;
+```
 
-    function close(
-        bytes32 channelId,
-        uint128 cumulativeAmount,
-        uint128 captureAmount,
-        bytes calldata signature
-    ) external;
-}
+```solidity
+function close(
+    bytes32 channelId,
+    uint128 cumulativeAmount,
+    uint128 captureAmount,
+    bytes calldata signature
+) external;
 ```
 
 Compared to the reference interface, this adds `expiresAt` to channel lifecycle (`open`, `topUp`) and adds explicit final `captureAmount` to `close`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -4,7 +4,7 @@ title: Enshrined MPP Channels Precompile
 description: Enshrines MPP payment channels as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal
 status: Draft
-related: TIP-20, TIP-1000, mpp-specs (tempo session/auth-capture)
+related: TIP-20, TIP-1000, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
@@ -26,6 +26,13 @@ MPP channels are currently specified as a Solidity contract reference implementa
 
 This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.
 
+## Related
+
+1. [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec)
+2. [TIP-1000](tip-1000.md)
+3. [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
+4. [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)
+
 ---
 
 # Specification
@@ -42,12 +49,12 @@ address constant MPP_CHANNEL_PRECOMPILE = 0x4D5050000000000000000000000000000000
 
 ## Implementation Details
 
-This precompile MUST follow the current reference implementation in:
+This TIP is normative. The current reference implementations are informative and live at:
 
-1. `tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`
-2. `tips/ref-impls/src/TempoStreamChannel.sol`
+1. [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol)
+2. [`tips/ref-impls/src/TempoStreamChannel.sol`](ref-impls/src/TempoStreamChannel.sol)
 
-with updates integrated directly in the sections below (expiry, explicit partial capture, native escrow movement, and payment-lane integration).
+Implementations SHOULD keep those reference artifacts aligned with the normative interface and execution rules defined below.
 
 Channels are unidirectional (`payer -> payee`) and token-specific.
 
@@ -67,9 +74,9 @@ struct Channel {
 }
 ```
 
-Compared to the reference implementation, this adds `expiresAt` and places it after `payee` for tight packing. This layout uses 5 storage slots total.
+This layout uses 5 storage slots total.
 
-`channelId` MUST use the deterministic domain-separated construction from the reference implementation:
+`channelId` MUST use the following deterministic domain-separated construction:
 
 ```solidity
 channelId = keccak256(
@@ -87,57 +94,32 @@ channelId = keccak256(
 
 ### Interface
 
-For unchanged functions, events, and errors, see the reference interface: [`ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol).
+The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol).
 
-This TIP updates only the following interface functions:
-
-```solidity
-function open(
-    address payee,
-    address token,
-    uint128 deposit,
-    bytes32 salt,
-    address authorizedSigner,
-    uint64 expiresAt
-) external returns (bytes32 channelId);
-```
-
-```solidity
-function topUp(
-    bytes32 channelId,
-    uint256 additionalDeposit,
-    uint64 newExpiresAt
-) external;
-```
-
-```solidity
-function close(
-    bytes32 channelId,
-    uint128 cumulativeAmount,
-    uint128 captureAmount,
-    bytes calldata signature
-) external;
-```
-
-Compared to the reference interface, this adds `expiresAt` to channel lifecycle (`open`, `topUp`) and adds explicit final `captureAmount` to `close`.
+Implementations MUST expose an external interface that is semantically identical to that file, including the `Channel` state layout, events, errors, and function signatures.
 
 ### Execution Semantics
 
-Voucher signatures keep the reference EIP-712 shape:
+Voucher signatures use the following EIP-712 type:
 
 ```solidity
 Voucher(bytes32 channelId,uint128 cumulativeAmount)
 ```
 
-Execution semantics are the same as the reference implementation except:
+Execution semantics are:
 
-1. `open` MUST validate `expiresAt > block.timestamp` and persist `expiresAt`.
-2. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST be strictly in the future.
-3. `settle` and `close` MUST reject any capture-increasing action after `expiresAt`.
-4. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
-5. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-6. `withdraw` MUST be allowed after close grace OR after expiry.
-7. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+1. `open` MUST reject zero deposit, invalid token address, invalid payee address, and any `expiresAt` value where `expiresAt <= block.timestamp`.
+2. `open` MUST persist `expiresAt`.
+3. `topUp` MAY extend expiry using `newExpiresAt`; when non-zero, it MUST satisfy `newExpiresAt > block.timestamp`.
+4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it and emit `CloseRequestCancelled`.
+5. `requestClose` MUST set `closeRequestedAt = block.timestamp` on the first successful call and leave it unchanged on later successful calls.
+6. `settle` MUST reject when `block.timestamp >= expiresAt`.
+7. `close` MUST reject when `block.timestamp >= expiresAt` and `captureAmount > previousSettled`.
+8. `close` MUST validate the voucher signature for any capture-increasing close.
+9. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
+11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+12. `withdraw` MUST be allowed when either the close grace period has elapsed or `block.timestamp >= expiresAt`.
 
 ## Native Escrow Movement
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -1,0 +1,235 @@
+---
+id: TIP-1034
+title: Enshrined MPP Channels Precompile
+description: Enshrines MPP auth-and-capture payment channels as a Tempo precompile with explicit expiry and partial capture semantics.
+authors: Tanishk Goyal
+status: Draft
+related: TIP-20, TIP-1000, mpp-specs (tempo session/auth-capture)
+protocolVersion: TBD
+---
+
+# TIP-1034: Enshrined MPP Channels Precompile
+
+## Abstract
+
+This TIP enshrines MPP payment channels in Tempo as a native precompile. The precompile preserves the existing unidirectional channel model (`open`, `settle`, `topUp`, `requestClose`, `withdraw`) while adding two auth-and-capture requirements from recent design discussions: explicit authorization expiry and explicit partial capture on final close.
+
+The goal is to provide a protocol-native escrow primitive that supports single capture, multi-capture, incremental authorization, void, and delegated signing flows with lower friction than a pure Solidity deployment.
+
+## Motivation
+
+Current MPP channel behavior exists as a Solidity reference contract (`TempoStreamChannel`). It proves the core flow but leaves key production constraints unsolved for Tempo-native auth-and-capture:
+
+1. `open` and `topUp` require token `approve` + `transferFrom` UX.
+2. Channel state is contract storage that remains after finalization unless manually pruned.
+3. There is no explicit channel expiry field for authorization-hold use cases.
+4. Partial capture at close should be explicit (`capture <= authorized`), not implicit in client-side voucher selection.
+
+From product and partner feedback (Shopify/Stripe-style auth-and-capture), Tempo needs a first-class escrow primitive with explicit expiry and clean close semantics that can be composed directly by SDKs, gateways, and merchants.
+
+---
+
+# Specification
+
+## Precompile Address
+
+This TIP introduces a new system precompile, referred to as `MPP_CHANNEL_PRECOMPILE` in this document. The final canonical address is assigned at implementation time and activated in the protocol version listed in this TIP.
+
+## Channel Model
+
+Channels are unidirectional (`payer -> payee`) and token-specific.
+
+```solidity
+struct Channel {
+    address payer;
+    address payee;
+    address token;
+    address authorizedSigner; // 0 => payer signs vouchers
+    uint128 deposit;          // total authorized funds escrowed
+    uint128 settled;          // total amount already paid to payee
+    uint64 expiresAt;         // hard expiry for capture authorization
+    uint64 closeRequestedAt;  // payer-initiated close timer start (0 if not requested)
+    bool finalized;
+}
+```
+
+`channelId` is deterministic and MUST include chain and precompile domain separation:
+
+```solidity
+channelId = keccak256(
+    abi.encode(
+        payer,
+        payee,
+        token,
+        salt,
+        authorizedSigner,
+        MPP_CHANNEL_PRECOMPILE,
+        block.chainid
+    )
+);
+```
+
+## Interface
+
+```solidity
+interface IMPPChannel {
+    error ChannelAlreadyExists();
+    error ChannelNotFound();
+    error ChannelFinalized();
+    error NotPayer();
+    error NotPayee();
+    error InvalidPayee();
+    error InvalidExpiry();
+    error ChannelExpired();
+    error InvalidSignature();
+    error AmountExceedsDeposit();
+    error AmountNotIncreasing();
+    error CaptureAmountInvalid();
+    error CloseNotReady();
+    error DepositOverflow();
+    error TransferFailed();
+
+    event ChannelOpened(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        address token,
+        address authorizedSigner,
+        bytes32 salt,
+        uint128 deposit,
+        uint64 expiresAt
+    );
+
+    event Settled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint128 cumulativeAuthorized,
+        uint128 deltaPaid,
+        uint128 newSettled
+    );
+
+    event TopUp(
+        bytes32 indexed channelId,
+        uint128 additionalDeposit,
+        uint128 newDeposit,
+        uint64 newExpiresAt
+    );
+
+    event CloseRequested(bytes32 indexed channelId, uint64 closeGraceEnd);
+
+    event ChannelClosed(
+        bytes32 indexed channelId,
+        uint128 finalCaptured,
+        uint128 refundedToPayer
+    );
+
+    function open(
+        address payee,
+        address token,
+        uint128 deposit,
+        bytes32 salt,
+        address authorizedSigner,
+        uint64 expiresAt
+    ) external returns (bytes32 channelId);
+
+    function settle(
+        bytes32 channelId,
+        uint128 cumulativeAuthorized,
+        bytes calldata signature
+    ) external;
+
+    function topUp(
+        bytes32 channelId,
+        uint128 additionalDeposit,
+        uint64 newExpiresAt
+    ) external;
+
+    /// @notice Final close with explicit partial capture.
+    /// @dev captureAmount MUST satisfy: settled <= captureAmount <= cumulativeAuthorized.
+    function close(
+        bytes32 channelId,
+        uint128 cumulativeAuthorized,
+        uint128 captureAmount,
+        bytes calldata signature
+    ) external;
+
+    function requestClose(bytes32 channelId) external;
+    function withdraw(bytes32 channelId) external;
+    function getChannel(bytes32 channelId) external view returns (Channel memory);
+}
+```
+
+## Voucher Semantics
+
+Voucher signatures authorize a maximum cumulative amount:
+
+```solidity
+Voucher(bytes32 channelId,uint128 cumulativeAuthorized)
+```
+
+Rules:
+
+1. `cumulativeAuthorized` MUST be `>= settled` and `<= deposit`.
+2. `settle` moves `delta = cumulativeAuthorized - settled` to payee and sets `settled = cumulativeAuthorized`.
+3. `close` allows `captureAmount <= cumulativeAuthorized` so the payee can do explicit partial capture at finalization time.
+4. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+
+## Expiry Semantics
+
+`expiresAt` is an explicit authorization deadline for capture:
+
+1. `open` MUST revert if `expiresAt <= block.timestamp`.
+2. `settle` and `close` that increase `settled` MUST revert after expiry.
+3. After expiry, payer MAY call `withdraw` immediately (no grace timer required).
+4. `topUp` MAY extend expiry with `newExpiresAt`; when non-zero, it MUST be strictly greater than the current block timestamp.
+
+This provides canonical auth-hold behavior (`authorize now, capture before deadline, void after deadline`).
+
+## Close And Void Flows
+
+1. **Payee final close:** `close(channelId, cumulativeAuthorized, captureAmount, signature)`.
+2. **Payer forced close:** `requestClose` starts grace timer; `withdraw` succeeds after timer.
+3. **Natural expiry void:** once expired, payer can withdraw remainder.
+4. **Top-up cancelation:** successful `topUp` clears an active close request.
+
+## Enshrined Execution Rules
+
+The precompile MUST enforce the following protocol-level behavior:
+
+1. `open` and `topUp` escrow transfers use TIP-20 system movement (equivalent to `systemTransferFrom`) so users do not need an explicit `approve` transaction.
+2. On finalization, channel storage MUST be fully deleted (or tombstoned with equivalent trie-pruning semantics) so completed channels do not accumulate permanent state.
+3. Calls to this precompile remain regular EVM calls, but builders MAY classify these selectors as payment-lane eligible in admission policy.
+
+## Supported Auth-And-Capture Verbs
+
+This single interface supports:
+
+1. **Single capture:** `open` then one `close`.
+2. **Multi-capture:** multiple `settle` calls then `close`.
+3. **Incremental auth:** `topUp` (optional expiry extension).
+4. **Void:** payer `withdraw` after forced close timer or expiry.
+5. **Delegation:** vouchers signed by `authorizedSigner`.
+
+## Out Of Scope
+
+The following are explicitly out of scope for this TIP revision:
+
+1. Rewards on escrowed channel balances.
+2. Multi-party channels.
+3. Generalized conditional execution language inside the channel precompile.
+
+---
+
+# Invariants
+
+1. `settled <= deposit` MUST hold in all reachable states.
+2. `settled` is monotonic and can never decrease.
+3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
+4. In `close`, `captureAmount` MUST satisfy `previousSettled <= captureAmount <= cumulativeAuthorized <= deposit`.
+5. No operation may increase captured amount after `expiresAt`.
+6. Only payer can `topUp`, `requestClose`, and `withdraw`.
+7. Only payee can `settle` and `close`.
+8. Once finalized, all state-changing methods MUST revert for that channel.
+9. Finalization must conserve funds: `finalCaptured + refundedToPayer == deposit`.
+10. Finalized channels MUST be removable from active state storage.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -1,24 +1,24 @@
 ---
 id: TIP-1034
-title: Enshrined MPP Channels Precompile
-description: Enshrines MPP payment channels as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
+title: TIP-20 Channel Escrow Precompile
+description: Enshrines TIP-20 channel escrow as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal
 status: Draft
 related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
-# TIP-1034: Enshrined MPP Channels Precompile
+# TIP-1034: TIP-20 Channel Escrow Precompile
 
 ## Abstract
 
-This TIP enshrines MPP payment channels in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
+This TIP enshrines TIP-20 channel escrow in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
 
 The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
 
 ## Motivation
 
-MPP channels are currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
+TIP-20 channel escrow is currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
 
 1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
 2. **Payment-Lane Access**: Channel operations become payment-lane transactions, so they are not throttled by the non-payment `general_gas_limit` path during block contention.
@@ -35,17 +35,17 @@ This produces a simpler and more reliable path for session and auth/capture styl
 This TIP introduces a new system precompile at:
 
 ```solidity
-address constant MPP_CHANNEL_PRECOMPILE = 0x4D50500000000000000000000000000000000000;
+address constant TIP20_CHANNEL_ESCROW = 0x4D50500000000000000000000000000000000000;
 ```
 
-`MPP_CHANNEL_PRECOMPILE` MUST refer to this address throughout this specification.
+`TIP20_CHANNEL_ESCROW` MUST refer to this address throughout this specification.
 
 ## Implementation Details
 
 This TIP is normative. The current reference implementations are informative and live at:
 
-1. [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol)
-2. [`tips/ref-impls/src/TempoStreamChannel.sol`](ref-impls/src/TempoStreamChannel.sol)
+1. [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol)
+2. [`tips/ref-impls/src/TIP20ChannelEscrow.sol`](ref-impls/src/TIP20ChannelEscrow.sol)
 
 Implementations SHOULD keep those reference artifacts aligned with the normative interface and execution rules defined below.
 
@@ -79,7 +79,7 @@ channelId = keccak256(
         token,
         salt,
         authorizedSigner,
-        MPP_CHANNEL_PRECOMPILE,
+        TIP20_CHANNEL_ESCROW,
         block.chainid
     )
 );
@@ -87,7 +87,7 @@ channelId = keccak256(
 
 ### Interface
 
-The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol).
+The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol).
 
 Implementations MUST expose an external interface that is semantically identical to that file, including the `Channel` state layout, events, errors, and function signatures.
 
@@ -143,13 +143,13 @@ Required behavior:
 
 ## Payment-Lane Integration (Mandatory)
 
-MPP channel operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.
+Channel escrow operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.
 
 ### Classification Rules
 
-Implementations MUST define a strict classifier `is_mpp_channel_payment(to, input)` that returns true iff:
+Implementations MUST define a strict classifier `is_channel_escrow_payment(to, input)` that returns true iff:
 
-1. `to == MPP_CHANNEL_PRECOMPILE`.
+1. `to == TIP20_CHANNEL_ESCROW`.
 2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
 3. Calldata length/encoding is valid for that selector.
 4. For `settle` and `close`, the trailing `signature` bytes use a valid TIP-1020 / Tempo transaction signature encoding.
@@ -163,16 +163,16 @@ For AA transactions, payment classification MUST satisfy all of:
 1. `calls.length > 0`.
 2. `tempo_authorization_list.length == 0`.
 3. `key_authorization` is absent.
-4. Every call satisfies either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+4. Every call satisfies either TIP-20 strict payment classification or `is_channel_escrow_payment`.
 
 An AA transaction with an empty `calls` array MUST be classified as non-payment.
 
 ### Required Integration Points
 
-1. The consensus-level payment classifier (`is_payment`) MUST include MPP channel calls and MUST enforce the same authorization-side-effect exclusions above.
-2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_mpp_channel_payment` and MUST enforce the same authorization-side-effect exclusions above.
-3. The transaction pool payment flag MUST be computed from the strict classifier, so MPP channel calls are admitted in the payment lane path.
-4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat MPP channel calls as payment, so they are not rejected by the non-payment overflow path.
+1. The consensus-level payment classifier (`is_payment`) MUST include TIP-20 channel escrow calls and MUST enforce the same authorization-side-effect exclusions above.
+2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_channel_escrow_payment` and MUST enforce the same authorization-side-effect exclusions above.
+3. The transaction pool payment flag MUST be computed from the strict classifier, so channel escrow calls are admitted in the payment lane path.
+4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat channel escrow calls as payment, so they are not rejected by the non-payment overflow path.
 
 ### What This Means Operationally
 
@@ -189,7 +189,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 5. Only payee can `settle` and `close`.
 6. Once finalized, all state-changing methods MUST revert for that channel.
 7. Fund conservation MUST hold at all terminal states.
-8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+8. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
 10. No capture-increasing operation may succeed past `expiresAt`.
 11. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -199,6 +199,6 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 
 - [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec)
 - [TIP-1000](tip-1000.md)
-- [TIP-1020](https://docs.tempo.xyz/protocol/tips/tip-1020)
+- [TIP-1020](tip-1020.md)
 - [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
 - [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -21,9 +21,13 @@ The goal is to provide a protocol-native escrow primitive that supports single c
 Current MPP channel behavior exists as a Solidity reference contract (`TempoStreamChannel`). It proves the core flow but leaves key production constraints unsolved for Tempo-native auth-and-capture:
 
 1. `open` and `topUp` require token `approve` + `transferFrom` UX.
-2. Channel state is contract storage that remains after finalization unless manually pruned.
-3. There is no explicit channel expiry field for authorization-hold use cases.
-4. Partial capture at close should be explicit (`capture <= authorized`), not implicit in client-side voucher selection.
+2. There is no explicit channel expiry field for authorization-hold use cases.
+3. Partial capture at close should be explicit (`capture <= authorized`), not implicit in client-side voucher selection.
+4. Channel operations are not currently first-class payment-lane transactions, so under congestion they can be crowded out by general traffic.
+
+PR #3136 already hardens the Solidity reference contract around tombstoning/finalization and validation guardrails (invalid token and zero-deposit reverts). This TIP treats those semantics as baseline behavior and extends the design with explicit expiry, explicit final partial capture, and lane admission.
+
+For payment-lane integration, the implementation should follow the existing Tempo lane architecture: transactions classified as payment are exempt from the non-payment `general_gas_limit` check in the payload builder. This TIP adds MPP channel calls to that payment classifier so channel lifecycle operations (`open`, `settle`, `topUp`, `close`, `requestClose`, `withdraw`) continue to make progress during volatile-fee or spam conditions.
 
 From product and partner feedback (Shopify/Stripe-style auth-and-capture), Tempo needs a first-class escrow primitive with explicit expiry and clean close semantics that can be composed directly by SDKs, gateways, and merchants.
 
@@ -41,6 +45,8 @@ Channels are unidirectional (`payer -> payee`) and token-specific.
 
 ```solidity
 struct Channel {
+    bool finalized;           // tombstone marker
+    uint64 closeRequestedAt;  // payer-initiated close timer start (0 if not requested)
     address payer;
     address payee;
     address token;
@@ -48,8 +54,6 @@ struct Channel {
     uint128 deposit;          // total authorized funds escrowed
     uint128 settled;          // total amount already paid to payee
     uint64 expiresAt;         // hard expiry for capture authorization
-    uint64 closeRequestedAt;  // payer-initiated close timer start (0 if not requested)
-    bool finalized;
 }
 ```
 
@@ -79,6 +83,8 @@ interface IMPPChannel {
     error NotPayer();
     error NotPayee();
     error InvalidPayee();
+    error InvalidToken();
+    error ZeroDeposit();
     error InvalidExpiry();
     error ChannelExpired();
     error InvalidSignature();
@@ -175,6 +181,16 @@ Rules:
 3. `close` allows `captureAmount <= cumulativeAuthorized` so the payee can do explicit partial capture at finalization time.
 4. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
 
+## Baseline Validation Semantics (PR #3136 Compatibility)
+
+The precompile MUST preserve the latest `TempoStreamChannel` interface behavior from PR #3136:
+
+1. `open` MUST revert with `InvalidToken` when `token` is not a TIP-20 token.
+2. `open` MUST revert with `ZeroDeposit` when `deposit == 0`.
+3. `topUp` MUST revert with `ZeroDeposit` when `additionalDeposit == 0`.
+4. `open` MUST treat tombstoned channels as existing (channel IDs are non-reusable).
+5. Finalization MUST clear channel fields and keep `finalized = true` as a tombstone marker.
+
 ## Expiry Semantics
 
 `expiresAt` is an explicit authorization deadline for capture:
@@ -199,7 +215,16 @@ The precompile MUST enforce the following protocol-level behavior:
 
 1. `open` and `topUp` escrow transfers use TIP-20 system movement (equivalent to `systemTransferFrom`) so users do not need an explicit `approve` transaction.
 2. On finalization, channel storage MUST be fully deleted (or tombstoned with equivalent trie-pruning semantics) so completed channels do not accumulate permanent state.
-3. Calls to this precompile remain regular EVM calls, but builders MAY classify these selectors as payment-lane eligible in admission policy.
+3. Calls to this precompile remain regular EVM calls, and MUST be payment-lane eligible.
+
+### Payment-Lane Admission Plan
+
+At activation, implementations SHOULD add MPP channel classification using the same pattern used for TIP-20 payments:
+
+1. Add a strict channel classifier: `to == MPP_CHANNEL_PRECOMPILE` and selector is one of `{open, settle, topUp, close, requestClose, withdraw}` with exact calldata shape checks.
+2. Include that classifier in the transaction pool payment flag (the strict builder/pool path) so DoS-resistant lane admission remains intact.
+3. Include the same classifier in the payload builder path that applies `general_gas_limit`, so channel transactions are treated as payment traffic and not dropped as non-payment overflow.
+4. Keep consensus-level and builder-level payment classification aligned for fork activation to avoid classification drift.
 
 ## Supported Auth-And-Capture Verbs
 
@@ -233,3 +258,6 @@ The following are explicitly out of scope for this TIP revision:
 8. Once finalized, all state-changing methods MUST revert for that channel.
 9. Finalization must conserve funds: `finalCaptured + refundedToPayer == deposit`.
 10. Finalized channels MUST be removable from active state storage.
+11. `open` and `topUp` MUST revert when deposit input is zero.
+12. `open` MUST revert when `token` is not a TIP-20 token.
+13. Finalized/tombstoned channel IDs MUST NOT be reopenable.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -32,7 +32,13 @@ This produces a simpler and more reliable path for session and auth/capture styl
 
 ## Precompile Address
 
-This TIP introduces a new system precompile, referred to as `MPP_CHANNEL_PRECOMPILE` in this document. The final canonical address is assigned at implementation time and activated in the protocol version listed in this TIP.
+This TIP introduces a new system precompile at:
+
+```solidity
+address constant MPP_CHANNEL_PRECOMPILE = 0x4D50500000000000000000000000000000000000;
+```
+
+`MPP_CHANNEL_PRECOMPILE` MUST refer to this address throughout this specification.
 
 ## Baseline Implementation
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -8,9 +8,9 @@ related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
-# TIP-1034: Enshrined MPP Channels Precompile
-
 Related: [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec), [TIP-1000](tip-1000.md), [TIP-1020](https://docs.tempo.xyz/protocol/tips/tip-1020), [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html), [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)
+
+# TIP-1034: Enshrined MPP Channels Precompile
 
 ## Abstract
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -87,82 +87,12 @@ channelId = keccak256(
 
 ### Interface
 
+For unchanged functions, events, and errors, see the reference interface: [`ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol).
+
+This TIP updates only the following interface functions:
+
 ```solidity
 interface IMPPChannel {
-    error ChannelAlreadyExists();
-    error ChannelNotFound();
-    error ChannelFinalized();
-    error NotPayer();
-    error NotPayee();
-    error InvalidPayee();
-    error InvalidToken();
-    error ZeroDeposit();
-    error InvalidExpiry();
-    error ChannelExpired();
-    error InvalidSignature();
-    error AmountExceedsDeposit();
-    error AmountNotIncreasing();
-    error CaptureAmountInvalid();
-    error CloseNotReady();
-    error DepositOverflow();
-    error TransferFailed();
-
-    event ChannelOpened(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee,
-        address token,
-        address authorizedSigner,
-        bytes32 salt,
-        uint128 deposit,
-        uint64 expiresAt
-    );
-
-    event Settled(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee,
-        uint128 cumulativeAmount,
-        uint128 deltaPaid,
-        uint128 newSettled
-    );
-
-    event TopUp(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee,
-        uint128 additionalDeposit,
-        uint128 newDeposit,
-        uint64 newExpiresAt
-    );
-
-    event CloseRequested(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee,
-        uint256 closeGraceEnd
-    );
-
-    event ChannelClosed(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee,
-        uint128 settledToPayee,
-        uint128 refundedToPayer
-    );
-
-    event CloseRequestCancelled(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee
-    );
-
-    event ChannelExpired(
-        bytes32 indexed channelId,
-        address indexed payer,
-        address indexed payee
-    );
-
     function open(
         address payee,
         address token,
@@ -171,12 +101,6 @@ interface IMPPChannel {
         address authorizedSigner,
         uint64 expiresAt
     ) external returns (bytes32 channelId);
-
-    function settle(
-        bytes32 channelId,
-        uint128 cumulativeAmount,
-        bytes calldata signature
-    ) external;
 
     function topUp(
         bytes32 channelId,
@@ -190,10 +114,6 @@ interface IMPPChannel {
         uint128 captureAmount,
         bytes calldata signature
     ) external;
-
-    function requestClose(bytes32 channelId) external;
-    function withdraw(bytes32 channelId) external;
-    function getChannel(bytes32 channelId) external view returns (Channel memory);
 }
 ```
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1034
 title: Enshrined MPP Channels Precompile
-description: Enshrines MPP auth-and-capture payment channels as a Tempo precompile with explicit expiry and partial capture semantics.
+description: Enshrines MPP payment channels as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal
 status: Draft
 related: TIP-20, TIP-1000, mpp-specs (tempo session/auth-capture)
@@ -12,24 +12,19 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP enshrines MPP payment channels in Tempo as a native precompile. The precompile preserves the existing unidirectional channel model (`open`, `settle`, `topUp`, `requestClose`, `withdraw`) while adding two auth-and-capture requirements from recent design discussions: explicit authorization expiry and explicit partial capture on final close.
+This TIP enshrines MPP payment channels in Tempo as a native precompile. The implementation baseline follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow.
 
-The goal is to provide a protocol-native escrow primitive that supports single capture, multi-capture, incremental authorization, void, and delegated signing flows with lower friction than a pure Solidity deployment.
+The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
 
 ## Motivation
 
-Current MPP channel behavior exists as a Solidity reference contract (`TempoStreamChannel`). It proves the core flow but leaves key production constraints unsolved for Tempo-native auth-and-capture:
+MPP channels are currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
 
-1. `open` and `topUp` require token `approve` + `transferFrom` UX.
-2. There is no explicit channel expiry field for authorization-hold use cases.
-3. Partial capture at close should be explicit (`capture <= authorized`), not implicit in client-side voucher selection.
-4. Channel operations are not currently first-class payment-lane transactions, so under congestion they can be crowded out by general traffic.
+1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
+2. **Payment-Lane Access**: Channel operations become payment-lane transactions, so they are not throttled by the non-payment `general_gas_limit` path during block contention.
+3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow.
 
-PR #3136 already hardens the Solidity reference contract around tombstoning/finalization and validation guardrails (invalid token and zero-deposit reverts). This TIP treats those semantics as baseline behavior and extends the design with explicit expiry, explicit final partial capture, and lane admission.
-
-For payment-lane integration, the implementation should follow the existing Tempo lane architecture: transactions classified as payment are exempt from the non-payment `general_gas_limit` check in the payload builder. This TIP adds MPP channel calls to that payment classifier so channel lifecycle operations (`open`, `settle`, `topUp`, `close`, `requestClose`, `withdraw`) continue to make progress during volatile-fee or spam conditions.
-
-From product and partner feedback (Shopify/Stripe-style auth-and-capture), Tempo needs a first-class escrow primitive with explicit expiry and clean close semantics that can be composed directly by SDKs, gateways, and merchants.
+This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.
 
 ---
 
@@ -39,25 +34,29 @@ From product and partner feedback (Shopify/Stripe-style auth-and-capture), Tempo
 
 This TIP introduces a new system precompile, referred to as `MPP_CHANNEL_PRECOMPILE` in this document. The final canonical address is assigned at implementation time and activated in the protocol version listed in this TIP.
 
-## Channel Model
+## Baseline Implementation
+
+Unless explicitly changed in `Changes Proposed`, the precompile MUST match the reference implementation behavior and interface in:
+
+1. `tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`
+2. `tips/ref-impls/src/TempoStreamChannel.sol`
 
 Channels are unidirectional (`payer -> payee`) and token-specific.
 
 ```solidity
 struct Channel {
-    bool finalized;           // tombstone marker
-    uint64 closeRequestedAt;  // payer-initiated close timer start (0 if not requested)
+    bool finalized;
+    uint64 closeRequestedAt;
     address payer;
     address payee;
     address token;
-    address authorizedSigner; // 0 => payer signs vouchers
-    uint128 deposit;          // total authorized funds escrowed
-    uint128 settled;          // total amount already paid to payee
-    uint64 expiresAt;         // hard expiry for capture authorization
+    address authorizedSigner;
+    uint128 deposit;
+    uint128 settled;
 }
 ```
 
-`channelId` is deterministic and MUST include chain and precompile domain separation:
+`channelId` MUST use the same deterministic domain-separated construction used in the reference implementation:
 
 ```solidity
 channelId = keccak256(
@@ -73,7 +72,7 @@ channelId = keccak256(
 );
 ```
 
-## Interface
+The baseline callable interface is:
 
 ```solidity
 interface IMPPChannel {
@@ -85,12 +84,9 @@ interface IMPPChannel {
     error InvalidPayee();
     error InvalidToken();
     error ZeroDeposit();
-    error InvalidExpiry();
-    error ChannelExpired();
     error InvalidSignature();
     error AmountExceedsDeposit();
     error AmountNotIncreasing();
-    error CaptureAmountInvalid();
     error CloseNotReady();
     error DepositOverflow();
     error TransferFailed();
@@ -102,32 +98,51 @@ interface IMPPChannel {
         address token,
         address authorizedSigner,
         bytes32 salt,
-        uint128 deposit,
-        uint64 expiresAt
+        uint128 deposit
     );
 
     event Settled(
         bytes32 indexed channelId,
         address indexed payer,
         address indexed payee,
-        uint128 cumulativeAuthorized,
+        uint128 cumulativeAmount,
         uint128 deltaPaid,
         uint128 newSettled
     );
 
     event TopUp(
         bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
         uint128 additionalDeposit,
-        uint128 newDeposit,
-        uint64 newExpiresAt
+        uint128 newDeposit
     );
 
-    event CloseRequested(bytes32 indexed channelId, uint64 closeGraceEnd);
+    event CloseRequested(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 closeGraceEnd
+    );
 
     event ChannelClosed(
         bytes32 indexed channelId,
-        uint128 finalCaptured,
+        address indexed payer,
+        address indexed payee,
+        uint128 settledToPayee,
         uint128 refundedToPayer
+    );
+
+    event CloseRequestCancelled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee
+    );
+
+    event ChannelExpired(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee
     );
 
     function open(
@@ -135,30 +150,18 @@ interface IMPPChannel {
         address token,
         uint128 deposit,
         bytes32 salt,
-        address authorizedSigner,
-        uint64 expiresAt
+        address authorizedSigner
     ) external returns (bytes32 channelId);
 
     function settle(
         bytes32 channelId,
-        uint128 cumulativeAuthorized,
+        uint128 cumulativeAmount,
         bytes calldata signature
     ) external;
 
-    function topUp(
-        bytes32 channelId,
-        uint128 additionalDeposit,
-        uint64 newExpiresAt
-    ) external;
+    function topUp(bytes32 channelId, uint256 additionalDeposit) external;
 
-    /// @notice Final close with explicit partial capture.
-    /// @dev captureAmount MUST satisfy: settled <= captureAmount <= cumulativeAuthorized.
-    function close(
-        bytes32 channelId,
-        uint128 cumulativeAuthorized,
-        uint128 captureAmount,
-        bytes calldata signature
-    ) external;
+    function close(bytes32 channelId, uint128 cumulativeAmount, bytes calldata signature) external;
 
     function requestClose(bytes32 channelId) external;
     function withdraw(bytes32 channelId) external;
@@ -166,83 +169,90 @@ interface IMPPChannel {
 }
 ```
 
-## Voucher Semantics
+## Baseline Channel Semantics
 
-Voucher signatures authorize a maximum cumulative amount:
+Voucher signatures use the same EIP-712 voucher shape:
 
 ```solidity
-Voucher(bytes32 channelId,uint128 cumulativeAuthorized)
+Voucher(bytes32 channelId,uint128 cumulativeAmount)
+```
+
+Baseline execution rules:
+
+1. `settle` transfers only the positive delta from prior `settled` to the new signed cumulative amount.
+2. `close` settles any final voucher delta and refunds the remainder to the payer.
+3. `requestClose` starts the close grace timer for payer-driven withdrawal.
+4. `withdraw` succeeds only after the grace timer in baseline behavior.
+5. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+
+## Native Escrow Movement
+
+In this precompile, escrow transfers MUST use system TIP-20 movement semantics equivalent to `systemTransferFrom`.
+
+Required behavior:
+
+1. `open` escrows `deposit` from `payer` to channel escrow state without requiring a prior user `approve` transaction.
+2. `topUp` escrows `additionalDeposit` the same way.
+3. `settle`, `close`, and `withdraw` payout paths continue to transfer TIP-20 value using protocol-native token movement.
+
+## Payment-Lane Integration (Mandatory)
+
+MPP channel operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.
+
+### Classification Rules
+
+Implementations MUST define a strict classifier `is_mpp_channel_payment(to, input)` that returns true iff:
+
+1. `to == MPP_CHANNEL_PRECOMPILE`.
+2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
+3. Calldata length/encoding is valid for that selector.
+
+For AA transactions, payment classification MUST require every call to satisfy either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+
+### Required Integration Points
+
+1. The consensus-level payment classifier (`is_payment`) MUST include MPP channel calls.
+2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_mpp_channel_payment`.
+3. The transaction pool payment flag MUST be computed from the strict classifier, so MPP channel calls are admitted in the payment lane path.
+4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat MPP channel calls as payment, so they are not rejected by the non-payment overflow path.
+
+### What This Means Operationally
+
+With this integration, channel lifecycle calls consume payment-lane capacity rather than non-payment capacity. Under high congestion, these transactions continue to compete in the same lane as other payment traffic instead of being excluded by non-payment limits.
+
+## Changes Proposed
+
+This section lists behavior changes beyond the baseline reference implementation.
+
+### Change 1: Explicit Authorization Expiry
+
+Add `expiresAt` to channel state and enforce authorization expiry semantics:
+
+1. `open` requires a valid future `expiresAt`.
+2. `settle` and `close` that increase captured amount MUST fail after expiry.
+3. After expiry, payer MAY reclaim remaining funds via `withdraw` without waiting for close grace.
+4. `topUp` MAY extend expiry by setting a new future deadline.
+
+### Change 2: Explicit Final Partial Capture
+
+Extend `close` to make final partial capture explicit:
+
+```solidity
+function close(
+    bytes32 channelId,
+    uint128 cumulativeAmount,
+    uint128 captureAmount,
+    bytes calldata signature
+) external;
 ```
 
 Rules:
 
-1. `cumulativeAuthorized` MUST be `>= settled` and `<= deposit`.
-2. `settle` moves `delta = cumulativeAuthorized - settled` to payee and sets `settled = cumulativeAuthorized`.
-3. `close` allows `captureAmount <= cumulativeAuthorized` so the payee can do explicit partial capture at finalization time.
-4. Signer MUST be `authorizedSigner` when set, otherwise `payer`.
+1. `captureAmount` MUST satisfy `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.
+2. Signature still authorizes `cumulativeAmount` (the upper bound).
+3. `captureAmount` determines final payee payout, with `deposit - captureAmount` refunded to payer.
 
-## Baseline Validation Semantics (PR #3136 Compatibility)
-
-The precompile MUST preserve the latest `TempoStreamChannel` interface behavior from PR #3136:
-
-1. `open` MUST revert with `InvalidToken` when `token` is not a TIP-20 token.
-2. `open` MUST revert with `ZeroDeposit` when `deposit == 0`.
-3. `topUp` MUST revert with `ZeroDeposit` when `additionalDeposit == 0`.
-4. `open` MUST treat tombstoned channels as existing (channel IDs are non-reusable).
-5. Finalization MUST clear channel fields and keep `finalized = true` as a tombstone marker.
-
-## Expiry Semantics
-
-`expiresAt` is an explicit authorization deadline for capture:
-
-1. `open` MUST revert if `expiresAt <= block.timestamp`.
-2. `settle` and `close` that increase `settled` MUST revert after expiry.
-3. After expiry, payer MAY call `withdraw` immediately (no grace timer required).
-4. `topUp` MAY extend expiry with `newExpiresAt`; when non-zero, it MUST be strictly greater than the current block timestamp.
-
-This provides canonical auth-hold behavior (`authorize now, capture before deadline, void after deadline`).
-
-## Close And Void Flows
-
-1. **Payee final close:** `close(channelId, cumulativeAuthorized, captureAmount, signature)`.
-2. **Payer forced close:** `requestClose` starts grace timer; `withdraw` succeeds after timer.
-3. **Natural expiry void:** once expired, payer can withdraw remainder.
-4. **Top-up cancelation:** successful `topUp` clears an active close request.
-
-## Enshrined Execution Rules
-
-The precompile MUST enforce the following protocol-level behavior:
-
-1. `open` and `topUp` escrow transfers use TIP-20 system movement (equivalent to `systemTransferFrom`) so users do not need an explicit `approve` transaction.
-2. On finalization, channel storage MUST be fully deleted (or tombstoned with equivalent trie-pruning semantics) so completed channels do not accumulate permanent state.
-3. Calls to this precompile remain regular EVM calls, and MUST be payment-lane eligible.
-
-### Payment-Lane Admission Plan
-
-At activation, implementations SHOULD add MPP channel classification using the same pattern used for TIP-20 payments:
-
-1. Add a strict channel classifier: `to == MPP_CHANNEL_PRECOMPILE` and selector is one of `{open, settle, topUp, close, requestClose, withdraw}` with exact calldata shape checks.
-2. Include that classifier in the transaction pool payment flag (the strict builder/pool path) so DoS-resistant lane admission remains intact.
-3. Include the same classifier in the payload builder path that applies `general_gas_limit`, so channel transactions are treated as payment traffic and not dropped as non-payment overflow.
-4. Keep consensus-level and builder-level payment classification aligned for fork activation to avoid classification drift.
-
-## Supported Auth-And-Capture Verbs
-
-This single interface supports:
-
-1. **Single capture:** `open` then one `close`.
-2. **Multi-capture:** multiple `settle` calls then `close`.
-3. **Incremental auth:** `topUp` (optional expiry extension).
-4. **Void:** payer `withdraw` after forced close timer or expiry.
-5. **Delegation:** vouchers signed by `authorizedSigner`.
-
-## Out Of Scope
-
-The following are explicitly out of scope for this TIP revision:
-
-1. Rewards on escrowed channel balances.
-2. Multi-party channels.
-3. Generalized conditional execution language inside the channel precompile.
+This keeps cumulative vouchers while making “authorize up to X, capture Y” explicit on finalization.
 
 ---
 
@@ -251,13 +261,11 @@ The following are explicitly out of scope for this TIP revision:
 1. `settled <= deposit` MUST hold in all reachable states.
 2. `settled` is monotonic and can never decrease.
 3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
-4. In `close`, `captureAmount` MUST satisfy `previousSettled <= captureAmount <= cumulativeAuthorized <= deposit`.
-5. No operation may increase captured amount after `expiresAt`.
-6. Only payer can `topUp`, `requestClose`, and `withdraw`.
-7. Only payee can `settle` and `close`.
-8. Once finalized, all state-changing methods MUST revert for that channel.
-9. Finalization must conserve funds: `finalCaptured + refundedToPayer == deposit`.
-10. Finalized channels MUST be removable from active state storage.
-11. `open` and `topUp` MUST revert when deposit input is zero.
-12. `open` MUST revert when `token` is not a TIP-20 token.
-13. Finalized/tombstoned channel IDs MUST NOT be reopenable.
+4. Only payer can `topUp`, `requestClose`, and `withdraw`.
+5. Only payee can `settle` and `close`.
+6. Once finalized, all state-changing methods MUST revert for that channel.
+7. Fund conservation MUST hold at all terminal states.
+8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers.
+9. `open` and `topUp` MUST not require a prior user `approve` transaction.
+10. If `Changes Proposed` are activated, no capture-increasing operation may succeed past `expiresAt`.
+11. If `Changes Proposed` are activated, `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount <= deposit`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -61,6 +61,7 @@ struct ChannelDescriptor {
     address token;
     bytes32 salt;
     address authorizedSigner;
+    bytes32 openTxHash;
 }
 
 struct ChannelState {
@@ -100,11 +101,10 @@ high 32 bits MUST remain zero.
 `closeData` MUST be encoded as:
 
 1. `0` for an active channel with no close request.
-2. `1` for a finalized channel tombstone.
-3. Any value `>= 2` for an active channel with a close request, where the stored value is the exact `closeRequestedAt` timestamp.
+2. Any non-zero value for an active channel with a close request, where the stored value is the
+   exact `closeRequestedAt` timestamp.
 
-This means timestamps `0` and `1` are reserved sentinel values and are not representable as
-close-request times.
+Closed channels MUST not retain any packed `ChannelState` slot at all.
 
 `channelId` MUST use the following deterministic domain-separated construction:
 
@@ -117,11 +117,16 @@ channelId = keccak256(
         token,
         salt,
         authorizedSigner,
+        openTxHash,
         TIP20_CHANNEL_ESCROW,
         block.chainid
     )
 );
 ```
+
+For `open`, `openTxHash` MUST be the hash of the enclosing channel-open transaction. For all
+post-open operations, `openTxHash` MUST be supplied via `ChannelDescriptor` so the implementation
+can recompute the same `channelId` without storing immutable descriptor fields on-chain.
 
 ### Interface
 
@@ -161,20 +166,21 @@ all settlement payouts still transfer to `payee`.
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
-2. `open` MUST persist only the packed `ChannelState` slot and MUST emit the full immutable descriptor in `ChannelOpened`.
+2. `open` MUST derive `openTxHash` from the enclosing transaction hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
-4. If `closeData >= 2`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
+4. If `closeData != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
-6. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
-7. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
-8. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
-9. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
-10. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
-11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-12. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
-13. `settle` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
-14. `close` MUST be callable only by `payee`.
-15. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
+6. `settle` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
+7. `close` MUST be callable only by `payee`.
+8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
+9. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
+10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
+11. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
+12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
+13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+14. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
+15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because `openTxHash` changes.
+16. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 ## Native Escrow Movement
 
@@ -258,10 +264,10 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 6. Only payee can `close`.
 7. A channel MUST consume exactly one storage slot of mutable on-chain state.
 8. `closeData == 0` MUST mean active with no close request.
-9. `closeData == 1` MUST mean finalized.
-10. `closeData >= 2` MUST mean active with a close request timestamp equal to `closeData`.
-11. Once finalized, all state-changing methods MUST revert for that channel.
-12. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
+9. `closeData != 0` MUST mean active with a close request timestamp equal to `closeData`.
+10. Closed channels MUST have no remaining mutable on-chain state.
+11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because `openTxHash` is different.
+12. Reopening the same `channelId` within one top-level transaction MUST be impossible.
 13. Fund conservation MUST hold at all terminal states.
 14. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 15. `open` and `topUp` MUST not require a prior user `approve` transaction.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -57,6 +57,7 @@ Channels are unidirectional (`payer -> payee`) and token-specific.
 struct ChannelDescriptor {
     address payer;
     address payee;
+    address operator;
     address token;
     bytes32 salt;
     address authorizedSigner;
@@ -112,6 +113,7 @@ channelId = keccak256(
     abi.encode(
         payer,
         payee,
+        operator,
         token,
         salt,
         authorizedSigner,
@@ -150,7 +152,11 @@ This means:
 
 Execution semantics use exact timestamp boundaries. Close-grace completion MUST use the strict
 predicate `block.timestamp >= closeRequestedAt + CLOSE_GRACE_PERIOD`. Implementations MUST NOT
-substitute a different operator.
+substitute a different comparison predicate.
+
+`operator` is an immutable settlement authority for the channel. `address(0)` means the payee is
+the only settlement operator. A nonzero `operator` MAY submit `settle` on the payee's behalf, but
+all settlement payouts still transfer to `payee`.
 
 Execution semantics are:
 
@@ -166,7 +172,9 @@ Execution semantics are:
 10. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 11. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
 12. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
-13. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
+13. `settle` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
+14. `close` MUST be callable only by `payee`.
+15. Terminal `close` and `withdraw` MUST set `closeData = 1` and MUST NOT delete the slot, so the same descriptor and `channelId` cannot be reopened and replay old vouchers.
 
 ## Native Escrow Movement
 
@@ -246,18 +254,19 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 2. `settled` is monotonic and can never decrease.
 3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
-5. Only payee can `settle` and `close`.
-6. A channel MUST consume exactly one storage slot of mutable on-chain state.
-7. `closeData == 0` MUST mean active with no close request.
-8. `closeData == 1` MUST mean finalized.
-9. `closeData >= 2` MUST mean active with a close request timestamp equal to `closeData`.
-10. Once finalized, all state-changing methods MUST revert for that channel.
-11. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
-12. Fund conservation MUST hold at all terminal states.
-13. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
-14. `open` and `topUp` MUST not require a prior user `approve` transaction.
-15. `withdraw` MUST require an active close request whose grace period has elapsed.
-16. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
+5. Only payee, or a nonzero operator, can `settle`.
+6. Only payee can `close`.
+7. A channel MUST consume exactly one storage slot of mutable on-chain state.
+8. `closeData == 0` MUST mean active with no close request.
+9. `closeData == 1` MUST mean finalized.
+10. `closeData >= 2` MUST mean active with a close request timestamp equal to `closeData`.
+11. Once finalized, all state-changing methods MUST revert for that channel.
+12. Finalized channels MUST retain a non-zero tombstone state so the same descriptor cannot be reopened.
+13. Fund conservation MUST hold at all terminal states.
+14. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+15. `open` and `topUp` MUST not require a prior user `approve` transaction.
+16. `withdraw` MUST require an active close request whose grace period has elapsed.
+17. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`, and `captureAmount <= deposit`.
 
 ## References
 

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -257,7 +257,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 # Invariants
 
 1. `settled <= deposit` MUST hold in all reachable states.
-2. `settled` is monotonic and can never decrease.
+2. `settled` is monotonically non-decreasing.
 3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
 5. Only payee, or a nonzero operator, can `settle`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -182,6 +182,12 @@ Execution semantics are:
 15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because `openTxHash` changes.
 16. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
+The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
+`captureAmount` parameter. The voucher proves that the payer authorized at least the captured
+amount, while `captureAmount` chooses the final escrow-bounded payout. `settle` does not have a
+separate capture parameter, so its `cumulativeAmount` is the exact new settled amount and MUST
+remain bounded by the current deposit.
+
 ## Native Escrow Movement
 
 In this precompile, escrow transfers MUST use system TIP-20 movement semantics equivalent to `systemTransferFrom`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -128,6 +128,28 @@ For `open`, `openTxHash` MUST be the hash of the enclosing channel-open transact
 post-open operations, `openTxHash` MUST be supplied via `ChannelDescriptor` so the implementation
 can recompute the same `channelId` without storing immutable descriptor fields on-chain.
 
+### Same-Transaction Opens
+
+Multiple `open` calls MAY appear in the same top-level transaction, including a Tempo AA batch, as
+long as each call derives a distinct `channelId`. Because all calls in the same top-level
+transaction share the same `openTxHash`, distinct same-transaction opens MUST differ in at least one
+other descriptor field, such as `payee`, `operator`, `token`, `salt`, or `authorizedSigner`.
+
+This is safe because vouchers are bound to the resulting `channelId`, and each distinct
+`channelId` has independent escrow state. For example, an AA transaction MAY atomically open
+several channels for different sessions or payees.
+
+An `open` call MUST NOT succeed if the derived `channelId` was already opened earlier in the same
+top-level transaction. This requirement covers both ordinary duplicate opens and the otherwise
+dangerous `open -> close` or `open -> withdraw` followed by a second `open` with the same
+descriptor. Terminal `close` and `withdraw` delete persistent channel state, so implementations MUST
+also maintain transient per-transaction opened-channel tracking to reject such same-transaction
+reopens after deletion.
+
+Reopening the same logical descriptor in a later transaction is allowed after terminal closure,
+because the later transaction has a different `openTxHash` and therefore derives a different
+`channelId`.
+
 ### Interface
 
 The canonical interface for this TIP is [`tips/verify/src/interfaces/ITIP20ChannelEscrow.sol`](verify/src/interfaces/ITIP20ChannelEscrow.sol).

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -67,7 +67,7 @@ struct ChannelDescriptor {
 struct ChannelState {
     uint96 settled;
     uint96 deposit;
-    uint32 closeData;
+    uint32 closeRequestedAt;
 }
 
 struct Channel {
@@ -86,7 +86,7 @@ The packed slot layout is:
 ```text
 bits   0..95   settled        uint96
 bits  96..191  deposit        uint96
-bits 192..223  closeData      uint32
+bits 192..223  closeRequestedAt uint32
 bits 224..255  reserved       zero
 ```
 
@@ -98,11 +98,11 @@ timestamps through February 2106, which is sufficient for close-request tracking
 are expected to live for minutes, hours, days, or months rather than many decades. The reserved
 high 32 bits MUST remain zero.
 
-`closeData` MUST be encoded as:
+`closeRequestedAt` MUST be encoded as:
 
 1. `0` for an active channel with no close request.
 2. Any non-zero value for an active channel with a close request, where the stored value is the
-   exact `closeRequestedAt` timestamp.
+   exact close-request timestamp.
 
 Closed channels MUST not retain any packed `ChannelState` slot at all.
 
@@ -124,17 +124,23 @@ channelId = keccak256(
 );
 ```
 
-For `open`, `expiringNonceHash` MUST be the expiring nonce hash of the enclosing
-channel-open transaction. This is the sender-bound transaction signing payload hash used for
-expiring nonce replay protection, not the full transaction hash, so it is invariant to fee-payer
-signature changes while still identifying a transaction that cannot be replayed. `open` MUST reject
-if the enclosing transaction does not have an expiring nonce hash available.
+For `open`, `expiringNonceHash` MUST be the replay-protected context hash of the enclosing
+channel-open transaction:
 
-The full transaction hash is intentionally not used because it commits to fee-payer signature data.
-Changing the fee payer would change the transaction hash even though the sender-authorized channel
-open payload is the same, which would make the channel ID relayer-dependent. Using the expiring
-nonce hash keeps the stateless, client-predictable properties of a transaction-derived seed while
-binding the channel ID to the replay-protected sender payload.
+```solidity
+expiringNonceHash = keccak256(abi.encodePacked(encodeForSigning, sender));
+```
+
+Here `encodeForSigning` is the exact byte payload whose hash is signed by the top-level transaction
+sender, and `sender` is the top-level transaction sender address. For Tempo AA transactions, this
+is exactly the existing expiring nonce hash construction: the signing payload omits the actual
+fee-payer signature, and when a fee payer is present it also omits the fee token chosen by the fee
+payer. For legacy, EIP-2930, EIP-1559, and EIP-7702 transactions, `encodeForSigning` is the usual
+unsigned transaction signing payload.
+
+`open` MUST reject if the enclosing execution context does not have this context hash available.
+For real signed transactions, the protocol always has both the sender and the corresponding signing
+payload.
 
 For all post-open operations, `expiringNonceHash` MUST be supplied via `ChannelDescriptor` so the
 implementation can recompute the same `channelId` without storing immutable descriptor fields
@@ -144,8 +150,8 @@ on-chain.
 
 Multiple `open` calls MAY appear in the same top-level transaction, including a Tempo AA batch, as
 long as each call derives a distinct `channelId`. Because all calls in the same top-level
-transaction share the same `expiringNonceHash`, distinct same-transaction opens MUST differ in at
-least one other descriptor field, such as `payee`, `operator`, `token`, `salt`, or
+transaction share the same `expiringNonceHash` context value, distinct same-transaction opens MUST
+differ in at least one other descriptor field, such as `payee`, `operator`, `token`, `salt`, or
 `authorizedSigner`.
 
 This is safe because vouchers are bound to the resulting `channelId`, and each distinct
@@ -160,8 +166,8 @@ also maintain transient per-transaction opened-channel tracking to reject such s
 reopens after deletion.
 
 Reopening the same logical descriptor in a later transaction is allowed after terminal closure,
-because the later transaction has a different `expiringNonceHash` and therefore derives a different
-`channelId`.
+because the later transaction has a different replay-protected context hash and therefore derives a
+different `channelId`.
 
 ### Interface
 
@@ -201,10 +207,10 @@ all settlement payouts still transfer to `payee`.
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
-2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's expiring nonce hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
+2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's replay-protected context hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
-4. If `closeData != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
-5. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
+4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
+5. `requestClose` MUST set `closeRequestedAt = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
 6. `settle` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
 7. `close` MUST be callable only by `payee`.
 8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
@@ -213,8 +219,8 @@ Execution semantics are:
 11. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
 12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-14. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
-15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because `expiringNonceHash` changes.
+14. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeRequestedAt`.
+15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
 16. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
@@ -304,10 +310,10 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 5. Only payee, or a nonzero operator, can `settle`.
 6. Only payee can `close`.
 7. A channel MUST consume exactly one storage slot of mutable on-chain state.
-8. `closeData == 0` MUST mean active with no close request.
-9. `closeData != 0` MUST mean active with a close request timestamp equal to `closeData`.
+8. `closeRequestedAt == 0` MUST mean active with no close request.
+9. `closeRequestedAt != 0` MUST mean active with a close request timestamp equal to `closeRequestedAt`.
 10. Closed channels MUST have no remaining mutable on-chain state.
-11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because `expiringNonceHash` is different.
+11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because the replay-protected context hash is different.
 12. Reopening the same `channelId` within one top-level transaction MUST be impossible.
 13. Fund conservation MUST hold at all terminal states.
 14. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -200,9 +200,9 @@ Execution semantics use exact timestamp boundaries. Close-grace completion MUST 
 predicate `block.timestamp >= closeRequestedAt + CLOSE_GRACE_PERIOD`. Implementations MUST NOT
 substitute a different comparison predicate.
 
-`operator` is an immutable settlement authority for the channel. `address(0)` means the payee is
-the only settlement operator. A nonzero `operator` MAY submit `settle` on the payee's behalf, but
-all settlement payouts still transfer to `payee`.
+`operator` is an immutable payee-side authority for the channel. `address(0)` means the payee is
+the only payee-side authority. A nonzero `operator` MAY submit `settle` and `close` on the payee's
+behalf, but all settlement and close-capture payouts still transfer to `payee`.
 
 Execution semantics are:
 
@@ -211,17 +211,16 @@ Execution semantics are:
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. If `closeRequestedAt != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeRequestedAt = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
-6. `settle` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
-7. `close` MUST be callable only by `payee`.
-8. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
-9. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
-10. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
-11. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
-12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
-13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
-14. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeRequestedAt`.
-15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
-16. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
+6. `settle` and `close` MUST be callable only by `payee`, or by `operator` when `operator != address(0)`.
+7. `close` MUST validate the voucher signature via TIP-1020 for any capture-increasing close.
+8. Signer MUST be `authorizedSigner` from the supplied descriptor when set, otherwise `payer` from the supplied descriptor.
+9. `close` MUST enforce `previousSettled <= captureAmount <= cumulativeAmount`.
+10. `close` MUST reject when `captureAmount > deposit`, even if `cumulativeAmount > deposit`.
+11. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
+12. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
+13. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeRequestedAt`.
+14. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because the replay-protected context hash changes.
+15. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
 `captureAmount` parameter. The voucher proves that the payer authorized at least the captured
@@ -307,8 +306,8 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 2. `settled` is monotonically non-decreasing.
 3. Any successful capture (`settle` or `close`) MUST be authorized by a valid voucher signature from the expected signer.
 4. Only payer can `topUp`, `requestClose`, and `withdraw`.
-5. Only payee, or a nonzero operator, can `settle`.
-6. Only payee can `close`.
+5. Only payee, or a nonzero operator, can `settle` and `close`.
+6. A zero operator does not authorize any caller.
 7. A channel MUST consume exactly one storage slot of mutable on-chain state.
 8. `closeRequestedAt == 0` MUST mean active with no close request.
 9. `closeRequestedAt != 0` MUST mean active with a close request timestamp equal to `closeRequestedAt`.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -21,7 +21,7 @@ The precompile is introduced to reduce execution overhead, remove the separate `
 TIP-20 channel escrow is currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
 
 1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
-2. **Payment-Lane Access**: Channel operations become payment-lane transactions, so they are not throttled by the non-payment `general_gas_limit` path during block contention.
+2. **Canonical implementation, evolved at network-upgrade cadence**: The escrow lives at a single canonical address on every Tempo node (`0x4D50500…`, ASCII "MPP"), with no admin or proxy admin, and ships behavior via network upgrades alongside the rest of the protocol. Wallets, indexers, and partner integrations bind to one stable surface rather than to a moving set of redeployments.
 3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow.
 
 This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -4,7 +4,7 @@ title: TIP-20 Channel Escrow Precompile
 description: Enshrines TIP-20 channel escrow as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal, Brendan Ryan
 status: Draft
-related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
+related: TIP-20, TIP-1000, TIP-1009, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
@@ -61,7 +61,7 @@ struct ChannelDescriptor {
     address token;
     bytes32 salt;
     address authorizedSigner;
-    bytes32 openTxHash;
+    bytes32 expiringNonceHash;
 }
 
 struct ChannelState {
@@ -117,23 +117,36 @@ channelId = keccak256(
         token,
         salt,
         authorizedSigner,
-        openTxHash,
+        expiringNonceHash,
         TIP20_CHANNEL_ESCROW,
         block.chainid
     )
 );
 ```
 
-For `open`, `openTxHash` MUST be the hash of the enclosing channel-open transaction. For all
-post-open operations, `openTxHash` MUST be supplied via `ChannelDescriptor` so the implementation
-can recompute the same `channelId` without storing immutable descriptor fields on-chain.
+For `open`, `expiringNonceHash` MUST be the expiring nonce hash of the enclosing
+channel-open transaction. This is the sender-bound transaction signing payload hash used for
+expiring nonce replay protection, not the full transaction hash, so it is invariant to fee-payer
+signature changes while still identifying a transaction that cannot be replayed. `open` MUST reject
+if the enclosing transaction does not have an expiring nonce hash available.
+
+The full transaction hash is intentionally not used because it commits to fee-payer signature data.
+Changing the fee payer would change the transaction hash even though the sender-authorized channel
+open payload is the same, which would make the channel ID relayer-dependent. Using the expiring
+nonce hash keeps the stateless, client-predictable properties of a transaction-derived seed while
+binding the channel ID to the replay-protected sender payload.
+
+For all post-open operations, `expiringNonceHash` MUST be supplied via `ChannelDescriptor` so the
+implementation can recompute the same `channelId` without storing immutable descriptor fields
+on-chain.
 
 ### Same-Transaction Opens
 
 Multiple `open` calls MAY appear in the same top-level transaction, including a Tempo AA batch, as
 long as each call derives a distinct `channelId`. Because all calls in the same top-level
-transaction share the same `openTxHash`, distinct same-transaction opens MUST differ in at least one
-other descriptor field, such as `payee`, `operator`, `token`, `salt`, or `authorizedSigner`.
+transaction share the same `expiringNonceHash`, distinct same-transaction opens MUST differ in at
+least one other descriptor field, such as `payee`, `operator`, `token`, `salt`, or
+`authorizedSigner`.
 
 This is safe because vouchers are bound to the resulting `channelId`, and each distinct
 `channelId` has independent escrow state. For example, an AA transaction MAY atomically open
@@ -147,7 +160,7 @@ also maintain transient per-transaction opened-channel tracking to reject such s
 reopens after deletion.
 
 Reopening the same logical descriptor in a later transaction is allowed after terminal closure,
-because the later transaction has a different `openTxHash` and therefore derives a different
+because the later transaction has a different `expiringNonceHash` and therefore derives a different
 `channelId`.
 
 ### Interface
@@ -188,7 +201,7 @@ all settlement payouts still transfer to `payee`.
 Execution semantics are:
 
 1. `open` MUST reject zero deposit, invalid token address, and invalid payee address.
-2. `open` MUST derive `openTxHash` from the enclosing transaction hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
+2. `open` MUST derive `expiringNonceHash` from the enclosing transaction's expiring nonce hash, persist only the packed `ChannelState` slot, and MUST emit the full immutable descriptor in `ChannelOpened`.
 3. Post-open methods (`settle`, `topUp`, `close`, `requestClose`, `withdraw`, and descriptor-based views) MUST recompute `channelId` from the supplied descriptor and use that derived id for storage lookup.
 4. If `closeData != 0`, a successful `topUp` MUST clear it back to `0` and emit `CloseRequestCancelled`.
 5. `requestClose` MUST set `closeData = uint32(block.timestamp)` on the first successful call and leave it unchanged on later successful calls.
@@ -201,7 +214,7 @@ Execution semantics are:
 12. A `close` voucher with `cumulativeAmount > deposit` remains valid for signature verification; `captureAmount` is the escrow-bounded amount that may actually be paid out.
 13. `close` MUST settle `captureAmount - previousSettled` to payee and refund `deposit - captureAmount` to payer.
 14. `withdraw` MUST be allowed only when the close grace period has elapsed from `closeData`.
-15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because `openTxHash` changes.
+15. Terminal `close` and `withdraw` MUST delete the stored slot entirely. Reopening the same logical channel in a later transaction MUST produce a different `channelId` because `expiringNonceHash` changes.
 16. Within one top-level transaction, `open` MUST reject any `channelId` that was already opened earlier in that same transaction, even if the channel was terminally closed or withdrawn before the later `open` call.
 
 The `cumulativeAmount > deposit` allowance is specific to `close`, because `close` has a separate
@@ -294,7 +307,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 8. `closeData == 0` MUST mean active with no close request.
 9. `closeData != 0` MUST mean active with a close request timestamp equal to `closeData`.
 10. Closed channels MUST have no remaining mutable on-chain state.
-11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because `openTxHash` is different.
+11. Reopening the same logical channel in a later transaction MUST yield a different `channelId` because `expiringNonceHash` is different.
 12. Reopening the same `channelId` within one top-level transaction MUST be impossible.
 13. Fund conservation MUST hold at all terminal states.
 14. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
@@ -306,6 +319,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 
 - [TIP-20](https://docs.tempo.xyz/protocol/tip20/spec)
 - [TIP-1000](tip-1000.md)
+- [TIP-1009](tip-1009.md)
 - [TIP-1020](tip-1020.md)
 - [Tempo Session Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-session-00.html)
 - [Tempo Charge Intent for HTTP Payment Authentication](https://paymentauth.org/draft-tempo-charge-00.html)

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -22,7 +22,7 @@ TIP-20 channel escrow is currently specified as a Solidity contract reference im
 
 1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
 2. **Canonical implementation, evolved at network-upgrade cadence**: The escrow lives at a single canonical address on every Tempo node (`0x4D50500…`, ASCII "MPP"), with no admin or proxy admin, and ships behavior via network upgrades alongside the rest of the protocol. Wallets, indexers, and partner integrations bind to one stable surface rather than to a moving set of redeployments.
-3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow.
+3. **Approve-less Escrow UX**: `open` and `topUp` can escrow TIP-20 funds through native system transfer (`systemTransferFrom` semantics), removing the extra `approve` transaction from the user flow and works uniformly for passkey accounts.
 
 This produces a simpler and more reliable path for session and auth/capture style integrations without changing the core channel model developers already use.
 

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -19,8 +19,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
 
     uint256 internal constant _DEPOSIT_OFFSET = 96;
-    uint256 internal constant _EXPIRES_AT_OFFSET = 192;
-    uint256 internal constant _CLOSE_DATA_OFFSET = 224;
+    uint256 internal constant _CLOSE_DATA_OFFSET = 192;
     uint32 internal constant _FINALIZED_CLOSE_DATA = 1;
 
     bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
@@ -36,8 +35,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         address token,
         uint96 deposit,
         bytes32 salt,
-        address authorizedSigner,
-        uint32 expiresAt
+        address authorizedSigner
     )
         external
         returns (bytes32 channelId)
@@ -45,7 +43,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (payee == address(0)) revert InvalidPayee();
         if (token == address(0)) revert InvalidToken();
         if (deposit == 0) revert ZeroDeposit();
-        if (expiresAt <= block.timestamp) revert InvalidExpiry();
 
         channelId = computeChannelId(msg.sender, payee, token, salt, authorizedSigner);
         if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
@@ -54,7 +51,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             ChannelState({
                 settled: 0,
                 deposit: deposit,
-                expiresAt: expiresAt,
                 closeData: 0
             })
         );
@@ -64,9 +60,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
 
-        emit ChannelOpened(
-            channelId, msg.sender, payee, token, authorizedSigner, salt, deposit, expiresAt
-        );
+        emit ChannelOpened(channelId, msg.sender, payee, token, authorizedSigner, salt, deposit);
     }
 
     function settle(
@@ -81,7 +75,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         if (msg.sender != descriptor.payee) revert NotPayee();
         if (_isFinalized(channel.closeData)) revert ChannelFinalized();
-        if (_isExpired(channel.expiresAt)) revert ChannelExpiredError();
         if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
         if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
 
@@ -101,8 +94,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     function topUp(
         ChannelDescriptor calldata descriptor,
-        uint96 additionalDeposit,
-        uint32 newExpiresAt
+        uint96 additionalDeposit
     )
         external
     {
@@ -113,10 +105,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         if (additionalDeposit > type(uint96).max - channel.deposit) revert DepositOverflow();
-        if (newExpiresAt != 0) {
-            if (newExpiresAt <= block.timestamp) revert InvalidExpiry();
-            if (newExpiresAt <= channel.expiresAt) revert InvalidExpiry();
-        }
 
         if (additionalDeposit > 0) {
             channel.deposit += additionalDeposit;
@@ -126,10 +114,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             bool success =
                 ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
             if (!success) revert TransferFailed();
-        }
-
-        if (newExpiresAt != 0) {
-            channel.expiresAt = newExpiresAt;
         }
 
         if (_closeRequestedAt(channel.closeData) != 0) {
@@ -144,8 +128,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             descriptor.payer,
             descriptor.payee,
             additionalDeposit,
-            channel.deposit,
-            channel.expiresAt
+            channel.deposit
         );
     }
 
@@ -189,7 +172,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (captureAmount > channel.deposit) revert AmountExceedsDeposit();
 
         if (captureAmount > previousSettled) {
-            if (_isExpired(channel.expiresAt)) revert ChannelExpiredError();
             _validateVoucher(descriptor, channelId, cumulativeAmount, signature);
         }
 
@@ -225,7 +207,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         bool closeGracePassed = closeRequestedAt != 0
             && block.timestamp >= uint256(closeRequestedAt) + CLOSE_GRACE_PERIOD;
 
-        if (!closeGracePassed && !_isExpired(channel.expiresAt)) revert CloseNotReady();
+        if (!closeGracePassed) revert CloseNotReady();
 
         uint96 refund = channel.deposit - channel.settled;
         channel.closeData = _FINALIZED_CLOSE_DATA;
@@ -236,7 +218,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             if (!success) revert TransferFailed();
         }
 
-        emit ChannelExpired(channelId, descriptor.payer, descriptor.payee);
         emit ChannelClosed(channelId, descriptor.payer, descriptor.payee, channel.settled, refund);
     }
 
@@ -333,7 +314,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         state.settled = uint96(packedState);
         state.deposit = uint96(packedState >> _DEPOSIT_OFFSET);
-        state.expiresAt = uint32(packedState >> _EXPIRES_AT_OFFSET);
         state.closeData = uint32(packedState >> _CLOSE_DATA_OFFSET);
     }
 
@@ -344,7 +324,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     {
         packedState = uint256(state.settled);
         packedState |= uint256(state.deposit) << _DEPOSIT_OFFSET;
-        packedState |= uint256(state.expiresAt) << _EXPIRES_AT_OFFSET;
         packedState |= uint256(state.closeData) << _CLOSE_DATA_OFFSET;
     }
 
@@ -354,10 +333,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     function _closeRequestedAt(uint32 closeData) internal pure returns (uint32) {
         return closeData >= 2 ? closeData : 0;
-    }
-
-    function _isExpired(uint32 expiresAt) internal view returns (bool) {
-        return block.timestamp >= expiresAt;
     }
 
     function _validateVoucher(

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -20,9 +20,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     uint256 internal constant _DEPOSIT_OFFSET = 96;
     uint256 internal constant _EXPIRES_AT_OFFSET = 192;
-    uint256 internal constant _STATUS_OFFSET = 224;
-    uint32 internal constant _FINALIZED_STATUS = 1;
-    uint32 internal constant _CLOSE_REQUEST_OFFSET = 2;
+    uint256 internal constant _CLOSE_DATA_OFFSET = 224;
+    uint32 internal constant _FINALIZED_CLOSE_DATA = 1;
 
     bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
@@ -53,14 +52,15 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         channelStates[channelId] = _encodeChannelState(
             ChannelState({
-                finalized: false,
-                closeRequestedAt: 0,
-                expiresAt: expiresAt,
+                settled: 0,
                 deposit: deposit,
-                settled: 0
+                expiresAt: expiresAt,
+                closeData: 0
             })
         );
 
+        // The reference contract keeps ERC-20-style allowance flow for local verification.
+        // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
 
@@ -80,7 +80,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payee) revert NotPayee();
-        if (channel.finalized) revert ChannelFinalized();
+        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
         if (_isExpired(channel.expiresAt)) revert ChannelExpiredError();
         if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
         if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
@@ -110,7 +110,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (channel.finalized) revert ChannelFinalized();
+        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         if (additionalDeposit > type(uint96).max - channel.deposit) revert DepositOverflow();
         if (newExpiresAt != 0) {
@@ -121,6 +121,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (additionalDeposit > 0) {
             channel.deposit += additionalDeposit;
 
+            // The reference contract keeps ERC-20-style allowance flow for local verification.
+            // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
             bool success =
                 ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
             if (!success) revert TransferFailed();
@@ -130,8 +132,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             channel.expiresAt = newExpiresAt;
         }
 
-        if (channel.closeRequestedAt != 0) {
-            channel.closeRequestedAt = 0;
+        if (_closeRequestedAt(channel.closeData) != 0) {
+            channel.closeData = 0;
             emit CloseRequestCancelled(channelId, descriptor.payer, descriptor.payee);
         }
 
@@ -152,10 +154,10 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (channel.finalized) revert ChannelFinalized();
+        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
-        if (channel.closeRequestedAt == 0) {
-            channel.closeRequestedAt = uint32(block.timestamp);
+        if (_closeRequestedAt(channel.closeData) == 0) {
+            channel.closeData = uint32(block.timestamp);
             channelStates[channelId] = _encodeChannelState(channel);
             emit CloseRequested(
                 channelId,
@@ -178,7 +180,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payee) revert NotPayee();
-        if (channel.finalized) revert ChannelFinalized();
+        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         uint96 previousSettled = channel.settled;
         if (captureAmount < previousSettled || captureAmount > cumulativeAmount) {
@@ -195,7 +197,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         uint96 refund = channel.deposit - captureAmount;
 
         channel.settled = captureAmount;
-        channel.finalized = true;
+        channel.closeData = _FINALIZED_CLOSE_DATA;
         channelStates[channelId] = _encodeChannelState(channel);
 
         if (delta > 0) {
@@ -217,15 +219,16 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (channel.finalized) revert ChannelFinalized();
+        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
-        bool closeGracePassed = channel.closeRequestedAt != 0
-            && block.timestamp >= uint256(channel.closeRequestedAt) + CLOSE_GRACE_PERIOD;
+        uint32 closeRequestedAt = _closeRequestedAt(channel.closeData);
+        bool closeGracePassed = closeRequestedAt != 0
+            && block.timestamp >= uint256(closeRequestedAt) + CLOSE_GRACE_PERIOD;
 
         if (!closeGracePassed && !_isExpired(channel.expiresAt)) revert CloseNotReady();
 
         uint96 refund = channel.deposit - channel.settled;
-        channel.finalized = true;
+        channel.closeData = _FINALIZED_CLOSE_DATA;
         channelStates[channelId] = _encodeChannelState(channel);
 
         if (refund > 0) {
@@ -328,13 +331,10 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             return state;
         }
 
-        uint32 status = uint32(packedState >> _STATUS_OFFSET);
-        state.finalized = status == _FINALIZED_STATUS;
-        state.closeRequestedAt =
-            status >= _CLOSE_REQUEST_OFFSET ? status - _CLOSE_REQUEST_OFFSET : 0;
-        state.expiresAt = uint32(packedState >> _EXPIRES_AT_OFFSET);
-        state.deposit = uint96(packedState >> _DEPOSIT_OFFSET);
         state.settled = uint96(packedState);
+        state.deposit = uint96(packedState >> _DEPOSIT_OFFSET);
+        state.expiresAt = uint32(packedState >> _EXPIRES_AT_OFFSET);
+        state.closeData = uint32(packedState >> _CLOSE_DATA_OFFSET);
     }
 
     function _encodeChannelState(ChannelState memory state)
@@ -342,17 +342,18 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         pure
         returns (uint256 packedState)
     {
-        uint32 status;
-        if (state.finalized) {
-            status = _FINALIZED_STATUS;
-        } else if (state.closeRequestedAt != 0) {
-            status = state.closeRequestedAt + _CLOSE_REQUEST_OFFSET;
-        }
-
         packedState = uint256(state.settled);
         packedState |= uint256(state.deposit) << _DEPOSIT_OFFSET;
         packedState |= uint256(state.expiresAt) << _EXPIRES_AT_OFFSET;
-        packedState |= uint256(status) << _STATUS_OFFSET;
+        packedState |= uint256(state.closeData) << _CLOSE_DATA_OFFSET;
+    }
+
+    function _isFinalized(uint32 closeData) internal pure returns (bool) {
+        return closeData == _FINALIZED_CLOSE_DATA;
+    }
+
+    function _closeRequestedAt(uint32 closeData) internal pure returns (uint32) {
+        return closeData >= 2 ? closeData : 0;
     }
 
     function _isExpired(uint32 expiresAt) internal view returns (bool) {

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { ISignatureVerifier } from "./interfaces/ISignatureVerifier.sol";
+import { ITIP20 } from "./interfaces/ITIP20.sol";
+import { ITIP20ChannelEscrow } from "./interfaces/ITIP20ChannelEscrow.sol";
+
+/// @title TIP20ChannelEscrow
+/// @notice Reference contract for the TIP-1034 channel model.
+contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
+
+    address public constant TIP20_CHANNEL_ESCROW = 0x4d50500000000000000000000000000000000000;
+    address public constant SIGNATURE_VERIFIER_PRECOMPILE =
+        0x5165300000000000000000000000000000000000;
+
+    bytes32 public constant VOUCHER_TYPEHASH =
+        keccak256("Voucher(bytes32 channelId,uint96 cumulativeAmount)");
+
+    uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
+
+    uint256 internal constant _DEPOSIT_OFFSET = 96;
+    uint256 internal constant _EXPIRES_AT_OFFSET = 192;
+    uint256 internal constant _STATUS_OFFSET = 224;
+    uint32 internal constant _FINALIZED_STATUS = 1;
+    uint32 internal constant _CLOSE_REQUEST_OFFSET = 2;
+
+    bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 internal constant _NAME_HASH = keccak256("TIP20 Channel Escrow");
+    bytes32 internal constant _VERSION_HASH = keccak256("1");
+
+    mapping(bytes32 => uint256) internal channelStates;
+
+    function open(
+        address payee,
+        address token,
+        uint96 deposit,
+        bytes32 salt,
+        address authorizedSigner,
+        uint32 expiresAt
+    )
+        external
+        returns (bytes32 channelId)
+    {
+        if (payee == address(0)) revert InvalidPayee();
+        if (token == address(0)) revert InvalidToken();
+        if (deposit == 0) revert ZeroDeposit();
+        if (expiresAt <= block.timestamp) revert InvalidExpiry();
+
+        channelId = computeChannelId(msg.sender, payee, token, salt, authorizedSigner);
+        if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
+
+        channelStates[channelId] = _encodeChannelState(
+            ChannelState({
+                finalized: false,
+                closeRequestedAt: 0,
+                expiresAt: expiresAt,
+                deposit: deposit,
+                settled: 0
+            })
+        );
+
+        bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
+        if (!success) revert TransferFailed();
+
+        emit ChannelOpened(
+            channelId, msg.sender, payee, token, authorizedSigner, salt, deposit, expiresAt
+        );
+    }
+
+    function settle(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        bytes calldata signature
+    )
+        external
+    {
+        bytes32 channelId = _channelId(descriptor);
+        ChannelState memory channel = _loadChannelState(channelId);
+
+        if (msg.sender != descriptor.payee) revert NotPayee();
+        if (channel.finalized) revert ChannelFinalized();
+        if (_isExpired(channel.expiresAt)) revert ChannelExpiredError();
+        if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
+        if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
+
+        _validateVoucher(descriptor, channelId, cumulativeAmount, signature);
+
+        uint96 delta = cumulativeAmount - channel.settled;
+        channel.settled = cumulativeAmount;
+        channelStates[channelId] = _encodeChannelState(channel);
+
+        bool success = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
+        if (!success) revert TransferFailed();
+
+        emit Settled(
+            channelId, descriptor.payer, descriptor.payee, cumulativeAmount, delta, channel.settled
+        );
+    }
+
+    function topUp(
+        ChannelDescriptor calldata descriptor,
+        uint96 additionalDeposit,
+        uint32 newExpiresAt
+    )
+        external
+    {
+        bytes32 channelId = _channelId(descriptor);
+        ChannelState memory channel = _loadChannelState(channelId);
+
+        if (msg.sender != descriptor.payer) revert NotPayer();
+        if (channel.finalized) revert ChannelFinalized();
+
+        if (additionalDeposit > type(uint96).max - channel.deposit) revert DepositOverflow();
+        if (newExpiresAt != 0) {
+            if (newExpiresAt <= block.timestamp) revert InvalidExpiry();
+            if (newExpiresAt <= channel.expiresAt) revert InvalidExpiry();
+        }
+
+        if (additionalDeposit > 0) {
+            channel.deposit += additionalDeposit;
+
+            bool success =
+                ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
+            if (!success) revert TransferFailed();
+        }
+
+        if (newExpiresAt != 0) {
+            channel.expiresAt = newExpiresAt;
+        }
+
+        if (channel.closeRequestedAt != 0) {
+            channel.closeRequestedAt = 0;
+            emit CloseRequestCancelled(channelId, descriptor.payer, descriptor.payee);
+        }
+
+        channelStates[channelId] = _encodeChannelState(channel);
+
+        emit TopUp(
+            channelId,
+            descriptor.payer,
+            descriptor.payee,
+            additionalDeposit,
+            channel.deposit,
+            channel.expiresAt
+        );
+    }
+
+    function requestClose(ChannelDescriptor calldata descriptor) external {
+        bytes32 channelId = _channelId(descriptor);
+        ChannelState memory channel = _loadChannelState(channelId);
+
+        if (msg.sender != descriptor.payer) revert NotPayer();
+        if (channel.finalized) revert ChannelFinalized();
+
+        if (channel.closeRequestedAt == 0) {
+            channel.closeRequestedAt = uint32(block.timestamp);
+            channelStates[channelId] = _encodeChannelState(channel);
+            emit CloseRequested(
+                channelId,
+                descriptor.payer,
+                descriptor.payee,
+                uint256(block.timestamp) + CLOSE_GRACE_PERIOD
+            );
+        }
+    }
+
+    function close(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        uint96 captureAmount,
+        bytes calldata signature
+    )
+        external
+    {
+        bytes32 channelId = _channelId(descriptor);
+        ChannelState memory channel = _loadChannelState(channelId);
+
+        if (msg.sender != descriptor.payee) revert NotPayee();
+        if (channel.finalized) revert ChannelFinalized();
+
+        uint96 previousSettled = channel.settled;
+        if (captureAmount < previousSettled || captureAmount > cumulativeAmount) {
+            revert CaptureAmountInvalid();
+        }
+        if (captureAmount > channel.deposit) revert AmountExceedsDeposit();
+
+        if (captureAmount > previousSettled) {
+            if (_isExpired(channel.expiresAt)) revert ChannelExpiredError();
+            _validateVoucher(descriptor, channelId, cumulativeAmount, signature);
+        }
+
+        uint96 delta = captureAmount - previousSettled;
+        uint96 refund = channel.deposit - captureAmount;
+
+        channel.settled = captureAmount;
+        channel.finalized = true;
+        channelStates[channelId] = _encodeChannelState(channel);
+
+        if (delta > 0) {
+            bool payeeTransferSucceeded = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
+            if (!payeeTransferSucceeded) revert TransferFailed();
+        }
+
+        if (refund > 0) {
+            bool payerTransferSucceeded =
+                ITIP20(descriptor.token).transfer(descriptor.payer, refund);
+            if (!payerTransferSucceeded) revert TransferFailed();
+        }
+
+        emit ChannelClosed(channelId, descriptor.payer, descriptor.payee, captureAmount, refund);
+    }
+
+    function withdraw(ChannelDescriptor calldata descriptor) external {
+        bytes32 channelId = _channelId(descriptor);
+        ChannelState memory channel = _loadChannelState(channelId);
+
+        if (msg.sender != descriptor.payer) revert NotPayer();
+        if (channel.finalized) revert ChannelFinalized();
+
+        bool closeGracePassed = channel.closeRequestedAt != 0
+            && block.timestamp >= uint256(channel.closeRequestedAt) + CLOSE_GRACE_PERIOD;
+
+        if (!closeGracePassed && !_isExpired(channel.expiresAt)) revert CloseNotReady();
+
+        uint96 refund = channel.deposit - channel.settled;
+        channel.finalized = true;
+        channelStates[channelId] = _encodeChannelState(channel);
+
+        if (refund > 0) {
+            bool success = ITIP20(descriptor.token).transfer(descriptor.payer, refund);
+            if (!success) revert TransferFailed();
+        }
+
+        emit ChannelExpired(channelId, descriptor.payer, descriptor.payee);
+        emit ChannelClosed(channelId, descriptor.payer, descriptor.payee, channel.settled, refund);
+    }
+
+    function getChannel(ChannelDescriptor calldata descriptor)
+        external
+        view
+        returns (Channel memory channel)
+    {
+        channel.descriptor = ChannelDescriptor({
+            payer: descriptor.payer,
+            payee: descriptor.payee,
+            token: descriptor.token,
+            salt: descriptor.salt,
+            authorizedSigner: descriptor.authorizedSigner
+        });
+        channel.state = _decodeChannelState(channelStates[_channelId(descriptor)]);
+    }
+
+    function getChannelState(bytes32 channelId) external view returns (ChannelState memory) {
+        return _decodeChannelState(channelStates[channelId]);
+    }
+
+    function getChannelStatesBatch(bytes32[] calldata channelIds)
+        external
+        view
+        returns (ChannelState[] memory states)
+    {
+        uint256 length = channelIds.length;
+        states = new ChannelState[](length);
+
+        for (uint256 i = 0; i < length; ++i) {
+            states[i] = _decodeChannelState(channelStates[channelIds[i]]);
+        }
+    }
+
+    function computeChannelId(
+        address payer,
+        address payee,
+        address token,
+        bytes32 salt,
+        address authorizedSigner
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                payer, payee, token, salt, authorizedSigner, TIP20_CHANNEL_ESCROW, block.chainid
+            )
+        );
+    }
+
+    function getVoucherDigest(
+        bytes32 channelId,
+        uint96 cumulativeAmount
+    )
+        external
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount));
+        return _hashTypedData(structHash);
+    }
+
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparator();
+    }
+
+    function _channelId(ChannelDescriptor calldata descriptor) internal view returns (bytes32) {
+        return computeChannelId(
+            descriptor.payer,
+            descriptor.payee,
+            descriptor.token,
+            descriptor.salt,
+            descriptor.authorizedSigner
+        );
+    }
+
+    function _loadChannelState(bytes32 channelId) internal view returns (ChannelState memory) {
+        uint256 packedState = channelStates[channelId];
+        if (packedState == 0) revert ChannelNotFound();
+        return _decodeChannelState(packedState);
+    }
+
+    function _decodeChannelState(uint256 packedState)
+        internal
+        pure
+        returns (ChannelState memory state)
+    {
+        if (packedState == 0) {
+            return state;
+        }
+
+        uint32 status = uint32(packedState >> _STATUS_OFFSET);
+        state.finalized = status == _FINALIZED_STATUS;
+        state.closeRequestedAt =
+            status >= _CLOSE_REQUEST_OFFSET ? status - _CLOSE_REQUEST_OFFSET : 0;
+        state.expiresAt = uint32(packedState >> _EXPIRES_AT_OFFSET);
+        state.deposit = uint96(packedState >> _DEPOSIT_OFFSET);
+        state.settled = uint96(packedState);
+    }
+
+    function _encodeChannelState(ChannelState memory state)
+        internal
+        pure
+        returns (uint256 packedState)
+    {
+        uint32 status;
+        if (state.finalized) {
+            status = _FINALIZED_STATUS;
+        } else if (state.closeRequestedAt != 0) {
+            status = state.closeRequestedAt + _CLOSE_REQUEST_OFFSET;
+        }
+
+        packedState = uint256(state.settled);
+        packedState |= uint256(state.deposit) << _DEPOSIT_OFFSET;
+        packedState |= uint256(state.expiresAt) << _EXPIRES_AT_OFFSET;
+        packedState |= uint256(status) << _STATUS_OFFSET;
+    }
+
+    function _isExpired(uint32 expiresAt) internal view returns (bool) {
+        return block.timestamp >= expiresAt;
+    }
+
+    function _validateVoucher(
+        ChannelDescriptor calldata descriptor,
+        bytes32 channelId,
+        uint96 cumulativeAmount,
+        bytes calldata signature
+    )
+        internal
+        view
+    {
+        bytes32 structHash = keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount));
+        bytes32 digest = _hashTypedData(structHash);
+        address expectedSigner = descriptor.authorizedSigner != address(0)
+            ? descriptor.authorizedSigner
+            : descriptor.payer;
+
+        bool isValid;
+        try ISignatureVerifier(SIGNATURE_VERIFIER_PRECOMPILE)
+            .verify(expectedSigner, digest, signature) returns (
+            bool valid
+        ) {
+            isValid = valid;
+        } catch {
+            revert InvalidSignature();
+        }
+
+        if (!isValid) revert InvalidSignature();
+    }
+
+    function _domainSeparator() internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _EIP712_DOMAIN_TYPEHASH,
+                _NAME_HASH,
+                _VERSION_HASH,
+                block.chainid,
+                TIP20_CHANNEL_ESCROW
+            )
+        );
+    }
+
+    function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+}

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -29,9 +29,17 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     mapping(bytes32 => uint256) internal channelStates;
     bytes32 internal _openTxHashContext;
+
     // Reference-contract-only approximation of the precompile's transient per-transaction guard.
-    // Because `channelId` includes `openTxHash`, this does not block real cross-transaction
-    // reopens, which always use a different transaction hash.
+    // The enshrined precompile should track `openedThisTx[channelId]` in transient storage and
+    // clear it automatically at the end of the top-level transaction. That allows multiple `open`
+    // calls in one AA batch when they derive distinct channel IDs, while preventing the same channel
+    // ID from being reopened after a same-transaction terminal `close` or `withdraw` deletes the
+    // persistent state slot.
+    //
+    // This Solidity reference uses persistent storage because tests cannot model precompile
+    // transient storage directly. Since `channelId` includes `openTxHash`, a real cross-transaction
+    // reopen has a different ID and is not blocked by this persistent approximation.
     mapping(bytes32 => bool) internal _openedChannelIdsForTest;
 
     error OpenTxHashNotSet();
@@ -60,7 +68,14 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         channelId = computeChannelId(
             msg.sender, payee, operator, token, salt, authorizedSigner, openTxHash
         );
+
+        // Reject ordinary duplicate opens while the channel is still active.
         if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
+
+        // Also reject same-top-level-transaction reopens of a channel ID that was opened earlier
+        // and then terminally closed or withdrawn. Without this guard, terminal deletion would make
+        // the persistent state slot look unused again even though the enclosing tx hash, and thus
+        // the derived channel ID, is unchanged for later calls in the same AA batch.
         if (_openedChannelIdsForTest[channelId]) revert ChannelAlreadyExists();
 
         channelStates[channelId] =
@@ -70,6 +85,9 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
+
+        // Mark after the escrow transfer succeeds so failed opens do not poison the guard. The real
+        // precompile marker is transient and only protects the current top-level transaction.
         _openedChannelIdsForTest[channelId] = true;
 
         emit ChannelOpened(

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -44,8 +44,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     // approximation.
     mapping(bytes32 => bool) internal _openedChannelIdsForTest;
 
-    error ExpiringNonceHashNotSet();
-
     /// @dev Reference-contract-only hook. The precompile derives this as
     /// `keccak256(abi.encodePacked(encodeForSigning, sender))` for every real transaction type.
     function setExpiringNonceHashForTest(bytes32 expiringNonceHash) external {

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -28,7 +28,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     bytes32 internal constant _VERSION_HASH = keccak256("1");
 
     mapping(bytes32 => uint256) internal channelStates;
-    bytes32 internal _openTxHashContext;
+    bytes32 internal _expiringNonceHashContext;
 
     // Reference-contract-only approximation of the precompile's transient per-transaction guard.
     // The enshrined precompile should track `openedThisTx[channelId]` in transient storage and
@@ -38,15 +38,16 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     // persistent state slot.
     //
     // This Solidity reference uses persistent storage because tests cannot model precompile
-    // transient storage directly. Since `channelId` includes `openTxHash`, a real cross-transaction
-    // reopen has a different ID and is not blocked by this persistent approximation.
+    // transient storage directly. Since `channelId` includes `expiringNonceHash`, a real
+    // cross-transaction reopen has a different ID and is not blocked by this persistent
+    // approximation.
     mapping(bytes32 => bool) internal _openedChannelIdsForTest;
 
-    error OpenTxHashNotSet();
+    error ExpiringNonceHashNotSet();
 
-    /// @dev Reference-contract-only hook. The precompile derives this from the enclosing tx hash.
-    function setOpenTxHashForTest(bytes32 openTxHash) external {
-        _openTxHashContext = openTxHash;
+    /// @dev Reference-contract-only hook. The precompile derives this from the enclosing tx's expiring nonce hash.
+    function setExpiringNonceHashForTest(bytes32 expiringNonceHash) external {
+        _expiringNonceHashContext = expiringNonceHash;
     }
 
     function open(
@@ -64,9 +65,9 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (token == address(0)) revert InvalidToken();
         if (deposit == 0) revert ZeroDeposit();
 
-        bytes32 openTxHash = _consumeOpenTxHash();
+        bytes32 expiringNonceHash = _consumeExpiringNonceHash();
         channelId = computeChannelId(
-            msg.sender, payee, operator, token, salt, authorizedSigner, openTxHash
+            msg.sender, payee, operator, token, salt, authorizedSigner, expiringNonceHash
         );
 
         // Reject ordinary duplicate opens while the channel is still active.
@@ -74,8 +75,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         // Also reject same-top-level-transaction reopens of a channel ID that was opened earlier
         // and then terminally closed or withdrawn. Without this guard, terminal deletion would make
-        // the persistent state slot look unused again even though the enclosing tx hash, and thus
-        // the derived channel ID, is unchanged for later calls in the same AA batch.
+        // the persistent state slot look unused again even though the enclosing expiring nonce
+        // hash, and thus the derived channel ID, is unchanged for later calls in the same AA batch.
         if (_openedChannelIdsForTest[channelId]) revert ChannelAlreadyExists();
 
         channelStates[channelId] =
@@ -98,7 +99,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             token,
             authorizedSigner,
             salt,
-            openTxHash,
+            expiringNonceHash,
             deposit
         );
     }
@@ -261,7 +262,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             token: descriptor.token,
             salt: descriptor.salt,
             authorizedSigner: descriptor.authorizedSigner,
-            openTxHash: descriptor.openTxHash
+            expiringNonceHash: descriptor.expiringNonceHash
         });
         channel.state = _decodeChannelState(channelStates[_channelId(descriptor)]);
     }
@@ -290,7 +291,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         address token,
         bytes32 salt,
         address authorizedSigner,
-        bytes32 openTxHash
+        bytes32 expiringNonceHash
     )
         public
         view
@@ -304,7 +305,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
                 token,
                 salt,
                 authorizedSigner,
-                openTxHash,
+                expiringNonceHash,
                 TIP20_CHANNEL_ESCROW,
                 block.chainid
             )
@@ -335,7 +336,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             descriptor.token,
             descriptor.salt,
             descriptor.authorizedSigner,
-            descriptor.openTxHash
+            descriptor.expiringNonceHash
         );
     }
 
@@ -417,10 +418,10 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
     }
 
-    function _consumeOpenTxHash() internal returns (bytes32 openTxHash) {
-        openTxHash = _openTxHashContext;
-        if (openTxHash == bytes32(0)) revert OpenTxHashNotSet();
-        delete _openTxHashContext;
+    function _consumeExpiringNonceHash() internal returns (bytes32 expiringNonceHash) {
+        expiringNonceHash = _expiringNonceHashContext;
+        if (expiringNonceHash == bytes32(0)) revert ExpiringNonceHashNotSet();
+        delete _expiringNonceHashContext;
     }
 
 }

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -20,7 +20,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     uint256 internal constant _DEPOSIT_OFFSET = 96;
     uint256 internal constant _CLOSE_DATA_OFFSET = 192;
-    uint32 internal constant _FINALIZED_CLOSE_DATA = 1;
 
     bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
@@ -29,6 +28,18 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     bytes32 internal constant _VERSION_HASH = keccak256("1");
 
     mapping(bytes32 => uint256) internal channelStates;
+    bytes32 internal _openTxHashContext;
+    // Reference-contract-only approximation of the precompile's transient per-transaction guard.
+    // Because `channelId` includes `openTxHash`, this does not block real cross-transaction
+    // reopens, which always use a different transaction hash.
+    mapping(bytes32 => bool) internal _openedChannelIdsForTest;
+
+    error OpenTxHashNotSet();
+
+    /// @dev Reference-contract-only hook. The precompile derives this from the enclosing tx hash.
+    function setOpenTxHashForTest(bytes32 openTxHash) external {
+        _openTxHashContext = openTxHash;
+    }
 
     function open(
         address payee,
@@ -45,23 +56,33 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (token == address(0)) revert InvalidToken();
         if (deposit == 0) revert ZeroDeposit();
 
-        channelId = computeChannelId(msg.sender, payee, operator, token, salt, authorizedSigner);
-        if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
-
-        channelStates[channelId] = _encodeChannelState(
-            ChannelState({
-                settled: 0,
-                deposit: deposit,
-                closeData: 0
-            })
+        bytes32 openTxHash = _consumeOpenTxHash();
+        channelId = computeChannelId(
+            msg.sender, payee, operator, token, salt, authorizedSigner, openTxHash
         );
+        if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
+        if (_openedChannelIdsForTest[channelId]) revert ChannelAlreadyExists();
+
+        channelStates[channelId] =
+            _encodeChannelState(ChannelState({ settled: 0, deposit: deposit, closeData: 0 }));
 
         // The reference contract keeps ERC-20-style allowance flow for local verification.
         // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
+        _openedChannelIdsForTest[channelId] = true;
 
-        emit ChannelOpened(channelId, msg.sender, payee, operator, token, authorizedSigner, salt, deposit);
+        emit ChannelOpened(
+            channelId,
+            msg.sender,
+            payee,
+            operator,
+            token,
+            authorizedSigner,
+            salt,
+            openTxHash,
+            deposit
+        );
     }
 
     function settle(
@@ -74,8 +95,12 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         bytes32 channelId = _channelId(descriptor);
         ChannelState memory channel = _loadChannelState(channelId);
 
-        _requirePayeeOrOperator(descriptor);
-        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
+        if (
+            msg.sender != descriptor.payee
+                && (descriptor.operator == address(0) || msg.sender != descriptor.operator)
+        ) {
+            revert NotPayeeOrOperator();
+        }
         if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
         if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
 
@@ -93,17 +118,11 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         );
     }
 
-    function topUp(
-        ChannelDescriptor calldata descriptor,
-        uint96 additionalDeposit
-    )
-        external
-    {
+    function topUp(ChannelDescriptor calldata descriptor, uint96 additionalDeposit) external {
         bytes32 channelId = _channelId(descriptor);
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         if (additionalDeposit > type(uint96).max - channel.deposit) revert DepositOverflow();
 
@@ -117,7 +136,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             if (!success) revert TransferFailed();
         }
 
-        if (_closeRequestedAt(channel.closeData) != 0) {
+        if (channel.closeData != 0) {
             channel.closeData = 0;
             emit CloseRequestCancelled(channelId, descriptor.payer, descriptor.payee);
         }
@@ -125,11 +144,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         channelStates[channelId] = _encodeChannelState(channel);
 
         emit TopUp(
-            channelId,
-            descriptor.payer,
-            descriptor.payee,
-            additionalDeposit,
-            channel.deposit
+            channelId, descriptor.payer, descriptor.payee, additionalDeposit, channel.deposit
         );
     }
 
@@ -138,9 +153,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
-        if (_closeRequestedAt(channel.closeData) == 0) {
+        if (channel.closeData == 0) {
             channel.closeData = uint32(block.timestamp);
             channelStates[channelId] = _encodeChannelState(channel);
             emit CloseRequested(
@@ -164,7 +178,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payee) revert NotPayee();
-        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         uint96 previousSettled = channel.settled;
         if (captureAmount < previousSettled || captureAmount > cumulativeAmount) {
@@ -179,9 +192,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         uint96 delta = captureAmount - previousSettled;
         uint96 refund = channel.deposit - captureAmount;
 
-        channel.settled = captureAmount;
-        channel.closeData = _FINALIZED_CLOSE_DATA;
-        channelStates[channelId] = _encodeChannelState(channel);
+        delete channelStates[channelId];
 
         if (delta > 0) {
             bool payeeTransferSucceeded = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
@@ -202,7 +213,6 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-        if (_isFinalized(channel.closeData)) revert ChannelFinalized();
 
         uint32 closeRequestedAt = _closeRequestedAt(channel.closeData);
         bool closeGracePassed = closeRequestedAt != 0
@@ -211,8 +221,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (!closeGracePassed) revert CloseNotReady();
 
         uint96 refund = channel.deposit - channel.settled;
-        channel.closeData = _FINALIZED_CLOSE_DATA;
-        channelStates[channelId] = _encodeChannelState(channel);
+        delete channelStates[channelId];
 
         if (refund > 0) {
             bool success = ITIP20(descriptor.token).transfer(descriptor.payer, refund);
@@ -233,7 +242,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             operator: descriptor.operator,
             token: descriptor.token,
             salt: descriptor.salt,
-            authorizedSigner: descriptor.authorizedSigner
+            authorizedSigner: descriptor.authorizedSigner,
+            openTxHash: descriptor.openTxHash
         });
         channel.state = _decodeChannelState(channelStates[_channelId(descriptor)]);
     }
@@ -261,7 +271,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         address operator,
         address token,
         bytes32 salt,
-        address authorizedSigner
+        address authorizedSigner,
+        bytes32 openTxHash
     )
         public
         view
@@ -275,6 +286,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
                 token,
                 salt,
                 authorizedSigner,
+                openTxHash,
                 TIP20_CHANNEL_ESCROW,
                 block.chainid
             )
@@ -304,14 +316,9 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             descriptor.operator,
             descriptor.token,
             descriptor.salt,
-            descriptor.authorizedSigner
+            descriptor.authorizedSigner,
+            descriptor.openTxHash
         );
-    }
-
-    function _requirePayeeOrOperator(ChannelDescriptor calldata descriptor) internal view {
-        if (msg.sender == descriptor.payee) return;
-        if (descriptor.operator != address(0) && msg.sender == descriptor.operator) return;
-        revert NotPayeeOrOperator();
     }
 
     function _loadChannelState(bytes32 channelId) internal view returns (ChannelState memory) {
@@ -344,12 +351,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         packedState |= uint256(state.closeData) << _CLOSE_DATA_OFFSET;
     }
 
-    function _isFinalized(uint32 closeData) internal pure returns (bool) {
-        return closeData == _FINALIZED_CLOSE_DATA;
-    }
-
     function _closeRequestedAt(uint32 closeData) internal pure returns (uint32) {
-        return closeData >= 2 ? closeData : 0;
+        return closeData;
     }
 
     function _validateVoucher(
@@ -394,6 +397,12 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+    function _consumeOpenTxHash() internal returns (bytes32 openTxHash) {
+        openTxHash = _openTxHashContext;
+        if (openTxHash == bytes32(0)) revert OpenTxHashNotSet();
+        delete _openTxHashContext;
     }
 
 }

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -32,6 +32,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
     function open(
         address payee,
+        address operator,
         address token,
         uint96 deposit,
         bytes32 salt,
@@ -44,7 +45,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         if (token == address(0)) revert InvalidToken();
         if (deposit == 0) revert ZeroDeposit();
 
-        channelId = computeChannelId(msg.sender, payee, token, salt, authorizedSigner);
+        channelId = computeChannelId(msg.sender, payee, operator, token, salt, authorizedSigner);
         if (channelStates[channelId] != 0) revert ChannelAlreadyExists();
 
         channelStates[channelId] = _encodeChannelState(
@@ -60,7 +61,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
 
-        emit ChannelOpened(channelId, msg.sender, payee, token, authorizedSigner, salt, deposit);
+        emit ChannelOpened(channelId, msg.sender, payee, operator, token, authorizedSigner, salt, deposit);
     }
 
     function settle(
@@ -73,7 +74,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         bytes32 channelId = _channelId(descriptor);
         ChannelState memory channel = _loadChannelState(channelId);
 
-        if (msg.sender != descriptor.payee) revert NotPayee();
+        _requirePayeeOrOperator(descriptor);
         if (_isFinalized(channel.closeData)) revert ChannelFinalized();
         if (cumulativeAmount > channel.deposit) revert AmountExceedsDeposit();
         if (cumulativeAmount <= channel.settled) revert AmountNotIncreasing();
@@ -229,6 +230,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         channel.descriptor = ChannelDescriptor({
             payer: descriptor.payer,
             payee: descriptor.payee,
+            operator: descriptor.operator,
             token: descriptor.token,
             salt: descriptor.salt,
             authorizedSigner: descriptor.authorizedSigner
@@ -256,6 +258,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     function computeChannelId(
         address payer,
         address payee,
+        address operator,
         address token,
         bytes32 salt,
         address authorizedSigner
@@ -266,7 +269,14 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     {
         return keccak256(
             abi.encode(
-                payer, payee, token, salt, authorizedSigner, TIP20_CHANNEL_ESCROW, block.chainid
+                payer,
+                payee,
+                operator,
+                token,
+                salt,
+                authorizedSigner,
+                TIP20_CHANNEL_ESCROW,
+                block.chainid
             )
         );
     }
@@ -291,10 +301,17 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
         return computeChannelId(
             descriptor.payer,
             descriptor.payee,
+            descriptor.operator,
             descriptor.token,
             descriptor.salt,
             descriptor.authorizedSigner
         );
+    }
+
+    function _requirePayeeOrOperator(ChannelDescriptor calldata descriptor) internal view {
+        if (msg.sender == descriptor.payee) return;
+        if (descriptor.operator != address(0) && msg.sender == descriptor.operator) return;
+        revert NotPayeeOrOperator();
     }
 
     function _loadChannelState(bytes32 channelId) internal view returns (ChannelState memory) {

--- a/tips/verify/src/TIP20ChannelEscrow.sol
+++ b/tips/verify/src/TIP20ChannelEscrow.sol
@@ -19,7 +19,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
 
     uint256 internal constant _DEPOSIT_OFFSET = 96;
-    uint256 internal constant _CLOSE_DATA_OFFSET = 192;
+    uint256 internal constant _CLOSE_REQUESTED_AT_OFFSET = 192;
 
     bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
@@ -38,14 +38,16 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     // persistent state slot.
     //
     // This Solidity reference uses persistent storage because tests cannot model precompile
-    // transient storage directly. Since `channelId` includes `expiringNonceHash`, a real
-    // cross-transaction reopen has a different ID and is not blocked by this persistent
+    // transient storage directly. Since `channelId` includes the transaction-derived
+    // `expiringNonceHash` context value, a real cross-transaction reopen has a different ID
+    // and is not blocked by this persistent
     // approximation.
     mapping(bytes32 => bool) internal _openedChannelIdsForTest;
 
     error ExpiringNonceHashNotSet();
 
-    /// @dev Reference-contract-only hook. The precompile derives this from the enclosing tx's expiring nonce hash.
+    /// @dev Reference-contract-only hook. The precompile derives this as
+    /// `keccak256(abi.encodePacked(encodeForSigning, sender))` for every real transaction type.
     function setExpiringNonceHashForTest(bytes32 expiringNonceHash) external {
         _expiringNonceHashContext = expiringNonceHash;
     }
@@ -75,12 +77,14 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         // Also reject same-top-level-transaction reopens of a channel ID that was opened earlier
         // and then terminally closed or withdrawn. Without this guard, terminal deletion would make
-        // the persistent state slot look unused again even though the enclosing expiring nonce
-        // hash, and thus the derived channel ID, is unchanged for later calls in the same AA batch.
+        // the persistent state slot look unused again even though the enclosing transaction-derived
+        // context hash, and thus the derived channel ID, is unchanged for later calls in the same
+        // top-level transaction.
         if (_openedChannelIdsForTest[channelId]) revert ChannelAlreadyExists();
 
-        channelStates[channelId] =
-            _encodeChannelState(ChannelState({ settled: 0, deposit: deposit, closeData: 0 }));
+        channelStates[channelId] = _encodeChannelState(
+            ChannelState({ settled: 0, deposit: deposit, closeRequestedAt: 0 })
+        );
 
         // The reference contract keeps ERC-20-style allowance flow for local verification.
         // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
@@ -155,8 +159,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
             if (!success) revert TransferFailed();
         }
 
-        if (channel.closeData != 0) {
-            channel.closeData = 0;
+        if (channel.closeRequestedAt != 0) {
+            channel.closeRequestedAt = 0;
             emit CloseRequestCancelled(channelId, descriptor.payer, descriptor.payee);
         }
 
@@ -173,8 +177,8 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         if (msg.sender != descriptor.payer) revert NotPayer();
 
-        if (channel.closeData == 0) {
-            channel.closeData = uint32(block.timestamp);
+        if (channel.closeRequestedAt == 0) {
+            channel.closeRequestedAt = uint32(block.timestamp);
             channelStates[channelId] = _encodeChannelState(channel);
             emit CloseRequested(
                 channelId,
@@ -233,7 +237,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         if (msg.sender != descriptor.payer) revert NotPayer();
 
-        uint32 closeRequestedAt = _closeRequestedAt(channel.closeData);
+        uint32 closeRequestedAt = channel.closeRequestedAt;
         bool closeGracePassed = closeRequestedAt != 0
             && block.timestamp >= uint256(closeRequestedAt) + CLOSE_GRACE_PERIOD;
 
@@ -357,7 +361,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
         state.settled = uint96(packedState);
         state.deposit = uint96(packedState >> _DEPOSIT_OFFSET);
-        state.closeData = uint32(packedState >> _CLOSE_DATA_OFFSET);
+        state.closeRequestedAt = uint32(packedState >> _CLOSE_REQUESTED_AT_OFFSET);
     }
 
     function _encodeChannelState(ChannelState memory state)
@@ -367,11 +371,7 @@ contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
     {
         packedState = uint256(state.settled);
         packedState |= uint256(state.deposit) << _DEPOSIT_OFFSET;
-        packedState |= uint256(state.closeData) << _CLOSE_DATA_OFFSET;
-    }
-
-    function _closeRequestedAt(uint32 closeData) internal pure returns (uint32) {
-        return closeData;
+        packedState |= uint256(state.closeRequestedAt) << _CLOSE_REQUESTED_AT_OFFSET;
     }
 
     function _validateVoucher(

--- a/tips/verify/src/interfaces/ISignatureVerifier.sol
+++ b/tips/verify/src/interfaces/ISignatureVerifier.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title ISignatureVerifier
+/// @notice Interface for the TIP-1020 Signature Verification Precompile
+/// @dev Deployed at 0x5165300000000000000000000000000000000000
+interface ISignatureVerifier {
+
+    error InvalidFormat();
+    error InvalidSignature();
+
+    /// @notice Recovers the signer of a Tempo signature (secp256k1, P256, WebAuthn).
+    /// @param hash The message hash that was signed
+    /// @param signature The encoded signature (see Tempo Transaction spec for formats)
+    /// @return signer Address of the signer if valid, reverts otherwise
+    function recover(bytes32 hash, bytes calldata signature) external view returns (address signer);
+
+    /// @notice Verifies a signer against a Tempo signature (secp256k1, P256, WebAuthn).
+    /// @param signer The input address verified against the recovered signer
+    /// @param hash The message hash that was signed
+    /// @param signature The encoded signature (see Tempo Transaction spec for formats)
+    /// @return True if the input address signed, false otherwise. Reverts on invalid signatures.
+    function verify(
+        address signer,
+        bytes32 hash,
+        bytes calldata signature
+    )
+        external
+        view
+        returns (bool);
+
+}

--- a/tips/verify/src/interfaces/ITIP20.sol
+++ b/tips/verify/src/interfaces/ITIP20.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title Minimal TIP-20 interface required by the historical TempoStreamChannel reference impl.
+interface ITIP20 {
+
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+
+}

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -16,7 +16,6 @@ interface ITIP20ChannelEscrow {
     struct ChannelState {
         uint96 settled;
         uint96 deposit;
-        uint32 expiresAt;
         uint32 closeData;
     }
 
@@ -33,8 +32,7 @@ interface ITIP20ChannelEscrow {
         address token,
         uint96 deposit,
         bytes32 salt,
-        address authorizedSigner,
-        uint32 expiresAt
+        address authorizedSigner
     )
         external
         returns (bytes32 channelId);
@@ -48,8 +46,7 @@ interface ITIP20ChannelEscrow {
 
     function topUp(
         ChannelDescriptor calldata descriptor,
-        uint96 additionalDeposit,
-        uint32 newExpiresAt
+        uint96 additionalDeposit
     )
         external;
 
@@ -105,8 +102,7 @@ interface ITIP20ChannelEscrow {
         address token,
         address authorizedSigner,
         bytes32 salt,
-        uint96 deposit,
-        uint32 expiresAt
+        uint96 deposit
     );
 
     event Settled(
@@ -123,8 +119,7 @@ interface ITIP20ChannelEscrow {
         address indexed payer,
         address indexed payee,
         uint96 additionalDeposit,
-        uint96 newDeposit,
-        uint32 newExpiresAt
+        uint96 newDeposit
     );
 
     event CloseRequested(
@@ -146,8 +141,6 @@ interface ITIP20ChannelEscrow {
         bytes32 indexed channelId, address indexed payer, address indexed payee
     );
 
-    event ChannelExpired(bytes32 indexed channelId, address indexed payer, address indexed payee);
-
     error ChannelAlreadyExists();
     error ChannelNotFound();
     error ChannelFinalized();
@@ -156,8 +149,6 @@ interface ITIP20ChannelEscrow {
     error InvalidPayee();
     error InvalidToken();
     error ZeroDeposit();
-    error InvalidExpiry();
-    error ChannelExpiredError();
     error InvalidSignature();
     error AmountExceedsDeposit();
     error AmountNotIncreasing();

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+/// @title ITIP20ChannelEscrow
+/// @notice Reference interface for the TIP-1034 channel model.
+interface ITIP20ChannelEscrow {
+
+    struct ChannelDescriptor {
+        address payer;
+        address payee;
+        address token;
+        bytes32 salt;
+        address authorizedSigner;
+    }
+
+    struct ChannelState {
+        bool finalized;
+        uint32 closeRequestedAt;
+        uint32 expiresAt;
+        uint96 deposit;
+        uint96 settled;
+    }
+
+    struct Channel {
+        ChannelDescriptor descriptor;
+        ChannelState state;
+    }
+
+    function CLOSE_GRACE_PERIOD() external view returns (uint64);
+    function VOUCHER_TYPEHASH() external view returns (bytes32);
+
+    function open(
+        address payee,
+        address token,
+        uint96 deposit,
+        bytes32 salt,
+        address authorizedSigner,
+        uint32 expiresAt
+    )
+        external
+        returns (bytes32 channelId);
+
+    function settle(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        bytes calldata signature
+    )
+        external;
+
+    function topUp(
+        ChannelDescriptor calldata descriptor,
+        uint96 additionalDeposit,
+        uint32 newExpiresAt
+    )
+        external;
+
+    function close(
+        ChannelDescriptor calldata descriptor,
+        uint96 cumulativeAmount,
+        uint96 captureAmount,
+        bytes calldata signature
+    )
+        external;
+
+    function requestClose(ChannelDescriptor calldata descriptor) external;
+
+    function withdraw(ChannelDescriptor calldata descriptor) external;
+
+    function getChannel(ChannelDescriptor calldata descriptor)
+        external
+        view
+        returns (Channel memory);
+
+    function getChannelState(bytes32 channelId) external view returns (ChannelState memory);
+
+    function getChannelStatesBatch(bytes32[] calldata channelIds)
+        external
+        view
+        returns (ChannelState[] memory);
+
+    function computeChannelId(
+        address payer,
+        address payee,
+        address token,
+        bytes32 salt,
+        address authorizedSigner
+    )
+        external
+        view
+        returns (bytes32);
+
+    function getVoucherDigest(
+        bytes32 channelId,
+        uint96 cumulativeAmount
+    )
+        external
+        view
+        returns (bytes32);
+
+    function domainSeparator() external view returns (bytes32);
+
+    event ChannelOpened(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        address token,
+        address authorizedSigner,
+        bytes32 salt,
+        uint96 deposit,
+        uint32 expiresAt
+    );
+
+    event Settled(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 cumulativeAmount,
+        uint96 deltaPaid,
+        uint96 newSettled
+    );
+
+    event TopUp(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 additionalDeposit,
+        uint96 newDeposit,
+        uint32 newExpiresAt
+    );
+
+    event CloseRequested(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint256 closeGraceEnd
+    );
+
+    event ChannelClosed(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        uint96 settledToPayee,
+        uint96 refundedToPayer
+    );
+
+    event CloseRequestCancelled(
+        bytes32 indexed channelId, address indexed payer, address indexed payee
+    );
+
+    event ChannelExpired(bytes32 indexed channelId, address indexed payer, address indexed payee);
+
+    error ChannelAlreadyExists();
+    error ChannelNotFound();
+    error ChannelFinalized();
+    error NotPayer();
+    error NotPayee();
+    error InvalidPayee();
+    error InvalidToken();
+    error ZeroDeposit();
+    error InvalidExpiry();
+    error ChannelExpiredError();
+    error InvalidSignature();
+    error AmountExceedsDeposit();
+    error AmountNotIncreasing();
+    error CaptureAmountInvalid();
+    error CloseNotReady();
+    error DepositOverflow();
+    error TransferFailed();
+
+}

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -14,11 +14,10 @@ interface ITIP20ChannelEscrow {
     }
 
     struct ChannelState {
-        bool finalized;
-        uint32 closeRequestedAt;
-        uint32 expiresAt;
-        uint96 deposit;
         uint96 settled;
+        uint96 deposit;
+        uint32 expiresAt;
+        uint32 closeData;
     }
 
     struct Channel {

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -12,6 +12,7 @@ interface ITIP20ChannelEscrow {
         address token;
         bytes32 salt;
         address authorizedSigner;
+        bytes32 openTxHash;
     }
 
     struct ChannelState {
@@ -46,11 +47,7 @@ interface ITIP20ChannelEscrow {
     )
         external;
 
-    function topUp(
-        ChannelDescriptor calldata descriptor,
-        uint96 additionalDeposit
-    )
-        external;
+    function topUp(ChannelDescriptor calldata descriptor, uint96 additionalDeposit) external;
 
     function close(
         ChannelDescriptor calldata descriptor,
@@ -82,7 +79,8 @@ interface ITIP20ChannelEscrow {
         address operator,
         address token,
         bytes32 salt,
-        address authorizedSigner
+        address authorizedSigner,
+        bytes32 openTxHash
     )
         external
         view
@@ -106,6 +104,7 @@ interface ITIP20ChannelEscrow {
         address token,
         address authorizedSigner,
         bytes32 salt,
+        bytes32 openTxHash,
         uint96 deposit
     );
 
@@ -147,7 +146,6 @@ interface ITIP20ChannelEscrow {
 
     error ChannelAlreadyExists();
     error ChannelNotFound();
-    error ChannelFinalized();
     error NotPayer();
     error NotPayee();
     error NotPayeeOrOperator();

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -8,6 +8,7 @@ interface ITIP20ChannelEscrow {
     struct ChannelDescriptor {
         address payer;
         address payee;
+        address operator;
         address token;
         bytes32 salt;
         address authorizedSigner;
@@ -29,6 +30,7 @@ interface ITIP20ChannelEscrow {
 
     function open(
         address payee,
+        address operator,
         address token,
         uint96 deposit,
         bytes32 salt,
@@ -77,6 +79,7 @@ interface ITIP20ChannelEscrow {
     function computeChannelId(
         address payer,
         address payee,
+        address operator,
         address token,
         bytes32 salt,
         address authorizedSigner
@@ -99,6 +102,7 @@ interface ITIP20ChannelEscrow {
         bytes32 indexed channelId,
         address indexed payer,
         address indexed payee,
+        address operator,
         address token,
         address authorizedSigner,
         bytes32 salt,
@@ -146,6 +150,7 @@ interface ITIP20ChannelEscrow {
     error ChannelFinalized();
     error NotPayer();
     error NotPayee();
+    error NotPayeeOrOperator();
     error InvalidPayee();
     error InvalidToken();
     error ZeroDeposit();

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -12,7 +12,7 @@ interface ITIP20ChannelEscrow {
         address token;
         bytes32 salt;
         address authorizedSigner;
-        bytes32 openTxHash;
+        bytes32 expiringNonceHash;
     }
 
     struct ChannelState {
@@ -80,7 +80,7 @@ interface ITIP20ChannelEscrow {
         address token,
         bytes32 salt,
         address authorizedSigner,
-        bytes32 openTxHash
+        bytes32 expiringNonceHash
     )
         external
         view
@@ -104,7 +104,7 @@ interface ITIP20ChannelEscrow {
         address token,
         address authorizedSigner,
         bytes32 salt,
-        bytes32 openTxHash,
+        bytes32 expiringNonceHash,
         uint96 deposit
     );
 

--- a/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/verify/src/interfaces/ITIP20ChannelEscrow.sol
@@ -18,7 +18,7 @@ interface ITIP20ChannelEscrow {
     struct ChannelState {
         uint96 settled;
         uint96 deposit;
-        uint32 closeData;
+        uint32 closeRequestedAt;
     }
 
     struct Channel {
@@ -152,6 +152,7 @@ interface ITIP20ChannelEscrow {
     error InvalidPayee();
     error InvalidToken();
     error ZeroDeposit();
+    error ExpiringNonceHashNotSet();
     error InvalidSignature();
     error AmountExceedsDeposit();
     error AmountNotIncreasing();

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -69,7 +69,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
     uint256 public payerKey;
     address public payee;
 
-    uint128 internal constant DEPOSIT = 1_000_000;
+    uint96 internal constant DEPOSIT = 1_000_000;
     bytes32 internal constant SALT = bytes32(uint256(1));
 
     function setUp() public override {
@@ -94,8 +94,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         token.approve(address(channel), type(uint256).max);
     }
 
-    function _defaultExpiry() internal view returns (uint64) {
-        return uint64(block.timestamp + 1 days);
+    function _defaultExpiry() internal view returns (uint32) {
+        return uint32(block.timestamp + 1 days);
     }
 
     function _openChannel() internal returns (bytes32) {
@@ -103,18 +103,39 @@ contract TIP20ChannelEscrowTest is BaseTest {
         return channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
     }
 
-    function _openChannelWithExpiry(uint64 expiresAt) internal returns (bytes32) {
+    function _openChannelWithExpiry(uint32 expiresAt) internal returns (bytes32) {
         vm.prank(payer);
         return channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
     }
 
-    function _signVoucher(bytes32 channelId, uint128 amount) internal view returns (bytes memory) {
+    function _descriptor() internal view returns (ITIP20ChannelEscrow.ChannelDescriptor memory) {
+        return _descriptor(SALT, address(0));
+    }
+
+    function _descriptor(
+        bytes32 salt,
+        address authorizedSigner
+    )
+        internal
+        view
+        returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
+    {
+        return ITIP20ChannelEscrow.ChannelDescriptor({
+            payer: payer,
+            payee: payee,
+            token: address(token),
+            salt: salt,
+            authorizedSigner: authorizedSigner
+        });
+    }
+
+    function _signVoucher(bytes32 channelId, uint96 amount) internal view returns (bytes memory) {
         return _signVoucher(channelId, amount, payerKey);
     }
 
     function _signVoucher(
         bytes32 channelId,
-        uint128 amount,
+        uint96 amount,
         uint256 signerKey
     )
         internal
@@ -127,22 +148,23 @@ contract TIP20ChannelEscrowTest is BaseTest {
     }
 
     function test_open_success() public {
-        uint64 expiresAt = _defaultExpiry();
+        uint32 expiresAt = _defaultExpiry();
 
         vm.prank(payer);
         bytes32 channelId =
             channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
 
-        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
-        assertFalse(ch.finalized);
-        assertEq(ch.closeRequestedAt, 0);
-        assertEq(ch.payer, payer);
-        assertEq(ch.payee, payee);
-        assertEq(ch.expiresAt, expiresAt);
-        assertEq(ch.token, address(token));
-        assertEq(ch.authorizedSigner, address(0));
-        assertEq(ch.deposit, DEPOSIT);
-        assertEq(ch.settled, 0);
+        ITIP20ChannelEscrow.Channel memory ch = channel.getChannel(_descriptor());
+        assertFalse(ch.state.finalized);
+        assertEq(ch.state.closeRequestedAt, 0);
+        assertEq(ch.descriptor.payer, payer);
+        assertEq(ch.descriptor.payee, payee);
+        assertEq(ch.state.expiresAt, expiresAt);
+        assertEq(ch.descriptor.token, address(token));
+        assertEq(ch.descriptor.authorizedSigner, address(0));
+        assertEq(ch.state.deposit, DEPOSIT);
+        assertEq(ch.state.settled, 0);
+        assertEq(channel.getChannelState(channelId).deposit, DEPOSIT);
     }
 
     function test_open_revert_zeroPayee() public {
@@ -166,7 +188,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_open_revert_invalidExpiry() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0), uint64(block.timestamp));
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0), uint32(block.timestamp));
     }
 
     function test_open_revert_duplicate() public {
@@ -182,20 +204,20 @@ contract TIP20ChannelEscrowTest is BaseTest {
         bytes memory sig = _signVoucher(channelId, 500_000);
 
         vm.prank(payee);
-        channel.settle(channelId, 500_000, sig);
+        channel.settle(_descriptor(), 500_000, sig);
 
-        assertEq(channel.getChannel(channelId).settled, 500_000);
+        assertEq(channel.getChannelState(channelId).settled, 500_000);
         assertEq(token.balanceOf(payee), 500_000);
     }
 
     function test_settle_revert_afterExpiry() public {
-        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
         bytes memory sig = _signVoucher(channelId, 500_000);
 
         vm.warp(block.timestamp + 10);
         vm.prank(payee);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelExpiredError.selector);
-        channel.settle(channelId, 500_000, sig);
+        channel.settle(_descriptor(), 500_000, sig);
     }
 
     function test_settle_revert_invalidSignature() public {
@@ -205,7 +227,16 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payee);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidSignature.selector);
-        channel.settle(channelId, 500_000, sig);
+        channel.settle(_descriptor(), 500_000, sig);
+    }
+
+    function test_settle_revert_wrongDescriptor() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 500_000);
+
+        vm.prank(payee);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelNotFound.selector);
+        channel.settle(_descriptor(bytes32(uint256(2)), address(0)), 500_000, sig);
     }
 
     function test_authorizedSigner_settleSuccess() public {
@@ -218,41 +249,41 @@ contract TIP20ChannelEscrowTest is BaseTest {
         bytes memory sig = _signVoucher(channelId, 500_000, delegateKey);
 
         vm.prank(payee);
-        channel.settle(channelId, 500_000, sig);
+        channel.settle(_descriptor(SALT, delegateSigner), 500_000, sig);
 
-        assertEq(channel.getChannel(channelId).settled, 500_000);
+        assertEq(channel.getChannelState(channelId).settled, 500_000);
     }
 
     function test_topUp_updatesDepositAndExpiry() public {
         bytes32 channelId = _openChannel();
-        uint64 nextExpiry = uint64(block.timestamp + 2 days);
+        uint32 nextExpiry = uint32(block.timestamp + 2 days);
 
         vm.prank(payer);
-        channel.topUp(channelId, 250_000, nextExpiry);
+        channel.topUp(_descriptor(), 250_000, nextExpiry);
 
-        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertEq(ch.deposit, DEPOSIT + 250_000);
         assertEq(ch.expiresAt, nextExpiry);
     }
 
     function test_topUp_revert_nonIncreasingExpiry() public {
-        bytes32 channelId = _openChannel();
+        _openChannel();
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
-        channel.topUp(channelId, 0, _defaultExpiry());
+        channel.topUp(_descriptor(), 0, _defaultExpiry());
     }
 
     function test_topUp_cancelsCloseRequest() public {
         bytes32 channelId = _openChannel();
 
         vm.prank(payer);
-        channel.requestClose(channelId);
+        channel.requestClose(_descriptor());
 
         vm.prank(payer);
-        channel.topUp(channelId, 100_000, 0);
+        channel.topUp(_descriptor(), 100_000, 0);
 
-        assertEq(channel.getChannel(channelId).closeRequestedAt, 0);
+        assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
     }
 
     function test_close_partialCapture_success() public {
@@ -263,9 +294,9 @@ contract TIP20ChannelEscrowTest is BaseTest {
         uint256 payerBalanceBefore = token.balanceOf(payer);
 
         vm.prank(payee);
-        channel.close(channelId, 900_000, 600_000, sig);
+        channel.close(_descriptor(), 900_000, 600_000, sig);
 
-        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertTrue(ch.finalized);
         assertEq(ch.settled, 600_000);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
@@ -277,16 +308,16 @@ contract TIP20ChannelEscrowTest is BaseTest {
         bytes memory settleSig = _signVoucher(channelId, 300_000);
 
         vm.prank(payee);
-        channel.settle(channelId, 300_000, settleSig);
+        channel.settle(_descriptor(), 300_000, settleSig);
 
         bytes memory closeSig = _signVoucher(channelId, 800_000);
         uint256 payeeBalanceBefore = token.balanceOf(payee);
 
         vm.prank(payee);
-        channel.close(channelId, 800_000, 500_000, closeSig);
+        channel.close(_descriptor(), 800_000, 500_000, closeSig);
 
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 200_000);
-        assertEq(channel.getChannel(channelId).settled, 500_000);
+        assertEq(channel.getChannelState(channelId).settled, 500_000);
     }
 
     function test_close_allowsVoucherAmountAboveDepositWhenCaptureWithinDeposit() public {
@@ -296,9 +327,9 @@ contract TIP20ChannelEscrowTest is BaseTest {
         uint256 payeeBalanceBefore = token.balanceOf(payee);
 
         vm.prank(payee);
-        channel.close(channelId, DEPOSIT + 250_000, DEPOSIT, sig);
+        channel.close(_descriptor(), DEPOSIT + 250_000, DEPOSIT, sig);
 
-        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertTrue(ch.finalized);
         assertEq(ch.settled, DEPOSIT);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
@@ -309,60 +340,72 @@ contract TIP20ChannelEscrowTest is BaseTest {
         bytes memory settleSig = _signVoucher(channelId, 300_000);
 
         vm.prank(payee);
-        channel.settle(channelId, 300_000, settleSig);
+        channel.settle(_descriptor(), 300_000, settleSig);
 
         vm.prank(payee);
         vm.expectRevert(ITIP20ChannelEscrow.CaptureAmountInvalid.selector);
-        channel.close(channelId, 300_000, 200_000, "");
+        channel.close(_descriptor(), 300_000, 200_000, "");
     }
 
     function test_close_afterExpiry_allowsNoAdditionalCapture() public {
-        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
         bytes memory sig = _signVoucher(channelId, 300_000);
 
         vm.prank(payee);
-        channel.settle(channelId, 300_000, sig);
+        channel.settle(_descriptor(), 300_000, sig);
 
         vm.warp(block.timestamp + 10);
 
         uint256 payerBalanceBefore = token.balanceOf(payer);
         vm.prank(payee);
-        channel.close(channelId, 300_000, 300_000, "");
+        channel.close(_descriptor(), 300_000, 300_000, "");
 
-        assertTrue(channel.getChannel(channelId).finalized);
+        assertTrue(channel.getChannelState(channelId).finalized);
         assertEq(token.balanceOf(payer), payerBalanceBefore + (DEPOSIT - 300_000));
+    }
+
+    function test_close_keepsTombstoneAndBlocksReopen() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 600_000);
+
+        vm.prank(payee);
+        channel.close(_descriptor(), 600_000, 600_000, sig);
+
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
     }
 
     function test_withdraw_afterGracePeriod() public {
         bytes32 channelId = _openChannel();
 
         vm.prank(payer);
-        channel.requestClose(channelId);
+        channel.requestClose(_descriptor());
 
         vm.warp(block.timestamp + channel.CLOSE_GRACE_PERIOD() + 1);
 
         uint256 payerBalanceBefore = token.balanceOf(payer);
         vm.prank(payer);
-        channel.withdraw(channelId);
+        channel.withdraw(_descriptor());
 
-        assertTrue(channel.getChannel(channelId).finalized);
+        assertTrue(channel.getChannelState(channelId).finalized);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 
     function test_withdraw_afterExpiryWithoutCloseRequest() public {
-        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
 
         vm.warp(block.timestamp + 10);
 
         uint256 payerBalanceBefore = token.balanceOf(payer);
         vm.prank(payer);
-        channel.withdraw(channelId);
+        channel.withdraw(_descriptor());
 
-        assertTrue(channel.getChannel(channelId).finalized);
+        assertTrue(channel.getChannelState(channelId).finalized);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 
-    function test_getChannelsBatch_success() public {
+    function test_getChannelStatesBatch_success() public {
         bytes32 channelId1 = _openChannel();
 
         vm.prank(payer);
@@ -372,13 +415,13 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         bytes memory sig = _signVoucher(channelId1, 400_000);
         vm.prank(payee);
-        channel.settle(channelId1, 400_000, sig);
+        channel.settle(_descriptor(), 400_000, sig);
 
         bytes32[] memory ids = new bytes32[](2);
         ids[0] = channelId1;
         ids[1] = channelId2;
 
-        TIP20ChannelEscrow.Channel[] memory states = channel.getChannelsBatch(ids);
+        ITIP20ChannelEscrow.ChannelState[] memory states = channel.getChannelStatesBatch(ids);
         assertEq(states.length, 2);
         assertEq(states[0].settled, 400_000);
         assertEq(states[1].settled, 0);

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -129,6 +129,10 @@ contract TIP20ChannelEscrowTest is BaseTest {
         });
     }
 
+    function _channelStateSlot(bytes32 channelId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(channelId, uint256(0)));
+    }
+
     function _signVoucher(bytes32 channelId, uint96 amount) internal view returns (bytes memory) {
         return _signVoucher(channelId, amount, payerKey);
     }
@@ -155,15 +159,14 @@ contract TIP20ChannelEscrowTest is BaseTest {
             channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
 
         ITIP20ChannelEscrow.Channel memory ch = channel.getChannel(_descriptor());
-        assertFalse(ch.state.finalized);
-        assertEq(ch.state.closeRequestedAt, 0);
         assertEq(ch.descriptor.payer, payer);
         assertEq(ch.descriptor.payee, payee);
-        assertEq(ch.state.expiresAt, expiresAt);
         assertEq(ch.descriptor.token, address(token));
         assertEq(ch.descriptor.authorizedSigner, address(0));
-        assertEq(ch.state.deposit, DEPOSIT);
         assertEq(ch.state.settled, 0);
+        assertEq(ch.state.deposit, DEPOSIT);
+        assertEq(ch.state.expiresAt, expiresAt);
+        assertEq(ch.state.closeData, 0);
         assertEq(channel.getChannelState(channelId).deposit, DEPOSIT);
     }
 
@@ -283,7 +286,21 @@ contract TIP20ChannelEscrowTest is BaseTest {
         vm.prank(payer);
         channel.topUp(_descriptor(), 100_000, 0);
 
-        assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
+        assertEq(channel.getChannelState(channelId).closeData, 0);
+    }
+
+    function test_requestClose_storesTimestampInCloseData() public {
+        bytes32 channelId = _openChannel();
+        uint32 closeRequestedAt = uint32(block.timestamp);
+
+        vm.prank(payer);
+        channel.requestClose(_descriptor());
+
+        ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
+        assertEq(ch.closeData, closeRequestedAt);
+
+        uint256 raw = uint256(vm.load(address(channel), _channelStateSlot(channelId)));
+        assertEq(uint32(raw >> 224), closeRequestedAt);
     }
 
     function test_close_partialCapture_success() public {
@@ -297,8 +314,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), 900_000, 600_000, sig);
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
-        assertTrue(ch.finalized);
         assertEq(ch.settled, 600_000);
+        assertEq(ch.closeData, 1);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
         assertEq(token.balanceOf(payer), payerBalanceBefore + 400_000);
     }
@@ -330,8 +347,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), DEPOSIT + 250_000, DEPOSIT, sig);
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
-        assertTrue(ch.finalized);
         assertEq(ch.settled, DEPOSIT);
+        assertEq(ch.closeData, 1);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
     }
 
@@ -360,7 +377,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         vm.prank(payee);
         channel.close(_descriptor(), 300_000, 300_000, "");
 
-        assertTrue(channel.getChannelState(channelId).finalized);
+        assertEq(channel.getChannelState(channelId).closeData, 1);
         assertEq(token.balanceOf(payer), payerBalanceBefore + (DEPOSIT - 300_000));
     }
 
@@ -370,6 +387,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payee);
         channel.close(_descriptor(), 600_000, 600_000, sig);
+
+        assertEq(channel.getChannelState(channelId).closeData, 1);
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
@@ -388,7 +407,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         vm.prank(payer);
         channel.withdraw(_descriptor());
 
-        assertTrue(channel.getChannelState(channelId).finalized);
+        assertEq(channel.getChannelState(channelId).closeData, 1);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 
@@ -401,7 +420,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         vm.prank(payer);
         channel.withdraw(_descriptor());
 
-        assertTrue(channel.getChannelState(channelId).finalized);
+        assertEq(channel.getChannelState(channelId).closeData, 1);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { TIP20 } from "../src/TIP20.sol";
+import { TIP20ChannelEscrow } from "../src/TIP20ChannelEscrow.sol";
+import { ITIP20ChannelEscrow } from "../src/interfaces/ITIP20ChannelEscrow.sol";
+import { BaseTest } from "./BaseTest.t.sol";
+
+contract MockSignatureVerifier {
+
+    error InvalidFormat();
+    error InvalidSignature();
+
+    function recover(bytes32 hash, bytes calldata signature)
+        external
+        pure
+        returns (address signer)
+    {
+        return _recover(hash, signature);
+    }
+
+    function verify(
+        address signer,
+        bytes32 hash,
+        bytes calldata signature
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return _recover(hash, signature) == signer;
+    }
+
+    function _recover(
+        bytes32 hash,
+        bytes calldata signature
+    )
+        internal
+        pure
+        returns (address signer)
+    {
+        if (signature.length != 65) revert InvalidSignature();
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+
+        if (v < 27) v += 27;
+        if (v != 27 && v != 28) revert InvalidSignature();
+
+        signer = ecrecover(hash, v, r, s);
+        if (signer == address(0)) revert InvalidSignature();
+    }
+
+}
+
+contract TIP20ChannelEscrowTest is BaseTest {
+
+    TIP20ChannelEscrow public channel;
+    TIP20 public token;
+
+    address public payer;
+    uint256 public payerKey;
+    address public payee;
+
+    uint128 internal constant DEPOSIT = 1_000_000;
+    bytes32 internal constant SALT = bytes32(uint256(1));
+
+    function setUp() public override {
+        super.setUp();
+
+        channel = new TIP20ChannelEscrow();
+        MockSignatureVerifier verifier = new MockSignatureVerifier();
+        vm.etch(channel.SIGNATURE_VERIFIER_PRECOMPILE(), address(verifier).code);
+        token = TIP20(
+            factory.createToken("Stream Token", "STR", "USD", pathUSD, admin, bytes32("stream"))
+        );
+
+        (payer, payerKey) = makeAddrAndKey("payer");
+        payee = makeAddr("payee");
+
+        vm.startPrank(admin);
+        token.grantRole(_ISSUER_ROLE, admin);
+        token.mint(payer, 20_000_000);
+        vm.stopPrank();
+
+        vm.prank(payer);
+        token.approve(address(channel), type(uint256).max);
+    }
+
+    function _defaultExpiry() internal view returns (uint64) {
+        return uint64(block.timestamp + 1 days);
+    }
+
+    function _openChannel() internal returns (bytes32) {
+        vm.prank(payer);
+        return channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+    }
+
+    function _openChannelWithExpiry(uint64 expiresAt) internal returns (bytes32) {
+        vm.prank(payer);
+        return channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
+    }
+
+    function _signVoucher(bytes32 channelId, uint128 amount) internal view returns (bytes memory) {
+        return _signVoucher(channelId, amount, payerKey);
+    }
+
+    function _signVoucher(
+        bytes32 channelId,
+        uint128 amount,
+        uint256 signerKey
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 digest = channel.getVoucherDigest(channelId, amount);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_open_success() public {
+        uint64 expiresAt = _defaultExpiry();
+
+        vm.prank(payer);
+        bytes32 channelId =
+            channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
+
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        assertFalse(ch.finalized);
+        assertEq(ch.closeRequestedAt, 0);
+        assertEq(ch.payer, payer);
+        assertEq(ch.payee, payee);
+        assertEq(ch.expiresAt, expiresAt);
+        assertEq(ch.token, address(token));
+        assertEq(ch.authorizedSigner, address(0));
+        assertEq(ch.deposit, DEPOSIT);
+        assertEq(ch.settled, 0);
+    }
+
+    function test_open_revert_zeroPayee() public {
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
+        channel.open(address(0), address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+    }
+
+    function test_open_revert_zeroToken() public {
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
+        channel.open(payee, address(0), DEPOSIT, SALT, address(0), _defaultExpiry());
+    }
+
+    function test_open_revert_zeroDeposit() public {
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
+        channel.open(payee, address(token), 0, SALT, address(0), _defaultExpiry());
+    }
+
+    function test_open_revert_invalidExpiry() public {
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0), uint64(block.timestamp));
+    }
+
+    function test_open_revert_duplicate() public {
+        _openChannel();
+
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+    }
+
+    function test_settle_success() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 500_000);
+
+        vm.prank(payee);
+        channel.settle(channelId, 500_000, sig);
+
+        assertEq(channel.getChannel(channelId).settled, 500_000);
+        assertEq(token.balanceOf(payee), 500_000);
+    }
+
+    function test_settle_revert_afterExpiry() public {
+        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+        bytes memory sig = _signVoucher(channelId, 500_000);
+
+        vm.warp(block.timestamp + 10);
+        vm.prank(payee);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelExpiredError.selector);
+        channel.settle(channelId, 500_000, sig);
+    }
+
+    function test_settle_revert_invalidSignature() public {
+        bytes32 channelId = _openChannel();
+        (, uint256 wrongKey) = makeAddrAndKey("wrong");
+        bytes memory sig = _signVoucher(channelId, 500_000, wrongKey);
+
+        vm.prank(payee);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidSignature.selector);
+        channel.settle(channelId, 500_000, sig);
+    }
+
+    function test_authorizedSigner_settleSuccess() public {
+        (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("delegate");
+
+        vm.prank(payer);
+        bytes32 channelId =
+            channel.open(payee, address(token), DEPOSIT, SALT, delegateSigner, _defaultExpiry());
+
+        bytes memory sig = _signVoucher(channelId, 500_000, delegateKey);
+
+        vm.prank(payee);
+        channel.settle(channelId, 500_000, sig);
+
+        assertEq(channel.getChannel(channelId).settled, 500_000);
+    }
+
+    function test_topUp_updatesDepositAndExpiry() public {
+        bytes32 channelId = _openChannel();
+        uint64 nextExpiry = uint64(block.timestamp + 2 days);
+
+        vm.prank(payer);
+        channel.topUp(channelId, 250_000, nextExpiry);
+
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        assertEq(ch.deposit, DEPOSIT + 250_000);
+        assertEq(ch.expiresAt, nextExpiry);
+    }
+
+    function test_topUp_revert_nonIncreasingExpiry() public {
+        bytes32 channelId = _openChannel();
+
+        vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
+        channel.topUp(channelId, 0, _defaultExpiry());
+    }
+
+    function test_topUp_cancelsCloseRequest() public {
+        bytes32 channelId = _openChannel();
+
+        vm.prank(payer);
+        channel.requestClose(channelId);
+
+        vm.prank(payer);
+        channel.topUp(channelId, 100_000, 0);
+
+        assertEq(channel.getChannel(channelId).closeRequestedAt, 0);
+    }
+
+    function test_close_partialCapture_success() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 900_000);
+
+        uint256 payeeBalanceBefore = token.balanceOf(payee);
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+
+        vm.prank(payee);
+        channel.close(channelId, 900_000, 600_000, sig);
+
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        assertTrue(ch.finalized);
+        assertEq(ch.settled, 600_000);
+        assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
+        assertEq(token.balanceOf(payer), payerBalanceBefore + 400_000);
+    }
+
+    function test_close_usesPreviousSettledForDelta() public {
+        bytes32 channelId = _openChannel();
+        bytes memory settleSig = _signVoucher(channelId, 300_000);
+
+        vm.prank(payee);
+        channel.settle(channelId, 300_000, settleSig);
+
+        bytes memory closeSig = _signVoucher(channelId, 800_000);
+        uint256 payeeBalanceBefore = token.balanceOf(payee);
+
+        vm.prank(payee);
+        channel.close(channelId, 800_000, 500_000, closeSig);
+
+        assertEq(token.balanceOf(payee), payeeBalanceBefore + 200_000);
+        assertEq(channel.getChannel(channelId).settled, 500_000);
+    }
+
+    function test_close_allowsVoucherAmountAboveDepositWhenCaptureWithinDeposit() public {
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, DEPOSIT + 250_000);
+
+        uint256 payeeBalanceBefore = token.balanceOf(payee);
+
+        vm.prank(payee);
+        channel.close(channelId, DEPOSIT + 250_000, DEPOSIT, sig);
+
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
+        assertTrue(ch.finalized);
+        assertEq(ch.settled, DEPOSIT);
+        assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
+    }
+
+    function test_close_revert_invalidCaptureAmount() public {
+        bytes32 channelId = _openChannel();
+        bytes memory settleSig = _signVoucher(channelId, 300_000);
+
+        vm.prank(payee);
+        channel.settle(channelId, 300_000, settleSig);
+
+        vm.prank(payee);
+        vm.expectRevert(ITIP20ChannelEscrow.CaptureAmountInvalid.selector);
+        channel.close(channelId, 300_000, 200_000, "");
+    }
+
+    function test_close_afterExpiry_allowsNoAdditionalCapture() public {
+        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+        bytes memory sig = _signVoucher(channelId, 300_000);
+
+        vm.prank(payee);
+        channel.settle(channelId, 300_000, sig);
+
+        vm.warp(block.timestamp + 10);
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        vm.prank(payee);
+        channel.close(channelId, 300_000, 300_000, "");
+
+        assertTrue(channel.getChannel(channelId).finalized);
+        assertEq(token.balanceOf(payer), payerBalanceBefore + (DEPOSIT - 300_000));
+    }
+
+    function test_withdraw_afterGracePeriod() public {
+        bytes32 channelId = _openChannel();
+
+        vm.prank(payer);
+        channel.requestClose(channelId);
+
+        vm.warp(block.timestamp + channel.CLOSE_GRACE_PERIOD() + 1);
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        vm.prank(payer);
+        channel.withdraw(channelId);
+
+        assertTrue(channel.getChannel(channelId).finalized);
+        assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
+    }
+
+    function test_withdraw_afterExpiryWithoutCloseRequest() public {
+        bytes32 channelId = _openChannelWithExpiry(uint64(block.timestamp + 10));
+
+        vm.warp(block.timestamp + 10);
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        vm.prank(payer);
+        channel.withdraw(channelId);
+
+        assertTrue(channel.getChannel(channelId).finalized);
+        assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
+    }
+
+    function test_getChannelsBatch_success() public {
+        bytes32 channelId1 = _openChannel();
+
+        vm.prank(payer);
+        bytes32 channelId2 = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(2)), address(0), _defaultExpiry()
+        );
+
+        bytes memory sig = _signVoucher(channelId1, 400_000);
+        vm.prank(payee);
+        channel.settle(channelId1, 400_000, sig);
+
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = channelId1;
+        ids[1] = channelId2;
+
+        TIP20ChannelEscrow.Channel[] memory states = channel.getChannelsBatch(ids);
+        assertEq(states.length, 2);
+        assertEq(states[0].settled, 400_000);
+        assertEq(states[1].settled, 0);
+    }
+
+    function test_computeChannelId_usesFixedPrecompileAddress() public {
+        TIP20ChannelEscrow other = new TIP20ChannelEscrow();
+
+        bytes32 id1 = channel.computeChannelId(payer, payee, address(token), SALT, address(0));
+        bytes32 id2 = other.computeChannelId(payer, payee, address(token), SALT, address(0));
+
+        assertEq(id1, id2);
+        assertEq(channel.domainSeparator(), other.domainSeparator());
+    }
+
+}

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -94,18 +94,9 @@ contract TIP20ChannelEscrowTest is BaseTest {
         token.approve(address(channel), type(uint256).max);
     }
 
-    function _defaultExpiry() internal view returns (uint32) {
-        return uint32(block.timestamp + 1 days);
-    }
-
     function _openChannel() internal returns (bytes32) {
         vm.prank(payer);
-        return channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
-    }
-
-    function _openChannelWithExpiry(uint32 expiresAt) internal returns (bytes32) {
-        vm.prank(payer);
-        return channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
+        return channel.open(payee, address(token), DEPOSIT, SALT, address(0));
     }
 
     function _descriptor() internal view returns (ITIP20ChannelEscrow.ChannelDescriptor memory) {
@@ -152,11 +143,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
     }
 
     function test_open_success() public {
-        uint32 expiresAt = _defaultExpiry();
-
         vm.prank(payer);
-        bytes32 channelId =
-            channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
+        bytes32 channelId = channel.open(payee, address(token), DEPOSIT, SALT, address(0));
 
         ITIP20ChannelEscrow.Channel memory ch = channel.getChannel(_descriptor());
         assertEq(ch.descriptor.payer, payer);
@@ -165,7 +153,6 @@ contract TIP20ChannelEscrowTest is BaseTest {
         assertEq(ch.descriptor.authorizedSigner, address(0));
         assertEq(ch.state.settled, 0);
         assertEq(ch.state.deposit, DEPOSIT);
-        assertEq(ch.state.expiresAt, expiresAt);
         assertEq(ch.state.closeData, 0);
         assertEq(channel.getChannelState(channelId).deposit, DEPOSIT);
     }
@@ -173,25 +160,19 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_open_revert_zeroPayee() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
-        channel.open(address(0), address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+        channel.open(address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroToken() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
-        channel.open(payee, address(0), DEPOSIT, SALT, address(0), _defaultExpiry());
+        channel.open(payee, address(0), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroDeposit() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
-        channel.open(payee, address(token), 0, SALT, address(0), _defaultExpiry());
-    }
-
-    function test_open_revert_invalidExpiry() public {
-        vm.prank(payer);
-        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0), uint32(block.timestamp));
+        channel.open(payee, address(token), 0, SALT, address(0));
     }
 
     function test_open_revert_duplicate() public {
@@ -199,7 +180,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_settle_success() public {
@@ -211,16 +192,6 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         assertEq(channel.getChannelState(channelId).settled, 500_000);
         assertEq(token.balanceOf(payee), 500_000);
-    }
-
-    function test_settle_revert_afterExpiry() public {
-        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
-        bytes memory sig = _signVoucher(channelId, 500_000);
-
-        vm.warp(block.timestamp + 10);
-        vm.prank(payee);
-        vm.expectRevert(ITIP20ChannelEscrow.ChannelExpiredError.selector);
-        channel.settle(_descriptor(), 500_000, sig);
     }
 
     function test_settle_revert_invalidSignature() public {
@@ -246,8 +217,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("delegate");
 
         vm.prank(payer);
-        bytes32 channelId =
-            channel.open(payee, address(token), DEPOSIT, SALT, delegateSigner, _defaultExpiry());
+        bytes32 channelId = channel.open(payee, address(token), DEPOSIT, SALT, delegateSigner);
 
         bytes memory sig = _signVoucher(channelId, 500_000, delegateKey);
 
@@ -257,24 +227,14 @@ contract TIP20ChannelEscrowTest is BaseTest {
         assertEq(channel.getChannelState(channelId).settled, 500_000);
     }
 
-    function test_topUp_updatesDepositAndExpiry() public {
+    function test_topUp_updatesDeposit() public {
         bytes32 channelId = _openChannel();
-        uint32 nextExpiry = uint32(block.timestamp + 2 days);
 
         vm.prank(payer);
-        channel.topUp(_descriptor(), 250_000, nextExpiry);
+        channel.topUp(_descriptor(), 250_000);
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertEq(ch.deposit, DEPOSIT + 250_000);
-        assertEq(ch.expiresAt, nextExpiry);
-    }
-
-    function test_topUp_revert_nonIncreasingExpiry() public {
-        _openChannel();
-
-        vm.prank(payer);
-        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
-        channel.topUp(_descriptor(), 0, _defaultExpiry());
     }
 
     function test_topUp_cancelsCloseRequest() public {
@@ -284,7 +244,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.requestClose(_descriptor());
 
         vm.prank(payer);
-        channel.topUp(_descriptor(), 100_000, 0);
+        channel.topUp(_descriptor(), 100_000);
 
         assertEq(channel.getChannelState(channelId).closeData, 0);
     }
@@ -300,7 +260,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         assertEq(ch.closeData, closeRequestedAt);
 
         uint256 raw = uint256(vm.load(address(channel), _channelStateSlot(channelId)));
-        assertEq(uint32(raw >> 224), closeRequestedAt);
+        assertEq(uint32(raw >> 192), closeRequestedAt);
     }
 
     function test_close_partialCapture_success() public {
@@ -364,14 +324,12 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), 300_000, 200_000, "");
     }
 
-    function test_close_afterExpiry_allowsNoAdditionalCapture() public {
-        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
+    function test_close_allowsNoAdditionalCaptureWithoutSignature() public {
+        bytes32 channelId = _openChannel();
         bytes memory sig = _signVoucher(channelId, 300_000);
 
         vm.prank(payee);
         channel.settle(_descriptor(), 300_000, sig);
-
-        vm.warp(block.timestamp + 10);
 
         uint256 payerBalanceBefore = token.balanceOf(payer);
         vm.prank(payee);
@@ -392,7 +350,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
+        channel.open(payee, address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_withdraw_afterGracePeriod() public {
@@ -411,26 +369,20 @@ contract TIP20ChannelEscrowTest is BaseTest {
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 
-    function test_withdraw_afterExpiryWithoutCloseRequest() public {
-        bytes32 channelId = _openChannelWithExpiry(uint32(block.timestamp + 10));
+    function test_withdraw_revert_withoutCloseRequest() public {
+        _openChannel();
 
-        vm.warp(block.timestamp + 10);
-
-        uint256 payerBalanceBefore = token.balanceOf(payer);
         vm.prank(payer);
+        vm.expectRevert(ITIP20ChannelEscrow.CloseNotReady.selector);
         channel.withdraw(_descriptor());
-
-        assertEq(channel.getChannelState(channelId).closeData, 1);
-        assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 
     function test_getChannelStatesBatch_success() public {
         bytes32 channelId1 = _openChannel();
 
         vm.prank(payer);
-        bytes32 channelId2 = channel.open(
-            payee, address(token), DEPOSIT, bytes32(uint256(2)), address(0), _defaultExpiry()
-        );
+        bytes32 channelId2 =
+            channel.open(payee, address(token), DEPOSIT, bytes32(uint256(2)), address(0));
 
         bytes memory sig = _signVoucher(channelId1, 400_000);
         vm.prank(payee);

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { TIP20 } from "../src/TIP20.sol";
 import { TIP20ChannelEscrow } from "../src/TIP20ChannelEscrow.sol";
 import { ITIP20ChannelEscrow } from "../src/interfaces/ITIP20ChannelEscrow.sol";
-import { BaseTest } from "./BaseTest.t.sol";
+import { MockTIP20 } from "./mocks/MockTIP20.sol";
+import { Test } from "forge-std/Test.sol";
 
 contract MockSignatureVerifier {
 
@@ -60,47 +60,43 @@ contract MockSignatureVerifier {
 
 }
 
-contract TIP20ChannelEscrowTest is BaseTest {
+contract TIP20ChannelEscrowTest is Test {
 
     TIP20ChannelEscrow public channel;
-    TIP20 public token;
+    MockTIP20 public token;
 
     address public payer;
     uint256 public payerKey;
     address public payee;
+    bytes32 internal lastOpenTxHash;
+    uint256 internal openTxCounter;
 
     uint96 internal constant DEPOSIT = 1_000_000;
     bytes32 internal constant SALT = bytes32(uint256(1));
 
-    function setUp() public override {
-        super.setUp();
-
+    function setUp() public {
         channel = new TIP20ChannelEscrow();
         MockSignatureVerifier verifier = new MockSignatureVerifier();
         vm.etch(channel.SIGNATURE_VERIFIER_PRECOMPILE(), address(verifier).code);
-        token = TIP20(
-            factory.createToken("Stream Token", "STR", "USD", pathUSD, admin, bytes32("stream"))
-        );
+        token = new MockTIP20("Stream Token", "STR", 20_000_000);
 
         (payer, payerKey) = makeAddrAndKey("payer");
         payee = makeAddr("payee");
 
-        vm.startPrank(admin);
-        token.grantRole(_ISSUER_ROLE, admin);
-        token.mint(payer, 20_000_000);
-        vm.stopPrank();
+        token.transfer(payer, 20_000_000);
 
         vm.prank(payer);
         token.approve(address(channel), type(uint256).max);
     }
 
     function _openChannel() internal returns (bytes32) {
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         return channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function _descriptor() internal view returns (ITIP20ChannelEscrow.ChannelDescriptor memory) {
-        return _descriptor(SALT, address(0));
+        return _descriptor(SALT, address(0), lastOpenTxHash);
     }
 
     function _descriptor(
@@ -111,13 +107,26 @@ contract TIP20ChannelEscrowTest is BaseTest {
         view
         returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
     {
-        return _descriptor(salt, address(0), authorizedSigner);
+        return _descriptor(salt, authorizedSigner, lastOpenTxHash);
     }
 
     function _descriptor(
         bytes32 salt,
+        address authorizedSigner,
+        bytes32 openTxHash
+    )
+        internal
+        view
+        returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
+    {
+        return _descriptorWithOperator(salt, address(0), authorizedSigner, openTxHash);
+    }
+
+    function _descriptorWithOperator(
+        bytes32 salt,
         address operator,
-        address authorizedSigner
+        address authorizedSigner,
+        bytes32 openTxHash
     )
         internal
         view
@@ -129,8 +138,15 @@ contract TIP20ChannelEscrowTest is BaseTest {
             operator: operator,
             token: address(token),
             salt: salt,
-            authorizedSigner: authorizedSigner
+            authorizedSigner: authorizedSigner,
+            openTxHash: openTxHash
         });
+    }
+
+    function _prepareNextOpenTxHash() internal returns (bytes32 openTxHash) {
+        openTxHash = keccak256(abi.encodePacked("open", ++openTxCounter));
+        channel.setOpenTxHashForTest(openTxHash);
+        lastOpenTxHash = openTxHash;
     }
 
     function _channelStateSlot(bytes32 channelId) internal pure returns (bytes32) {
@@ -156,6 +172,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
     }
 
     function test_open_success() public {
+        bytes32 openTxHash = _prepareNextOpenTxHash();
+
         vm.prank(payer);
         bytes32 channelId =
             channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
@@ -166,6 +184,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         assertEq(ch.descriptor.operator, address(0));
         assertEq(ch.descriptor.token, address(token));
         assertEq(ch.descriptor.authorizedSigner, address(0));
+        assertEq(ch.descriptor.openTxHash, openTxHash);
         assertEq(ch.state.settled, 0);
         assertEq(ch.state.deposit, DEPOSIT);
         assertEq(ch.state.closeData, 0);
@@ -173,29 +192,35 @@ contract TIP20ChannelEscrowTest is BaseTest {
     }
 
     function test_open_revert_zeroPayee() public {
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
         channel.open(address(0), address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroToken() public {
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
         channel.open(payee, address(0), address(0), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroDeposit() public {
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
         channel.open(payee, address(0), address(token), 0, SALT, address(0));
     }
 
-    function test_open_revert_duplicate() public {
-        _openChannel();
+    function test_open_same_descriptor_uses_distinct_open_tx_hashes() public {
+        bytes32 channelId1 = _openChannel();
+        bytes32 openTxHash1 = lastOpenTxHash;
 
-        vm.prank(payer);
-        vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
-        channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
+        bytes32 channelId2 = _openChannel();
+        bytes32 openTxHash2 = lastOpenTxHash;
+
+        assertNotEq(openTxHash1, openTxHash2);
+        assertNotEq(channelId1, channelId2);
     }
 
     function test_settle_success() public {
@@ -231,6 +256,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_authorizedSigner_settleSuccess() public {
         (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("delegate");
 
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         bytes32 channelId =
             channel.open(payee, address(0), address(token), DEPOSIT, SALT, delegateSigner);
@@ -246,14 +272,16 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_operator_settleSuccess() public {
         address operator = makeAddr("operator");
 
+        _prepareNextOpenTxHash();
         vm.prank(payer);
-        bytes32 channelId =
-            channel.open(payee, operator, address(token), DEPOSIT, SALT, address(0));
+        bytes32 channelId = channel.open(payee, operator, address(token), DEPOSIT, SALT, address(0));
 
         bytes memory sig = _signVoucher(channelId, 500_000);
 
         vm.prank(operator);
-        channel.settle(_descriptor(SALT, operator, address(0)), 500_000, sig);
+        channel.settle(
+            _descriptorWithOperator(SALT, operator, address(0), lastOpenTxHash), 500_000, sig
+        );
 
         assertEq(channel.getChannelState(channelId).settled, 500_000);
         assertEq(token.balanceOf(payee), 500_000);
@@ -316,8 +344,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), 900_000, 600_000, sig);
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
-        assertEq(ch.settled, 600_000);
-        assertEq(ch.closeData, 1);
+        assertEq(ch.settled, 0);
+        assertEq(ch.closeData, 0);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
         assertEq(token.balanceOf(payer), payerBalanceBefore + 400_000);
     }
@@ -336,7 +364,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), 800_000, 500_000, closeSig);
 
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 200_000);
-        assertEq(channel.getChannelState(channelId).settled, 500_000);
+        assertEq(channel.getChannelState(channelId).settled, 0);
     }
 
     function test_close_allowsVoucherAmountAboveDepositWhenCaptureWithinDeposit() public {
@@ -349,8 +377,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), DEPOSIT + 250_000, DEPOSIT, sig);
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
-        assertEq(ch.settled, DEPOSIT);
-        assertEq(ch.closeData, 1);
+        assertEq(ch.settled, 0);
+        assertEq(ch.closeData, 0);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
     }
 
@@ -366,33 +394,23 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.close(_descriptor(), 300_000, 200_000, "");
     }
 
-    function test_close_allowsNoAdditionalCaptureWithoutSignature() public {
-        bytes32 channelId = _openChannel();
-        bytes memory sig = _signVoucher(channelId, 300_000);
-
-        vm.prank(payee);
-        channel.settle(_descriptor(), 300_000, sig);
-
-        uint256 payerBalanceBefore = token.balanceOf(payer);
-        vm.prank(payee);
-        channel.close(_descriptor(), 300_000, 300_000, "");
-
-        assertEq(channel.getChannelState(channelId).closeData, 1);
-        assertEq(token.balanceOf(payer), payerBalanceBefore + (DEPOSIT - 300_000));
-    }
-
-    function test_close_keepsTombstoneAndBlocksReopen() public {
+    function test_close_clears_state_and_allows_reopen_with_new_open_tx_hash() public {
         bytes32 channelId = _openChannel();
         bytes memory sig = _signVoucher(channelId, 600_000);
+        bytes32 originalOpenTxHash = lastOpenTxHash;
 
         vm.prank(payee);
         channel.close(_descriptor(), 600_000, 600_000, sig);
 
-        assertEq(channel.getChannelState(channelId).closeData, 1);
+        assertEq(channel.getChannelState(channelId).closeData, 0);
 
+        channel.setOpenTxHashForTest(originalOpenTxHash);
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
         channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
+
+        bytes32 reopenedChannelId = _openChannel();
+        assertNotEq(reopenedChannelId, channelId);
     }
 
     function test_withdraw_afterGracePeriod() public {
@@ -407,21 +425,15 @@ contract TIP20ChannelEscrowTest is BaseTest {
         vm.prank(payer);
         channel.withdraw(_descriptor());
 
-        assertEq(channel.getChannelState(channelId).closeData, 1);
+        assertEq(channel.getChannelState(channelId).closeData, 0);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
-    }
-
-    function test_withdraw_revert_withoutCloseRequest() public {
-        _openChannel();
-
-        vm.prank(payer);
-        vm.expectRevert(ITIP20ChannelEscrow.CloseNotReady.selector);
-        channel.withdraw(_descriptor());
     }
 
     function test_getChannelStatesBatch_success() public {
         bytes32 channelId1 = _openChannel();
+        bytes32 channel1OpenTxHash = lastOpenTxHash;
 
+        _prepareNextOpenTxHash();
         vm.prank(payer);
         bytes32 channelId2 = channel.open(
             payee, address(0), address(token), DEPOSIT, bytes32(uint256(2)), address(0)
@@ -429,7 +441,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         bytes memory sig = _signVoucher(channelId1, 400_000);
         vm.prank(payee);
-        channel.settle(_descriptor(), 400_000, sig);
+        channel.settle(_descriptor(SALT, address(0), channel1OpenTxHash), 400_000, sig);
 
         bytes32[] memory ids = new bytes32[](2);
         ids[0] = channelId1;
@@ -443,11 +455,14 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
     function test_computeChannelId_usesFixedPrecompileAddress() public {
         TIP20ChannelEscrow other = new TIP20ChannelEscrow();
+        bytes32 openTxHash = keccak256("openTxHash");
 
-        bytes32 id1 =
-            channel.computeChannelId(payer, payee, address(0), address(token), SALT, address(0));
-        bytes32 id2 =
-            other.computeChannelId(payer, payee, address(0), address(token), SALT, address(0));
+        bytes32 id1 = channel.computeChannelId(
+            payer, payee, address(0), address(token), SALT, address(0), openTxHash
+        );
+        bytes32 id2 = other.computeChannelId(
+            payer, payee, address(0), address(token), SALT, address(0), openTxHash
+        );
 
         assertEq(id1, id2);
         assertEq(channel.domainSeparator(), other.domainSeparator());

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -68,8 +68,8 @@ contract TIP20ChannelEscrowTest is Test {
     address public payer;
     uint256 public payerKey;
     address public payee;
-    bytes32 internal lastOpenTxHash;
-    uint256 internal openTxCounter;
+    bytes32 internal lastExpiringNonceHash;
+    uint256 internal expiringNonceCounter;
 
     uint96 internal constant DEPOSIT = 1_000_000;
     bytes32 internal constant SALT = bytes32(uint256(1));
@@ -90,13 +90,13 @@ contract TIP20ChannelEscrowTest is Test {
     }
 
     function _openChannel() internal returns (bytes32) {
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         return channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function _descriptor() internal view returns (ITIP20ChannelEscrow.ChannelDescriptor memory) {
-        return _descriptor(SALT, address(0), lastOpenTxHash);
+        return _descriptor(SALT, address(0), lastExpiringNonceHash);
     }
 
     function _descriptor(
@@ -107,26 +107,26 @@ contract TIP20ChannelEscrowTest is Test {
         view
         returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
     {
-        return _descriptor(salt, authorizedSigner, lastOpenTxHash);
+        return _descriptor(salt, authorizedSigner, lastExpiringNonceHash);
     }
 
     function _descriptor(
         bytes32 salt,
         address authorizedSigner,
-        bytes32 openTxHash
+        bytes32 expiringNonceHash
     )
         internal
         view
         returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
     {
-        return _descriptorWithOperator(salt, address(0), authorizedSigner, openTxHash);
+        return _descriptorWithOperator(salt, address(0), authorizedSigner, expiringNonceHash);
     }
 
     function _descriptorWithOperator(
         bytes32 salt,
         address operator,
         address authorizedSigner,
-        bytes32 openTxHash
+        bytes32 expiringNonceHash
     )
         internal
         view
@@ -139,14 +139,14 @@ contract TIP20ChannelEscrowTest is Test {
             token: address(token),
             salt: salt,
             authorizedSigner: authorizedSigner,
-            openTxHash: openTxHash
+            expiringNonceHash: expiringNonceHash
         });
     }
 
-    function _prepareNextOpenTxHash() internal returns (bytes32 openTxHash) {
-        openTxHash = keccak256(abi.encodePacked("open", ++openTxCounter));
-        channel.setOpenTxHashForTest(openTxHash);
-        lastOpenTxHash = openTxHash;
+    function _prepareNextExpiringNonceHash() internal returns (bytes32 expiringNonceHash) {
+        expiringNonceHash = keccak256(abi.encodePacked("open", ++expiringNonceCounter));
+        channel.setExpiringNonceHashForTest(expiringNonceHash);
+        lastExpiringNonceHash = expiringNonceHash;
     }
 
     function _channelStateSlot(bytes32 channelId) internal pure returns (bytes32) {
@@ -172,7 +172,7 @@ contract TIP20ChannelEscrowTest is Test {
     }
 
     function test_open_success() public {
-        bytes32 openTxHash = _prepareNextOpenTxHash();
+        bytes32 expiringNonceHash = _prepareNextExpiringNonceHash();
 
         vm.prank(payer);
         bytes32 channelId =
@@ -184,7 +184,7 @@ contract TIP20ChannelEscrowTest is Test {
         assertEq(ch.descriptor.operator, address(0));
         assertEq(ch.descriptor.token, address(token));
         assertEq(ch.descriptor.authorizedSigner, address(0));
-        assertEq(ch.descriptor.openTxHash, openTxHash);
+        assertEq(ch.descriptor.expiringNonceHash, expiringNonceHash);
         assertEq(ch.state.settled, 0);
         assertEq(ch.state.deposit, DEPOSIT);
         assertEq(ch.state.closeData, 0);
@@ -192,53 +192,53 @@ contract TIP20ChannelEscrowTest is Test {
     }
 
     function test_open_revert_zeroPayee() public {
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
         channel.open(address(0), address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroToken() public {
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
         channel.open(payee, address(0), address(0), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroDeposit() public {
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
         channel.open(payee, address(0), address(token), 0, SALT, address(0));
     }
 
-    function test_open_same_descriptor_uses_distinct_open_tx_hashes() public {
+    function test_open_same_descriptor_uses_distinct_expiring_nonce_hashes() public {
         bytes32 channelId1 = _openChannel();
-        bytes32 openTxHash1 = lastOpenTxHash;
+        bytes32 expiringNonceHash1 = lastExpiringNonceHash;
 
         bytes32 channelId2 = _openChannel();
-        bytes32 openTxHash2 = lastOpenTxHash;
+        bytes32 expiringNonceHash2 = lastExpiringNonceHash;
 
-        assertNotEq(openTxHash1, openTxHash2);
+        assertNotEq(expiringNonceHash1, expiringNonceHash2);
         assertNotEq(channelId1, channelId2);
     }
 
-    function test_open_allows_distinct_channel_ids_with_same_open_tx_hash() public {
-        bytes32 sharedOpenTxHash = keccak256("same top-level tx");
+    function test_open_allows_distinct_channel_ids_with_same_expiring_nonce_hash() public {
+        bytes32 sharedExpiringNonceHash = keccak256("same top-level tx");
 
-        channel.setOpenTxHashForTest(sharedOpenTxHash);
+        channel.setExpiringNonceHashForTest(sharedExpiringNonceHash);
         vm.prank(payer);
         bytes32 channelId1 =
             channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
 
-        channel.setOpenTxHashForTest(sharedOpenTxHash);
+        channel.setExpiringNonceHashForTest(sharedExpiringNonceHash);
         vm.prank(payer);
         bytes32 channelId2 = channel.open(
             payee, address(0), address(token), DEPOSIT, bytes32(uint256(2)), address(0)
         );
 
-        // Same top-level transaction means the same openTxHash, but distinct descriptors still
-        // derive independent channel IDs and are safe to open atomically in one AA batch.
+        // Same top-level transaction means the same expiringNonceHash, but distinct descriptors
+        // still derive independent channel IDs and are safe to open atomically in one AA batch.
         assertNotEq(channelId1, channelId2);
         assertEq(channel.getChannelState(channelId1).deposit, DEPOSIT);
         assertEq(channel.getChannelState(channelId2).deposit, DEPOSIT);
@@ -277,7 +277,7 @@ contract TIP20ChannelEscrowTest is Test {
     function test_authorizedSigner_settleSuccess() public {
         (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("delegate");
 
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         bytes32 channelId =
             channel.open(payee, address(0), address(token), DEPOSIT, SALT, delegateSigner);
@@ -293,7 +293,7 @@ contract TIP20ChannelEscrowTest is Test {
     function test_operator_settleSuccess() public {
         address operator = makeAddr("operator");
 
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         bytes32 channelId = channel.open(payee, operator, address(token), DEPOSIT, SALT, address(0));
 
@@ -301,7 +301,7 @@ contract TIP20ChannelEscrowTest is Test {
 
         vm.prank(operator);
         channel.settle(
-            _descriptorWithOperator(SALT, operator, address(0), lastOpenTxHash), 500_000, sig
+            _descriptorWithOperator(SALT, operator, address(0), lastExpiringNonceHash), 500_000, sig
         );
 
         assertEq(channel.getChannelState(channelId).settled, 500_000);
@@ -415,26 +415,26 @@ contract TIP20ChannelEscrowTest is Test {
         channel.close(_descriptor(), 300_000, 200_000, "");
     }
 
-    function test_close_clears_state_and_allows_reopen_with_new_open_tx_hash() public {
+    function test_close_clears_state_and_allows_reopen_with_new_expiring_nonce_hash() public {
         bytes32 channelId = _openChannel();
         bytes memory sig = _signVoucher(channelId, 600_000);
-        bytes32 originalOpenTxHash = lastOpenTxHash;
+        bytes32 originalExpiringNonceHash = lastExpiringNonceHash;
 
         vm.prank(payee);
         channel.close(_descriptor(), 600_000, 600_000, sig);
 
         assertEq(channel.getChannelState(channelId).closeData, 0);
 
-        // Reusing the original openTxHash approximates a later call in the same top-level AA batch.
+        // Reusing the original expiringNonceHash approximates a later call in the same top-level AA batch.
         // The persistent channel slot has been deleted by close, so the per-transaction opened-ID
         // guard is what prevents reopening the same channel ID before the transaction ends.
-        channel.setOpenTxHashForTest(originalOpenTxHash);
+        channel.setExpiringNonceHashForTest(originalExpiringNonceHash);
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
         channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
 
-        // A later transaction has a fresh openTxHash, so the same logical descriptor derives a new
-        // channel ID and may be opened after the previous channel terminally closed.
+        // A later transaction has a fresh expiringNonceHash, so the same logical descriptor derives
+        // a new channel ID and may be opened after the previous channel terminally closed.
         bytes32 reopenedChannelId = _openChannel();
         assertNotEq(reopenedChannelId, channelId);
     }
@@ -457,9 +457,9 @@ contract TIP20ChannelEscrowTest is Test {
 
     function test_getChannelStatesBatch_success() public {
         bytes32 channelId1 = _openChannel();
-        bytes32 channel1OpenTxHash = lastOpenTxHash;
+        bytes32 channel1ExpiringNonceHash = lastExpiringNonceHash;
 
-        _prepareNextOpenTxHash();
+        _prepareNextExpiringNonceHash();
         vm.prank(payer);
         bytes32 channelId2 = channel.open(
             payee, address(0), address(token), DEPOSIT, bytes32(uint256(2)), address(0)
@@ -467,7 +467,7 @@ contract TIP20ChannelEscrowTest is Test {
 
         bytes memory sig = _signVoucher(channelId1, 400_000);
         vm.prank(payee);
-        channel.settle(_descriptor(SALT, address(0), channel1OpenTxHash), 400_000, sig);
+        channel.settle(_descriptor(SALT, address(0), channel1ExpiringNonceHash), 400_000, sig);
 
         bytes32[] memory ids = new bytes32[](2);
         ids[0] = channelId1;
@@ -481,13 +481,13 @@ contract TIP20ChannelEscrowTest is Test {
 
     function test_computeChannelId_usesFixedPrecompileAddress() public {
         TIP20ChannelEscrow other = new TIP20ChannelEscrow();
-        bytes32 openTxHash = keccak256("openTxHash");
+        bytes32 expiringNonceHash = keccak256("expiringNonceHash");
 
         bytes32 id1 = channel.computeChannelId(
-            payer, payee, address(0), address(token), SALT, address(0), openTxHash
+            payer, payee, address(0), address(token), SALT, address(0), expiringNonceHash
         );
         bytes32 id2 = other.computeChannelId(
-            payer, payee, address(0), address(token), SALT, address(0), openTxHash
+            payer, payee, address(0), address(token), SALT, address(0), expiringNonceHash
         );
 
         assertEq(id1, id2);

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -96,7 +96,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
     function _openChannel() internal returns (bytes32) {
         vm.prank(payer);
-        return channel.open(payee, address(token), DEPOSIT, SALT, address(0));
+        return channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function _descriptor() internal view returns (ITIP20ChannelEscrow.ChannelDescriptor memory) {
@@ -111,9 +111,22 @@ contract TIP20ChannelEscrowTest is BaseTest {
         view
         returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
     {
+        return _descriptor(salt, address(0), authorizedSigner);
+    }
+
+    function _descriptor(
+        bytes32 salt,
+        address operator,
+        address authorizedSigner
+    )
+        internal
+        view
+        returns (ITIP20ChannelEscrow.ChannelDescriptor memory)
+    {
         return ITIP20ChannelEscrow.ChannelDescriptor({
             payer: payer,
             payee: payee,
+            operator: operator,
             token: address(token),
             salt: salt,
             authorizedSigner: authorizedSigner
@@ -144,11 +157,13 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
     function test_open_success() public {
         vm.prank(payer);
-        bytes32 channelId = channel.open(payee, address(token), DEPOSIT, SALT, address(0));
+        bytes32 channelId =
+            channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
 
         ITIP20ChannelEscrow.Channel memory ch = channel.getChannel(_descriptor());
         assertEq(ch.descriptor.payer, payer);
         assertEq(ch.descriptor.payee, payee);
+        assertEq(ch.descriptor.operator, address(0));
         assertEq(ch.descriptor.token, address(token));
         assertEq(ch.descriptor.authorizedSigner, address(0));
         assertEq(ch.state.settled, 0);
@@ -160,19 +175,19 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_open_revert_zeroPayee() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
-        channel.open(address(0), address(token), DEPOSIT, SALT, address(0));
+        channel.open(address(0), address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroToken() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
-        channel.open(payee, address(0), DEPOSIT, SALT, address(0));
+        channel.open(payee, address(0), address(0), DEPOSIT, SALT, address(0));
     }
 
     function test_open_revert_zeroDeposit() public {
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
-        channel.open(payee, address(token), 0, SALT, address(0));
+        channel.open(payee, address(0), address(token), 0, SALT, address(0));
     }
 
     function test_open_revert_duplicate() public {
@@ -180,7 +195,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0));
+        channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_settle_success() public {
@@ -217,7 +232,8 @@ contract TIP20ChannelEscrowTest is BaseTest {
         (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("delegate");
 
         vm.prank(payer);
-        bytes32 channelId = channel.open(payee, address(token), DEPOSIT, SALT, delegateSigner);
+        bytes32 channelId =
+            channel.open(payee, address(0), address(token), DEPOSIT, SALT, delegateSigner);
 
         bytes memory sig = _signVoucher(channelId, 500_000, delegateKey);
 
@@ -225,6 +241,32 @@ contract TIP20ChannelEscrowTest is BaseTest {
         channel.settle(_descriptor(SALT, delegateSigner), 500_000, sig);
 
         assertEq(channel.getChannelState(channelId).settled, 500_000);
+    }
+
+    function test_operator_settleSuccess() public {
+        address operator = makeAddr("operator");
+
+        vm.prank(payer);
+        bytes32 channelId =
+            channel.open(payee, operator, address(token), DEPOSIT, SALT, address(0));
+
+        bytes memory sig = _signVoucher(channelId, 500_000);
+
+        vm.prank(operator);
+        channel.settle(_descriptor(SALT, operator, address(0)), 500_000, sig);
+
+        assertEq(channel.getChannelState(channelId).settled, 500_000);
+        assertEq(token.balanceOf(payee), 500_000);
+    }
+
+    function test_operator_zeroDoesNotAuthorizeArbitrarySettler() public {
+        address operator = makeAddr("operator");
+        bytes32 channelId = _openChannel();
+        bytes memory sig = _signVoucher(channelId, 500_000);
+
+        vm.prank(operator);
+        vm.expectRevert(ITIP20ChannelEscrow.NotPayeeOrOperator.selector);
+        channel.settle(_descriptor(), 500_000, sig);
     }
 
     function test_topUp_updatesDeposit() public {
@@ -350,7 +392,7 @@ contract TIP20ChannelEscrowTest is BaseTest {
 
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
-        channel.open(payee, address(token), DEPOSIT, SALT, address(0));
+        channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
     }
 
     function test_withdraw_afterGracePeriod() public {
@@ -381,8 +423,9 @@ contract TIP20ChannelEscrowTest is BaseTest {
         bytes32 channelId1 = _openChannel();
 
         vm.prank(payer);
-        bytes32 channelId2 =
-            channel.open(payee, address(token), DEPOSIT, bytes32(uint256(2)), address(0));
+        bytes32 channelId2 = channel.open(
+            payee, address(0), address(token), DEPOSIT, bytes32(uint256(2)), address(0)
+        );
 
         bytes memory sig = _signVoucher(channelId1, 400_000);
         vm.prank(payee);
@@ -401,8 +444,10 @@ contract TIP20ChannelEscrowTest is BaseTest {
     function test_computeChannelId_usesFixedPrecompileAddress() public {
         TIP20ChannelEscrow other = new TIP20ChannelEscrow();
 
-        bytes32 id1 = channel.computeChannelId(payer, payee, address(token), SALT, address(0));
-        bytes32 id2 = other.computeChannelId(payer, payee, address(token), SALT, address(0));
+        bytes32 id1 =
+            channel.computeChannelId(payer, payee, address(0), address(token), SALT, address(0));
+        bytes32 id2 =
+            other.computeChannelId(payer, payee, address(0), address(token), SALT, address(0));
 
         assertEq(id1, id2);
         assertEq(channel.domainSeparator(), other.domainSeparator());

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -187,7 +187,7 @@ contract TIP20ChannelEscrowTest is Test {
         assertEq(ch.descriptor.expiringNonceHash, expiringNonceHash);
         assertEq(ch.state.settled, 0);
         assertEq(ch.state.deposit, DEPOSIT);
-        assertEq(ch.state.closeData, 0);
+        assertEq(ch.state.closeRequestedAt, 0);
         assertEq(channel.getChannelState(channelId).deposit, DEPOSIT);
     }
 
@@ -337,10 +337,10 @@ contract TIP20ChannelEscrowTest is Test {
         vm.prank(payer);
         channel.topUp(_descriptor(), 100_000);
 
-        assertEq(channel.getChannelState(channelId).closeData, 0);
+        assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
     }
 
-    function test_requestClose_storesTimestampInCloseData() public {
+    function test_requestClose_storesTimestampInCloseRequestedAt() public {
         bytes32 channelId = _openChannel();
         uint32 closeRequestedAt = uint32(block.timestamp);
 
@@ -348,7 +348,7 @@ contract TIP20ChannelEscrowTest is Test {
         channel.requestClose(_descriptor());
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
-        assertEq(ch.closeData, closeRequestedAt);
+        assertEq(ch.closeRequestedAt, closeRequestedAt);
 
         uint256 raw = uint256(vm.load(address(channel), _channelStateSlot(channelId)));
         assertEq(uint32(raw >> 192), closeRequestedAt);
@@ -366,7 +366,7 @@ contract TIP20ChannelEscrowTest is Test {
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertEq(ch.settled, 0);
-        assertEq(ch.closeData, 0);
+        assertEq(ch.closeRequestedAt, 0);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
         assertEq(token.balanceOf(payer), payerBalanceBefore + 400_000);
     }
@@ -399,7 +399,7 @@ contract TIP20ChannelEscrowTest is Test {
 
         ITIP20ChannelEscrow.ChannelState memory ch = channel.getChannelState(channelId);
         assertEq(ch.settled, 0);
-        assertEq(ch.closeData, 0);
+        assertEq(ch.closeRequestedAt, 0);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
     }
 
@@ -423,7 +423,7 @@ contract TIP20ChannelEscrowTest is Test {
         vm.prank(payee);
         channel.close(_descriptor(), 600_000, 600_000, sig);
 
-        assertEq(channel.getChannelState(channelId).closeData, 0);
+        assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
 
         // Reusing the original expiringNonceHash approximates a later call in the same top-level AA batch.
         // The persistent channel slot has been deleted by close, so the per-transaction opened-ID
@@ -451,7 +451,7 @@ contract TIP20ChannelEscrowTest is Test {
         vm.prank(payer);
         channel.withdraw(_descriptor());
 
-        assertEq(channel.getChannelState(channelId).closeData, 0);
+        assertEq(channel.getChannelState(channelId).closeRequestedAt, 0);
         assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
     }
 

--- a/tips/verify/test/TIP20ChannelEscrow.t.sol
+++ b/tips/verify/test/TIP20ChannelEscrow.t.sol
@@ -223,6 +223,27 @@ contract TIP20ChannelEscrowTest is Test {
         assertNotEq(channelId1, channelId2);
     }
 
+    function test_open_allows_distinct_channel_ids_with_same_open_tx_hash() public {
+        bytes32 sharedOpenTxHash = keccak256("same top-level tx");
+
+        channel.setOpenTxHashForTest(sharedOpenTxHash);
+        vm.prank(payer);
+        bytes32 channelId1 =
+            channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
+
+        channel.setOpenTxHashForTest(sharedOpenTxHash);
+        vm.prank(payer);
+        bytes32 channelId2 = channel.open(
+            payee, address(0), address(token), DEPOSIT, bytes32(uint256(2)), address(0)
+        );
+
+        // Same top-level transaction means the same openTxHash, but distinct descriptors still
+        // derive independent channel IDs and are safe to open atomically in one AA batch.
+        assertNotEq(channelId1, channelId2);
+        assertEq(channel.getChannelState(channelId1).deposit, DEPOSIT);
+        assertEq(channel.getChannelState(channelId2).deposit, DEPOSIT);
+    }
+
     function test_settle_success() public {
         bytes32 channelId = _openChannel();
         bytes memory sig = _signVoucher(channelId, 500_000);
@@ -404,11 +425,16 @@ contract TIP20ChannelEscrowTest is Test {
 
         assertEq(channel.getChannelState(channelId).closeData, 0);
 
+        // Reusing the original openTxHash approximates a later call in the same top-level AA batch.
+        // The persistent channel slot has been deleted by close, so the per-transaction opened-ID
+        // guard is what prevents reopening the same channel ID before the transaction ends.
         channel.setOpenTxHashForTest(originalOpenTxHash);
         vm.prank(payer);
         vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
         channel.open(payee, address(0), address(token), DEPOSIT, SALT, address(0));
 
+        // A later transaction has a fresh openTxHash, so the same logical descriptor derives a new
+        // channel ID and may be opened after the previous channel terminally closed.
         bytes32 reopenedChannelId = _openChannel();
         assertNotEq(reopenedChannelId, channelId);
     }


### PR DESCRIPTION
Specifies TIP-1034 as a descriptor-derived channel escrow precompile where only one packed mutable storage slot is kept on-chain per channel. Immutable channel identity (`payer`, `payee`, `token`, `authorizedSigner`, `salt`) moves to calldata and `ChannelOpened` logs, while `settled`, `deposit`, `expiresAt`, and `closeData` make up the single stored channel state word.

The reference interface, reference implementation, and tests now follow the same design, including `closeData` sentinels (`0` = active, `1` = finalized, `>=2` = close requested at timestamp) so terminal channels keep a tombstone and cannot be reopened with the same descriptor.
