### PR TITLE
fix(alloy): preserve provider builder state in nonce filler extensions

### DIFF
--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -114,7 +114,7 @@ impl TempoProviderBuilderExt
         JoinFill<Identity, TempoFillers<Random2DNonceFiller>>,
         TempoNetwork,
     > {
-        ProviderBuilder::default().filler(TempoFillers::default())
+        self.filler(TempoFillers::default())
     }
 
     fn with_expiring_nonces(
@@ -124,14 +124,14 @@ impl TempoProviderBuilderExt
         JoinFill<Identity, TempoFillers<ExpiringNonceFiller>>,
         TempoNetwork,
     > {
-        ProviderBuilder::default().filler(TempoFillers::default())
+        self.filler(TempoFillers::default())
     }
 
     fn with_nonce_key_filler(
         self,
     ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
     {
-        ProviderBuilder::default().filler(TempoFillers::default())
+        self.filler(TempoFillers::default())
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes a builder-state bug in `TempoProviderBuilderExt` where nonce-filler helpers reset the provider builder instead of extending it.

## What changed
- Updated `with_random_2d_nonces`, `with_expiring_nonces`, and `with_nonce_key_filler` to use `self.filler(...)`.
- Removed use of `ProviderBuilder::default()` inside these methods so existing builder configuration is preserved.

## Impact
- Prevents silent loss of previously configured provider-builder state.
- Makes nonce-filler extension methods composable and behaviorally consistent when called after other builder configuration steps.
