### PR TITLE
refactor(consensus): remove public polynomial from enter span

### DIFF
--- a/crates/commonware-node/src/epoch/manager/actor.rs
+++ b/crates/commonware-node/src/epoch/manager/actor.rs
@@ -272,7 +272,6 @@ where
         skip_all,
         fields(
             %epoch,
-            ?public,
             ?participants,
         ),
         err(level = Level::WARN)


### PR DESCRIPTION
Removes the `?public` field from the `#[instrument]` on `enter()` in the epoch manager. The public polynomial (DKG sharing params) is verbose and not useful in logs — the network identity is enough.

Prompted by: alexey