### PR TITLE
fix(dex): check recipient auth on payout token in cancel_stale_order

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1202,38 +1202,19 @@ impl StablecoinDEX {
     /// T4+: also checks recipient authorization on the payout token (bid=base, ask=quote).
     fn is_maker_authorized(&self, order: &Order) -> Result<bool> {
         let book = self.books[order.book_key()].read()?;
-        let registry = TIP403Registry::new();
 
-        let escrow_token = if order.is_bid() {
-            book.quote
+        let (token_in, token_out) = if order.is_bid() {
+            (book.quote, book.base)
         } else {
-            book.base
+            (book.base, book.quote)
         };
-        let escrow_policy_id = TIP20Token::from_address(escrow_token)?.transfer_policy_id()?;
-        let sender_authorized =
-            match registry.is_authorized_as(escrow_policy_id, order.maker(), AuthRole::sender()) {
-                Ok(authorized) => authorized,
-                Err(e) if is_policy_lookup_error(&e) => false,
-                Err(e) => return Err(e),
-            };
 
-        if !sender_authorized {
+        if !is_authorized_for_token(token_in, order.maker(), AuthRole::sender())? {
             return Ok(false);
         }
 
         if self.storage.spec().is_t4() {
-            let payout_token = if order.is_bid() {
-                book.base
-            } else {
-                book.quote
-            };
-            let payout_policy_id = TIP20Token::from_address(payout_token)?.transfer_policy_id()?;
-            match registry.is_authorized_as(payout_policy_id, order.maker(), AuthRole::recipient())
-            {
-                Ok(authorized) => Ok(authorized),
-                Err(e) if is_policy_lookup_error(&e) => Ok(false),
-                Err(e) => Err(e),
-            }
+            is_authorized_for_token(token_out, order.maker(), AuthRole::recipient())
         } else {
             Ok(true)
         }
@@ -1548,6 +1529,18 @@ impl StablecoinDEX {
         }
 
         Ok(amount_out)
+    }
+}
+
+/// Checks whether `address` is authorized under the transfer policy of `token` for the given
+/// `role`. Returns `false` instead of erroring when the policy lookup fails.
+fn is_authorized_for_token(token: Address, address: Address, role: AuthRole) -> Result<bool> {
+    let policy_id = TIP20Token::from_address(token)?.transfer_policy_id()?;
+    let registry = TIP403Registry::new();
+    match registry.is_authorized_as(policy_id, address, role) {
+        Ok(authorized) => Ok(authorized),
+        Err(e) if is_policy_lookup_error(&e) => Ok(false),
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -882,32 +882,6 @@ impl StablecoinDEX {
         Ok((amount_out, next_tick_info))
     }
 
-    /// T2+: cancel stale orders at the head of the queue until an authorized maker is found.
-    /// Returns the updated level and order, or `None` if no authorized orders remain.
-    fn skip_stale_orders(
-        &mut self,
-        book_key: B256,
-        bid: bool,
-    ) -> Result<Option<(TickLevel, Order)>> {
-        if !self.storage.spec().is_t2() {
-            return Ok(None);
-        }
-
-        loop {
-            let level = match self.get_best_price_level(book_key, bid) {
-                Ok(level) => level,
-                Err(_) => return Ok(None),
-            };
-            let order = self.orders[level.head].read()?;
-
-            if self.is_maker_authorized(&order)? {
-                return Ok(Some((level, order)));
-            }
-
-            self.cancel_active_order(order)?;
-        }
-    }
-
     /// Fill orders for exact output amount
     fn fill_orders_exact_out(
         &mut self,
@@ -916,14 +890,8 @@ impl StablecoinDEX {
         mut amount_out: u128,
         taker: Address,
     ) -> Result<u128> {
-        let (mut level, mut order) = match self.skip_stale_orders(book_key, bid)? {
-            Some(result) => result,
-            None => {
-                let level = self.get_best_price_level(book_key, bid)?;
-                let order = self.orders[level.head].read()?;
-                (level, order)
-            }
-        };
+        let mut level = self.get_best_price_level(book_key, bid)?;
+        let mut order = self.orders[level.head].read()?;
 
         let mut total_amount_in: u128 = 0;
 
@@ -1002,14 +970,8 @@ impl StablecoinDEX {
         mut amount_in: u128,
         taker: Address,
     ) -> Result<u128> {
-        let (mut level, mut order) = match self.skip_stale_orders(book_key, bid)? {
-            Some(result) => result,
-            None => {
-                let level = self.get_best_price_level(book_key, bid)?;
-                let order = self.orders[level.head].read()?;
-                (level, order)
-            }
-        };
+        let mut level = self.get_best_price_level(book_key, bid)?;
+        let mut order = self.orders[level.head].read()?;
 
         let mut total_amount_out: u128 = 0;
 
@@ -4337,161 +4299,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_skips_stale_order_t2() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-            exchange.initialize()?;
-
-            let alice = Address::random();
-            let bob = Address::random();
-            let charlie = Address::random();
-            let admin = Address::random();
-
-            let mut registry = TIP403Registry::new();
-            let policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-
-            let (base_addr, quote_addr) =
-                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 4)?;
-
-            // Also give bob tokens
-            let mut base = TIP20Token::from_address(base_addr)?;
-            base.mint(
-                admin,
-                ITIP20::mintCall {
-                    to: bob,
-                    amount: U256::from(MIN_ORDER_AMOUNT * 2),
-                },
-            )?;
-            base.approve(
-                bob,
-                ITIP20::approveCall {
-                    spender: exchange.address,
-                    amount: U256::from(MIN_ORDER_AMOUNT * 2),
-                },
-            )?;
-
-            // Apply blacklist policy to base token (escrow for ask orders)
-            base.change_transfer_policy_id(
-                admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: policy_id,
-                },
-            )?;
-
-            exchange.create_pair(base_addr)?;
-
-            // Alice places ask order first (will be at head of queue)
-            let alice_order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
-            // Bob places ask order second (behind alice)
-            let bob_order_id = exchange.place(bob, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
-
-            // Blacklist alice (sender on escrow token)
-            registry.modify_policy_blacklist(
-                admin,
-                ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: alice,
-                    restricted: true,
-                },
-            )?;
-
-            // Charlie swaps quote for base — alice's order is at head but stale
-            exchange.set_balance(charlie, quote_addr, MIN_ORDER_AMOUNT)?;
-            exchange.swap_exact_amount_in(charlie, quote_addr, base_addr, MIN_ORDER_AMOUNT, 0)?;
-
-            // Alice's stale order should have been skipped/cancelled
-            let alice_order = exchange.orders[alice_order_id].read()?;
-            assert!(
-                alice_order.maker().is_zero(),
-                "Alice's stale order should have been cancelled during fill"
-            );
-
-            // Bob's order should have been filled
-            let bob_order = exchange.orders[bob_order_id].read()?;
-            assert!(
-                bob_order.maker().is_zero(),
-                "Bob's order should have been filled"
-            );
-
-            // Alice gets her escrow refunded to internal balance (from cancel)
-            assert_eq!(exchange.balance_of(alice, base_addr)?, MIN_ORDER_AMOUNT);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_fill_does_not_skip_stale_order_pre_t2() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-            exchange.initialize()?;
-
-            let alice = Address::random();
-            let charlie = Address::random();
-            let admin = Address::random();
-
-            let mut registry = TIP403Registry::new();
-            let policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-
-            let (base_addr, quote_addr) =
-                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 4)?;
-
-            let mut base = TIP20Token::from_address(base_addr)?;
-            base.change_transfer_policy_id(
-                admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: policy_id,
-                },
-            )?;
-
-            exchange.create_pair(base_addr)?;
-
-            // Alice places ask order
-            exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
-
-            // Blacklist alice
-            registry.modify_policy_blacklist(
-                admin,
-                ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: alice,
-                    restricted: true,
-                },
-            )?;
-
-            // Pre-T2: swap fills alice's stale order (no skip)
-            exchange.set_balance(charlie, quote_addr, MIN_ORDER_AMOUNT)?;
-            let amount_out = exchange.swap_exact_amount_in(
-                charlie,
-                quote_addr,
-                base_addr,
-                MIN_ORDER_AMOUNT,
-                0,
-            )?;
-
-            assert!(amount_out > 0, "Swap should fill stale order pre-T2");
-            // Alice gets payout credited to internal balance
-            assert!(exchange.balance_of(alice, quote_addr)? > 0);
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_place_when_base_blacklisted() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -4869,8 +4676,7 @@ mod tests {
     #[test]
     fn test_flip_order_fill_ignores_business_logic_error() -> eyre::Result<()> {
         // Business logic errors during flip are silently ignored (always).
-        // T2 excluded: stale-order skipping cancels the order before fill.
-        for spec in [TempoHardfork::T1, TempoHardfork::T1A] {
+        for spec in [TempoHardfork::T1, TempoHardfork::T1A, TempoHardfork::T2] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let FlipOrderTestCtx {

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1174,7 +1174,7 @@ impl StablecoinDEX {
     /// Cancels an order whose maker is blocked by [`TIP403Registry`] policy, allowing anyone to
     /// clean up stale liquidity.
     ///
-    /// [TIP-1015]: T3+ checks sender authorization on the escrow token and recipient
+    /// [TIP-1015]: T4+ checks sender authorization on the escrow token and recipient
     /// authorization on the payout token. An order is stale if the maker fails either check.
     ///
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
@@ -1199,7 +1199,7 @@ impl StablecoinDEX {
     /// Returns `true` if the maker is authorized to keep the order open.
     ///
     /// Checks sender authorization on the escrow token (bid=quote, ask=base).
-    /// T3+: also checks recipient authorization on the payout token (bid=base, ask=quote).
+    /// T4+: also checks recipient authorization on the payout token (bid=base, ask=quote).
     fn is_maker_authorized(&self, order: &Order) -> Result<bool> {
         let book = self.books[order.book_key()].read()?;
         let registry = TIP403Registry::new();
@@ -1221,7 +1221,7 @@ impl StablecoinDEX {
             return Ok(false);
         }
 
-        if self.storage.spec().is_t3() {
+        if self.storage.spec().is_t4() {
             let payout_token = if order.is_bid() {
                 book.base
             } else {
@@ -4194,61 +4194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_pre_t3() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-            exchange.initialize()?;
-
-            let alice = Address::random();
-            let admin = Address::random();
-
-            let mut registry = TIP403Registry::new();
-            let policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-
-            let (base_addr, quote_addr) =
-                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
-
-            exchange.create_pair(base_addr)?;
-            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
-
-            let mut quote = TIP20Token::from_address(quote_addr)?;
-            quote.change_transfer_policy_id(
-                admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: policy_id,
-                },
-            )?;
-
-            registry.modify_policy_blacklist(
-                admin,
-                ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: alice,
-                    restricted: true,
-                },
-            )?;
-
-            // Pre-T3: recipient check on payout token is not performed, order is not stale
-            let result = exchange.cancel_stale_order(order_id);
-            assert!(result.is_err());
-            assert!(matches!(
-                result.unwrap_err(),
-                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
-            ));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_t3() -> eyre::Result<()> {
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_pre_t4() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
@@ -4289,7 +4235,61 @@ mod tests {
                 },
             )?;
 
-            // T3+: recipient check on payout token kicks in, order is stale
+            // Pre-T4: recipient check on payout token is not performed, order is not stale
+            let result = exchange.cancel_stale_order(order_id);
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_t4() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T4);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
+
+            exchange.create_pair(base_addr)?;
+            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            let mut quote = TIP20Token::from_address(quote_addr)?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // T4+: recipient check on payout token kicks in, order is stale
             exchange.cancel_stale_order(order_id)?;
 
             assert_eq!(exchange.balance_of(alice, base_addr)?, MIN_ORDER_AMOUNT);

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1174,7 +1174,8 @@ impl StablecoinDEX {
     /// Cancels an order whose maker is blocked by [`TIP403Registry`] policy, allowing anyone to
     /// clean up stale liquidity.
     ///
-    /// [TIP-1015]: T2+ checks sender authorization (maker must be able to send escrowed tokens)
+    /// [TIP-1015]: T2+ checks sender authorization on the escrow token and recipient
+    /// authorization on the payout token. An order is stale if the maker fails either check.
     ///
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
     ///
@@ -1188,21 +1189,48 @@ impl StablecoinDEX {
             return Err(StablecoinDEXError::order_does_not_exist().into());
         }
 
-        let book = self.books[order.book_key()].read()?;
-        let token = if order.is_bid() {
-            book.quote
+        if self.is_maker_authorized(&order)? {
+            Err(StablecoinDEXError::order_not_stale().into())
         } else {
-            book.base
-        };
+            self.cancel_active_order(order)
+        }
+    }
 
-        let policy_id = TIP20Token::from_address(token)?.transfer_policy_id()?;
-        // If the policy lookup fails because the policy is invalid or missing, the order is stale.
-        // Pre-T2 this surfaces as Panic(UnderOverflow); T2+ returns TIP403RegistryError variants.
-        match TIP403Registry::new().is_authorized_as(policy_id, order.maker(), AuthRole::sender()) {
-            Ok(true) => Err(StablecoinDEXError::order_not_stale().into()),
-            Ok(false) => self.cancel_active_order(order),
-            Err(e) if is_policy_lookup_error(&e) => self.cancel_active_order(order),
-            Err(e) => Err(e),
+    /// Returns `true` if the maker is authorized to keep the order open.
+    ///
+    /// Checks sender authorization on the escrow token (bid=quote, ask=base).
+    /// T2+: also checks recipient authorization on the payout token (bid=base, ask=quote).
+    fn is_maker_authorized(&self, order: &Order) -> Result<bool> {
+        let book = self.books[order.book_key()].read()?;
+        let registry = TIP403Registry::new();
+
+        let escrow_token = if order.is_bid() { book.quote } else { book.base };
+        let escrow_policy_id = TIP20Token::from_address(escrow_token)?.transfer_policy_id()?;
+        let sender_authorized =
+            match registry.is_authorized_as(escrow_policy_id, order.maker(), AuthRole::sender()) {
+                Ok(authorized) => authorized,
+                Err(e) if is_policy_lookup_error(&e) => false,
+                Err(e) => return Err(e),
+            };
+
+        if !sender_authorized {
+            return Ok(false);
+        }
+
+        if self.storage.spec().is_t2() {
+            let payout_token = if order.is_bid() { book.base } else { book.quote };
+            let payout_policy_id = TIP20Token::from_address(payout_token)?.transfer_policy_id()?;
+            match registry.is_authorized_as(
+                payout_policy_id,
+                order.maker(),
+                AuthRole::recipient(),
+            ) {
+                Ok(authorized) => Ok(authorized),
+                Err(e) if is_policy_lookup_error(&e) => Ok(false),
+                Err(e) => Err(e),
+            }
+        } else {
+            Ok(true)
         }
     }
 
@@ -4158,6 +4186,111 @@ mod tests {
             })?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_pre_t2() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
+
+            exchange.create_pair(base_addr)?;
+            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            let mut quote = TIP20Token::from_address(quote_addr)?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // Pre-T2: recipient check on payout token is not performed, order is not stale
+            let result = exchange.cancel_stale_order(order_id);
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_t2() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
+
+            exchange.create_pair(base_addr)?;
+            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            let mut quote = TIP20Token::from_address(quote_addr)?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // T2+: recipient check on payout token kicks in, order is stale
+            exchange.cancel_stale_order(order_id)?;
+
+            assert_eq!(exchange.balance_of(alice, base_addr)?, MIN_ORDER_AMOUNT);
+
+            Ok(())
+        })
     }
 
     #[test]

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1242,7 +1242,11 @@ impl StablecoinDEX {
         let book = self.books[order.book_key()].read()?;
         let registry = TIP403Registry::new();
 
-        let escrow_token = if order.is_bid() { book.quote } else { book.base };
+        let escrow_token = if order.is_bid() {
+            book.quote
+        } else {
+            book.base
+        };
         let escrow_policy_id = TIP20Token::from_address(escrow_token)?.transfer_policy_id()?;
         let sender_authorized =
             match registry.is_authorized_as(escrow_policy_id, order.maker(), AuthRole::sender()) {
@@ -1256,13 +1260,14 @@ impl StablecoinDEX {
         }
 
         if self.storage.spec().is_t2() {
-            let payout_token = if order.is_bid() { book.base } else { book.quote };
+            let payout_token = if order.is_bid() {
+                book.base
+            } else {
+                book.quote
+            };
             let payout_policy_id = TIP20Token::from_address(payout_token)?.transfer_policy_id()?;
-            match registry.is_authorized_as(
-                payout_policy_id,
-                order.maker(),
-                AuthRole::recipient(),
-            ) {
+            match registry.is_authorized_as(payout_policy_id, order.maker(), AuthRole::recipient())
+            {
                 Ok(authorized) => Ok(authorized),
                 Err(e) if is_policy_lookup_error(&e) => Ok(false),
                 Err(e) => Err(e),

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1174,7 +1174,7 @@ impl StablecoinDEX {
     /// Cancels an order whose maker is blocked by [`TIP403Registry`] policy, allowing anyone to
     /// clean up stale liquidity.
     ///
-    /// [TIP-1015]: T2+ checks sender authorization on the escrow token and recipient
+    /// [TIP-1015]: T3+ checks sender authorization on the escrow token and recipient
     /// authorization on the payout token. An order is stale if the maker fails either check.
     ///
     /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
@@ -1199,7 +1199,7 @@ impl StablecoinDEX {
     /// Returns `true` if the maker is authorized to keep the order open.
     ///
     /// Checks sender authorization on the escrow token (bid=quote, ask=base).
-    /// T2+: also checks recipient authorization on the payout token (bid=base, ask=quote).
+    /// T3+: also checks recipient authorization on the payout token (bid=base, ask=quote).
     fn is_maker_authorized(&self, order: &Order) -> Result<bool> {
         let book = self.books[order.book_key()].read()?;
         let registry = TIP403Registry::new();
@@ -1221,7 +1221,7 @@ impl StablecoinDEX {
             return Ok(false);
         }
 
-        if self.storage.spec().is_t2() {
+        if self.storage.spec().is_t3() {
             let payout_token = if order.is_bid() {
                 book.base
             } else {
@@ -4194,61 +4194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_pre_t2() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
-        StorageCtx::enter(&mut storage, || {
-            let mut exchange = StablecoinDEX::new();
-            exchange.initialize()?;
-
-            let alice = Address::random();
-            let admin = Address::random();
-
-            let mut registry = TIP403Registry::new();
-            let policy_id = registry.create_policy(
-                admin,
-                ITIP403Registry::createPolicyCall {
-                    admin,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-
-            let (base_addr, quote_addr) =
-                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
-
-            exchange.create_pair(base_addr)?;
-            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
-
-            let mut quote = TIP20Token::from_address(quote_addr)?;
-            quote.change_transfer_policy_id(
-                admin,
-                ITIP20::changeTransferPolicyIdCall {
-                    newPolicyId: policy_id,
-                },
-            )?;
-
-            registry.modify_policy_blacklist(
-                admin,
-                ITIP403Registry::modifyPolicyBlacklistCall {
-                    policyId: policy_id,
-                    account: alice,
-                    restricted: true,
-                },
-            )?;
-
-            // Pre-T2: recipient check on payout token is not performed, order is not stale
-            let result = exchange.cancel_stale_order(order_id);
-            assert!(result.is_err());
-            assert!(matches!(
-                result.unwrap_err(),
-                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
-            ));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_t2() -> eyre::Result<()> {
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_pre_t3() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
@@ -4289,7 +4235,61 @@ mod tests {
                 },
             )?;
 
-            // T2+: recipient check on payout token kicks in, order is stale
+            // Pre-T3: recipient check on payout token is not performed, order is not stale
+            let result = exchange.cancel_stale_order(order_id);
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cancel_stale_order_recipient_blacklisted_on_payout_token_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 2)?;
+
+            exchange.create_pair(base_addr)?;
+            let order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            let mut quote = TIP20Token::from_address(quote_addr)?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // T3+: recipient check on payout token kicks in, order is stale
             exchange.cancel_stale_order(order_id)?;
 
             assert_eq!(exchange.balance_of(alice, base_addr)?, MIN_ORDER_AMOUNT);

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -882,6 +882,32 @@ impl StablecoinDEX {
         Ok((amount_out, next_tick_info))
     }
 
+    /// T2+: cancel stale orders at the head of the queue until an authorized maker is found.
+    /// Returns the updated level and order, or `None` if no authorized orders remain.
+    fn skip_stale_orders(
+        &mut self,
+        book_key: B256,
+        bid: bool,
+    ) -> Result<Option<(TickLevel, Order)>> {
+        if !self.storage.spec().is_t2() {
+            return Ok(None);
+        }
+
+        loop {
+            let level = match self.get_best_price_level(book_key, bid) {
+                Ok(level) => level,
+                Err(_) => return Ok(None),
+            };
+            let order = self.orders[level.head].read()?;
+
+            if self.is_maker_authorized(&order)? {
+                return Ok(Some((level, order)));
+            }
+
+            self.cancel_active_order(order)?;
+        }
+    }
+
     /// Fill orders for exact output amount
     fn fill_orders_exact_out(
         &mut self,
@@ -890,8 +916,14 @@ impl StablecoinDEX {
         mut amount_out: u128,
         taker: Address,
     ) -> Result<u128> {
-        let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let (mut level, mut order) = match self.skip_stale_orders(book_key, bid)? {
+            Some(result) => result,
+            None => {
+                let level = self.get_best_price_level(book_key, bid)?;
+                let order = self.orders[level.head].read()?;
+                (level, order)
+            }
+        };
 
         let mut total_amount_in: u128 = 0;
 
@@ -970,8 +1002,14 @@ impl StablecoinDEX {
         mut amount_in: u128,
         taker: Address,
     ) -> Result<u128> {
-        let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read()?;
+        let (mut level, mut order) = match self.skip_stale_orders(book_key, bid)? {
+            Some(result) => result,
+            None => {
+                let level = self.get_best_price_level(book_key, bid)?;
+                let order = self.orders[level.head].read()?;
+                (level, order)
+            }
+        };
 
         let mut total_amount_out: u128 = 0;
 
@@ -4294,6 +4332,161 @@ mod tests {
     }
 
     #[test]
+    fn test_fill_skips_stale_order_t2() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let bob = Address::random();
+            let charlie = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 4)?;
+
+            // Also give bob tokens
+            let mut base = TIP20Token::from_address(base_addr)?;
+            base.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: bob,
+                    amount: U256::from(MIN_ORDER_AMOUNT * 2),
+                },
+            )?;
+            base.approve(
+                bob,
+                ITIP20::approveCall {
+                    spender: exchange.address,
+                    amount: U256::from(MIN_ORDER_AMOUNT * 2),
+                },
+            )?;
+
+            // Apply blacklist policy to base token (escrow for ask orders)
+            base.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            exchange.create_pair(base_addr)?;
+
+            // Alice places ask order first (will be at head of queue)
+            let alice_order_id = exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+            // Bob places ask order second (behind alice)
+            let bob_order_id = exchange.place(bob, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            // Blacklist alice (sender on escrow token)
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // Charlie swaps quote for base — alice's order is at head but stale
+            exchange.set_balance(charlie, quote_addr, MIN_ORDER_AMOUNT)?;
+            exchange.swap_exact_amount_in(charlie, quote_addr, base_addr, MIN_ORDER_AMOUNT, 0)?;
+
+            // Alice's stale order should have been skipped/cancelled
+            let alice_order = exchange.orders[alice_order_id].read()?;
+            assert!(
+                alice_order.maker().is_zero(),
+                "Alice's stale order should have been cancelled during fill"
+            );
+
+            // Bob's order should have been filled
+            let bob_order = exchange.orders[bob_order_id].read()?;
+            assert!(
+                bob_order.maker().is_zero(),
+                "Bob's order should have been filled"
+            );
+
+            // Alice gets her escrow refunded to internal balance (from cancel)
+            assert_eq!(exchange.balance_of(alice, base_addr)?, MIN_ORDER_AMOUNT);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_fill_does_not_skip_stale_order_pre_t2() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let charlie = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            let (base_addr, quote_addr) =
+                setup_test_tokens(admin, alice, exchange.address, MIN_ORDER_AMOUNT * 4)?;
+
+            let mut base = TIP20Token::from_address(base_addr)?;
+            base.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            exchange.create_pair(base_addr)?;
+
+            // Alice places ask order
+            exchange.place(alice, base_addr, MIN_ORDER_AMOUNT, false, 0)?;
+
+            // Blacklist alice
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // Pre-T2: swap fills alice's stale order (no skip)
+            exchange.set_balance(charlie, quote_addr, MIN_ORDER_AMOUNT)?;
+            let amount_out = exchange.swap_exact_amount_in(
+                charlie,
+                quote_addr,
+                base_addr,
+                MIN_ORDER_AMOUNT,
+                0,
+            )?;
+
+            assert!(amount_out > 0, "Swap should fill stale order pre-T2");
+            // Alice gets payout credited to internal balance
+            assert!(exchange.balance_of(alice, quote_addr)? > 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_place_when_base_blacklisted() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -4671,7 +4864,8 @@ mod tests {
     #[test]
     fn test_flip_order_fill_ignores_business_logic_error() -> eyre::Result<()> {
         // Business logic errors during flip are silently ignored (always).
-        for spec in [TempoHardfork::T1, TempoHardfork::T1A, TempoHardfork::T2] {
+        // T2 excluded: stale-order skipping cancels the order before fill.
+        for spec in [TempoHardfork::T1, TempoHardfork::T1A] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let FlipOrderTestCtx {


### PR DESCRIPTION
Closes SIGP-163

`cancel_stale_order` now also checks recipient authorization on the payout token (T4+), so orders from makers blacklisted as recipients can be cleaned up by third parties. Pre-T4 behavior is unchanged.
