### PR TITLE
fix(readme): pass provider by reference

### DIFF
--- a/crates/alloy/README.md
+++ b/crates/alloy/README.md
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
  
     let token = ITIP20::new( 
         address!("0x20c0000000000000000000000000000000000001"), // AlphaUSD 
-        provider, 
+        &provider, 
     ); 
  
     let receipt = token 


### PR DESCRIPTION
Fix ITIP20 example: pass `&provider` instead of provider to `ITIP20::new()` to match the actual API used in `examples/transfer.rs`.