### PR TITLE
feat(bench): multi-phase load profiles with ramps and credit-based pacer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11898,6 +11898,7 @@ dependencies = [
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
+ "reqwest 0.13.2",
  "reth-tracing",
  "rlimit",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3779,7 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,8 +4218,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4768,7 +4768,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6168,7 +6168,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10849,7 +10849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10929,7 +10929,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11307,6 +11307,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11531,7 +11544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11770,7 +11783,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11879,7 +11892,6 @@ dependencies = [
  "clap",
  "eyre",
  "futures",
- "governor",
  "indicatif",
  "itertools 0.14.0",
  "mimalloc",
@@ -11890,6 +11902,7 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempo-alloy",
  "tempo-contracts",
  "tempo-precompiles",
@@ -13334,6 +13347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13732,7 +13751,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bin/tempo-bench/Cargo.toml
+++ b/bin/tempo-bench/Cargo.toml
@@ -35,6 +35,7 @@ itertools.workspace = true
 reth-tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml = "0.9"
 tokio-util.workspace = true
 tokio.workspace = true
 
@@ -43,6 +44,6 @@ indicatif = { workspace = true, features = ["rayon", "futures"] }
 mimalloc = "0.1.48"
 rayon.workspace = true
 rlimit = "0.11.0"
-governor = "0.10.4"
+
 rand.workspace = true
 rand_08.workspace = true

--- a/bin/tempo-bench/Cargo.toml
+++ b/bin/tempo-bench/Cargo.toml
@@ -36,6 +36,7 @@ reth-tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
+reqwest.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -164,31 +164,75 @@ Run benchmark against more than one node:
 tempo-bench run-max-tps --duration 15 --tps 20000 --target-urls http://node-1:8545 --target-urls http://node-2:8545
 ```
 
-### Scenarios
+### Scenarios & Load Profiles
 
-Use `--scenario` to run predefined stress tests. Scenario defaults can be overridden
-by passing individual flags (e.g. `--scenario sustained-max --duration 60`).
+tempo-bench supports **multi-phase load profiles** — each run can ramp up, sustain,
+spike, crash, and recover over arbitrary time windows.
 
-| Scenario | TPS | Duration | Description |
-|---|---|---|---|
-| `sustained-max` | 10k | 5 min | Sustained load. Tests txpool backlog and drain. |
-| `mixed-workload` | 5k | 5 min | 80% TIP-20 / 15% MPP / 5% ERC-20. Realistic traffic. |
-| `burst-spike` | 10k | 30s | Short burst. Tests txpool elasticity and recovery. |
-| `fat-batch` | 100 | 2 min | Low TPS placeholder for future fat-batch txs (~30M gas). |
-| `state-heavy` | 5k | 2 min | Random new recipients (cold SSTOREs). Forces disk I/O. |
-| `txpool-flood` | 50k | 60s | Massive ingress flood. Tests memory limits and OOM resilience. |
-| `conflicting` | 5k | 2 min | Existing recipients from signer set. Placeholder for hot-spot mode. |
-| `rpc-saturation` | 10k | 5 min | High concurrency (500). Use multiple `--target-urls`. |
+#### Built-in scenarios (`--scenario`)
+
+Use `--scenario` to run a predefined profile. Scenario defaults (accounts, weights,
+concurrency) can be overridden with individual flags.
+
+| Scenario | Profile | Description |
+|---|---|---|
+| `sustained-max` | 10k TPS × 5 min | Sustained load. Tests txpool backlog and drain. |
+| `mixed-workload` | 5k TPS × 5 min | 80% TIP-20 / 15% MPP / 5% ERC-20. |
+| `burst-spike` | 0→10k→25k→1k→5k | Multi-phase ramp/spike/recovery over 10 min. |
+| `fat-batch` | 100 TPS × 2 min | Placeholder for future fat-batch txs. |
+| `state-heavy` | 5k TPS × 2 min | Cold SSTOREs via random new recipients. |
+| `txpool-flood` | 50k TPS × 60s | Tests memory limits and OOM resilience. |
+| `conflicting` | 5k TPS × 2 min | Existing recipients. Placeholder for hot-spot. |
+| `rpc-saturation` | 10k TPS × 5 min | 500 concurrent requests. |
+| `full-stress-cycle` | 0→2k→10k→25k→1k→10k→0 | ~58 min full stress cycle. |
 
 ```bash
-# Run sustained max scenario on mainnet RPC
-tempo-bench run-max-tps --scenario sustained-max --target-urls https://rpc.tempo.xyz --faucet
+# Run the full stress cycle
+tempo-bench run-max-tps --scenario full-stress-cycle --target-urls https://rpc.tempo.xyz --faucet
 
-# Run mixed workload with custom duration
-tempo-bench run-max-tps --scenario mixed-workload --duration 60 --target-urls https://rpc.tempo.xyz --faucet
+# Simple constant-TPS run (backwards compatible)
+tempo-bench run-max-tps --tps 10000 --duration 300 --target-urls https://rpc.tempo.xyz --faucet
 ```
 
-The benchmark will continuously output performance metrics including transaction generation rates, network throughput, queue lengths, and response times.
+#### Custom profiles (`--profile`)
+
+Define your own multi-phase profile in YAML:
+
+```yaml
+# my-profile.yaml
+phases:
+  - name: warm-up
+    target_tps: 2000
+    duration: 120
+    ramp: true        # linear ramp from previous phase (or 0)
+
+  - name: sustain
+    target_tps: 5000
+    duration: 600     # duration in seconds
+
+  - name: spike
+    target_tps: 15000
+    duration: 30
+    ramp: true
+
+  - name: recover
+    target_tps: 2000
+    duration: 300
+    ramp: true
+```
+
+```bash
+tempo-bench run-max-tps --profile my-profile.yaml --target-urls https://rpc.tempo.xyz --faucet
+```
+
+See `profiles/` for example profiles.
+
+#### How it works
+
+The load profile controls **TPS over time**. For ramp phases, TPS is linearly
+interpolated between the previous phase's end TPS and the target TPS. A
+credit-based pacer dispatches transactions at the target rate with 50ms
+granularity. The transaction mix (weights) stays constant across phases.
 
 ## Quick Start
 

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -227,6 +227,40 @@ tempo-bench run-max-tps --profile my-profile.yaml --target-urls https://rpc.temp
 
 See `profiles/` for example profiles.
 
+#### Burst spikes
+
+Any phase can overlay periodic burst spikes on top of its base TPS:
+
+```yaml
+- name: spikey-baseline
+  target_tps: 3000         # base TPS between bursts
+  duration: 300
+  burst:
+    tps: 20000             # spike to 20k during burst
+    duration: 5            # each burst lasts 5 seconds
+    interval: 30           # burst every 30 seconds
+```
+
+This produces a square-wave pattern: 25 seconds at 3k TPS, then 5 seconds at
+20k TPS, repeating. Useful for simulating bursty real-world traffic patterns
+without needing dozens of micro-phases.
+
+#### Multi-RPC saturation
+
+When multiple `--target-urls` are provided, each RPC gets its own independent
+concurrency budget of `--max-concurrent-requests`. Load is distributed via
+round-robin, so 3 RPCs with `--max-concurrent-requests 200` = 600 total
+concurrent connections (200 per RPC).
+
+```bash
+# Saturate 3 RPCs independently with 200 concurrent requests each
+tempo-bench run-max-tps --scenario sustained-max \
+  --target-urls http://node-1:8545 \
+  --target-urls http://node-2:8545 \
+  --target-urls http://node-3:8545 \
+  --max-concurrent-requests 200 --faucet
+```
+
 #### How it works
 
 The load profile controls **TPS over time**. For ramp phases, TPS is linearly

--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -152,12 +152,6 @@ Run benchmark on MacOS:
 tempo-bench run-max-tps --duration 15 --tps 20000 --disable-thread-pinning
 ```
 
-Run benchmark with less workers than the default:
-
-```bash
-tempo-bench run-max-tps --duration 15 --tps 20 -w 1
-```
-
 Run benchmark with more accounts than the default:
 
 ```bash
@@ -170,7 +164,31 @@ Run benchmark against more than one node:
 tempo-bench run-max-tps --duration 15 --tps 20000 --target-urls http://node-1:8545 --target-urls http://node-2:8545
 ```
 
-The benchmark will continuously output performance metrics including transaction generation rates, network throughput, queue lengths, and response times. As the total transaction count increases, the rate limiter will automatically scale up according to your configured thresholds.
+### Scenarios
+
+Use `--scenario` to run predefined stress tests. Scenario defaults can be overridden
+by passing individual flags (e.g. `--scenario sustained-max --duration 60`).
+
+| Scenario | TPS | Duration | Description |
+|---|---|---|---|
+| `sustained-max` | 10k | 5 min | Sustained load. Tests txpool backlog and drain. |
+| `mixed-workload` | 5k | 5 min | 80% TIP-20 / 15% MPP / 5% ERC-20. Realistic traffic. |
+| `burst-spike` | 10k | 30s | Short burst. Tests txpool elasticity and recovery. |
+| `fat-batch` | 100 | 2 min | Low TPS placeholder for future fat-batch txs (~30M gas). |
+| `state-heavy` | 5k | 2 min | Random new recipients (cold SSTOREs). Forces disk I/O. |
+| `txpool-flood` | 50k | 60s | Massive ingress flood. Tests memory limits and OOM resilience. |
+| `conflicting` | 5k | 2 min | Existing recipients from signer set. Placeholder for hot-spot mode. |
+| `rpc-saturation` | 10k | 5 min | High concurrency (500). Use multiple `--target-urls`. |
+
+```bash
+# Run sustained max scenario on mainnet RPC
+tempo-bench run-max-tps --scenario sustained-max --target-urls https://rpc.tempo.xyz --faucet
+
+# Run mixed workload with custom duration
+tempo-bench run-max-tps --scenario mixed-workload --duration 60 --target-urls https://rpc.tempo.xyz --faucet
+```
+
+The benchmark will continuously output performance metrics including transaction generation rates, network throughput, queue lengths, and response times.
 
 ## Quick Start
 

--- a/bin/tempo-bench/profiles/burst-recovery.yaml
+++ b/bin/tempo-bench/profiles/burst-recovery.yaml
@@ -1,0 +1,41 @@
+# Burst and recovery: 10 minutes
+# Repeated burst/recover cycles to test txpool elasticity
+phases:
+  - name: baseline
+    target_tps: 3000
+    duration: 60
+
+  - name: burst-1
+    target_tps: 15000
+    duration: 30
+    ramp: true
+
+  - name: recover-1
+    target_tps: 3000
+    duration: 60
+    ramp: true
+
+  - name: burst-2
+    target_tps: 20000
+    duration: 30
+    ramp: true
+
+  - name: recover-2
+    target_tps: 3000
+    duration: 60
+    ramp: true
+
+  - name: burst-3
+    target_tps: 25000
+    duration: 30
+    ramp: true
+
+  - name: recover-3
+    target_tps: 3000
+    duration: 120
+    ramp: true
+
+  - name: cooldown
+    target_tps: 0
+    duration: 60
+    ramp: true

--- a/bin/tempo-bench/profiles/full-stress-cycle.yaml
+++ b/bin/tempo-bench/profiles/full-stress-cycle.yaml
@@ -1,0 +1,48 @@
+# Full stress cycle: ~58 minutes
+# Warm up → sustain → spike → crash → recover → sustain → cool down
+phases:
+  - name: warm-up
+    target_tps: 2000
+    duration: 120
+    ramp: true
+
+  - name: sustain-low
+    target_tps: 2000
+    duration: 600
+
+  - name: ramp-up
+    target_tps: 10000
+    duration: 180
+    ramp: true
+
+  - name: sustain-high
+    target_tps: 10000
+    duration: 900
+
+  - name: spike
+    target_tps: 25000
+    duration: 30
+    ramp: true
+
+  - name: crash-down
+    target_tps: 1000
+    duration: 30
+    ramp: true
+
+  - name: sustain-low-recovery
+    target_tps: 1000
+    duration: 600
+
+  - name: ramp-back
+    target_tps: 10000
+    duration: 300
+    ramp: true
+
+  - name: sustain-final
+    target_tps: 10000
+    duration: 600
+
+  - name: cooldown
+    target_tps: 0
+    duration: 120
+    ramp: true

--- a/bin/tempo-bench/profiles/spikey-load.yaml
+++ b/bin/tempo-bench/profiles/spikey-load.yaml
@@ -1,0 +1,20 @@
+# Spikey load: 5 minutes
+# Sustained baseline with periodic burst spikes every 30 seconds
+phases:
+  - name: warm-up
+    target_tps: 3000
+    duration: 30
+    ramp: true
+
+  - name: spikey-sustained
+    target_tps: 3000
+    duration: 240
+    burst:
+      tps: 20000       # spike to 20k
+      duration: 5       # each burst lasts 5s
+      interval: 30      # every 30s
+
+  - name: cooldown
+    target_tps: 0
+    duration: 30
+    ramp: true

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -1,5 +1,6 @@
 mod dex;
 mod erc20;
+pub(crate) mod metrics_scraper;
 mod mpp;
 pub(crate) mod scenario;
 
@@ -211,6 +212,19 @@ pub struct MaxTpsArgs {
     /// nonce management.
     #[arg(long)]
     use_standard_nonces: bool,
+
+    /// Prometheus metrics endpoints to scrape during the benchmark.
+    ///
+    /// When set, periodically fetches Prometheus metrics from each URL and includes
+    /// the time-series data in `report.json` for post-run analysis/graphing.
+    ///
+    /// Example: `--metrics-urls http://localhost:9001/metrics`
+    #[arg(long, value_delimiter = ',', action = clap::ArgAction::Append)]
+    metrics_urls: Vec<Url>,
+
+    /// Interval in seconds between metrics scrapes.
+    #[arg(long, default_value_t = 1)]
+    metrics_interval: u64,
 }
 
 impl MaxTpsArgs {
@@ -599,6 +613,17 @@ impl MaxTpsArgs {
             cancel_token.clone(),
         ));
 
+        // Start metrics scraper if configured
+        let metrics_collector = if !self.metrics_urls.is_empty() {
+            Some(metrics_scraper::spawn_scraper(
+                self.metrics_urls.clone(),
+                Duration::from_secs(self.metrics_interval),
+                cancel_token.clone(),
+            ))
+        } else {
+            None
+        };
+
         let start_block_number = provider.get_block_number().await?;
 
         // Pre-generate a buffer of signed transaction bytes from the infinite generator stream
@@ -797,12 +822,25 @@ impl MaxTpsArgs {
             "Collected a sample of receipts"
         );
 
+        // Collect metrics snapshots
+        let metrics_snapshots = metrics_collector
+            .map(|c| c.into_snapshots())
+            .unwrap_or_default();
+
+        if !metrics_snapshots.is_empty() {
+            info!(
+                snapshots = metrics_snapshots.len(),
+                "Collected metrics snapshots"
+            );
+        }
+
         generate_report(
             provider,
             start_block_number,
             end_block_number,
             &self,
             &profile,
+            metrics_snapshots,
         )
         .await?;
 
@@ -1186,6 +1224,8 @@ struct BenchmarkMetadata {
 struct BenchmarkReport {
     metadata: BenchmarkMetadata,
     blocks: Vec<BenchmarkedBlock>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    metrics: Vec<metrics_scraper::MetricsSnapshot>,
 }
 
 pub async fn generate_report(
@@ -1194,6 +1234,7 @@ pub async fn generate_report(
     end_block: BlockNumber,
     args: &MaxTpsArgs,
     profile: &LoadProfile,
+    metrics_snapshots: Vec<metrics_scraper::MetricsSnapshot>,
 ) -> eyre::Result<()> {
     info!(start_block, end_block, "Generating report");
 
@@ -1272,6 +1313,7 @@ pub async fn generate_report(
     let report = BenchmarkReport {
         metadata,
         blocks: benchmarked_blocks,
+        metrics: metrics_snapshots,
     };
 
     let path = "report.json";

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -7,7 +7,7 @@ use alloy_consensus::Transaction;
 use itertools::Itertools;
 use reth_tracing::{
     RethTracer, Tracer,
-    tracing::{debug, error, info},
+    tracing::{debug, error, info, warn},
 };
 use tempo_alloy::{
     TempoNetwork, fillers::ExpiringNonceFiller, provider::ext::TempoProviderBuilderExt,
@@ -36,7 +36,6 @@ use futures::{
     future::BoxFuture,
     stream::{self},
 };
-use governor::{Quota, RateLimiter, state::StreamRateLimitExt};
 use indicatif::{ProgressBar, ProgressIterator};
 use rand::{random_range, seq::IndexedRandom};
 use rlimit::Resource;
@@ -45,13 +44,14 @@ use std::{
     collections::VecDeque,
     fs::File,
     io::BufWriter,
-    num::{NonZeroU32, NonZeroU64},
+    num::NonZeroU64,
+    path::PathBuf,
     str::FromStr,
     sync::{
         Arc, OnceLock,
         atomic::{AtomicUsize, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tempo_contracts::precompiles::{
     IFeeManager::IFeeManagerInstance,
@@ -66,30 +66,33 @@ use tempo_precompiles::{
     tip_fee_manager::DEFAULT_FEE_TOKEN,
     tip20::ISSUER_ROLE,
 };
-use tokio::{
-    select,
-    time::{interval, sleep},
-};
+use tokio::{select, time::interval};
 use tokio_util::sync::CancellationToken;
 
 use crate::cmd::signer_providers::SignerProviderManager;
 
-use self::scenario::Scenario;
+use self::scenario::{LoadProfile, Scenario};
 
 /// Run maximum TPS throughput benchmarking
 #[derive(Parser, Debug)]
 pub struct MaxTpsArgs {
-    /// Predefined stress test scenario. Overrides default values for TPS, duration,
-    /// weights, and other parameters. Any explicitly passed flags take precedence.
-    #[arg(long, value_enum)]
+    /// Predefined stress test scenario. Sets a load profile plus defaults for accounts,
+    /// weights, and concurrency. Mutually exclusive with `--profile`.
+    #[arg(long, value_enum, conflicts_with = "profile")]
     scenario: Option<Scenario>,
 
-    /// Target transactions per second.
-    /// Required unless `--scenario` is set.
+    /// Custom load profile (YAML file defining phases with TPS ramps).
+    /// Mutually exclusive with `--scenario`.
+    #[arg(long, conflicts_with = "scenario")]
+    profile: Option<PathBuf>,
+
+    /// Target TPS. When used with `--scenario`/`--profile`, creates a single constant-TPS
+    /// phase that overrides the profile. When used alone (no scenario/profile), also
+    /// requires `--duration`.
     #[arg(short, long)]
     tps: Option<u64>,
 
-    /// Test duration in seconds
+    /// Test duration in seconds. Used with `--tps` to create a simple constant-TPS profile.
     #[arg(short, long, default_value_t = 30)]
     duration: u64,
 
@@ -214,29 +217,13 @@ impl MaxTpsArgs {
     const WEIGHT_PRECISION: f64 = 1000.0;
 
     /// Apply scenario overrides to fields that were left at their CLI defaults.
-    ///
-    /// Scenario values are used as defaults — any explicitly passed flag wins.
-    /// We detect "explicitly passed" by checking whether the current value differs
-    /// from the clap default. This is imperfect (a user could pass the default value),
-    /// but good enough for practical use.
-    fn apply_scenario(&mut self) {
+    fn apply_scenario_overrides(&mut self) {
         let Some(scenario) = self.scenario else {
             return;
         };
 
         let o = scenario.overrides();
 
-        // tps is Option — scenario fills it if the user didn't
-        if self.tps.is_none() {
-            self.tps = o.tps;
-        }
-
-        // For fields with clap defaults, only override if still at default
-        if self.duration == 30
-            && let Some(v) = o.duration
-        {
-            self.duration = v;
-        }
         if self.accounts.get() == 100
             && let Some(v) = o.accounts
         {
@@ -282,24 +269,62 @@ impl MaxTpsArgs {
         }
     }
 
+    /// Resolve the load profile from CLI args.
+    ///
+    /// Priority: `--tps` override > `--profile` file > `--scenario` preset > bare `--tps --duration`.
+    fn resolve_profile(&self) -> eyre::Result<LoadProfile> {
+        // If --tps is given, it always creates a simple constant profile
+        if let Some(tps) = self.tps {
+            eyre::ensure!(tps > 0, "--tps must be > 0");
+            return Ok(LoadProfile {
+                phases: vec![scenario::Phase {
+                    name: "constant".into(),
+                    target_tps: tps,
+                    duration: Duration::from_secs(self.duration),
+                    ramp: false,
+                }],
+            });
+        }
+
+        // --profile <file>
+        if let Some(ref path) = self.profile {
+            return LoadProfile::from_file(path);
+        }
+
+        // --scenario <name>
+        if let Some(scenario) = self.scenario {
+            return Ok(scenario.profile());
+        }
+
+        eyre::bail!("one of --tps, --scenario, or --profile is required")
+    }
+
     pub async fn run(mut self) -> eyre::Result<()> {
         RethTracer::new().init()?;
 
-        self.apply_scenario();
+        self.apply_scenario_overrides();
+        let profile = self.resolve_profile()?;
 
-        // Resolve tps early and store it back so run_with_manager can access it
-        let tps = self
-            .tps
-            .ok_or_eyre("--tps is required (or use --scenario to set it)")?;
-        eyre::ensure!(tps > 0, "--tps must be > 0");
-        eyre::ensure!(u32::try_from(tps).is_ok(), "--tps must be <= {}", u32::MAX);
-        self.tps = Some(tps);
-
-        if let Some(ref scenario) = self.scenario {
-            info!(%scenario, tps, duration = self.duration, accounts = %self.accounts,
-                tip20 = self.tip20_weight, erc20 = self.erc20_weight, mpp = self.mpp_weight,
-                existing_recipients = self.existing_recipients,
-                "Running scenario");
+        info!(
+            phases = profile.phases.len(),
+            total_duration_secs = profile.total_duration().as_secs(),
+            expected_txs = profile.expected_total_txs(),
+            max_tps = profile.max_tps(),
+            tip20 = self.tip20_weight,
+            erc20 = self.erc20_weight,
+            mpp = self.mpp_weight,
+            existing_recipients = self.existing_recipients,
+            "Load profile resolved"
+        );
+        for (i, phase) in profile.phases.iter().enumerate() {
+            info!(
+                phase = i,
+                name = %phase.name,
+                target_tps = phase.target_tps,
+                duration_secs = phase.duration.as_secs(),
+                ramp = phase.ramp,
+                "  Phase"
+            );
         }
 
         let accounts = self.accounts.get();
@@ -336,7 +361,8 @@ impl MaxTpsArgs {
                 }),
                 signer_provider_factory,
             );
-            self.run_with_manager(signer_provider_manager).await
+            self.run_with_manager(signer_provider_manager, profile)
+                .await
         } else if self.use_standard_nonces {
             info!(
                 accounts = self.accounts,
@@ -356,7 +382,8 @@ impl MaxTpsArgs {
                 }),
                 signer_provider_factory,
             );
-            self.run_with_manager(signer_provider_manager).await
+            self.run_with_manager(signer_provider_manager, profile)
+                .await
         } else {
             // Default: Use expiring nonces (TIP-1009)
             // Use the default 25-second expiry window (protocol max is 30s).
@@ -379,17 +406,16 @@ impl MaxTpsArgs {
                 }),
                 signer_provider_factory,
             );
-            self.run_with_manager(signer_provider_manager).await
+            self.run_with_manager(signer_provider_manager, profile)
+                .await
         }
     }
 
     async fn run_with_manager<F: TxFiller<TempoNetwork> + 'static>(
         self,
         signer_provider_manager: SignerProviderManager<F>,
+        profile: LoadProfile,
     ) -> eyre::Result<()> {
-        // tps was validated and stored in run() before calling this method
-        let tps = self.tps.expect("tps resolved in run()");
-
         // Validate required addresses before sending any transactions
         eyre::ensure!(
             self.mpp_weight == 0.0 || self.mpp_contract_address.is_some(),
@@ -502,8 +528,6 @@ impl MaxTpsArgs {
             None
         };
 
-        // Generate and send transactions
-        let total_txs = tps * self.duration;
         let tip20_weight = (self.tip20_weight * Self::WEIGHT_PRECISION).trunc() as u64;
         let place_order_weight = (self.place_order_weight * Self::WEIGHT_PRECISION).trunc() as u64;
         let swap_weight = (self.swap_weight * Self::WEIGHT_PRECISION).trunc() as u64;
@@ -548,32 +572,33 @@ impl MaxTpsArgs {
             expiry_secs,
         };
 
-        info!(total_txs, "Generating and sending transactions");
+        let total_duration = profile.total_duration();
+        let expected_txs = profile.expected_total_txs();
+        let pregen_buffer = (profile.max_tps() as usize).clamp(100, 5_000);
+
+        info!(
+            expected_txs,
+            pregen_buffer,
+            total_duration_secs = total_duration.as_secs(),
+            "Generating and sending transactions"
+        );
 
         let counters = TransactionCounters::default();
-        let target_count = total_txs as usize;
         let cancel_token = CancellationToken::new();
 
         // Start TPS monitor
-        tokio::spawn(monitor_tps(
+        tokio::spawn(monitor_tps_profiled(
             counters.clone(),
-            target_count,
+            profile.clone(),
             cancel_token.clone(),
         ));
 
-        let rate_limiter =
-            RateLimiter::direct(Quota::per_second(NonZeroU32::new(tps as u32).unwrap()));
         let start_block_number = provider.get_block_number().await?;
 
-        let mut pending_txs =
+        // Pre-generate a buffer of signed transaction bytes from the infinite generator stream
+        let mut tx_stream =
             generate_transactions(signer_provider_manager.clone(), gen_input, counters.clone())
-                // Take exactly the required number of transactions to not over-send
-                .take(target_count)
-                // Stop when duration exceeded, no matter if we sent all transactions or not
-                .take_until(sleep(Duration::from_secs(self.duration)))
-                // Keep a buffer of pre-generated transactions to send as fast as possible
-                .buffer_unordered(tps as usize)
-                // Filter only successfully generated transactions
+                .buffer_unordered(pregen_buffer)
                 .filter_map(|result| async {
                     match result {
                         Ok(bytes) => Some(bytes),
@@ -583,51 +608,111 @@ impl MaxTpsArgs {
                         }
                     }
                 })
-                .boxed()
-                .ratelimit_stream(&rate_limiter)
-                // Pair each transaction with a random provider to send it
-                .zip(stream::repeat_with(|| {
-                    signer_provider_manager.random_unsigned_provider()
-                }))
-                // Prepare transaction sending futures
-                .map(|(bytes, provider)| async move {
-                    tokio::time::timeout(
+                .boxed();
+
+        // Credit-based pacer: dispatches transactions according to the load profile
+        let start = Instant::now();
+        let mut credit = 0.0f64;
+        let mut last_elapsed = Duration::ZERO;
+        let mut last_phase: Option<String> = None;
+        let mut pending_txs: VecDeque<PendingTransactionBuilder<TempoNetwork>> = VecDeque::new();
+        let tick = Duration::from_millis(50);
+        let mut in_flight = 0usize;
+
+        // Channel for collecting send results
+        let (result_tx, mut result_rx) =
+            tokio::sync::mpsc::channel::<SendResult>(self.max_concurrent_requests * 2);
+
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= total_duration {
+                break;
+            }
+
+            // Log phase transitions
+            if let Some(current_phase) = profile.phase_at(elapsed) {
+                let current = current_phase.to_string();
+                if last_phase.as_deref() != Some(current_phase) {
+                    let current_tps = profile.tps_at(elapsed);
+                    info!(
+                        phase = %current,
+                        target_tps = current_tps as u64,
+                        elapsed_secs = elapsed.as_secs(),
+                        "Phase transition"
+                    );
+                    last_phase = Some(current);
+                }
+            }
+
+            // Refill credit based on elapsed time
+            credit += profile.tx_budget_between(last_elapsed, elapsed);
+            last_elapsed = elapsed;
+
+            // Drain completed send results
+            while let Ok(result) = result_rx.try_recv() {
+                in_flight -= 1;
+                match result {
+                    SendResult::Success(pending_tx) => {
+                        counters.sent.fetch_add(1, Ordering::Relaxed);
+                        counters.success.fetch_add(1, Ordering::Relaxed);
+                        pending_txs.push_back(pending_tx);
+                    }
+                    SendResult::Failed => {
+                        counters.sent.fetch_add(1, Ordering::Relaxed);
+                        counters.failed.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+
+            // Dispatch transactions up to available credit and concurrency
+            let to_send = (credit.floor() as usize)
+                .min(self.max_concurrent_requests.saturating_sub(in_flight));
+
+            for _ in 0..to_send {
+                // Pull a pre-generated tx from the buffer
+                let Some(bytes) = tx_stream.next().await else {
+                    warn!("Transaction generator exhausted");
+                    break;
+                };
+
+                credit -= 1.0;
+                in_flight += 1;
+
+                let provider = signer_provider_manager.random_unsigned_provider();
+                let result_tx = result_tx.clone();
+                tokio::spawn(async move {
+                    let result = tokio::time::timeout(
                         Duration::from_secs(1),
                         provider.send_raw_transaction(&bytes),
                     )
-                    .await
-                })
-                // Send transactions in parallel with up to the specified concurrency limit
-                .buffer_unordered(self.max_concurrent_requests)
-                .filter_map({
-                    let counters = counters.clone();
-                    move |result| {
-                        let counters = counters.clone();
-                        async move {
-                            match result {
-                                Ok(Ok(pending_tx)) => {
-                                    counters.sent.fetch_add(1, Ordering::Relaxed);
-                                    counters.success.fetch_add(1, Ordering::Relaxed);
-                                    Some(pending_tx)
-                                }
-                                Ok(Err(err)) => {
-                                    counters.sent.fetch_add(1, Ordering::Relaxed);
-                                    counters.failed.fetch_add(1, Ordering::Relaxed);
-                                    debug!(?err, "Failed to send transaction");
-                                    None
-                                }
-                                Err(_) => {
-                                    counters.sent.fetch_add(1, Ordering::Relaxed);
-                                    counters.failed.fetch_add(1, Ordering::Relaxed);
-                                    debug!("Transaction sending timed out");
-                                    None
-                                }
-                            }
-                        }
-                    }
-                })
-                .collect::<VecDeque<_>>()
-                .await;
+                    .await;
+
+                    let send_result = match result {
+                        Ok(Ok(pending_tx)) => SendResult::Success(pending_tx),
+                        _ => SendResult::Failed,
+                    };
+                    let _ = result_tx.send(send_result).await;
+                });
+            }
+
+            tokio::time::sleep(tick).await;
+        }
+
+        // Drain remaining in-flight results
+        drop(result_tx);
+        while let Some(result) = result_rx.recv().await {
+            match result {
+                SendResult::Success(pending_tx) => {
+                    counters.sent.fetch_add(1, Ordering::Relaxed);
+                    counters.success.fetch_add(1, Ordering::Relaxed);
+                    pending_txs.push_back(pending_tx);
+                }
+                SendResult::Failed => {
+                    counters.sent.fetch_add(1, Ordering::Relaxed);
+                    counters.failed.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
 
         cancel_token.cancel();
 
@@ -684,10 +769,23 @@ impl MaxTpsArgs {
             "Collected a sample of receipts"
         );
 
-        generate_report(provider, start_block_number, end_block_number, &self).await?;
+        generate_report(
+            provider,
+            start_block_number,
+            end_block_number,
+            &self,
+            &profile,
+        )
+        .await?;
 
         Ok(())
     }
+}
+
+/// Result of a single transaction send attempt.
+enum SendResult {
+    Success(PendingTransactionBuilder<TempoNetwork>),
+    Failed,
 }
 
 #[derive(Debug, Clone)]
@@ -1024,9 +1122,18 @@ struct BenchmarkedBlock {
 }
 
 #[derive(Serialize)]
-struct BenchmarkMetadata {
+struct ProfilePhaseMetadata {
+    name: String,
     target_tps: u64,
-    run_duration_secs: u64,
+    duration_secs: u64,
+    ramp: bool,
+}
+
+#[derive(Serialize)]
+struct BenchmarkMetadata {
+    max_tps: u64,
+    expected_total_txs: u64,
+    total_duration_secs: u64,
     accounts: u64,
     chain_id: u64,
     total_connections: usize,
@@ -1043,6 +1150,7 @@ struct BenchmarkMetadata {
     swap_weight: f64,
     erc20_weight: f64,
     mpp_weight: f64,
+    phases: Vec<ProfilePhaseMetadata>,
 }
 
 #[derive(Serialize)]
@@ -1056,6 +1164,7 @@ pub async fn generate_report(
     start_block: BlockNumber,
     end_block: BlockNumber,
     args: &MaxTpsArgs,
+    profile: &LoadProfile,
 ) -> eyre::Result<()> {
     info!(start_block, end_block, "Generating report");
 
@@ -1100,9 +1209,21 @@ pub async fn generate_report(
         last_block_timestamp = Some(timestamp);
     }
 
+    let phases = profile
+        .phases
+        .iter()
+        .map(|p| ProfilePhaseMetadata {
+            name: p.name.clone(),
+            target_tps: p.target_tps,
+            duration_secs: p.duration.as_secs(),
+            ramp: p.ramp,
+        })
+        .collect();
+
     let metadata = BenchmarkMetadata {
-        target_tps: args.tps.unwrap_or(0),
-        run_duration_secs: args.duration,
+        max_tps: profile.max_tps(),
+        expected_total_txs: profile.expected_total_txs(),
+        total_duration_secs: profile.total_duration().as_secs(),
         accounts: args.accounts.get(),
         chain_id: provider.get_chain_id().await?,
         total_connections: args.max_concurrent_requests,
@@ -1116,6 +1237,7 @@ pub async fn generate_report(
         swap_weight: args.swap_weight,
         erc20_weight: args.erc20_weight,
         mpp_weight: args.mpp_weight,
+        phases,
     };
 
     let report = BenchmarkReport {
@@ -1133,21 +1255,36 @@ pub async fn generate_report(
     Ok(())
 }
 
-async fn monitor_tps(counters: TransactionCounters, target_count: usize, token: CancellationToken) {
+async fn monitor_tps_profiled(
+    counters: TransactionCounters,
+    profile: LoadProfile,
+    token: CancellationToken,
+) {
     let mut last_count = 0;
     let mut ticker = interval(Duration::from_secs(1));
+    let start = Instant::now();
 
     loop {
         select! {
             _ = ticker.tick() => {
+                let elapsed = start.elapsed();
                 let current_count = counters.sent.load(Ordering::Relaxed);
-                let tps = current_count - last_count;
+                let actual_tps = current_count - last_count;
                 last_count = current_count;
 
-                info!(tps, total = current_count, "Status");
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                let target_tps = profile.tps_at(elapsed) as u64;
+                let phase = profile.phase_at(elapsed).unwrap_or("done");
 
-                if current_count == target_count {
+                info!(
+                    actual_tps,
+                    target_tps,
+                    total = current_count,
+                    phase,
+                    elapsed_secs = elapsed.as_secs(),
+                    "Status"
+                );
+
+                if elapsed >= profile.total_duration() {
                     break;
                 }
             }

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -282,6 +282,7 @@ impl MaxTpsArgs {
                     target_tps: tps,
                     duration: Duration::from_secs(self.duration),
                     ramp: false,
+                    burst: None,
                 }],
             });
         }
@@ -576,9 +577,14 @@ impl MaxTpsArgs {
         let expected_txs = profile.expected_total_txs();
         let pregen_buffer = (profile.max_tps() as usize).clamp(100, 5_000);
 
+        let providers_with_urls = signer_provider_manager.unsigned_providers_with_urls();
+        let num_urls = providers_with_urls.len();
+
         info!(
             expected_txs,
             pregen_buffer,
+            num_urls,
+            per_url_concurrency = self.max_concurrent_requests,
             total_duration_secs = total_duration.as_secs(),
             "Generating and sending transactions"
         );
@@ -617,11 +623,14 @@ impl MaxTpsArgs {
         let mut last_phase: Option<String> = None;
         let mut pending_txs: VecDeque<PendingTransactionBuilder<TempoNetwork>> = VecDeque::new();
         let tick = Duration::from_millis(50);
-        let mut in_flight = 0usize;
+
+        // Per-URL in-flight tracking with round-robin distribution
+        let mut in_flight_per_url = vec![0usize; num_urls];
+        let mut rr_index = 0usize;
 
         // Channel for collecting send results
         let (result_tx, mut result_rx) =
-            tokio::sync::mpsc::channel::<SendResult>(self.max_concurrent_requests * 2);
+            tokio::sync::mpsc::channel::<SendResult>(self.max_concurrent_requests * num_urls * 2);
 
         loop {
             let elapsed = start.elapsed();
@@ -634,9 +643,11 @@ impl MaxTpsArgs {
                 let current = current_phase.to_string();
                 if last_phase.as_deref() != Some(current_phase) {
                     let current_tps = profile.tps_at(elapsed);
+                    let total_in_flight: usize = in_flight_per_url.iter().sum();
                     info!(
                         phase = %current,
                         target_tps = current_tps as u64,
+                        total_in_flight,
                         elapsed_secs = elapsed.as_secs(),
                         "Phase transition"
                     );
@@ -650,49 +661,66 @@ impl MaxTpsArgs {
 
             // Drain completed send results
             while let Ok(result) = result_rx.try_recv() {
-                in_flight -= 1;
                 match result {
-                    SendResult::Success(pending_tx) => {
+                    SendResult::Success(url_idx, pending_tx) => {
+                        in_flight_per_url[url_idx] -= 1;
                         counters.sent.fetch_add(1, Ordering::Relaxed);
                         counters.success.fetch_add(1, Ordering::Relaxed);
                         pending_txs.push_back(pending_tx);
                     }
-                    SendResult::Failed => {
+                    SendResult::Failed(url_idx) => {
+                        in_flight_per_url[url_idx] -= 1;
                         counters.sent.fetch_add(1, Ordering::Relaxed);
                         counters.failed.fetch_add(1, Ordering::Relaxed);
                     }
                 }
             }
 
-            // Dispatch transactions up to available credit and concurrency
-            let to_send = (credit.floor() as usize)
-                .min(self.max_concurrent_requests.saturating_sub(in_flight));
+            // Dispatch transactions up to available credit and per-URL concurrency
+            let total_capacity: usize = in_flight_per_url
+                .iter()
+                .map(|&f| self.max_concurrent_requests.saturating_sub(f))
+                .sum();
+            let to_send = (credit.floor() as usize).min(total_capacity);
 
             for _ in 0..to_send {
-                // Pull a pre-generated tx from the buffer
-                let Some(bytes) = tx_stream.next().await else {
-                    warn!("Transaction generator exhausted");
+                // Find next URL with available capacity via round-robin
+                let mut found = false;
+                for _ in 0..num_urls {
+                    let idx = rr_index % num_urls;
+                    rr_index += 1;
+                    if in_flight_per_url[idx] < self.max_concurrent_requests {
+                        // Pull a pre-generated tx from the buffer
+                        let Some(bytes) = tx_stream.next().await else {
+                            warn!("Transaction generator exhausted");
+                            break;
+                        };
+
+                        credit -= 1.0;
+                        in_flight_per_url[idx] += 1;
+
+                        let provider = providers_with_urls[idx].1.clone();
+                        let result_tx = result_tx.clone();
+                        tokio::spawn(async move {
+                            let result = tokio::time::timeout(
+                                Duration::from_secs(1),
+                                provider.send_raw_transaction(&bytes),
+                            )
+                            .await;
+
+                            let send_result = match result {
+                                Ok(Ok(pending_tx)) => SendResult::Success(idx, pending_tx),
+                                _ => SendResult::Failed(idx),
+                            };
+                            let _ = result_tx.send(send_result).await;
+                        });
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
                     break;
-                };
-
-                credit -= 1.0;
-                in_flight += 1;
-
-                let provider = signer_provider_manager.random_unsigned_provider();
-                let result_tx = result_tx.clone();
-                tokio::spawn(async move {
-                    let result = tokio::time::timeout(
-                        Duration::from_secs(1),
-                        provider.send_raw_transaction(&bytes),
-                    )
-                    .await;
-
-                    let send_result = match result {
-                        Ok(Ok(pending_tx)) => SendResult::Success(pending_tx),
-                        _ => SendResult::Failed,
-                    };
-                    let _ = result_tx.send(send_result).await;
-                });
+                }
             }
 
             tokio::time::sleep(tick).await;
@@ -702,12 +730,12 @@ impl MaxTpsArgs {
         drop(result_tx);
         while let Some(result) = result_rx.recv().await {
             match result {
-                SendResult::Success(pending_tx) => {
+                SendResult::Success(_, pending_tx) => {
                     counters.sent.fetch_add(1, Ordering::Relaxed);
                     counters.success.fetch_add(1, Ordering::Relaxed);
                     pending_txs.push_back(pending_tx);
                 }
-                SendResult::Failed => {
+                SendResult::Failed(_) => {
                     counters.sent.fetch_add(1, Ordering::Relaxed);
                     counters.failed.fetch_add(1, Ordering::Relaxed);
                 }
@@ -783,9 +811,10 @@ impl MaxTpsArgs {
 }
 
 /// Result of a single transaction send attempt.
+/// The `usize` is the URL index for per-URL in-flight tracking.
 enum SendResult {
-    Success(PendingTransactionBuilder<TempoNetwork>),
-    Failed,
+    Success(usize, PendingTransactionBuilder<TempoNetwork>),
+    Failed(usize),
 }
 
 #[derive(Debug, Clone)]

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -1,6 +1,7 @@
 mod dex;
 mod erc20;
 mod mpp;
+pub(crate) mod scenario;
 
 use alloy_consensus::Transaction;
 use itertools::Itertools;
@@ -73,12 +74,20 @@ use tokio_util::sync::CancellationToken;
 
 use crate::cmd::signer_providers::SignerProviderManager;
 
+use self::scenario::Scenario;
+
 /// Run maximum TPS throughput benchmarking
 #[derive(Parser, Debug)]
 pub struct MaxTpsArgs {
-    /// Target transactions per second
+    /// Predefined stress test scenario. Overrides default values for TPS, duration,
+    /// weights, and other parameters. Any explicitly passed flags take precedence.
+    #[arg(long, value_enum)]
+    scenario: Option<Scenario>,
+
+    /// Target transactions per second.
+    /// Required unless `--scenario` is set.
     #[arg(short, long)]
-    tps: u64,
+    tps: Option<u64>,
 
     /// Test duration in seconds
     #[arg(short, long, default_value_t = 30)]
@@ -204,8 +213,94 @@ pub struct MaxTpsArgs {
 impl MaxTpsArgs {
     const WEIGHT_PRECISION: f64 = 1000.0;
 
-    pub async fn run(self) -> eyre::Result<()> {
+    /// Apply scenario overrides to fields that were left at their CLI defaults.
+    ///
+    /// Scenario values are used as defaults — any explicitly passed flag wins.
+    /// We detect "explicitly passed" by checking whether the current value differs
+    /// from the clap default. This is imperfect (a user could pass the default value),
+    /// but good enough for practical use.
+    fn apply_scenario(&mut self) {
+        let Some(scenario) = self.scenario else {
+            return;
+        };
+
+        let o = scenario.overrides();
+
+        // tps is Option — scenario fills it if the user didn't
+        if self.tps.is_none() {
+            self.tps = o.tps;
+        }
+
+        // For fields with clap defaults, only override if still at default
+        if self.duration == 30
+            && let Some(v) = o.duration
+        {
+            self.duration = v;
+        }
+        if self.accounts.get() == 100
+            && let Some(v) = o.accounts
+        {
+            self.accounts = NonZeroU64::new(v).unwrap_or(self.accounts);
+        }
+        if self.max_concurrent_requests == 100
+            && let Some(v) = o.max_concurrent_requests
+        {
+            self.max_concurrent_requests = v;
+        }
+        if self.tip20_weight == 1.0
+            && let Some(v) = o.tip20_weight
+        {
+            self.tip20_weight = v;
+        }
+        if self.erc20_weight == 0.0
+            && let Some(v) = o.erc20_weight
+        {
+            self.erc20_weight = v;
+        }
+        if self.mpp_weight == 0.0
+            && let Some(v) = o.mpp_weight
+        {
+            self.mpp_weight = v;
+        }
+        if self.place_order_weight == 0.0
+            && let Some(v) = o.place_order_weight
+        {
+            self.place_order_weight = v;
+        }
+        if self.swap_weight == 0.0
+            && let Some(v) = o.swap_weight
+        {
+            self.swap_weight = v;
+        }
+        if !self.existing_recipients
+            && let Some(v) = o.existing_recipients
+        {
+            self.existing_recipients = v;
+        }
+        if self.benchmark_mode.is_none() {
+            self.benchmark_mode = o.benchmark_mode;
+        }
+    }
+
+    pub async fn run(mut self) -> eyre::Result<()> {
         RethTracer::new().init()?;
+
+        self.apply_scenario();
+
+        // Resolve tps early and store it back so run_with_manager can access it
+        let tps = self
+            .tps
+            .ok_or_eyre("--tps is required (or use --scenario to set it)")?;
+        eyre::ensure!(tps > 0, "--tps must be > 0");
+        eyre::ensure!(u32::try_from(tps).is_ok(), "--tps must be <= {}", u32::MAX);
+        self.tps = Some(tps);
+
+        if let Some(ref scenario) = self.scenario {
+            info!(%scenario, tps, duration = self.duration, accounts = %self.accounts,
+                tip20 = self.tip20_weight, erc20 = self.erc20_weight, mpp = self.mpp_weight,
+                existing_recipients = self.existing_recipients,
+                "Running scenario");
+        }
 
         let accounts = self.accounts.get();
 
@@ -292,6 +387,9 @@ impl MaxTpsArgs {
         self,
         signer_provider_manager: SignerProviderManager<F>,
     ) -> eyre::Result<()> {
+        // tps was validated and stored in run() before calling this method
+        let tps = self.tps.expect("tps resolved in run()");
+
         // Validate required addresses before sending any transactions
         eyre::ensure!(
             self.mpp_weight == 0.0 || self.mpp_contract_address.is_some(),
@@ -405,7 +503,7 @@ impl MaxTpsArgs {
         };
 
         // Generate and send transactions
-        let total_txs = self.tps * self.duration;
+        let total_txs = tps * self.duration;
         let tip20_weight = (self.tip20_weight * Self::WEIGHT_PRECISION).trunc() as u64;
         let place_order_weight = (self.place_order_weight * Self::WEIGHT_PRECISION).trunc() as u64;
         let swap_weight = (self.swap_weight * Self::WEIGHT_PRECISION).trunc() as u64;
@@ -464,7 +562,7 @@ impl MaxTpsArgs {
         ));
 
         let rate_limiter =
-            RateLimiter::direct(Quota::per_second(NonZeroU32::new(self.tps as u32).unwrap()));
+            RateLimiter::direct(Quota::per_second(NonZeroU32::new(tps as u32).unwrap()));
         let start_block_number = provider.get_block_number().await?;
 
         let mut pending_txs =
@@ -474,7 +572,7 @@ impl MaxTpsArgs {
                 // Stop when duration exceeded, no matter if we sent all transactions or not
                 .take_until(sleep(Duration::from_secs(self.duration)))
                 // Keep a buffer of pre-generated transactions to send as fast as possible
-                .buffer_unordered(self.tps as usize)
+                .buffer_unordered(tps as usize)
                 // Filter only successfully generated transactions
                 .filter_map(|result| async {
                     match result {
@@ -1003,7 +1101,7 @@ pub async fn generate_report(
     }
 
     let metadata = BenchmarkMetadata {
-        target_tps: args.tps,
+        target_tps: args.tps.unwrap_or(0),
         run_duration_secs: args.duration,
         accounts: args.accounts.get(),
         chain_id: provider.get_chain_id().await?,

--- a/bin/tempo-bench/src/cmd/max_tps/metrics_scraper.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/metrics_scraper.rs
@@ -1,0 +1,229 @@
+use alloy::transports::http::reqwest::{self, Url};
+use reth_tracing::tracing::{debug, info, warn};
+use serde::Serialize;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use tokio_util::sync::CancellationToken;
+
+/// A single timestamped snapshot of Prometheus metrics from one node.
+#[derive(Debug, Clone, Serialize)]
+pub struct MetricsSnapshot {
+    /// Seconds since benchmark start.
+    pub elapsed_secs: f64,
+    /// Which metrics URL this came from.
+    pub url: String,
+    /// Parsed metric name → value (gauges and counters only).
+    pub metrics: BTreeMap<String, f64>,
+}
+
+/// Collects metrics snapshots over time.
+#[derive(Debug, Clone)]
+pub struct MetricsCollector {
+    snapshots: Arc<Mutex<Vec<MetricsSnapshot>>>,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self {
+            snapshots: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn push(&self, snapshot: MetricsSnapshot) {
+        self.snapshots.lock().unwrap().push(snapshot);
+    }
+
+    /// Consume the collector and return all snapshots.
+    pub fn into_snapshots(self) -> Vec<MetricsSnapshot> {
+        match Arc::try_unwrap(self.snapshots) {
+            Ok(mutex) => mutex.into_inner().unwrap(),
+            Err(arc) => arc.lock().unwrap().clone(),
+        }
+    }
+}
+
+/// Parse Prometheus exposition format text into metric name → value pairs.
+///
+/// Only parses simple numeric lines (gauges, counters, untyped).
+/// Skips comments, histograms buckets, and info metrics.
+fn parse_prometheus_text(text: &str) -> BTreeMap<String, f64> {
+    let mut metrics = BTreeMap::new();
+
+    for line in text.lines() {
+        let line = line.trim();
+
+        // Skip empty lines and comments
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Format: metric_name{labels} value [timestamp]
+        // or:     metric_name value [timestamp]
+        let (name_part, rest) = if line.find('{').is_some() {
+            // Has labels — use full name{labels} as key
+            if let Some(brace_end) = line.find('}') {
+                let key = &line[..=brace_end];
+                let rest = line[brace_end + 1..].trim();
+                (key, rest)
+            } else {
+                continue;
+            }
+        } else {
+            // No labels — split on whitespace
+            match line.split_once(|c: char| c.is_whitespace()) {
+                Some((name, rest)) => (name, rest.trim()),
+                None => continue,
+            }
+        };
+
+        // Parse value (first token after name)
+        let value_str = rest.split_whitespace().next().unwrap_or("");
+        if let Ok(value) = value_str.parse::<f64>()
+            && value.is_finite()
+        {
+            metrics.insert(name_part.to_string(), value);
+        }
+    }
+
+    metrics
+}
+
+/// Spawn a background task that periodically scrapes Prometheus metrics.
+///
+/// Returns the collector handle and the join handle for the scraper task.
+pub fn spawn_scraper(
+    metrics_urls: Vec<Url>,
+    scrape_interval: Duration,
+    token: CancellationToken,
+) -> MetricsCollector {
+    let collector = MetricsCollector::new();
+    let collector_clone = collector.clone();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("failed to create metrics HTTP client");
+
+    info!(
+        urls = ?metrics_urls.iter().map(|u| u.as_str()).collect::<Vec<_>>(),
+        interval_secs = scrape_interval.as_secs(),
+        "Starting metrics scraper"
+    );
+
+    tokio::spawn(async move {
+        let start = Instant::now();
+        let mut ticker = tokio::time::interval(scrape_interval);
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    let elapsed = start.elapsed();
+
+                    for url in &metrics_urls {
+                        match client.get(url.clone()).send().await {
+                            Ok(resp) => match resp.text().await {
+                                Ok(body) => {
+                                    let metrics = parse_prometheus_text(&body);
+                                    debug!(
+                                        url = %url,
+                                        metric_count = metrics.len(),
+                                        elapsed_secs = elapsed.as_secs(),
+                                        "Scraped metrics"
+                                    );
+                                    collector_clone.push(MetricsSnapshot {
+                                        elapsed_secs: elapsed.as_secs_f64(),
+                                        url: url.to_string(),
+                                        metrics,
+                                    });
+                                }
+                                Err(e) => {
+                                    warn!(url = %url, error = %e, "Failed to read metrics response body");
+                                }
+                            },
+                            Err(e) => {
+                                warn!(url = %url, error = %e, "Failed to scrape metrics");
+                            }
+                        }
+                    }
+                }
+                _ = token.cancelled() => {
+                    // Do one final scrape
+                    let elapsed = start.elapsed();
+                    for url in &metrics_urls {
+                        if let Ok(resp) = client.get(url.clone()).send().await
+                            && let Ok(body) = resp.text().await {
+                                let metrics = parse_prometheus_text(&body);
+                                collector_clone.push(MetricsSnapshot {
+                                    elapsed_secs: elapsed.as_secs_f64(),
+                                    url: url.to_string(),
+                                    metrics,
+                                });
+                            }
+                    }
+                    break;
+                }
+            }
+        }
+
+        info!(
+            total_snapshots = collector_clone.snapshots.lock().unwrap().len(),
+            "Metrics scraper stopped"
+        );
+    });
+
+    collector
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_metrics() {
+        let text = r#"
+# HELP reth_block_time Block time in milliseconds
+# TYPE reth_block_time gauge
+reth_block_time 250
+reth_txpool_pending 1234
+reth_process_cpu_seconds_total 42.5
+"#;
+        let metrics = parse_prometheus_text(text);
+        assert_eq!(metrics["reth_block_time"], 250.0);
+        assert_eq!(metrics["reth_txpool_pending"], 1234.0);
+        assert_eq!(metrics["reth_process_cpu_seconds_total"], 42.5);
+    }
+
+    #[test]
+    fn test_parse_labeled_metrics() {
+        let text = r#"
+http_requests_total{method="GET",path="/api"} 100
+http_requests_total{method="POST",path="/api"} 50
+"#;
+        let metrics = parse_prometheus_text(text);
+        assert_eq!(
+            metrics[r#"http_requests_total{method="GET",path="/api"}"#],
+            100.0
+        );
+        assert_eq!(
+            metrics[r#"http_requests_total{method="POST",path="/api"}"#],
+            50.0
+        );
+    }
+
+    #[test]
+    fn test_parse_skips_invalid() {
+        let text = r#"
+# comment
+valid_metric 42
+
+invalid_line
+metric_with_nan NaN
+metric_with_inf +Inf
+"#;
+        let metrics = parse_prometheus_text(text);
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics["valid_metric"], 42.0);
+    }
+}

--- a/bin/tempo-bench/src/cmd/max_tps/scenario.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/scenario.rs
@@ -2,6 +2,17 @@ use clap::ValueEnum;
 use serde::Deserialize;
 use std::{fmt, path::Path, time::Duration};
 
+/// Periodic burst/spike configuration within a phase.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BurstConfig {
+    /// TPS during the burst window.
+    pub tps: u64,
+    /// How long each burst lasts (seconds).
+    pub duration: u64,
+    /// Time between burst starts (seconds). Must be > burst duration.
+    pub interval: u64,
+}
+
 /// A single phase in a load profile.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Phase {
@@ -16,6 +27,9 @@ pub struct Phase {
     /// If false, jump to `target_tps` immediately.
     #[serde(default)]
     pub ramp: bool,
+    /// Optional periodic burst/spike overlay.
+    #[serde(default)]
+    pub burst: Option<BurstConfig>,
 }
 
 fn deserialize_duration_secs<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -55,7 +69,29 @@ impl LoadProfile {
         let mut prev_tps = 0u64;
         for phase in &self.phases {
             let secs = phase.duration.as_secs_f64();
-            if phase.ramp {
+            if let Some(burst) = &phase.burst {
+                let base_tps = if phase.ramp {
+                    (prev_tps as f64 + phase.target_tps as f64) / 2.0
+                } else {
+                    phase.target_tps as f64
+                };
+                let interval = burst.interval as f64;
+                let burst_dur = burst.duration as f64;
+                let normal_dur = interval - burst_dur;
+                let full_intervals = (secs / interval).floor() as u64;
+                let remainder = secs - (full_intervals as f64 * interval);
+                // Full intervals
+                total +=
+                    full_intervals as f64 * (burst.tps as f64 * burst_dur + base_tps * normal_dur);
+                // Partial last interval
+                if remainder > 0.0 {
+                    if remainder <= burst_dur {
+                        total += burst.tps as f64 * remainder;
+                    } else {
+                        total += burst.tps as f64 * burst_dur + base_tps * (remainder - burst_dur);
+                    }
+                }
+            } else if phase.ramp {
                 // Trapezoid: avg of start and end TPS
                 total += (prev_tps as f64 + phase.target_tps as f64) / 2.0 * secs;
             } else {
@@ -68,7 +104,11 @@ impl LoadProfile {
 
     /// Maximum TPS across all phases.
     pub fn max_tps(&self) -> u64 {
-        self.phases.iter().map(|p| p.target_tps).max().unwrap_or(0)
+        self.phases
+            .iter()
+            .map(|p| p.target_tps.max(p.burst.as_ref().map_or(0, |b| b.tps)))
+            .max()
+            .unwrap_or(0)
     }
 
     /// Returns the target TPS at elapsed time `t` from profile start.
@@ -79,13 +119,24 @@ impl LoadProfile {
         for phase in &self.phases {
             let phase_end = elapsed + phase.duration;
             if t < phase_end {
-                if phase.ramp && !phase.duration.is_zero() {
+                let base = if phase.ramp && !phase.duration.is_zero() {
                     let progress = (t - elapsed).as_secs_f64() / phase.duration.as_secs_f64();
                     let start = prev_tps as f64;
                     let end = phase.target_tps as f64;
-                    return start + (end - start) * progress;
+                    start + (end - start) * progress
+                } else {
+                    phase.target_tps as f64
+                };
+
+                if let Some(burst) = &phase.burst {
+                    let time_in_phase = (t - elapsed).as_secs_f64();
+                    let cycle_pos = time_in_phase % burst.interval as f64;
+                    if cycle_pos < burst.duration as f64 {
+                        return burst.tps as f64;
+                    }
                 }
-                return phase.target_tps as f64;
+
+                return base;
             }
             elapsed = phase_end;
             prev_tps = phase.target_tps;
@@ -192,6 +243,7 @@ impl Scenario {
                     target_tps: 10_000,
                     duration: Duration::from_secs(300),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::MixedWorkload => LoadProfile {
@@ -200,6 +252,7 @@ impl Scenario {
                     target_tps: 5_000,
                     duration: Duration::from_secs(300),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::BurstSpike => LoadProfile {
@@ -209,36 +262,42 @@ impl Scenario {
                         target_tps: 10_000,
                         duration: Duration::from_secs(60),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "hold".into(),
                         target_tps: 10_000,
                         duration: Duration::from_secs(120),
                         ramp: false,
+                        burst: None,
                     },
                     Phase {
                         name: "spike".into(),
                         target_tps: 25_000,
                         duration: Duration::from_secs(30),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "crash-down".into(),
                         target_tps: 1_000,
                         duration: Duration::from_secs(30),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "recover".into(),
                         target_tps: 5_000,
                         duration: Duration::from_secs(180),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "sustain".into(),
                         target_tps: 5_000,
                         duration: Duration::from_secs(180),
                         ramp: false,
+                        burst: None,
                     },
                 ],
             },
@@ -248,6 +307,7 @@ impl Scenario {
                     target_tps: 100,
                     duration: Duration::from_secs(120),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::StateHeavy => LoadProfile {
@@ -256,6 +316,7 @@ impl Scenario {
                     target_tps: 5_000,
                     duration: Duration::from_secs(120),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::TxpoolFlood => LoadProfile {
@@ -264,6 +325,7 @@ impl Scenario {
                     target_tps: 50_000,
                     duration: Duration::from_secs(60),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::Conflicting => LoadProfile {
@@ -272,6 +334,7 @@ impl Scenario {
                     target_tps: 5_000,
                     duration: Duration::from_secs(120),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::RpcSaturation => LoadProfile {
@@ -280,6 +343,7 @@ impl Scenario {
                     target_tps: 10_000,
                     duration: Duration::from_secs(300),
                     ramp: false,
+                    burst: None,
                 }],
             },
             Scenario::FullStressCycle => LoadProfile {
@@ -289,60 +353,70 @@ impl Scenario {
                         target_tps: 2_000,
                         duration: Duration::from_secs(120),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "sustain-low".into(),
                         target_tps: 2_000,
                         duration: Duration::from_secs(600),
                         ramp: false,
+                        burst: None,
                     },
                     Phase {
                         name: "ramp-up".into(),
                         target_tps: 10_000,
                         duration: Duration::from_secs(180),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "sustain-high".into(),
                         target_tps: 10_000,
                         duration: Duration::from_secs(900),
                         ramp: false,
+                        burst: None,
                     },
                     Phase {
                         name: "spike".into(),
                         target_tps: 25_000,
                         duration: Duration::from_secs(30),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "crash-down".into(),
                         target_tps: 1_000,
                         duration: Duration::from_secs(30),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "sustain-low-recovery".into(),
                         target_tps: 1_000,
                         duration: Duration::from_secs(600),
                         ramp: false,
+                        burst: None,
                     },
                     Phase {
                         name: "ramp-back".into(),
                         target_tps: 10_000,
                         duration: Duration::from_secs(300),
                         ramp: true,
+                        burst: None,
                     },
                     Phase {
                         name: "sustain-final".into(),
                         target_tps: 10_000,
                         duration: Duration::from_secs(600),
                         ramp: false,
+                        burst: None,
                     },
                     Phase {
                         name: "cooldown".into(),
                         target_tps: 0,
                         duration: Duration::from_secs(120),
                         ramp: true,
+                        burst: None,
                     },
                 ],
             },
@@ -434,6 +508,7 @@ mod tests {
                 target_tps: 5000,
                 duration: Duration::from_secs(60),
                 ramp: false,
+                burst: None,
             }],
         };
         assert_eq!(profile.tps_at(Duration::from_secs(0)), 5000.0);
@@ -450,6 +525,7 @@ mod tests {
                 target_tps: 10_000,
                 duration: Duration::from_secs(100),
                 ramp: true,
+                burst: None,
             }],
         };
         // Ramps from 0 (implicit start) to 10k over 100s
@@ -467,12 +543,14 @@ mod tests {
                     target_tps: 1000,
                     duration: Duration::from_secs(10),
                     ramp: false,
+                    burst: None,
                 },
                 Phase {
                     name: "ramp-up".into(),
                     target_tps: 5000,
                     duration: Duration::from_secs(10),
                     ramp: true,
+                    burst: None,
                 },
             ],
         };
@@ -491,6 +569,7 @@ mod tests {
                 target_tps: 1000,
                 duration: Duration::from_secs(10),
                 ramp: false,
+                burst: None,
             }],
         };
         assert_eq!(profile.expected_total_txs(), 10_000);
@@ -504,6 +583,7 @@ mod tests {
                 target_tps: 1000,
                 duration: Duration::from_secs(10),
                 ramp: true,
+                burst: None,
             }],
         };
         // Ramp from 0 to 1000 over 10s = avg 500 * 10 = 5000
@@ -526,12 +606,14 @@ mod tests {
                     target_tps: 100,
                     duration: Duration::from_secs(10),
                     ramp: false,
+                    burst: None,
                 },
                 Phase {
                     name: "b".into(),
                     target_tps: 200,
                     duration: Duration::from_secs(10),
                     ramp: false,
+                    burst: None,
                 },
             ],
         };
@@ -544,5 +626,69 @@ mod tests {
     fn test_max_tps() {
         let profile = Scenario::BurstSpike.profile();
         assert_eq!(profile.max_tps(), 25_000);
+    }
+
+    #[test]
+    fn test_burst_tps() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "burst-phase".into(),
+                target_tps: 2000,
+                duration: Duration::from_secs(60),
+                ramp: false,
+                burst: Some(BurstConfig {
+                    tps: 20_000,
+                    duration: 5,
+                    interval: 30,
+                }),
+            }],
+        };
+        // t=0: in burst window (cycle_pos=0 < 5)
+        assert_eq!(profile.tps_at(Duration::from_secs(0)), 20_000.0);
+        // t=6: outside burst window (cycle_pos=6 >= 5)
+        assert_eq!(profile.tps_at(Duration::from_secs(6)), 2000.0);
+        // t=30: second burst starts (cycle_pos=0 < 5)
+        assert_eq!(profile.tps_at(Duration::from_secs(30)), 20_000.0);
+        // t=36: outside second burst (cycle_pos=6 >= 5)
+        assert_eq!(profile.tps_at(Duration::from_secs(36)), 2000.0);
+    }
+
+    #[test]
+    fn test_burst_max_tps() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "burst-phase".into(),
+                target_tps: 2000,
+                duration: Duration::from_secs(60),
+                ramp: false,
+                burst: Some(BurstConfig {
+                    tps: 20_000,
+                    duration: 5,
+                    interval: 30,
+                }),
+            }],
+        };
+        assert_eq!(profile.max_tps(), 20_000);
+    }
+
+    #[test]
+    fn test_burst_expected_txs() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "burst-phase".into(),
+                target_tps: 2000,
+                duration: Duration::from_secs(60),
+                ramp: false,
+                burst: Some(BurstConfig {
+                    tps: 20_000,
+                    duration: 5,
+                    interval: 30,
+                }),
+            }],
+        };
+        // 60s / 30s interval = 2 full intervals, no remainder
+        // Each interval: 5s * 20000 + 25s * 2000 = 100000 + 50000 = 150000
+        // Total: 2 * 150000 = 300000
+        assert_eq!(profile.expected_total_txs(), 300_000);
     }
 }

--- a/bin/tempo-bench/src/cmd/max_tps/scenario.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/scenario.rs
@@ -1,43 +1,169 @@
 use clap::ValueEnum;
-use std::fmt;
+use serde::Deserialize;
+use std::{fmt, path::Path, time::Duration};
 
-/// Predefined benchmark scenarios for stress testing.
+/// A single phase in a load profile.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Phase {
+    /// Human-readable name for logging.
+    pub name: String,
+    /// Target TPS at the end of this phase.
+    pub target_tps: u64,
+    /// How long this phase lasts.
+    #[serde(deserialize_with = "deserialize_duration_secs")]
+    pub duration: Duration,
+    /// If true, linearly ramp from previous phase's TPS to `target_tps`.
+    /// If false, jump to `target_tps` immediately.
+    #[serde(default)]
+    pub ramp: bool,
+}
+
+fn deserialize_duration_secs<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let secs = u64::deserialize(deserializer)?;
+    Ok(Duration::from_secs(secs))
+}
+
+/// A load profile defines TPS over time as a sequence of phases.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoadProfile {
+    pub phases: Vec<Phase>,
+}
+
+impl LoadProfile {
+    /// Load a profile from a YAML file.
+    pub fn from_file(path: &Path) -> eyre::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let profile: LoadProfile = serde_yaml::from_str(&content)?;
+        eyre::ensure!(
+            !profile.phases.is_empty(),
+            "profile must have at least one phase"
+        );
+        Ok(profile)
+    }
+
+    /// Total duration across all phases.
+    pub fn total_duration(&self) -> Duration {
+        self.phases.iter().map(|p| p.duration).sum()
+    }
+
+    /// Expected total transactions (area under the TPS curve).
+    pub fn expected_total_txs(&self) -> u64 {
+        let mut total = 0.0f64;
+        let mut prev_tps = 0u64;
+        for phase in &self.phases {
+            let secs = phase.duration.as_secs_f64();
+            if phase.ramp {
+                // Trapezoid: avg of start and end TPS
+                total += (prev_tps as f64 + phase.target_tps as f64) / 2.0 * secs;
+            } else {
+                total += phase.target_tps as f64 * secs;
+            }
+            prev_tps = phase.target_tps;
+        }
+        total.ceil() as u64
+    }
+
+    /// Maximum TPS across all phases.
+    pub fn max_tps(&self) -> u64 {
+        self.phases.iter().map(|p| p.target_tps).max().unwrap_or(0)
+    }
+
+    /// Returns the target TPS at elapsed time `t` from profile start.
+    pub fn tps_at(&self, t: Duration) -> f64 {
+        let mut elapsed = Duration::ZERO;
+        let mut prev_tps = 0u64;
+
+        for phase in &self.phases {
+            let phase_end = elapsed + phase.duration;
+            if t < phase_end {
+                if phase.ramp && !phase.duration.is_zero() {
+                    let progress = (t - elapsed).as_secs_f64() / phase.duration.as_secs_f64();
+                    let start = prev_tps as f64;
+                    let end = phase.target_tps as f64;
+                    return start + (end - start) * progress;
+                }
+                return phase.target_tps as f64;
+            }
+            elapsed = phase_end;
+            prev_tps = phase.target_tps;
+        }
+
+        // Past the end of the profile
+        0.0
+    }
+
+    /// Compute number of transactions that should have been sent between `from` and `to`.
+    pub fn tx_budget_between(&self, from: Duration, to: Duration) -> f64 {
+        // Numerical integration with 100ms steps
+        let step = Duration::from_millis(100);
+        let mut t = from;
+        let mut budget = 0.0f64;
+        while t < to {
+            let dt = (to - t).min(step);
+            let tps = self.tps_at(t + dt / 2); // midpoint for better accuracy
+            budget += tps * dt.as_secs_f64();
+            t += dt;
+        }
+        budget
+    }
+
+    /// Name of the current phase at elapsed time `t`.
+    pub fn phase_at(&self, t: Duration) -> Option<&str> {
+        let mut elapsed = Duration::ZERO;
+        for phase in &self.phases {
+            let phase_end = elapsed + phase.duration;
+            if t < phase_end {
+                return Some(&phase.name);
+            }
+            elapsed = phase_end;
+        }
+        None
+    }
+}
+
+/// Static overrides that a scenario applies to [`MaxTpsArgs`].
+/// `None` means "keep whatever the user passed (or the CLI default)".
+#[derive(Default)]
+pub struct ScenarioOverrides {
+    pub accounts: Option<u64>,
+    pub max_concurrent_requests: Option<usize>,
+    pub tip20_weight: Option<f64>,
+    pub erc20_weight: Option<f64>,
+    pub mpp_weight: Option<f64>,
+    pub place_order_weight: Option<f64>,
+    pub swap_weight: Option<f64>,
+    pub existing_recipients: Option<bool>,
+    pub benchmark_mode: Option<String>,
+}
+
+/// Predefined benchmark scenarios.
 ///
-/// Each scenario overrides specific CLI defaults (TPS, duration, weights, concurrency, etc.)
-/// while still allowing individual flags to take precedence.
+/// Each scenario provides a load profile (phases) plus static overrides
+/// for accounts, weights, concurrency, etc.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Scenario {
-    /// 10k TPS sustained for 5 minutes. Tests txpool backlog and drain behavior
-    /// when ingress exceeds processing capacity.
+    /// 10k TPS sustained for 5 minutes.
     SustainedMax,
-
-    /// Realistic mainnet traffic: 80% TIP-20, 15% MPP, 5% ERC-20 at 5k TPS for 5 minutes.
+    /// Realistic mainnet traffic: 80% TIP-20, 15% MPP, 5% ERC-20 at 5k TPS for 5 min.
     MixedWorkload,
-
-    /// 1k TPS baseline → instant spike to 10k TPS → back to 1k.
-    /// Tests txpool elasticity and recovery.
+    /// Ramp to 10k, hold, spike to 25k, crash to 1k, recover — 10 min total.
     BurstSpike,
-
-    /// Low TPS with existing recipients — placeholder for future fat-batch tx generator
-    /// that targets 30M gas cap per tx. Currently sends normal TIP-20 transfers at low TPS.
+    /// Low TPS placeholder for future fat-batch txs.
     FatBatch,
-
-    /// Transactions to random new addresses (cold SSTOREs for account creation).
-    /// Forces disk I/O and state growth, breaking the in-memory fast path.
+    /// Random new recipients (cold SSTOREs). Forces disk I/O.
     StateHeavy,
-
-    /// 50k TPS flood of cheap TIP-20 transfers for 60 seconds.
-    /// Tests txpool memory limits and OOM resilience.
+    /// 50k TPS flood for 60 seconds.
     TxpoolFlood,
-
-    /// Transfers to existing signer addresses from many accounts.
-    /// Placeholder for future hot-spot recipient mode that forces serial state access.
-    /// Currently uses random existing recipients from the signer set.
+    /// Existing recipients, placeholder for hot-spot mode.
     Conflicting,
-
-    /// 10k TPS with high concurrency (500 concurrent requests).
-    /// Use multiple `--target-urls` for full RPC saturation effect.
+    /// High concurrency (500 concurrent requests).
     RpcSaturation,
+    /// Full stress cycle: warm up → sustain → spike → crash → recover → sustain → cool down.
+    /// ~58 minutes total.
+    FullStressCycle,
 }
 
 impl fmt::Display for Scenario {
@@ -51,43 +177,190 @@ impl fmt::Display for Scenario {
             Scenario::TxpoolFlood => write!(f, "txpool-flood"),
             Scenario::Conflicting => write!(f, "conflicting"),
             Scenario::RpcSaturation => write!(f, "rpc-saturation"),
+            Scenario::FullStressCycle => write!(f, "full-stress-cycle"),
         }
     }
 }
 
-/// Overrides that a scenario applies to [`MaxTpsArgs`].
-/// `None` means "keep whatever the user passed (or the CLI default)".
-#[derive(Default)]
-pub struct ScenarioOverrides {
-    pub tps: Option<u64>,
-    pub duration: Option<u64>,
-    pub accounts: Option<u64>,
-    pub max_concurrent_requests: Option<usize>,
-    pub tip20_weight: Option<f64>,
-    pub erc20_weight: Option<f64>,
-    pub mpp_weight: Option<f64>,
-    pub place_order_weight: Option<f64>,
-    pub swap_weight: Option<f64>,
-    pub existing_recipients: Option<bool>,
-    pub benchmark_mode: Option<String>,
-}
-
 impl Scenario {
+    /// Load profile for this scenario.
+    pub fn profile(self) -> LoadProfile {
+        match self {
+            Scenario::SustainedMax => LoadProfile {
+                phases: vec![Phase {
+                    name: "sustained-max".into(),
+                    target_tps: 10_000,
+                    duration: Duration::from_secs(300),
+                    ramp: false,
+                }],
+            },
+            Scenario::MixedWorkload => LoadProfile {
+                phases: vec![Phase {
+                    name: "mixed-workload".into(),
+                    target_tps: 5_000,
+                    duration: Duration::from_secs(300),
+                    ramp: false,
+                }],
+            },
+            Scenario::BurstSpike => LoadProfile {
+                phases: vec![
+                    Phase {
+                        name: "ramp-up".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(60),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "hold".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(120),
+                        ramp: false,
+                    },
+                    Phase {
+                        name: "spike".into(),
+                        target_tps: 25_000,
+                        duration: Duration::from_secs(30),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "crash-down".into(),
+                        target_tps: 1_000,
+                        duration: Duration::from_secs(30),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "recover".into(),
+                        target_tps: 5_000,
+                        duration: Duration::from_secs(180),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "sustain".into(),
+                        target_tps: 5_000,
+                        duration: Duration::from_secs(180),
+                        ramp: false,
+                    },
+                ],
+            },
+            Scenario::FatBatch => LoadProfile {
+                phases: vec![Phase {
+                    name: "fat-batch".into(),
+                    target_tps: 100,
+                    duration: Duration::from_secs(120),
+                    ramp: false,
+                }],
+            },
+            Scenario::StateHeavy => LoadProfile {
+                phases: vec![Phase {
+                    name: "state-heavy".into(),
+                    target_tps: 5_000,
+                    duration: Duration::from_secs(120),
+                    ramp: false,
+                }],
+            },
+            Scenario::TxpoolFlood => LoadProfile {
+                phases: vec![Phase {
+                    name: "txpool-flood".into(),
+                    target_tps: 50_000,
+                    duration: Duration::from_secs(60),
+                    ramp: false,
+                }],
+            },
+            Scenario::Conflicting => LoadProfile {
+                phases: vec![Phase {
+                    name: "conflicting".into(),
+                    target_tps: 5_000,
+                    duration: Duration::from_secs(120),
+                    ramp: false,
+                }],
+            },
+            Scenario::RpcSaturation => LoadProfile {
+                phases: vec![Phase {
+                    name: "rpc-saturation".into(),
+                    target_tps: 10_000,
+                    duration: Duration::from_secs(300),
+                    ramp: false,
+                }],
+            },
+            Scenario::FullStressCycle => LoadProfile {
+                phases: vec![
+                    Phase {
+                        name: "warm-up".into(),
+                        target_tps: 2_000,
+                        duration: Duration::from_secs(120),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "sustain-low".into(),
+                        target_tps: 2_000,
+                        duration: Duration::from_secs(600),
+                        ramp: false,
+                    },
+                    Phase {
+                        name: "ramp-up".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(180),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "sustain-high".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(900),
+                        ramp: false,
+                    },
+                    Phase {
+                        name: "spike".into(),
+                        target_tps: 25_000,
+                        duration: Duration::from_secs(30),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "crash-down".into(),
+                        target_tps: 1_000,
+                        duration: Duration::from_secs(30),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "sustain-low-recovery".into(),
+                        target_tps: 1_000,
+                        duration: Duration::from_secs(600),
+                        ramp: false,
+                    },
+                    Phase {
+                        name: "ramp-back".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(300),
+                        ramp: true,
+                    },
+                    Phase {
+                        name: "sustain-final".into(),
+                        target_tps: 10_000,
+                        duration: Duration::from_secs(600),
+                        ramp: false,
+                    },
+                    Phase {
+                        name: "cooldown".into(),
+                        target_tps: 0,
+                        duration: Duration::from_secs(120),
+                        ramp: true,
+                    },
+                ],
+            },
+        }
+    }
+
+    /// Static overrides (accounts, weights, concurrency) for this scenario.
     pub fn overrides(self) -> ScenarioOverrides {
         match self {
-            Scenario::SustainedMax => ScenarioOverrides {
-                tps: Some(10_000),
-                duration: Some(300),
+            Scenario::SustainedMax | Scenario::FullStressCycle => ScenarioOverrides {
                 accounts: Some(200),
                 max_concurrent_requests: Some(200),
                 tip20_weight: Some(1.0),
                 existing_recipients: Some(true),
-                benchmark_mode: Some("sustained-max".into()),
+                benchmark_mode: Some(self.to_string()),
                 ..ScenarioOverrides::default()
             },
             Scenario::MixedWorkload => ScenarioOverrides {
-                tps: Some(5_000),
-                duration: Some(300),
                 accounts: Some(200),
                 max_concurrent_requests: Some(200),
                 tip20_weight: Some(0.80),
@@ -98,11 +371,6 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
             Scenario::BurstSpike => ScenarioOverrides {
-                // The burst is emulated by running at 10k TPS for a short window.
-                // A real multi-phase ramp requires orchestrator changes;
-                // for now, the spike phase is the interesting part.
-                tps: Some(10_000),
-                duration: Some(30),
                 accounts: Some(200),
                 max_concurrent_requests: Some(200),
                 tip20_weight: Some(1.0),
@@ -111,9 +379,6 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
             Scenario::FatBatch => ScenarioOverrides {
-                // Lower TPS because each tx is huge (~30M gas).
-                tps: Some(100),
-                duration: Some(120),
                 accounts: Some(50),
                 max_concurrent_requests: Some(50),
                 tip20_weight: Some(1.0),
@@ -122,19 +387,14 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
             Scenario::StateHeavy => ScenarioOverrides {
-                tps: Some(5_000),
-                duration: Some(120),
                 accounts: Some(500),
                 max_concurrent_requests: Some(200),
                 tip20_weight: Some(1.0),
-                // Random recipients = cold SSTOREs for new accounts
                 existing_recipients: Some(false),
                 benchmark_mode: Some("state-heavy".into()),
                 ..ScenarioOverrides::default()
             },
             Scenario::TxpoolFlood => ScenarioOverrides {
-                tps: Some(50_000),
-                duration: Some(60),
                 accounts: Some(500),
                 max_concurrent_requests: Some(500),
                 tip20_weight: Some(1.0),
@@ -143,8 +403,6 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
             Scenario::Conflicting => ScenarioOverrides {
-                tps: Some(5_000),
-                duration: Some(120),
                 accounts: Some(500),
                 max_concurrent_requests: Some(200),
                 tip20_weight: Some(1.0),
@@ -153,8 +411,6 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
             Scenario::RpcSaturation => ScenarioOverrides {
-                tps: Some(10_000),
-                duration: Some(300),
                 accounts: Some(200),
                 max_concurrent_requests: Some(500),
                 tip20_weight: Some(1.0),
@@ -163,5 +419,130 @@ impl Scenario {
                 ..ScenarioOverrides::default()
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_phase_tps() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "hold".into(),
+                target_tps: 5000,
+                duration: Duration::from_secs(60),
+                ramp: false,
+            }],
+        };
+        assert_eq!(profile.tps_at(Duration::from_secs(0)), 5000.0);
+        assert_eq!(profile.tps_at(Duration::from_secs(30)), 5000.0);
+        assert_eq!(profile.tps_at(Duration::from_secs(59)), 5000.0);
+        assert_eq!(profile.tps_at(Duration::from_secs(60)), 0.0); // past end
+    }
+
+    #[test]
+    fn test_ramp_phase_tps() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "ramp".into(),
+                target_tps: 10_000,
+                duration: Duration::from_secs(100),
+                ramp: true,
+            }],
+        };
+        // Ramps from 0 (implicit start) to 10k over 100s
+        assert_eq!(profile.tps_at(Duration::ZERO), 0.0);
+        assert_eq!(profile.tps_at(Duration::from_secs(50)), 5000.0);
+        assert_eq!(profile.tps_at(Duration::from_secs(100)), 0.0); // past end
+    }
+
+    #[test]
+    fn test_multi_phase_tps() {
+        let profile = LoadProfile {
+            phases: vec![
+                Phase {
+                    name: "hold-low".into(),
+                    target_tps: 1000,
+                    duration: Duration::from_secs(10),
+                    ramp: false,
+                },
+                Phase {
+                    name: "ramp-up".into(),
+                    target_tps: 5000,
+                    duration: Duration::from_secs(10),
+                    ramp: true,
+                },
+            ],
+        };
+        // First phase: constant 1000
+        assert_eq!(profile.tps_at(Duration::from_secs(5)), 1000.0);
+        // Second phase: ramp from 1000 to 5000 over 10s
+        assert_eq!(profile.tps_at(Duration::from_secs(10)), 1000.0); // start of ramp
+        assert_eq!(profile.tps_at(Duration::from_secs(15)), 3000.0); // midpoint
+    }
+
+    #[test]
+    fn test_expected_total_txs() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "hold".into(),
+                target_tps: 1000,
+                duration: Duration::from_secs(10),
+                ramp: false,
+            }],
+        };
+        assert_eq!(profile.expected_total_txs(), 10_000);
+    }
+
+    #[test]
+    fn test_expected_total_txs_ramp() {
+        let profile = LoadProfile {
+            phases: vec![Phase {
+                name: "ramp".into(),
+                target_tps: 1000,
+                duration: Duration::from_secs(10),
+                ramp: true,
+            }],
+        };
+        // Ramp from 0 to 1000 over 10s = avg 500 * 10 = 5000
+        assert_eq!(profile.expected_total_txs(), 5000);
+    }
+
+    #[test]
+    fn test_full_stress_cycle_duration() {
+        let profile = Scenario::FullStressCycle.profile();
+        // 120 + 600 + 180 + 900 + 30 + 30 + 600 + 300 + 600 + 120 = 3480s = 58 min
+        assert_eq!(profile.total_duration(), Duration::from_secs(3480));
+    }
+
+    #[test]
+    fn test_phase_at() {
+        let profile = LoadProfile {
+            phases: vec![
+                Phase {
+                    name: "a".into(),
+                    target_tps: 100,
+                    duration: Duration::from_secs(10),
+                    ramp: false,
+                },
+                Phase {
+                    name: "b".into(),
+                    target_tps: 200,
+                    duration: Duration::from_secs(10),
+                    ramp: false,
+                },
+            ],
+        };
+        assert_eq!(profile.phase_at(Duration::from_secs(5)), Some("a"));
+        assert_eq!(profile.phase_at(Duration::from_secs(15)), Some("b"));
+        assert_eq!(profile.phase_at(Duration::from_secs(20)), None);
+    }
+
+    #[test]
+    fn test_max_tps() {
+        let profile = Scenario::BurstSpike.profile();
+        assert_eq!(profile.max_tps(), 25_000);
     }
 }

--- a/bin/tempo-bench/src/cmd/max_tps/scenario.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/scenario.rs
@@ -1,0 +1,167 @@
+use clap::ValueEnum;
+use std::fmt;
+
+/// Predefined benchmark scenarios for stress testing.
+///
+/// Each scenario overrides specific CLI defaults (TPS, duration, weights, concurrency, etc.)
+/// while still allowing individual flags to take precedence.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum Scenario {
+    /// 10k TPS sustained for 5 minutes. Tests txpool backlog and drain behavior
+    /// when ingress exceeds processing capacity.
+    SustainedMax,
+
+    /// Realistic mainnet traffic: 80% TIP-20, 15% MPP, 5% ERC-20 at 5k TPS for 5 minutes.
+    MixedWorkload,
+
+    /// 1k TPS baseline → instant spike to 10k TPS → back to 1k.
+    /// Tests txpool elasticity and recovery.
+    BurstSpike,
+
+    /// Low TPS with existing recipients — placeholder for future fat-batch tx generator
+    /// that targets 30M gas cap per tx. Currently sends normal TIP-20 transfers at low TPS.
+    FatBatch,
+
+    /// Transactions to random new addresses (cold SSTOREs for account creation).
+    /// Forces disk I/O and state growth, breaking the in-memory fast path.
+    StateHeavy,
+
+    /// 50k TPS flood of cheap TIP-20 transfers for 60 seconds.
+    /// Tests txpool memory limits and OOM resilience.
+    TxpoolFlood,
+
+    /// Transfers to existing signer addresses from many accounts.
+    /// Placeholder for future hot-spot recipient mode that forces serial state access.
+    /// Currently uses random existing recipients from the signer set.
+    Conflicting,
+
+    /// 10k TPS with high concurrency (500 concurrent requests).
+    /// Use multiple `--target-urls` for full RPC saturation effect.
+    RpcSaturation,
+}
+
+impl fmt::Display for Scenario {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scenario::SustainedMax => write!(f, "sustained-max"),
+            Scenario::MixedWorkload => write!(f, "mixed-workload"),
+            Scenario::BurstSpike => write!(f, "burst-spike"),
+            Scenario::FatBatch => write!(f, "fat-batch"),
+            Scenario::StateHeavy => write!(f, "state-heavy"),
+            Scenario::TxpoolFlood => write!(f, "txpool-flood"),
+            Scenario::Conflicting => write!(f, "conflicting"),
+            Scenario::RpcSaturation => write!(f, "rpc-saturation"),
+        }
+    }
+}
+
+/// Overrides that a scenario applies to [`MaxTpsArgs`].
+/// `None` means "keep whatever the user passed (or the CLI default)".
+#[derive(Default)]
+pub struct ScenarioOverrides {
+    pub tps: Option<u64>,
+    pub duration: Option<u64>,
+    pub accounts: Option<u64>,
+    pub max_concurrent_requests: Option<usize>,
+    pub tip20_weight: Option<f64>,
+    pub erc20_weight: Option<f64>,
+    pub mpp_weight: Option<f64>,
+    pub place_order_weight: Option<f64>,
+    pub swap_weight: Option<f64>,
+    pub existing_recipients: Option<bool>,
+    pub benchmark_mode: Option<String>,
+}
+
+impl Scenario {
+    pub fn overrides(self) -> ScenarioOverrides {
+        match self {
+            Scenario::SustainedMax => ScenarioOverrides {
+                tps: Some(10_000),
+                duration: Some(300),
+                accounts: Some(200),
+                max_concurrent_requests: Some(200),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("sustained-max".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::MixedWorkload => ScenarioOverrides {
+                tps: Some(5_000),
+                duration: Some(300),
+                accounts: Some(200),
+                max_concurrent_requests: Some(200),
+                tip20_weight: Some(0.80),
+                mpp_weight: Some(0.15),
+                erc20_weight: Some(0.05),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("mixed-workload".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::BurstSpike => ScenarioOverrides {
+                // The burst is emulated by running at 10k TPS for a short window.
+                // A real multi-phase ramp requires orchestrator changes;
+                // for now, the spike phase is the interesting part.
+                tps: Some(10_000),
+                duration: Some(30),
+                accounts: Some(200),
+                max_concurrent_requests: Some(200),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("burst-spike".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::FatBatch => ScenarioOverrides {
+                // Lower TPS because each tx is huge (~30M gas).
+                tps: Some(100),
+                duration: Some(120),
+                accounts: Some(50),
+                max_concurrent_requests: Some(50),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("fat-batch".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::StateHeavy => ScenarioOverrides {
+                tps: Some(5_000),
+                duration: Some(120),
+                accounts: Some(500),
+                max_concurrent_requests: Some(200),
+                tip20_weight: Some(1.0),
+                // Random recipients = cold SSTOREs for new accounts
+                existing_recipients: Some(false),
+                benchmark_mode: Some("state-heavy".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::TxpoolFlood => ScenarioOverrides {
+                tps: Some(50_000),
+                duration: Some(60),
+                accounts: Some(500),
+                max_concurrent_requests: Some(500),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("txpool-flood".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::Conflicting => ScenarioOverrides {
+                tps: Some(5_000),
+                duration: Some(120),
+                accounts: Some(500),
+                max_concurrent_requests: Some(200),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("conflicting".into()),
+                ..ScenarioOverrides::default()
+            },
+            Scenario::RpcSaturation => ScenarioOverrides {
+                tps: Some(10_000),
+                duration: Some(300),
+                accounts: Some(200),
+                max_concurrent_requests: Some(500),
+                tip20_weight: Some(1.0),
+                existing_recipients: Some(true),
+                benchmark_mode: Some("rpc-saturation".into()),
+                ..ScenarioOverrides::default()
+            },
+        }
+    }
+}

--- a/bin/tempo-bench/src/cmd/signer_providers.rs
+++ b/bin/tempo-bench/src/cmd/signer_providers.rs
@@ -114,6 +114,15 @@ impl<F: TxFiller<TempoNetwork> + 'static> SignerProviderManager<F> {
             .clone()
     }
 
+    /// Returns unsigned providers paired with their target URLs.
+    pub fn unsigned_providers_with_urls(&self) -> Vec<(&Url, &BenchProvider<F>)> {
+        self.0
+            .target_urls
+            .iter()
+            .zip(self.0.unsigned_providers.iter())
+            .collect()
+    }
+
     /// Returns a random signer.
     pub fn random_signer(&self) -> &Secp256k1Signer {
         self.0.signers.choose(&mut rand::rng()).unwrap()


### PR DESCRIPTION
Replaces the static single-TPS scenario system with multi-phase load profiles,
burst spikes, and per-RPC concurrency.

**Load profiles** — each phase defines target TPS, duration, and optional linear ramp.
Three ways to define load:
- `--tps 10000 --duration 300` — simple constant, backwards compatible
- `--scenario full-stress-cycle` — built-in multi-phase preset (~58 min)
- `--profile my-profile.yaml` — custom YAML phases

**Burst spikes** — any phase can overlay periodic square-wave bursts:
```yaml
- name: spikey-baseline
  target_tps: 3000
  duration: 300
  burst:
    tps: 20000
    duration: 5
    interval: 30
```

**Per-RPC concurrency** — each `--target-url` gets its own `max_concurrent_requests`
budget via round-robin dispatch. 3 RPCs × 200 concurrent = 600 total connections,
each RPC independently saturated.

**Credit-based pacer** — replaces `governor` rate limiter with 50ms-tick dispatch
loop. One long-lived tx generator stream across all phases.

Built-in scenarios: `burst-spike` is now multi-phase (ramp→hold→spike→crash→recover),
`full-stress-cycle` runs warm-up→sustain→spike→crash→recover→sustain→cooldown.
Report metadata includes full phase list. Monitor logs show actual vs target TPS and
current phase.

Co-Authored-By: Georgios Konstantopoulos <17802178+gakonst@users.noreply.github.com>

Prompted by: georgios