### PR TITLE
docs(tip-1034): Implicit Approval List

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -1,0 +1,75 @@
+---
+id: TIP-1034
+title: Implicit Approval List
+description: Defines an in-protocol list of contracts that are allowed to use systemTransferFrom() to bypass approval requirements, and for which attempts to approve() them are a no-op.
+authors: Dan Robinson
+status: Draft
+related: TIP-1025
+---
+
+# TIP-1034: Implicit Approval List
+
+## Abstract
+
+This TIP introduces a protocol-level Implicit Approval List: a set of contract addresses that are allowed to use `system_transfer_from()` to transfer TIP-20 tokens from `msg.sender` without a prior `approve()` call, and for which `approve()` is a no-op. The initial list consists of:
+
+- **TipFeeManager (FeeAMM)**: `0xfeEC000000000000000000000000000000000000`
+- **StablecoinDEX**: `0xDEc0000000000000000000000000000000000000`
+- **MPP Channels**: `0x33b901018174DDabE4841042ab76ba85D4e24f25`
+
+This TIP supersedes [TIP-1025](./tip-1025.md), which defined the implicit approval behavior for the StablecoinDEX and TipFeeManager individually. TIP-1034 generalizes TIP-1025 into a named, extensible list and adds the MPP Channels contract as the first non-precompile member.
+
+## Motivation
+
+[TIP-1025](./tip-1025.md) demonstrated that system contracts which only pull tokens from `msg.sender` gain significant UX and gas improvements from bypassing the approval flow. Rather than adding this behavior ad-hoc to individual TIPs each time a new qualifying contract is introduced, the protocol should maintain an explicit list of implicitly approved addresses. This:
+
+1. **Formalizes the pattern**: Makes the set of implicitly approved contracts visible and auditable in one place.
+2. **Simplifies future additions**: New qualifying contracts can be added to the list via a TIP that amends this one, rather than defining the implicit approval mechanics from scratch.
+3. **Adds the MPP Channels contract**: The MPP Channels contract (`0x33b901018174DDabE4841042ab76ba85D4e24f25`) uses `transferFrom` on the caller to escrow funds into payment channels. It only ever pulls from `msg.sender` and is a natural candidate for implicit approval.
+
+## Assumptions
+
+- The behavior of implicit approval (how `system_transfer_from` works, how `approve()` becomes a no-op, how spending limits and transfer policies interact) is defined in [TIP-1025](./tip-1025.md). This TIP inherits that specification in full.
+- Contracts on the Implicit Approval List SHOULD only call `transferFrom` (or the equivalent system call) on `msg.sender` for the current call. Contracts that pull tokens from addresses other than the direct caller MUST NOT be added to this list, as doing so would allow them to move tokens without the owner's transaction-level consent.
+
+---
+
+# Specification
+
+## Implicit Approval List
+
+The protocol maintains a set of addresses called the Implicit Approval List. For any address on this list:
+
+1. The contract MAY use `system_transfer_from()` to transfer TIP-20 tokens from `msg.sender` without a prior `approve()` call.
+2. `approve(spender, amount)` where `spender` is on the list is a no-op: the call succeeds, writes no allowance state, emits no `Approval` event, and does not deduct AccountKeychain spending limits.
+3. All other TIP-20 semantics (transfer policies via TIP-403, spending limit enforcement, `Transfer` event emission) remain unchanged.
+
+The full behavioral specification — including hardfork gating, interaction with existing approvals, AccountKeychain spending limits, and safety arguments — is defined in [TIP-1025](./tip-1025.md).
+
+## Initial List
+
+| Address | Contract | Rationale |
+|---------|----------|-----------|
+| `0xfeEC000000000000000000000000000000000000` | TipFeeManager (FeeAMM) | Already uses `system_transfer_from`; only pulls from `msg.sender` via `rebalanceSwap` and `mint` |
+| `0xDEc0000000000000000000000000000000000000` | StablecoinDEX | Only pulls from `msg.sender` via `place`, `placeFlip`, `swapExactAmountIn`, `swapExactAmountOut` |
+| `0x33b901018174DDabE4841042ab76ba85D4e24f25` | MPP Channels | Only pulls from `msg.sender` to escrow funds into payment channels |
+
+## Eligibility Criteria
+
+A contract SHOULD only be added to the Implicit Approval List if it satisfies the following:
+
+1. The contract only calls `transferFrom` (or `system_transfer_from`) on `msg.sender` for the current call. There MUST be no reachable code path where the contract pulls tokens from an address other than the direct caller.
+2. The contract enforces direct-call-only semantics (no `DELEGATECALL`), so `msg.sender` cannot be spoofed by an intermediate contract.
+
+## Future Amendments
+
+Additional contracts may be added to the Implicit Approval List via future TIPs that reference and amend this one. Each addition must include a safety argument demonstrating that the contract only pulls from `msg.sender`.
+
+# Invariants
+
+1. **Caller-only pulls**: Every contract on the Implicit Approval List MUST only pull tokens from the direct caller (`msg.sender`). No external entry point may pass a different address to `system_transfer_from` for wallet-level token pulls.
+2. **No-op approve**: `approve(spender, amount)` where `spender` is on the Implicit Approval List MUST succeed, write no allowance state, emit no `Approval` event, and not deduct access key spending limits.
+3. **Policy enforcement**: All token pulls MUST continue to enforce TIP-403 transfer policies.
+4. **Spending limit enforcement**: All token pulls MUST enforce AccountKeychain spending limits.
+5. **Event consistency**: All token pulls MUST emit the standard TIP-20 `Transfer` event.
+6. **List consistency**: The on-chain Implicit Approval List MUST match the set defined in this TIP (and any future amendments). No address may be implicitly approved without a corresponding TIP.


### PR DESCRIPTION
Introduces TIP-1034: a protocol-level Implicit Approval List of contracts allowed to use `system_transfer_from()` without prior `approve()`, and for which `approve()` is a no-op.

Initial list: FeeAMM, StablecoinDEX, and the MPP Channels contract (`0x33b901018174DDabE4841042ab76ba85D4e24f25`).

Supersedes TIP-1025, which defined this behavior individually. TIP-1034 generalizes it into a named, extensible list.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan