### PR TITLE
fix: add persistence barrier on production shutdown

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -41,6 +41,7 @@ use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands, evm::revm::prim
 use reth_ethereum_cli::Cli;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
 use reth_rpc_server_types::DefaultRpcModuleValidator;
+use reth_storage_api::DatabaseProviderFactory as _;
 use std::{sync::Arc, thread};
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use tempo_commonware_node::{feed as consensus_feed, run_consensus_stack};
@@ -467,6 +468,9 @@ fn main() -> eyre::Result<()> {
             .await
             .wrap_err("failed launching execution node")?;
 
+        // Keep a provider handle for the persistence barrier on shutdown.
+        let provider = node.provider.clone();
+
         let _ = args_and_node_handle_tx.send((node, args));
 
         // TODO: emit these inside a span
@@ -481,6 +485,14 @@ fn main() -> eyre::Result<()> {
                 tracing::info!("received shutdown signal");
             }
         }
+
+        // Acquire a RW transaction and immediately drop it. This blocks until
+        // any pending write transaction completes, ensuring all database writes
+        // are fully flushed before the process exits. Without this, a pending
+        // persistence write could still be in-flight (static files and RocksDB
+        // committed but MDBX not yet), leading to cross-backend inconsistencies
+        // on restart.
+        drop(provider.database_provider_rw());
 
         #[cfg(feature = "pyroscope")]
         if let Some(agent) = pyroscope_agent {


### PR DESCRIPTION
Adds an explicit persistence write-drain barrier to the production shutdown path, matching what E2E tests already do in [`testing_node.rs:393-404`](https://github.com/tempoxyz/tempo/blob/2d0b4b6/crates/e2e/src/testing_node.rs#L393-L404).

## Problem

On `DatabaseProvider::commit()`, Tempo writes to 3 backends in order: Static Files → RocksDB → MDBX. The persistence writer runs on an OS thread (`spawn_os_thread`), outside tokio's task accounting.

On Ctrl+C, reth's `CliRunner` calls `graceful_shutdown_with_timeout(5s)` — but that only waits for tokio graceful tasks, not the persistence OS thread. If the process exits mid-commit, Static Files and RocksDB can be ahead of MDBX.

**Impact:** on restart, the node sees inconsistent state across backends and needs to roll back, potentially losing the tail of recently persisted blocks.

```mermaid
sequenceDiagram
    participant P as Process
    participant SF as Static Files
    participant R as RocksDB
    participant M as MDBX

    Note over P: Ctrl+C during save_blocks()
    P->>SF: finalize ✅
    P->>R: commit ✅
    Note over P: Process exits before MDBX commit
    P--xM: commit ❌
    Note over SF,M: Restart: SF+RocksDB at block N, MDBX at N-1
```

## Fix

Before returning from the shutdown closure, acquire and immediately drop a RW transaction via `database_provider_rw()`. MDBX only allows one writer at a time, so this blocks until any in-flight write completes.

```mermaid
flowchart LR
    A["select! exits"] --> B["database_provider_rw() — blocks until writer finishes"]
    B --> C["drop — all 3 backends consistent"]

    style B fill:#1a3a1a,stroke:#4ade80,color:#4ade80
```

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk