### PR TITLE
docs(tip-1034): Implicit Approval List

### DIFF
--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -49,9 +49,9 @@ The protocol maintains an explicit set of addresses called the Implicit Approval
 
 1. The contract may transfer TIP-20 tokens from `msg.sender` without a prior `approve()` call. The mechanism depends on whether the contract is a precompile or a regular contract (see [Implementation](#implementation)).
 2. `approve(spender, amount)` where `spender` is on the list and `amount > 0`: the call succeeds but does not affect allowance state, does not emit an `Approval` event, and does not deduct AccountKeychain spending limits.
-3. `approve(spender, 0)` where `spender` is on the list: the call succeeds, deletes any existing allowance slot for that owner/spender pair, does not emit an `Approval` event, and does not deduct AccountKeychain spending limits.
+3. `approve(spender, 0)` where `spender` is on the list: the call succeeds, deletes any existing allowance slot for that owner/spender pair, emits `Approval(owner, spender, 0)` if an allowance was deleted, and does not deduct AccountKeychain spending limits.
 4. `permit()` where `spender` is on the list and `amount > 0`: the call succeeds and increments the owner's nonce, but does not affect allowance state and does not emit an `Approval` event.
-5. `permit()` where `spender` is on the list and `amount = 0`: the call succeeds, increments the owner's nonce, deletes any existing allowance slot for that owner/spender pair, and does not emit an `Approval` event.
+5. `permit()` where `spender` is on the list and `amount = 0`: the call succeeds, increments the owner's nonce, deletes any existing allowance slot for that owner/spender pair, and emits `Approval(owner, spender, 0)` if an allowance was deleted.
 6. Token pulls through listed contracts still enforce balance checks, TIP-403 transfer policies, AccountKeychain spending limits, and `Transfer` event emission. The only check bypassed is the allowance check.
 
 ## Implementation


### PR DESCRIPTION
Introduces TIP-1034: a protocol-level Implicit Approval List of contracts allowed to use `system_transfer_from()` without prior `approve()`, and for which `approve()` and `permit()` are no-ops.

Initial list: FeeAMM, StablecoinDEX, and MPP Channels (`0x33b901018174DDabE4841042ab76ba85D4e24f25`).

Supersedes TIP-1025, generalizing it into a named, extensible list. Incorporates review feedback from TIP-1025:
- References TIP-20 throughout (not ERC-20)
- Addresses `permit()` alongside `approve()`
- Removes test cases section (invariants only)
- Frames spending limit enforcement as intentional, not a side effect
- Documents pre-existing approval / stale slot behavior
- Defines eligibility criteria for future additions

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan