### PR TITLE
feat(metrics): add payment volume metric to payload builder

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -382,6 +382,7 @@ where
 
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
+        let mut payment_volume = U256::ZERO;
         while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
@@ -490,6 +491,7 @@ where
 
             // update and add to total fees
             total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
+            payment_volume = payment_volume.saturating_add(pool_tx.transaction.value());
             cumulative_gas_used += gas_used;
             if !is_payment {
                 non_payment_gas_used += gas_used;
@@ -551,6 +553,7 @@ where
                     }
                 }
 
+                payment_volume = payment_volume.saturating_add(tx.value());
                 subblock_tx_count += 1.0;
             }
 
@@ -625,6 +628,10 @@ where
         let gas_used = block.gas_used();
         self.metrics.gas_used.record(gas_used as f64);
         self.metrics.gas_used_last.set(gas_used as f64);
+
+        let payment_volume_f64 = payment_volume.saturating_to::<u128>() as f64;
+        self.metrics.payment_volume.record(payment_volume_f64);
+        self.metrics.payment_volume_last.set(payment_volume_f64);
 
         let requests = chain_spec
             .is_prague_active_at_timestamp(attributes.timestamp())

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -73,6 +73,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) rlp_block_size_bytes: Histogram,
     /// RLP-encoded block size in bytes for the last payload.
     pub(crate) rlp_block_size_bytes_last: Gauge,
+    /// Total payment volume (sum of transaction values) in the payload, in wei.
+    pub(crate) payment_volume: Histogram,
+    /// Total payment volume for the last payload, in wei.
+    pub(crate) payment_volume_last: Gauge,
     /// Time to compute the hashed post-state from the bundle state.
     pub(crate) hashed_post_state_duration_seconds: Histogram,
     /// Time to compute the state root and trie updates via `state_root_with_updates`.


### PR DESCRIPTION
## Summary

Adds `reth_tempo_payload_builder_payment_volume` (histogram) and `reth_tempo_payload_builder_payment_volume_last` (gauge) metrics that track total transaction value (sum of `tx.value()`) per block.

This enables a **TPV (Transaction Payment Volume)** panel on the Tempo Overview Grafana dashboard.

## Changes

- **`crates/payload/builder/src/metrics.rs`**: Added `payment_volume` histogram and `payment_volume_last` gauge fields
- **`crates/payload/builder/src/lib.rs`**: Accumulates `tx.value()` for both pool transactions and subblock transactions, records the metric alongside gas_used

## Grafana Query

Once deployed, the TPV panel can use:

```promql
avg(
  reth_tempo_payload_builder_payment_volume_last{namespace=~"$namespace"}
  * on (pod, namespace) group_left
  kube_pod_labels{
    label_app_tempo_xyz_nodetype="validator"
  }
)
```

Note: values are in wei — divide by `1e18` for human-readable amounts.