### PR TITLE
feat: start jemalloc debug server before storage healing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ governor = "0.10.4"
 indexmap = "2.13.0"
 indicatif = "0.18"
 itertools = "0.14.0"
+jemalloc_pprof = { version = "0.8", default-features = false }
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
 metrics = "0.24.3"

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -70,6 +70,8 @@ jiff.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+axum = { workspace = true, optional = true }
+jemalloc_pprof = { workspace = true, optional = true }
 pyroscope = { workspace = true, optional = true }
 pyroscope_pprofrs = { workspace = true, optional = true }
 
@@ -113,6 +115,8 @@ jemalloc-prof = [
 	"reth-ethereum-cli/jemalloc-prof",
 	"tempo-node/jemalloc-prof",
 	"reth-ethereum/jemalloc-prof",
+	"dep:axum",
+	"dep:jemalloc_pprof",
 ]
 jemalloc-symbols = [
 	"jemalloc-prof",

--- a/bin/tempo/src/jemalloc_debug.rs
+++ b/bin/tempo/src/jemalloc_debug.rs
@@ -1,0 +1,61 @@
+//! Early jemalloc pprof debug server.
+//!
+//! Starts a lightweight HTTP server that serves jemalloc heap profiles at
+//! `/debug/pprof/heap` before the main node launch. This makes profiling
+//! available during early startup phases like storage healing, which happen
+//! before the reth metrics endpoint is ready.
+
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+use std::net::SocketAddr;
+use tracing::info;
+
+/// Starts the jemalloc debug server on the given address.
+pub(crate) async fn start(addr: SocketAddr) -> eyre::Result<()> {
+    let app = Router::new().route("/debug/pprof/heap", get(handle_pprof_heap));
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|e| eyre::eyre!("failed to bind jemalloc debug server to {addr}: {e}"))?;
+
+    info!(target: "tempo::debug", %addr, "Starting early jemalloc debug server");
+
+    tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app).await {
+            tracing::error!(target: "tempo::debug", %err, "jemalloc debug server failed");
+        }
+    });
+
+    Ok(())
+}
+
+async fn handle_pprof_heap() -> impl IntoResponse {
+    let prof_ctl = match jemalloc_pprof::PROF_CTL.as_ref() {
+        Some(ctl) => ctl,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "jemalloc profiling not enabled",
+            )
+                .into_response();
+        }
+    };
+
+    let mut prof_ctl = prof_ctl.lock().await;
+
+    match prof_ctl.dump_pprof() {
+        Ok(pprof) => (
+            StatusCode::OK,
+            [
+                ("content-type", "application/octet-stream"),
+                ("content-encoding", "gzip"),
+            ],
+            pprof,
+        )
+            .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to dump pprof: {err}"),
+        )
+            .into_response(),
+    }
+}

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -31,6 +31,8 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 mod defaults;
 mod init_state;
+#[cfg(all(feature = "jemalloc-prof", unix))]
+mod jemalloc_debug;
 mod tempo_cmd;
 
 use clap::{CommandFactory, FromArgMatches};
@@ -81,6 +83,14 @@ struct TempoArgs {
 
     #[command(flatten)]
     pub node_args: TempoNodeArgs,
+
+    /// Start a jemalloc pprof debug server early, before storage healing.
+    ///
+    /// This makes heap profiling available during startup phases that happen
+    /// before the main metrics endpoint is ready.
+    #[arg(long = "debug.pprof-addr", value_name = "ADDR", help_heading = "Debug")]
+    #[cfg(all(feature = "jemalloc-prof", unix))]
+    pub debug_pprof_addr: Option<std::net::SocketAddr>,
 
     #[command(flatten)]
     #[cfg(feature = "pyroscope")]
@@ -380,6 +390,15 @@ fn main() -> eyre::Result<()> {
         |spec: Arc<TempoChainSpec>| (TempoEvmConfig::new(spec.clone()), TempoConsensus::new(spec));
 
     cli.run_with_components::<TempoNode>(components, async move |builder, args| {
+        // Start early jemalloc debug server before node launch so that heap
+        // profiling is available during storage healing and other early phases.
+        #[cfg(all(feature = "jemalloc-prof", unix))]
+        if let Some(addr) = args.debug_pprof_addr {
+            jemalloc_debug::start(addr)
+                .await
+                .wrap_err("failed to start early jemalloc debug server")?;
+        }
+
         let faucet_args = args.faucet_args.clone();
         let validator_key = args
             .consensus


### PR DESCRIPTION
Adds `--debug.pprof-addr` flag (behind `jemalloc-prof` feature) that starts a lightweight axum server serving `/debug/pprof/heap` before the reth node launch flow. The reth metrics endpoint only becomes available after storage healing, so this gives us heap profiling during early startup.

Usage: `tempo node --debug.pprof-addr 0.0.0.0:6061`

Then: `curl localhost:6061/debug/pprof/heap > heap.pb.gz && pprof -http=:8080 heap.pb.gz`

Prompted by: alexey