### PR TITLE
feat(xtask): add migrate-validator subcommand

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,6 +26,7 @@ alloy = { workspace = true, features = [
   "providers",
   "reqwest",
   "reqwest-rustls-tls",
+  "rpc-types",
   "signers",
   "signer-local",
   "signer-mnemonic",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use crate::{
     generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
     generate_localnet::GenerateLocalnet, generate_state_bloat::GenerateStateBloat,
-    get_dkg_outcome::GetDkgOutcome,
+    get_dkg_outcome::GetDkgOutcome, migrate_validator::MigrateValidator,
 };
 
 use alloy::signers::{local::MnemonicBuilder, utils::secret_key_to_address};
@@ -18,6 +18,7 @@ mod generate_localnet;
 mod generate_state_bloat;
 mod genesis_args;
 mod get_dkg_outcome;
+mod migrate_validator;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -38,6 +39,10 @@ async fn main() -> eyre::Result<()> {
             .run()
             .await
             .wrap_err("failed to generate state bloat file"),
+        Action::MigrateValidator(args) => args
+            .run()
+            .await
+            .wrap_err("failed to migrate validator"),
     }
 }
 
@@ -59,6 +64,7 @@ enum Action {
     GenerateLocalnet(GenerateLocalnet),
     GenerateAddPeer(GenerateAddPeer),
     GenerateStateBloat(GenerateStateBloat),
+    MigrateValidator(MigrateValidator),
 }
 
 #[derive(Debug, clap::Args)]

--- a/xtask/src/migrate_validator.rs
+++ b/xtask/src/migrate_validator.rs
@@ -1,0 +1,65 @@
+use alloy::{
+    primitives::B256,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    signers::local::PrivateKeySigner,
+    sol_types::SolCall,
+};
+use eyre::WrapErr as _;
+use std::path::PathBuf;
+use tempo_contracts::precompiles::IValidatorConfigV2;
+use tempo_precompiles::VALIDATOR_CONFIG_V2_ADDRESS;
+
+/// Migrate a validator from V1 to V2 using the `ValidatorConfigV2.migrateValidator` contract call.
+///
+/// This calls `migrateValidator(uint64 idx)` on the `ValidatorConfigV2` precompile,
+/// which copies validator state from V1 at the given index. Must be called by the
+/// contract owner.
+#[derive(Debug, clap::Args)]
+pub(crate) struct MigrateValidator {
+    /// The V1 validator index to migrate.
+    #[arg(long, value_name = "INDEX")]
+    idx: u64,
+
+    /// Path to the file holding the Ethereum private key (raw 32 bytes).
+    #[arg(long, value_name = "FILE")]
+    private_key: PathBuf,
+
+    /// The RPC URL to submit the transaction to.
+    #[arg(long, value_name = "RPC_URL")]
+    rpc_url: String,
+}
+
+impl MigrateValidator {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let private_key_bytes =
+            std::fs::read(&self.private_key).wrap_err("failed reading private key")?;
+        let private_key =
+            B256::try_from(private_key_bytes.as_slice()).wrap_err("invalid private key")?;
+
+        let signer =
+            PrivateKeySigner::from_bytes(&private_key).wrap_err("invalid signer key")?;
+
+        let provider = ProviderBuilder::new()
+            .wallet(signer)
+            .connect(&self.rpc_url)
+            .await
+            .wrap_err("failed to connect to RPC")?;
+
+        let calldata = IValidatorConfigV2::migrateValidatorCall { idx: self.idx };
+
+        let tx = TransactionRequest::default()
+            .to(VALIDATOR_CONFIG_V2_ADDRESS)
+            .input(calldata.abi_encode().into());
+
+        let pending = provider
+            .send_transaction(tx)
+            .await
+            .wrap_err("failed to send migrateValidator transaction")?;
+
+        let tx_hash = pending.tx_hash();
+        println!("migrateValidator(idx={}) submitted: {tx_hash}", self.idx);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `migrate-validator` subcommand to `tempo-xtask` that sends a `ValidatorConfigV2.migrateValidator(uint64 idx)` transaction to migrate a single validator from V1 to V2.

## Changes
- `xtask/src/migrate_validator.rs`: new `MigrateValidator` command, modelled after `AddValidator` in `bin/tempo/src/tempo_cmd.rs`
- `xtask/src/main.rs`: register module + dispatch
- `xtask/Cargo.toml`: add `rpc-types` feature to alloy

## Usage
```bash
cargo xtask migrate-validator --idx 0 --private-key /path/to/owner.key --rpc-url https://rpc.tempo.xyz
```

## Testing
`cargo clippy -p tempo-xtask -- -D warnings` passes clean.

Prompted by: janis