### PR TITLE
docs(tip-1028): tip-1028

### DIFF
--- a/tips/tip-1028.md
+++ b/tips/tip-1028.md
@@ -43,6 +43,13 @@ The current TIP-403 system only supports token-level policies: the token issuer 
 
 TIP-403 policies manage sets of *counterparty addresses* — they answer "is this address authorized?" Token filtering answers a fundamentally different question: "is this token authorized?" Reusing the policy primitive for both would conflate two distinct concepts. Token sets are a parallel primitive with identical mechanics (admin, type, membership) but a separate ID space and separate storage, keeping the semantics clean.
 
+## Assumptions
+
+- TIP-403 policy IDs keep their existing semantics (`0` = always reject, `1` = always allow) and continue to be available as globally recognized built-ins.
+- Token set IDs use the same built-in conventions (`0` = always reject, `1` = always allow), and are allocated from a dedicated counter and storage namespace separate from policy IDs.
+- TIP-20 transfer and mint flows that invoke TIP-1015 authorization hooks continue to route all relevant inbound checks through the receiver-side authorization path described in this TIP.
+- Addresses that need outbound restrictions implement them through account-level controls (for example multisigs or smart contract wallet logic), since outbound protocol-level enforcement remains out of scope.
+
 
 # Specification
 


### PR DESCRIPTION
Adds the missing `Assumptions` section to TIP-1028 to align with the TIP template requirements.

Previous PR was closed before reviewers were able to approve