### PR TITLE
fix(dex): check recipient auth in cancel_stale_order

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1184,19 +1184,34 @@ impl StablecoinDEX {
         }
 
         let book = self.books[order.book_key()].read()?;
-        let token = if order.is_bid() {
-            book.quote
+        let (escrow_token, payout_token) = if order.is_bid() {
+            (book.quote, book.base)
         } else {
-            book.base
+            (book.base, book.quote)
         };
 
-        let policy_id = TIP20Token::from_address(token)?.transfer_policy_id()?;
+        let registry = TIP403Registry::new();
+
+        // Check sender auth on escrow token
+        let escrow_policy = TIP20Token::from_address(escrow_token)?.transfer_policy_id()?;
         // Invalid policy ids throw under_overflow. Treat as unauthorized to clear the orders.
-        match TIP403Registry::new().is_authorized_as(policy_id, order.maker(), AuthRole::sender()) {
-            Ok(true) => Err(StablecoinDEXError::order_not_stale().into()),
-            Err(e) if e != TempoPrecompileError::under_overflow() => Err(e),
-            _ => self.cancel_active_order(order),
+        match registry.is_authorized_as(escrow_policy, order.maker(), AuthRole::sender()) {
+            Ok(true) => {}
+            Err(e) if e != TempoPrecompileError::under_overflow() => return Err(e),
+            _ => return self.cancel_active_order(order),
         }
+
+        // (T2+) Check recipient auth on payout token
+        if self.storage.spec().is_t2() {
+            let payout_policy = TIP20Token::from_address(payout_token)?.transfer_policy_id()?;
+            match registry.is_authorized_as(payout_policy, order.maker(), AuthRole::recipient()) {
+                Ok(true) => {}
+                Err(e) if e != TempoPrecompileError::under_overflow() => return Err(e),
+                _ => return self.cancel_active_order(order),
+            }
+        }
+
+        Err(StablecoinDEXError::order_not_stale().into())
     }
 
     /// Withdraws `amount` from the caller's DEX balance, transferring

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -4034,6 +4034,66 @@ mod tests {
     }
 
     #[test]
+    fn test_cancel_stale_order_output_token_blacklists_maker() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1).with_spec(TempoHardfork::T2);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            // Create quote (pathUSD) with policy
+            let mut quote = TIP20Setup::path_usd(admin).apply()?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            // Create base token (no policy)
+            let base = TIP20Setup::create("USDC", "USDC", admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(MIN_ORDER_AMOUNT * 2))
+                .with_approval(alice, exchange.address, U256::from(MIN_ORDER_AMOUNT * 2))
+                .apply()?;
+
+            exchange.create_pair(base.address())?;
+            // Sell order: escrow=base, payout=quote
+            let order_id = exchange.place(alice, base.address(), MIN_ORDER_AMOUNT, false, 0)?;
+
+            // Blacklist alice as recipient on the payout (quote) token
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            exchange.cancel_stale_order(order_id)?;
+
+            assert_eq!(
+                exchange.balance_of(alice, base.address())?,
+                MIN_ORDER_AMOUNT
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_cancel_stale_not_stale() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, || {
@@ -4067,6 +4127,66 @@ mod tests {
             exchange.create_pair(base.address())?;
             let order_id = exchange.place(alice, base.address(), MIN_ORDER_AMOUNT, false, 0)?;
 
+            let result = exchange.cancel_stale_order(order_id);
+            assert!(result.is_err());
+            assert!(matches!(
+                result.unwrap_err(),
+                TempoPrecompileError::StablecoinDEX(StablecoinDEXError::OrderNotStale(_))
+            ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_cancel_stale_not_stale_output_token_blacklist_t1() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let alice = Address::random();
+            let admin = Address::random();
+
+            let mut registry = TIP403Registry::new();
+            let policy_id = registry.create_policy(
+                admin,
+                ITIP403Registry::createPolicyCall {
+                    admin,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+
+            // Create quote (pathUSD) with policy
+            let mut quote = TIP20Setup::path_usd(admin).apply()?;
+            quote.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: policy_id,
+                },
+            )?;
+
+            // Create base token (no policy)
+            let base = TIP20Setup::create("USDC", "USDC", admin)
+                .with_issuer(admin)
+                .with_mint(alice, U256::from(MIN_ORDER_AMOUNT * 2))
+                .with_approval(alice, exchange.address, U256::from(MIN_ORDER_AMOUNT * 2))
+                .apply()?;
+
+            exchange.create_pair(base.address())?;
+            let order_id = exchange.place(alice, base.address(), MIN_ORDER_AMOUNT, false, 0)?;
+
+            // Blacklist alice as recipient on the payout (quote) token
+            registry.modify_policy_blacklist(
+                admin,
+                ITIP403Registry::modifyPolicyBlacklistCall {
+                    policyId: policy_id,
+                    account: alice,
+                    restricted: true,
+                },
+            )?;
+
+            // On T1 the payout-token recipient check is skipped, so order is not stale
             let result = exchange.cancel_stale_order(order_id);
             assert!(result.is_err());
             assert!(matches!(


### PR DESCRIPTION
On T2+, also check payout token recipient authorization so orders from deauthorized recipients can be cleaned up.

Closes ZELLIC-66