### PR TITLE
fix(txpool): evict stale inline key-auth txs on KeyAuthorized

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod transaction;
 pub mod validator;
 
-pub use transaction::{KeychainSubject, RevokedKeys, SpendingLimitUpdates};
+pub use transaction::{AuthorizedKeys, KeychainSubject, RevokedKeys, SpendingLimitUpdates};
 
 // Tempo pool module with 2D nonce support
 pub mod tempo_pool;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -1,7 +1,7 @@
 //! Transaction pool maintenance tasks.
 
 use crate::{
-    RevokedKeys, SpendingLimitUpdates, TempoTransactionPool,
+    AuthorizedKeys, RevokedKeys, SpendingLimitUpdates, TempoTransactionPool,
     metrics::TempoPoolMaintenanceMetrics,
     paused::{PausedEntry, PausedFeeTokenPool},
     transaction::TempoPooledTransaction,
@@ -48,6 +48,9 @@ pub struct TempoPoolUpdates {
     /// Revoked keychain keys.
     /// Indexed by account for efficient lookup.
     pub revoked_keys: RevokedKeys,
+    /// Newly authorized keychain keys.
+    /// Indexed by account for efficient lookup.
+    pub authorized_keys: AuthorizedKeys,
     /// Spending limit changes.
     /// When a spending limit changes, transactions from that key paying with that token
     /// may become unexecutable if the new limit is below their value.
@@ -88,6 +91,7 @@ impl TempoPoolUpdates {
     pub fn is_empty(&self) -> bool {
         self.expired_txs.is_empty()
             && self.revoked_keys.is_empty()
+            && self.authorized_keys.is_empty()
             && self.spending_limit_changes.is_empty()
             && self.validator_token_changes.is_empty()
             && self.user_token_changes.is_empty()
@@ -112,9 +116,13 @@ impl TempoPoolUpdates {
             .flatten()
             .flat_map(|receipt| &receipt.logs)
         {
-            // Key revocations and spending limit changes
+            // Key authorization/revocation and spending limit changes
             if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
-                if let Ok(event) = IAccountKeychain::KeyRevoked::decode_log(log) {
+                if let Ok(event) = IAccountKeychain::KeyAuthorized::decode_log(log) {
+                    updates
+                        .authorized_keys
+                        .insert(event.account, event.publicKey);
+                } else if let Ok(event) = IAccountKeychain::KeyRevoked::decode_log(log) {
                     updates.revoked_keys.insert(event.account, event.publicKey);
                 } else if let Ok(event) = IAccountKeychain::SpendingLimitUpdated::decode_log(log) {
                     updates.spending_limit_changes.insert(
@@ -196,6 +204,7 @@ impl TempoPoolUpdates {
     /// Returns true if there are any invalidation events that require scanning the pool.
     pub fn has_invalidation_events(&self) -> bool {
         !self.revoked_keys.is_empty()
+            || !self.authorized_keys.is_empty()
             || !self.spending_limit_changes.is_empty()
             || !self.spending_limit_spends.is_empty()
             || !self.validator_token_changes.is_empty()
@@ -764,12 +773,14 @@ where
                     );
                 }
 
-                // 5. Evict revoked keys and spending limit updates from paused pool
-                if !updates.revoked_keys.is_empty()
+                // 5. Evict invalidated keychain transactions from paused pool
+                if !updates.authorized_keys.is_empty()
+                    || !updates.revoked_keys.is_empty()
                     || !updates.spending_limit_changes.is_empty()
                     || !updates.spending_limit_spends.is_empty()
                 {
                     state.paused_pool.evict_invalidated(
+                        &updates.authorized_keys,
                         &updates.revoked_keys,
                         &updates.spending_limit_changes,
                         &updates.spending_limit_spends,
@@ -802,13 +813,15 @@ where
                 metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
 
                 // 9. Evict invalidated transactions in a single pool scan
-                // This checks revoked keys, spending limit changes, validator token changes,
+                // This checks newly authorized/revoked keys, spending limit changes,
+                // validator token changes,
                 // blacklist additions, and whitelist removals together to avoid scanning
                 // all transactions multiple times per block.
                 if updates.has_invalidation_events() {
                     let invalidation_start = Instant::now();
                     debug!(
                         target: "txpool",
+                        authorized_keys = updates.authorized_keys.len(),
                         revoked_keys = updates.revoked_keys.len(),
                         spending_limit_changes = updates.spending_limit_changes.len(),
                         spending_limit_spends = updates.spending_limit_spends.len(),
@@ -1446,6 +1459,18 @@ mod tests {
                 Address::random(),
                 Some(Address::random()),
             );
+            assert!(updates.has_invalidation_events());
+        }
+
+        /// has_invalidation_events returns true when authorized_keys is non-empty.
+        #[test]
+        fn has_invalidation_events_includes_authorized_keys() {
+            let mut updates = TempoPoolUpdates::new();
+            assert!(!updates.has_invalidation_events());
+
+            updates
+                .authorized_keys
+                .insert(Address::random(), Address::random());
             assert!(updates.has_invalidation_events());
         }
     }

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -5,7 +5,9 @@
 //! When the token is unpaused, transactions are moved back to the main pool
 //! and re-validated.
 
-use crate::{RevokedKeys, SpendingLimitUpdates, transaction::TempoPooledTransaction};
+use crate::{
+    AuthorizedKeys, RevokedKeys, SpendingLimitUpdates, transaction::TempoPooledTransaction,
+};
 use alloy_primitives::{Address, TxHash, map::HashMap};
 use reth_transaction_pool::ValidPoolTransaction;
 use std::{sync::Arc, time::Instant};
@@ -201,11 +203,13 @@ impl PausedFeeTokenPool {
     /// Returns the number of transactions removed.
     pub fn evict_invalidated(
         &mut self,
+        authorized_keys: &AuthorizedKeys,
         revoked_keys: &RevokedKeys,
         spending_limit_updates: &SpendingLimitUpdates,
         spending_limit_spends: &SpendingLimitUpdates,
     ) -> usize {
-        if revoked_keys.is_empty()
+        if authorized_keys.is_empty()
+            && revoked_keys.is_empty()
             && spending_limit_updates.is_empty()
             && spending_limit_spends.is_empty()
         {
@@ -219,7 +223,14 @@ impl PausedFeeTokenPool {
                 let Some(subject) = entry.tx.transaction.keychain_subject() else {
                     return true;
                 };
-                !subject.matches_revoked(revoked_keys)
+                let inline_key_auth = entry
+                    .tx
+                    .transaction
+                    .inner()
+                    .as_aa()
+                    .is_some_and(|aa| aa.tx().key_authorization.is_some());
+                !(inline_key_auth && subject.matches_authorized(authorized_keys))
+                    && !subject.matches_revoked(revoked_keys)
                     && !subject.matches_spending_limit_update(spending_limit_updates)
                     && !subject.matches_spending_limit_update(spending_limit_spends)
             });
@@ -382,14 +393,101 @@ mod tests {
         let mut spends = SpendingLimitUpdates::new();
         spends.insert(user_address, key_id, Some(fee_token));
 
-        let evicted =
-            pool.evict_invalidated(&RevokedKeys::new(), &SpendingLimitUpdates::new(), &spends);
+        let evicted = pool.evict_invalidated(
+            &AuthorizedKeys::new(),
+            &RevokedKeys::new(),
+            &SpendingLimitUpdates::new(),
+            &spends,
+        );
 
         assert_eq!(
             evicted, 1,
             "Should evict the keychain tx matching the spend"
         );
         assert_eq!(pool.len(), 1, "Non-keychain tx should remain");
+    }
+
+    #[test]
+    fn test_evict_invalidated_with_authorized_keys_inline_key_auth_only() {
+        let mut pool = PausedFeeTokenPool::new();
+        let user_address = Address::random();
+        let fee_token = Address::random();
+
+        let access_key_signer = alloy_signer_local::PrivateKeySigner::random();
+        let key_id = alloy_signer::Signer::address(&access_key_signer);
+
+        // This tx uses keychain signature only (no inline key_authorization) and should remain.
+        let keychain_only = Arc::new(wrap_valid_tx(
+            TxBuilder::aa(user_address)
+                .fee_token(fee_token)
+                .build_keychain(user_address, &access_key_signer),
+            reth_transaction_pool::TransactionOrigin::External,
+        ));
+
+        // This tx includes inline key_authorization and should be evicted on KeyAuthorized.
+        let mut inline_key_auth_tx = TxBuilder::aa(user_address)
+            .fee_token(fee_token)
+            .build_keychain(user_address, &access_key_signer);
+        if let Some(aa) = inline_key_auth_tx.inner().as_aa() {
+            use tempo_primitives::transaction::{
+                KeyAuthorization, PrimitiveSignature, SignatureType,
+            };
+
+            let auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id,
+                expiry: None,
+                limits: None,
+            }
+            .into_signed(PrimitiveSignature::Secp256k1(
+                alloy_primitives::Signature::test_signature(),
+            ));
+
+            let mut inner = aa.tx().clone();
+            inner.key_authorization = Some(auth);
+
+            let recovered = reth_primitives_traits::Recovered::new_unchecked(
+                tempo_primitives::TempoTxEnvelope::AA(tempo_primitives::AASigned::new_unhashed(
+                    inner,
+                    aa.signature().clone(),
+                )),
+                user_address,
+            );
+            inline_key_auth_tx = TempoPooledTransaction::new(recovered);
+        }
+
+        let inline_key_auth = Arc::new(wrap_valid_tx(
+            inline_key_auth_tx,
+            reth_transaction_pool::TransactionOrigin::External,
+        ));
+
+        pool.insert_batch(
+            fee_token,
+            vec![
+                PausedEntry {
+                    tx: keychain_only,
+                    valid_before: None,
+                },
+                PausedEntry {
+                    tx: inline_key_auth,
+                    valid_before: None,
+                },
+            ],
+        );
+
+        let mut authorized = AuthorizedKeys::new();
+        authorized.insert(user_address, key_id);
+
+        let evicted = pool.evict_invalidated(
+            &authorized,
+            &RevokedKeys::new(),
+            &SpendingLimitUpdates::new(),
+            &SpendingLimitUpdates::new(),
+        );
+
+        assert_eq!(evicted, 1, "Only inline key-auth tx should be evicted");
+        assert_eq!(pool.len(), 1, "Keychain-only tx should remain");
     }
 
     #[test]

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -226,13 +226,14 @@ impl PausedFeeTokenPool {
                         .transaction
                         .matches_authorized_inline_key(authorized_keys);
                 };
-                !entry
+                let invalidated = entry
                     .tx
                     .transaction
                     .matches_authorized_inline_key(authorized_keys)
-                    && !subject.matches_revoked(revoked_keys)
-                    && !subject.matches_spending_limit_update(spending_limit_updates)
-                    && !subject.matches_spending_limit_update(spending_limit_spends)
+                    || subject.matches_revoked(revoked_keys)
+                    || subject.matches_spending_limit_update(spending_limit_updates)
+                    || subject.matches_spending_limit_update(spending_limit_spends);
+                !invalidated
             });
             count += before - meta.entries.len();
         }

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -221,15 +221,15 @@ impl PausedFeeTokenPool {
             let before = meta.entries.len();
             meta.entries.retain(|entry| {
                 let Some(subject) = entry.tx.transaction.keychain_subject() else {
-                    return true;
+                    return !entry
+                        .tx
+                        .transaction
+                        .matches_authorized_inline_key(authorized_keys);
                 };
-                let inline_key_auth = entry
+                !entry
                     .tx
                     .transaction
-                    .inner()
-                    .as_aa()
-                    .is_some_and(|aa| aa.tx().key_authorization.is_some());
-                !(inline_key_auth && subject.matches_authorized(authorized_keys))
+                    .matches_authorized_inline_key(authorized_keys)
                     && !subject.matches_revoked(revoked_keys)
                     && !subject.matches_spending_limit_update(spending_limit_updates)
                     && !subject.matches_spending_limit_update(spending_limit_spends)

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -149,6 +149,8 @@ where
     /// Evicts transactions that are no longer valid due to on-chain events.
     ///
     /// This performs a single scan of all pooled transactions and checks for:
+    /// 0. **Newly authorized keychain keys**: Pending inline key-authorizations for keys that
+    ///    were just authorized on-chain (duplicates become deterministically invalid)
     /// 1. **Revoked keychain keys**: AA transactions signed with keys that have been revoked
     /// 2. **Spending limit updates**: AA transactions signed with keys whose spending limit
     ///    changed for a token matching the transaction's fee token
@@ -202,6 +204,7 @@ where
         };
 
         let mut to_remove = Vec::new();
+        let mut authorized_count = 0;
         let mut revoked_count = 0;
         let mut spending_limit_count = 0;
         let mut spending_limit_spend_count = 0;
@@ -214,6 +217,23 @@ where
         for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
             // Extract keychain subject once per transaction (if applicable)
             let keychain_subject = tx.transaction.keychain_subject();
+
+            // Check 0: Newly authorized keychain keys.
+            // Once a KeyAuthorized event is mined, pending inline key-authorizations for the same
+            // (account, key_id) become deterministically invalid (`access key already exists`).
+            if !updates.authorized_keys.is_empty()
+                && tx
+                    .transaction
+                    .inner()
+                    .as_aa()
+                    .is_some_and(|aa| aa.tx().key_authorization.is_some())
+                && let Some(ref subject) = keychain_subject
+                && subject.matches_authorized(&updates.authorized_keys)
+            {
+                to_remove.push(*tx.hash());
+                authorized_count += 1;
+                continue;
+            }
 
             // Check 1: Revoked keychain keys
             if !updates.revoked_keys.is_empty()
@@ -366,6 +386,7 @@ where
             tracing::debug!(
                 target: "txpool",
                 total = to_remove.len(),
+                authorized_count,
                 revoked_count,
                 spending_limit_count,
                 spending_limit_spend_count,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -224,11 +224,7 @@ where
             if !updates.authorized_keys.is_empty()
                 && tx
                     .transaction
-                    .inner()
-                    .as_aa()
-                    .is_some_and(|aa| aa.tx().key_authorization.is_some())
-                && let Some(ref subject) = keychain_subject
-                && subject.matches_authorized(&updates.authorized_keys)
+                    .matches_authorized_inline_key(&updates.authorized_keys)
             {
                 to_remove.push(*tx.hash());
                 authorized_count += 1;

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -155,6 +155,18 @@ impl TempoPooledTransaction {
         })
     }
 
+    /// Returns true if this transaction carries an inline key authorization that matches a
+    /// newly authorized key.
+    ///
+    /// This covers root-signed inline key-auth transactions that do not have keychain signatures,
+    /// so `keychain_subject()` would be `None`.
+    pub fn matches_authorized_inline_key(&self, authorized_keys: &AuthorizedKeys) -> bool {
+        self.inner()
+            .as_aa()
+            .and_then(|aa| aa.tx().key_authorization.as_ref())
+            .is_some_and(|auth| authorized_keys.contains(self.sender(), auth.key_id))
+    }
+
     /// Returns the unique identifier for this AA transaction.
     pub(crate) fn aa_transaction_id(&self) -> Option<AA2dTransactionId> {
         let nonce_key = self.nonce_key()?;
@@ -1007,6 +1019,45 @@ mod tests {
 
         authorized.insert(account, key_id);
         assert!(subject.matches_authorized(&authorized));
+    }
+
+    #[test]
+    fn matches_authorized_inline_key_for_root_signed_tx() {
+        let user_address = Address::random();
+        let key_id = Address::random();
+
+        let mut tx = TxBuilder::aa(user_address).build();
+        if let Some(aa) = tx.inner().as_aa() {
+            let mut inner = aa.tx().clone();
+            inner.key_authorization = Some(
+                tempo_primitives::transaction::KeyAuthorization {
+                    chain_id: 42431,
+                    key_type: tempo_primitives::transaction::SignatureType::Secp256k1,
+                    key_id,
+                    expiry: None,
+                    limits: None,
+                }
+                .into_signed(
+                    tempo_primitives::transaction::PrimitiveSignature::Secp256k1(
+                        Signature::test_signature(),
+                    ),
+                ),
+            );
+            let recovered = Recovered::new_unchecked(
+                tempo_primitives::TempoTxEnvelope::AA(tempo_primitives::AASigned::new_unhashed(
+                    inner,
+                    aa.signature().clone(),
+                )),
+                user_address,
+            );
+            tx = TempoPooledTransaction::new(recovered);
+        }
+
+        let mut authorized = AuthorizedKeys::new();
+        assert!(!tx.matches_authorized_inline_key(&authorized));
+
+        authorized.insert(user_address, key_id);
+        assert!(tx.matches_authorized_inline_key(&authorized));
     }
 
     #[test]

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -979,6 +979,37 @@ mod tests {
     }
 
     #[test]
+    fn authorized_keys_index_contains_inserted_key() {
+        let mut authorized = AuthorizedKeys::new();
+        let account = Address::random();
+        let key_id = Address::random();
+
+        assert!(authorized.is_empty());
+        authorized.insert(account, key_id);
+
+        assert!(!authorized.is_empty());
+        assert_eq!(authorized.len(), 1);
+        assert!(authorized.contains(account, key_id));
+    }
+
+    #[test]
+    fn keychain_subject_matches_authorized() {
+        let account = Address::random();
+        let key_id = Address::random();
+        let subject = KeychainSubject {
+            account,
+            key_id,
+            fee_token: Address::random(),
+        };
+
+        let mut authorized = AuthorizedKeys::new();
+        assert!(!subject.matches_authorized(&authorized));
+
+        authorized.insert(account, key_id);
+        assert!(subject.matches_authorized(&authorized));
+    }
+
+    #[test]
     fn test_pool_transaction_into_consensus() {
         let sender = Address::random();
         let tx = TxBuilder::aa(sender).build();
@@ -1092,6 +1123,45 @@ impl RevokedKeys {
     }
 }
 
+/// Index of newly authorized keychain keys, keyed by account for efficient lookup.
+///
+/// Used to evict pending inline key-authorization transactions that become deterministically
+/// invalid once a matching `KeyAuthorized` event is mined.
+#[derive(Debug, Clone, Default)]
+pub struct AuthorizedKeys {
+    /// Map from account to list of newly authorized key_ids.
+    by_account: AddressMap<Vec<Address>>,
+}
+
+impl AuthorizedKeys {
+    /// Creates a new empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts an authorized key.
+    pub fn insert(&mut self, account: Address, key_id: Address) {
+        self.by_account.entry(account).or_default().push(key_id);
+    }
+
+    /// Returns true if the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.by_account.is_empty()
+    }
+
+    /// Returns the total number of authorized keys.
+    pub fn len(&self) -> usize {
+        self.by_account.values().map(Vec::len).sum()
+    }
+
+    /// Returns true if the given (account, key_id) combination is in the index.
+    pub fn contains(&self, account: Address, key_id: Address) -> bool {
+        self.by_account
+            .get(&account)
+            .is_some_and(|key_ids| key_ids.contains(&key_id))
+    }
+}
+
 /// Index of spending limit updates, keyed by account for efficient lookup.
 ///
 /// Uses account as the primary key with a list of (key_id, token) pairs,
@@ -1163,6 +1233,11 @@ impl KeychainSubject {
     /// the typically small list of key_ids for that account.
     pub fn matches_revoked(&self, revoked_keys: &RevokedKeys) -> bool {
         revoked_keys.contains(self.account, self.key_id)
+    }
+
+    /// Returns true if this subject matches any of the newly authorized keys.
+    pub fn matches_authorized(&self, authorized_keys: &AuthorizedKeys) -> bool {
+        authorized_keys.contains(self.account, self.key_id)
     }
 
     /// Returns true if this subject is affected by any of the spending limit updates.


### PR DESCRIPTION
Closes #SIGP-172

Adds txpool invalidation for inline key-authorization transactions when `KeyAuthorized` is emitted. Once a key is authorized on-chain, duplicate pending inline key-auth txs for the same `(account, key_id)` become deterministically invalid (`access key already exists`) and are now evicted from both main and paused pools.

This also introduces a dedicated `AuthorizedKeys` index and coverage for the new invalidation path in pool maintenance and paused pool tests.