### PR TITLE
chore(deps): update reth from main (2026-03-17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -5050,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -5439,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -5762,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"
@@ -6264,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -6274,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6936,9 +6936,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -7762,7 +7762,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7818,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7851,7 +7851,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7994,7 +7994,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8062,7 +8062,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8149,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8164,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8189,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8213,7 +8213,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8237,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8329,7 +8329,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8461,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8489,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8520,7 +8520,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8542,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8643,7 +8643,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "clap",
  "eyre",
@@ -8666,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8713,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8742,7 +8742,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8766,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8790,7 +8790,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8810,7 +8810,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8879,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8893,7 +8893,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "serde",
  "serde_json",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "bytes",
  "futures",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "bindgen",
  "cc",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "futures",
  "metrics",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9069,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9094,7 +9094,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9348,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "bytes",
  "eyre",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9437,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9503,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9538,10 +9538,11 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
@@ -9583,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9612,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9628,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9641,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9719,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9750,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9793,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9813,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9844,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9888,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9936,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9950,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9966,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10018,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10045,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10059,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10079,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10094,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10118,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10135,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10156,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10172,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10182,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "clap",
  "eyre",
@@ -10201,7 +10202,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "clap",
  "eyre",
@@ -10219,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10263,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10289,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10316,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10336,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10360,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10382,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "zstd",
 ]
@@ -10518,9 +10519,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb0f462c8a3d9989d3dbc62d7cca4dfecd7072cfa5d563ab90ced60590ed1da"
+checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11277,9 +11278,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11296,11 +11297,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12680,9 +12681,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,53 +120,53 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

**reth**: [`9060c50...a0b0d88`](https://github.com/paradigmxyz/reth/compare/9060c50...a0b0d88)

**Workflow Run**: [link](https://github.com/tempoxyz/tempo/actions/runs/23196808249)

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019cfc04-927f-725a-8d9d-79be9d9864e8
- Bumped all `reth-*` workspace dependency pins from rev `9060c50` to rev `a0b0d88` across 46 crates to track a newer Reth SDK commit
