### PR TITLE
refactor(precompiles): remove unused get_validators from ValidatorConfigV2

### DIFF
--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -227,10 +227,10 @@ mod tests {
             let result = vc.call(&calldata, owner)?;
             assert!(!result.reverted);
 
-            let validators = vc.get_validators()?;
-            assert_eq!(validators.len(), 1);
-            assert_eq!(validators[0].validatorAddress, validator_addr);
-            assert_eq!(validators[0].publicKey, public_key);
+            assert_eq!(vc.validator_count()?, 1);
+            let v = vc.validator_by_index(0)?;
+            assert_eq!(v.validatorAddress, validator_addr);
+            assert_eq!(v.publicKey, public_key);
 
             Ok(())
         })

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -290,17 +290,6 @@ impl ValidatorConfigV2 {
         self.read_validator_at(idx1 - 1)
     }
 
-    /// Returns all validators ever added, including deactivated entries and rotation snapshots,
-    /// ordered by their global index.
-    pub fn get_validators(&self) -> Result<Vec<IValidatorConfigV2::Validator>> {
-        let count = self.validator_count()?;
-        let mut out = Vec::with_capacity(count as usize);
-        for i in 0..count {
-            out.push(self.read_validator_at(i)?);
-        }
-        Ok(out)
-    }
-
     /// Returns only active validators (where `deactivatedAtHeight == 0`).
     ///
     /// NOTE: the order of returned validator records is NOT stable and should NOT be relied upon.
@@ -1562,7 +1551,7 @@ mod tests {
             assert_eq!(active.len(), 1);
             assert_eq!(active[0].validatorAddress, v2);
 
-            assert_eq!(vc.get_validators()?.len(), 2);
+            assert_eq!(vc.validator_count()?, 2);
 
             Ok(())
         })


### PR DESCRIPTION
`get_validators` does a linear scan over all validator records but is not dispatched from the EVM — only used in two tests. Remove it and replace test assertions with `validator_count()` + `validator_by_index()`.

Prompted by: rusowsky