### PR TITLE
test: disable retries in ci-flaky nextest profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,6 +37,7 @@ slow-timeout = { period = "3m", terminate-after = 1 }
 [profile.ci-flaky]
 inherits = "ci"
 fail-fast = true
+retries = 0
 failure-output = "final"
 slow-timeout = { period = "3m", terminate-after = 1 }
 default-filter = "package(tempo-e2e) & test(can_restart_after_joining_from_snapshot)"


### PR DESCRIPTION
ci-flaky inherits from ci which sets retries=2. Override to retries=0 so flaky snapshot-restart tests fail immediately without retry.

Prompted by: janis