### PR TITLE
deps: bump lz4_flex 0.12.0 -> 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5762,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"


### PR DESCRIPTION
Fixes RUSTSEC-2026-0041 (CVE-2026-32829) — decompressing invalid LZ4 data with the block API could leak uninitialized memory or reused buffer contents. Patched in 0.12.1.

Transitive dep via `reth-nippy-jar`, bumped with `cargo update lz4_flex`.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey