### PR TITLE
docs: add TIP-1037 FeeAMM TIP-403 policy exemptions

### DIFF
--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -11,7 +11,7 @@ related: TIP-403, TIP-1015, TIP-20
 
 ## Abstract
 
-This TIP modifies how TIP-403 transfer policies interact with the FeeAMM/FeeManager precompile. The FeeManager address is exempted from TIP-403 authorization checks during the protocol fee collection path (`collectFeePreTx`, `transferFeePreTx`, `executeFeeSwap`, `transferFeePostTx`), while full TIP-403 enforcement is preserved on all public AMM operations (`mint`, `burn`, `rebalanceSwap`, `distributeFees`). Additionally, `mint` is extended with a new authorization check: the caller must be authorized as both sender and recipient on the `userToken`, even when only depositing `validatorToken`.
+This TIP modifies how TIP-403 transfer policies interact with the FeeAMM/FeeManager precompile. The FeeManager address is exempted from TIP-403 authorization checks during the protocol fee collection path (`collectFeePreTx`, `transferFeePreTx`, `executeFeeSwap`, `transferFeePostTx`), while full TIP-403 enforcement is preserved on all public AMM operations (`mint`, `burn`, `rebalanceSwap`, `distributeFees`). Additionally, `mint` is extended with a new authorization check that treats the operation as if the caller were transferring both tokens to the pool: the caller must be authorized as a sender on the `userToken` and the FeeManager must be an authorized recipient, even when only `validatorToken` is deposited.
 
 ## Motivation
 
@@ -153,7 +153,7 @@ The FeeManager address exemption does **not** remove issuer control. Instead, it
 | Issuer action | Fee payment | AMM pools | `distributeFees` |
 |---------------|-------------|-----------|-------------------|
 | Whitelist FeeManager | ✅ | ✅ Pools can be created, rebalanced | ✅ Fees distributed |
-| Don't whitelist FeeManager | ✅ Same-token fees work. Cross-token fees require pool liquidity (see below). | ❌ `mint` blocked (FeeManager not authorized as recipient on `validatorToken` `systemTransferFrom`). No pools → no cross-token fee swaps. | ❌ `transfer` from FeeManager blocked |
+| Don't whitelist FeeManager | ✅ Same-token fees work. Cross-token fees require pool liquidity (see below). | ❌ `mint` blocked (FeeManager not authorized as recipient on either token). No pools → no cross-token fee swaps. | ❌ `transfer` from FeeManager blocked |
 
 ### Edge Case: Stranded Fees
 
@@ -181,7 +181,7 @@ This is an expected consequence: the issuer has not opted their token into the f
 
 1. **Whitelist token without FeeManager whitelisted — same-token fees**: Whitelisted user pays fees in token X where `userToken == validatorToken`. Fees are collected successfully. `distributeFees` reverts (FeeManager not authorized as sender).
 
-2. **Whitelist token without FeeManager whitelisted — cross-token fees**: `mint` reverts when attempting to create pool liquidity (FeeManager not authorized as `validatorToken` recipient). Without liquidity, cross-token fee collection reverts with `InsufficientLiquidity`.
+2. **Whitelist token without FeeManager whitelisted — cross-token fees**: `mint` reverts when attempting to create pool liquidity (FeeManager not authorized as recipient on either token). Without liquidity, cross-token fee collection reverts with `InsufficientLiquidity`.
 
 3. **Whitelist token with FeeManager whitelisted**: All operations succeed. Fees collected, swapped, distributed. AMM mint/burn/rebalance all work.
 


### PR DESCRIPTION
Adds TIP-1037, which exempts the FeeAMM address from TIP-403 checks during fee collection while preserving full enforcement on public AMM operations (mint, burn, rebalanceSwap, distributeFees). Also adds a new authorization gate on `mint` requiring the caller to be authorized on the `userToken`.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan