### PR TITLE
refactor(chainspec): replace hardfork matches with fallthrough if

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -65,8 +65,8 @@ macro_rules! tempo_hardfork {
             paste::paste! {
                 $(
                     #[doc = concat!("Returns true if this hardfork is ", stringify!($variant), " or later.")]
-                    pub fn [<is_ $variant:lower>](&self) -> bool {
-                        *self >= Self::$variant
+                    pub const fn [<is_ $variant:lower>](&self) -> bool {
+                        *self as u64 >= Self::$variant as u64
                     }
                 )*
             }
@@ -196,24 +196,20 @@ impl TempoHardfork {
     ///
     /// Economic conversion: ceil(basefee × gas_used / 10^12) = cost in microdollars (TIP-20 tokens)
     pub const fn base_fee(&self) -> u64 {
-        match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
-                crate::spec::TEMPO_T1_BASE_FEE
-            }
-            Self::T0 | Self::Genesis => crate::spec::TEMPO_T0_BASE_FEE,
+        if self.is_t1() {
+            return crate::spec::TEMPO_T1_BASE_FEE;
         }
+        crate::spec::TEMPO_T0_BASE_FEE
     }
 
     /// Returns the fixed general gas limit for T1+, or None for pre-T1.
     /// - Pre-T1: None
     /// - T1+: 30M gas (fixed)
     pub const fn general_gas_limit(&self) -> Option<u64> {
-        match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
-                Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT)
-            }
-            Self::T0 | Self::Genesis => None,
+        if self.is_t1() {
+            return Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT);
         }
+        None
     }
 
     /// Returns the per-transaction gas limit cap.
@@ -222,32 +218,26 @@ impl TempoHardfork {
     ///
     /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     pub const fn tx_gas_limit_cap(&self) -> Option<u64> {
-        match self {
-            Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
-                Some(crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP)
-            }
-            Self::T0 | Self::Genesis | Self::T1 => Some(MAX_TX_GAS_LIMIT_OSAKA),
+        if self.is_t1a() {
+            return Some(crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP);
         }
+        Some(MAX_TX_GAS_LIMIT_OSAKA)
     }
 
     /// Gas cost for using an existing 2D nonce key
     pub const fn gas_existing_nonce_key(&self) -> u64 {
-        match self {
-            Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
-                crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
-            }
-            Self::T2 | Self::T3 => crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS,
+        if self.is_t2() {
+            return crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS;
         }
+        crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
     }
 
     /// Gas cost for using a new 2D nonce key
     pub const fn gas_new_nonce_key(&self) -> u64 {
-        match self {
-            Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
-                crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
-            }
-            Self::T2 | Self::T3 => crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS,
+        if self.is_t2() {
+            return crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS;
         }
+        crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
     }
 }
 


### PR DESCRIPTION
Replaces exhaustive `match` arms in `TempoHardfork` methods with fallthrough `if self.is_*() { return x; } y` pattern. New hardforks no longer require updating every function body.

Also makes the `is_*` helpers `const fn` (using discriminant comparison) so they work in the existing `const fn` methods.

Prompted by: Dragan