### PR TITLE
chore(deps): update reth from main (2026-03-20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,9 +1496,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -5149,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof"
@@ -7763,7 +7763,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7819,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8037,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8091,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8273,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "clap",
  "eyre",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8757,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8811,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8880,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "serde",
  "serde_json",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8932,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "bytes",
  "futures",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "bindgen",
  "cc",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "futures",
  "metrics",
@@ -8990,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9118,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9188,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9397,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "bytes",
  "eyre",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9494,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9643,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9968,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10020,7 +10020,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10047,7 +10047,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10158,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10174,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "clap",
  "eyre",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "clap",
  "eyre",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10265,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10291,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10318,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
+source = "git+https://github.com/paradigmxyz/reth?rev=cf3028a#cf3028a52fa48f810e094de5f9ec6a6029ab53d2"
 dependencies = [
  "zstd",
 ]
@@ -11754,9 +11754,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,7 +3304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6528,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -7763,7 +7763,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7787,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7819,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8037,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8063,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8091,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8238,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8273,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8554,7 +8554,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "clap",
  "eyre",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8757,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8811,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8880,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8904,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8932,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "bytes",
  "futures",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "bindgen",
  "cc",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "futures",
  "metrics",
@@ -8990,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9118,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9188,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9397,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9494,7 +9494,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9504,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9643,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9968,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10020,7 +10020,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10047,7 +10047,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10158,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10174,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "clap",
  "eyre",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "clap",
  "eyre",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10265,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10291,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10318,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=2a94eed#2a94eedd6173753a53e4d51487beeddf62733524"
+source = "git+https://github.com/paradigmxyz/reth?rev=89ad006#89ad00601eea957c051a26ff8b55e79973e180b1"
 dependencies = [
  "zstd",
 ]
@@ -14494,18 +14494,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,53 +120,53 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2a94eed", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,53 +120,53 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "89ad006", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "cf3028a", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

**reth**: [`2a94eed...cf3028a`](https://github.com/paradigmxyz/reth/compare/2a94eed...cf3028a)

**Workflow Run**: [link](https://github.com/tempoxyz/tempo/actions/runs/23340886328)

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019d0b05-ada1-75f6-9659-3f9f7bad9149
- Bumped all `reth-*` workspace dependency pins from rev `89ad006` to `cf3028a` (no API, feature, or crate-set changes — straight revision bump)
