### PR TITLE
test(rpc): dedicate CI job for RPC matrix tests with retry logic

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,6 +41,15 @@ failure-output = "final"
 slow-timeout = { period = "3m", terminate-after = 1 }
 default-filter = "package(tempo-e2e) & test(can_restart_after_joining_from_snapshot)"
 
+# Dedicated profile for live RPC matrix tests (testnet/devnet).
+# These hit rate-limited external endpoints, so we serialize them and allow
+# more retries than regular tests.
+[profile.ci-rpc]
+inherits = "ci"
+test-threads = 1
+retries = 3
+slow-timeout = { period = "5m", terminate-after = 1 }
+
 # tempo-node integration tests (pool, block_building, etc.) also launch full
 # execution nodes with rayon pools. Limit to 4 slots so at most 8 run in parallel.
 [[profile.ci.overrides]]

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -1,0 +1,51 @@
+name: RPC Tests
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/node/**'
+      - 'crates/primitives/**'
+      - 'crates/revm/**'
+  pull_request:
+    paths:
+      - 'crates/node/**'
+      - 'crates/primitives/**'
+      - 'crates/revm/**'
+  merge_group:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  RUSTC_WRAPPER: "sccache"
+  TEMPO_TESTNET_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
+  TEMPO_DEVNET_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+
+jobs:
+  rpc-tests:
+    name: rpc-tests (${{ matrix.network }})
+    runs-on: depot-ubuntu-latest-4
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        network: [testnet, devnet]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19
+        with:
+          tool: nextest@0.9.124
+      - name: Build RPC tests
+        run: cargo nextest run --profile ci-rpc -E 'package(tempo-node) & binary(it) & test(/test_matrices_${{ matrix.network }}/)' --no-run
+      - name: Run RPC tests
+        run: cargo nextest run --profile ci-rpc -E 'package(tempo-node) & binary(it) & test(/test_matrices_${{ matrix.network }}/)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,24 +109,24 @@ jobs:
       # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
         if: needs.check-precompiles.outputs.coverage == 'true'
-        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2 --no-run
+        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
         env:
           RUSTFLAGS: -C instrument-coverage
       - name: Run tests with coverage
         if: needs.check-precompiles.outputs.coverage == 'true'
         run: |
           mkdir -p coverage
-          cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2
+          cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
         env:
           RUSTFLAGS: -C instrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/coverage/cargo-%p-%m.profraw
       # Build and run tests WITHOUT coverage (when precompiles not changed)
       - name: Build and compile tests
         if: needs.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2 --no-run
+        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2 --no-run
       - name: Run tests
         if: needs.check-precompiles.outputs.coverage != 'true'
-        run: cargo nextest run --profile ci -E 'not package(tempo-e2e)' --partition count:${{ matrix.partition }}/2
+        run: cargo nextest run --profile ci -E 'not (package(tempo-e2e) | (package(tempo-node) & binary(it) & test(/test_matrices_(testnet|devnet)/)))' --partition count:${{ matrix.partition }}/2
       - name: Generate precompiles coverage profdata
         if: needs.check-precompiles.outputs.coverage == 'true'
         run: |

--- a/crates/node/tests/it/tempo_transaction/rpc.rs
+++ b/crates/node/tests/it/tempo_transaction/rpc.rs
@@ -2,11 +2,19 @@
 //!
 //! These tests target a live RPC endpoint and cover the same core transaction
 //! matrices as the local integration tests, using the faucet for funding.
+//!
+//! Uses alloy's [`RetryBackoffLayer`] to automatically retry transient RPC
+//! errors (429 rate-limits, connection errors) with backoff at the transport
+//! level, so individual call sites don't need manual retry logic.
 use alloy::{
     consensus::BlockHeader,
     primitives::{Address, B256, Bytes, U256},
     providers::Provider,
     signers::local::PrivateKeySigner,
+    transports::{
+        RpcError, TransportErrorKind,
+        layers::{RateLimitRetryPolicy, RetryBackoffLayer},
+    },
 };
 use alloy_eips::Encodable2718;
 use reth_primitives_traits::transaction::TxHashRef;
@@ -21,6 +29,36 @@ use super::helpers::*;
 /// Maximum number of 1-second poll iterations when waiting for RPC state to settle.
 const RPC_POLL_RETRIES: usize = 30;
 
+/// Sends a raw transaction with duplicate-submission handling.
+///
+/// If the request reached the node but the response was lost, the retry layer
+/// will resend — which may return "already known". We treat that as success
+/// and fall through to `wait_for_receipt`.
+///
+/// Uses `serde_json::Value` for deserialization because `eth_sendRawTransaction`
+/// returns a `B256` hash while `eth_sendRawTransactionSync` returns a full
+/// receipt object.
+async fn send_raw_tx(
+    provider: &alloy::providers::RootProvider,
+    method: &'static str,
+    encoded: Vec<u8>,
+) -> eyre::Result<()> {
+    match provider
+        .raw_request::<_, serde_json::Value>(method.into(), [encoded])
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(e) if is_already_known(&e) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Returns `true` if the error indicates the tx was already accepted.
+fn is_already_known(err: &RpcError<TransportErrorKind>) -> bool {
+    let msg = err.to_string().to_lowercase();
+    msg.contains("already known") || msg.contains("known transaction")
+}
+
 pub(super) struct RpcEnv {
     provider: alloy::providers::RootProvider,
     chain_id: u64,
@@ -30,7 +68,21 @@ pub(super) struct RpcEnv {
 impl RpcEnv {
     async fn connect(rpc_url: &str) -> eyre::Result<Self> {
         reth_tracing::init_test_tracing();
-        let provider = alloy::providers::RootProvider::new_http(rpc_url.parse()?);
+
+        // Extend the default rate-limit policy to also retry connection errors.
+        let policy =
+            RateLimitRetryPolicy::default().or(|err: &alloy::transports::TransportError| {
+                let msg = err.to_string();
+                msg.contains("connection error")
+                    || msg.contains("SendRequest")
+                    || msg.contains("error sending request")
+            });
+        let retry = RetryBackoffLayer::new_with_policy(4, 100, 330, policy);
+        let client = alloy::rpc::client::RpcClient::builder()
+            .layer(retry)
+            .http(rpc_url.parse()?);
+        let provider = alloy::providers::RootProvider::new(client);
+
         let chain_id = provider.get_chain_id().await?;
 
         // Chain IDs from genesis/*.json (mirrors bootnodes() in spec.rs)
@@ -109,11 +161,7 @@ impl super::types::TestEnv for RpcEnv {
         encoded: Vec<u8>,
         tx_hash: B256,
     ) -> eyre::Result<serde_json::Value> {
-        let raw_result: B256 = self
-            .provider
-            .raw_request("eth_sendRawTransaction".into(), [encoded])
-            .await?;
-        assert_eq!(raw_result, tx_hash, "RPC should return tx hash");
+        send_raw_tx(&self.provider, "eth_sendRawTransaction", encoded).await?;
         let receipt = wait_for_receipt(&self.provider, tx_hash).await?;
         let status = receipt["status"]
             .as_str()
@@ -146,9 +194,8 @@ impl super::types::TestEnv for RpcEnv {
             let signature = sign_aa_tx_secp256k1(&tx, signer)?;
             let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
             let tx_hash = *envelope.tx_hash();
-            self.provider
-                .raw_request::<_, B256>("eth_sendRawTransaction".into(), [envelope.encoded_2718()])
-                .await?;
+            let encoded = envelope.encoded_2718();
+            send_raw_tx(&self.provider, "eth_sendRawTransaction", encoded).await?;
             wait_for_receipt(&self.provider, tx_hash).await?;
         }
 
@@ -165,6 +212,43 @@ impl super::types::TestEnv for RpcEnv {
         Ok(())
     }
 
+    async fn submit_tx_expecting_rejection(
+        &self,
+        encoded: Vec<u8>,
+        expected_reason: Option<&str>,
+    ) -> eyre::Result<()> {
+        // The retry layer handles transient errors transparently. After it
+        // exhausts retries, any remaining error is either a real RPC rejection
+        // (what we're testing for) or a persistent transport failure.
+        let result = self
+            .provider
+            .raw_request::<_, B256>("eth_sendRawTransaction".into(), [encoded])
+            .await;
+
+        match result {
+            Ok(_) => panic!("Transaction should be rejected, but was accepted"),
+            Err(RpcError::Transport(_)) => {
+                // Transport error that persisted through all retries — not a
+                // real rejection, so we must not count it as a test pass.
+                Err(eyre::eyre!(
+                    "Rejection test failed: persistent transport error after retries: {}",
+                    result.unwrap_err()
+                ))
+            }
+            Err(e) => {
+                // Non-retryable error = real RPC validation rejection.
+                if let Some(reason) = expected_reason {
+                    let err_str = e.to_string().to_lowercase();
+                    assert!(
+                        err_str.contains(&reason.to_lowercase()),
+                        "Rejection error should contain '{reason}', got: {e}"
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
     async fn current_block_timestamp(&mut self) -> eyre::Result<u64> {
         let block = self
             .provider
@@ -179,10 +263,7 @@ impl super::types::TestEnv for RpcEnv {
         encoded: Vec<u8>,
         tx_hash: B256,
     ) -> eyre::Result<serde_json::Value> {
-        let _: B256 = self
-            .provider
-            .raw_request("eth_sendRawTransaction".into(), [encoded])
-            .await?;
+        send_raw_tx(&self.provider, "eth_sendRawTransaction", encoded).await?;
         wait_for_receipt(&self.provider, tx_hash).await
     }
 
@@ -191,10 +272,7 @@ impl super::types::TestEnv for RpcEnv {
         encoded: Vec<u8>,
         tx_hash: B256,
     ) -> eyre::Result<serde_json::Value> {
-        let _: serde_json::Value = self
-            .provider
-            .raw_request("eth_sendRawTransactionSync".into(), [encoded])
-            .await?;
+        send_raw_tx(&self.provider, "eth_sendRawTransactionSync", encoded).await?;
         let receipt = wait_for_receipt(&self.provider, tx_hash).await?;
         let status = receipt["status"]
             .as_str()


### PR DESCRIPTION
## Motivation

`test_matrices_testnet` / `test_matrices_devnet` flake frequently — they hit rate-limited live RPC endpoints and fail with 429s and connection errors when running concurrently with 800+ other tests in the main `test` job.

## Solution

Extract RPC matrix tests into a dedicated non-gating CI job (`rpc-tests`) with a `ci-rpc` nextest profile (`test-threads = 1`, `retries = 3`, `slow-timeout = 5m`). Add exponential backoff retry logic for transient RPC errors, duplicate-submission handling (`already known`), and a `submit_tx_expecting_rejection` override that distinguishes transport failures from real validation rejections.

Prompted by: rusowsky