### PR TITLE
fix: use bash 3 compatible dedup in install script

### DIFF
--- a/tempoup/install
+++ b/tempoup/install
@@ -130,12 +130,17 @@ configure_shell() {
         shell_configs+=("$HOME/.profile")
     fi
 
-    # Deduplicate
-    local -A seen
+    # Deduplicate (bash 3 compatible)
     local unique_configs=()
     for cfg in "${shell_configs[@]}"; do
-        if [[ -z "${seen[$cfg]:-}" ]]; then
-            seen[$cfg]=1
+        local already_seen=0
+        for existing in "${unique_configs[@]}"; do
+            if [[ "$existing" == "$cfg" ]]; then
+                already_seen=1
+                break
+            fi
+        done
+        if [[ "$already_seen" -eq 0 ]]; then
             unique_configs+=("$cfg")
         fi
     done


### PR DESCRIPTION
macOS ships with bash 3.2 which doesn't support `local -A` (associative arrays). The install script fails with:

```
/tmp/tempo_install.sh: line 134: local: -A: invalid option
```

Replaces the associative array dedup with a simple loop — works on bash 3+.

Prompted by: zygis