### PR TITLE
docs(tip-1015): clarify mutability of compound policies

### DIFF
--- a/tips/tip-1015.md
+++ b/tips/tip-1015.md
@@ -12,7 +12,7 @@ protocolVersion: T2
 
 ## Abstract
 
-This TIP extends the TIP-403 policy registry to support **compound policies** that allow token issuers to specify different authorization rules for senders, recipients, and mint recipients. A compound policy references three simple policies: one for sender authorization, one for recipient authorization, and one for mint recipient authorization. Compound policies are immutable once created.
+This TIP extends the TIP-403 policy registry to support **compound policies** that allow token issuers to specify different authorization rules for senders, recipients, and mint recipients. A compound policy references three simple policies: one for sender authorization, one for recipient authorization, and one for mint recipient authorization. Compound policies are structurally immutable once created — their constituent policy ID references cannot be changed. However, the referenced simple policies themselves remain mutable and can be modified by their respective admins, which will affect the compound policy's effective authorization behavior.
 
 ## Motivation
 
@@ -62,7 +62,7 @@ Policy data is stored in a unified `PolicyRecord` struct that contains both base
 ```solidity
 struct PolicyData {
     uint8 policyType;   // 0 = WHITELIST, 1 = BLACKLIST, 2 = COMPOUND
-    address admin;      // Policy administrator (zero for immutable compound policies)
+    address admin;      // Policy administrator (zero for compound policies — compound structure is immutable)
 }
 
 struct PolicyRecord {
@@ -99,13 +99,14 @@ interface ITIP403Registry {
     //                      Compound Policy Creation
     // =========================================================================
 
-    /// @notice Creates a new immutable compound policy
+    /// @notice Creates a new compound policy (structurally immutable — references cannot be changed after creation)
     /// @param senderPolicyId Policy ID to check for transfer senders
     /// @param recipientPolicyId Policy ID to check for transfer recipients
     /// @param mintRecipientPolicyId Policy ID to check for mint recipients
     /// @return newPolicyId ID of the newly created compound policy
     /// @dev All three policy IDs must reference existing simple policies (not compound).
-    /// Compound policies are immutable - they cannot be modified after creation.
+    /// Compound policy references are immutable — the constituent policy IDs cannot be changed after creation.
+    /// Note: the referenced simple policies themselves remain mutable by their admins.
     /// Emits CompoundPolicyCreated event.
     function createCompoundPolicy(
         uint64 senderPolicyId,
@@ -339,12 +340,16 @@ function cancelStaleOrder(uint128 orderId) external {
 }
 ```
 
-## Immutability
+## Mutability
 
-Compound policies are immutable once created. To change policy behavior, token issuers must:
+Compound policies are **structurally immutable** once created — their constituent policy ID references cannot be changed, and they have no admin. However, the referenced simple policies remain independently mutable by their respective admins. Modifications to a referenced simple policy's whitelist or blacklist will immediately affect the authorization behavior of any compound policy that references it.
+
+To change which simple policies a compound policy references, token issuers must:
 
 1. Create a new compound policy with the desired configuration
 2. Update the token's `transferPolicyId` to the new policy
+
+To modify authorization behavior without changing the compound policy itself, the admin of a referenced simple policy can modify that simple policy's whitelist or blacklist directly.
 
 ## Backward Compatibility
 
@@ -360,7 +365,7 @@ This TIP is fully backward compatible:
 
 1. **Simple Policy Constraint**: All three policy IDs in a compound policy MUST reference simple policies (WHITELIST or BLACKLIST). Compound policies cannot reference other compound policies.
 
-2. **Immutability**: Once created, a compound policy's constituent policy IDs cannot be changed. The compound policy itself has no admin.
+2. **Structural Immutability**: Once created, a compound policy's constituent policy ID references cannot be changed. The compound policy itself has no admin. Note that the referenced simple policies remain mutable by their respective admins.
 
 3. **Existence Check**: `createCompoundPolicy` MUST revert if any of the referenced policy IDs does not exist.
 


### PR DESCRIPTION
Updates the TIP-1015 spec to clarify that compound policies are structurally immutable (their constituent policy ID references cannot be changed), but the referenced simple policies remain mutable by their respective admins.


Prompted by: daniel