### PR TITLE
feat(cli): allow add-validator and rotate-validator to sign inline

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -49,6 +49,10 @@ pub(crate) struct ExtArgs {
 
 /// Tempo-specific subcommands that extend the reth CLI.
 #[derive(Debug, Subcommand)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "one-off commands; size doesn't matter"
+)]
 pub(crate) enum TempoSubcommand {
     /// Consensus-related commands.
     #[command(subcommand)]


### PR DESCRIPTION
Add `--signing-key` to `add-validator` and `rotate-validator` so the
ed25519 signature is computed inline — no separate `create-*-signature`
step needed.

Sign and submit in one go:

```
tempo consensus add-validator \
  --signing-key /path/to/ed25519.key \
  --private-key /path/to/eth.key \
  --rpc-url https://rpc.tempo.xyz \
  --validator-address 0x... \
  --public-key 0x... \
  --ingress 1.2.3.4:9000 \
  --egress 1.2.3.4 \
  --fee-recipient 0x...
```

```
tempo consensus rotate-validator \
  --signing-key /path/to/ed25519.key \
  --private-key /path/to/eth.key \
  --rpc-url https://rpc.tempo.xyz \
  --validator-address 0x... \
  --public-key 0x... \
  --ingress 1.2.3.4:9000 \
  --egress 1.2.3.4
```

Passing a pre-computed `--signature` still works as before.

Prompted by: janis