### PR TITLE
feat: ERC-1271 support for TempoStreamChannel

### DIFF
--- a/tips/ref-impls/src/TempoStreamChannel.sol
+++ b/tips/ref-impls/src/TempoStreamChannel.sol
@@ -5,6 +5,7 @@ import { TempoUtilities } from "./TempoUtilities.sol";
 import { ITIP20 } from "./interfaces/ITIP20.sol";
 import { ITempoStreamChannel } from "./interfaces/ITempoStreamChannel.sol";
 import { ECDSA } from "solady/utils/ECDSA.sol";
+import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { EIP712 } from "solady/utils/EIP712.sol";
 
 /**
@@ -129,16 +130,7 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
             revert AmountNotIncreasing();
         }
 
-        bytes32 structHash = keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount));
-        bytes32 digest = _hashTypedData(structHash);
-        address signer = ECDSA.recoverCalldata(digest, signature);
-
-        address expectedSigner =
-            channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
-
-        if (signer != expectedSigner) {
-            revert InvalidSignature();
-        }
+        _verifyVoucher(channel, channelId, cumulativeAmount, signature);
 
         uint128 delta = cumulativeAmount - channel.settled;
         channel.settled = cumulativeAmount;
@@ -262,17 +254,7 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
                 revert AmountExceedsDeposit();
             }
 
-            bytes32 structHash =
-                keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount));
-            bytes32 digest = _hashTypedData(structHash);
-            address signer = ECDSA.recoverCalldata(digest, signature);
-
-            address expectedSigner =
-                channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
-
-            if (signer != expectedSigner) {
-                revert InvalidSignature();
-            }
+            _verifyVoucher(channel, channelId, cumulativeAmount, signature);
 
             delta = cumulativeAmount - settledAmount;
             settledAmount = cumulativeAmount;
@@ -422,6 +404,28 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
     }
 
     // --- Internal Functions ---
+
+    /// @dev Verify a voucher signature. Supports both ECDSA (EOA) and
+    ///      ERC-1271 (smart contract) signers via SignatureCheckerLib.
+    function _verifyVoucher(
+        Channel storage channel,
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        bytes calldata signature
+    ) internal view {
+        bytes32 structHash = keccak256(abi.encode(VOUCHER_TYPEHASH, channelId, cumulativeAmount));
+        bytes32 digest = _hashTypedData(structHash);
+
+        address expectedSigner =
+            channel.authorizedSigner != address(0) ? channel.authorizedSigner : channel.payer;
+
+        // SignatureCheckerLib.isValidSignatureNowCalldata:
+        //   1. Tries ecrecover first (EOA — identical to current behavior)
+        //   2. Falls back to ERC-1271 isValidSignature (contract signers)
+        if (!SignatureCheckerLib.isValidSignatureNowCalldata(expectedSigner, digest, signature)) {
+            revert InvalidSignature();
+        }
+    }
 
     function _clearAndFinalize(bytes32 channelId) internal {
         delete channels[channelId];

--- a/tips/ref-impls/test/TempoStreamChannel.t.sol
+++ b/tips/ref-impls/test/TempoStreamChannel.t.sol
@@ -6,6 +6,7 @@ import { TempoStreamChannel } from "../src/TempoStreamChannel.sol";
 import { ITempoStreamChannel } from "../src/interfaces/ITempoStreamChannel.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 import { MockTIP20 } from "./mocks/MockTIP20.sol";
+import { MockERC1271Signer } from "./mocks/MockERC1271Signer.sol";
 
 contract TempoStreamChannelTest is BaseTest {
 
@@ -978,6 +979,158 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payer);
         vm.expectRevert(ITempoStreamChannel.InvalidPayee.selector);
         channel.open(address(0), address(token), DEPOSIT, SALT, address(0));
+    }
+
+    // --- ERC-1271 Smart Contract Signer Tests ---
+
+    function test_erc1271_contractPayer_eoaSigner() public {
+        // Contract pays, EOA signs vouchers (e.g. vault + admin key)
+        (address adminSigner, uint256 adminSignerKey) = makeAddrAndKey("admin");
+        MockERC1271Signer contractPayer = new MockERC1271Signer(adminSigner);
+
+        vm.startPrank(admin);
+        token.mint(address(contractPayer), 10_000_000);
+        vm.stopPrank();
+
+        contractPayer.approveToken(address(token), address(channel), type(uint256).max);
+
+        // Open: contract is payer, EOA is authorizedSigner
+        vm.prank(address(contractPayer));
+        bytes32 channelId = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(42)), adminSigner
+        );
+
+        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        assertEq(ch.payer, address(contractPayer));
+        assertEq(ch.authorizedSigner, adminSigner);
+
+        // Sign voucher with EOA admin key (standard ECDSA path)
+        bytes32 digest = channel.getVoucherDigest(channelId, 500_000);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(adminSignerKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.prank(payee);
+        channel.settle(channelId, 500_000, sig);
+
+        assertEq(channel.getChannel(channelId).settled, 500_000);
+        assertEq(token.balanceOf(payee), 500_000);
+    }
+
+    function test_erc1271_contractAsSigner() public {
+        // Contract is both payer AND authorizedSigner.
+        // Vouchers are signed by the delegated EOA key, verified via
+        // ERC-1271 isValidSignature on the contract.
+        (address adminSigner, uint256 adminSignerKey) = makeAddrAndKey("admin1271");
+        MockERC1271Signer contractSigner = new MockERC1271Signer(adminSigner);
+
+        vm.startPrank(admin);
+        token.mint(address(contractSigner), 10_000_000);
+        vm.stopPrank();
+
+        contractSigner.approveToken(address(token), address(channel), type(uint256).max);
+
+        // Open: contract is both payer and authorizedSigner
+        vm.prank(address(contractSigner));
+        bytes32 channelId = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(43)),
+            address(contractSigner) // ERC-1271 signer
+        );
+
+        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        assertEq(ch.authorizedSigner, address(contractSigner));
+
+        // Sign with the delegated EOA key
+        bytes32 digest = channel.getVoucherDigest(channelId, 600_000);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(adminSignerKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        // Settle — escrow calls contractSigner.isValidSignature()
+        vm.prank(payee);
+        channel.settle(channelId, 600_000, sig);
+
+        assertEq(channel.getChannel(channelId).settled, 600_000);
+        assertEq(token.balanceOf(payee), 600_000);
+    }
+
+    function test_erc1271_rejectsWrongKey() public {
+        (address adminSigner,) = makeAddrAndKey("rightKey");
+        MockERC1271Signer contractSigner = new MockERC1271Signer(adminSigner);
+
+        vm.startPrank(admin);
+        token.mint(address(contractSigner), 10_000_000);
+        vm.stopPrank();
+
+        contractSigner.approveToken(address(token), address(channel), type(uint256).max);
+
+        vm.prank(address(contractSigner));
+        bytes32 channelId = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(44)),
+            address(contractSigner)
+        );
+
+        // Sign with a WRONG key
+        (, uint256 wrongKey) = makeAddrAndKey("wrongKey");
+        bytes32 digest = channel.getVoucherDigest(channelId, 500_000);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.prank(payee);
+        vm.expectRevert(ITempoStreamChannel.InvalidSignature.selector);
+        channel.settle(channelId, 500_000, sig);
+    }
+
+    function test_erc1271_closeWithContractSigner() public {
+        (address adminSigner, uint256 adminSignerKey) = makeAddrAndKey("adminClose");
+        MockERC1271Signer contractSigner = new MockERC1271Signer(adminSigner);
+
+        vm.startPrank(admin);
+        token.mint(address(contractSigner), 10_000_000);
+        vm.stopPrank();
+
+        contractSigner.approveToken(address(token), address(channel), type(uint256).max);
+
+        vm.prank(address(contractSigner));
+        bytes32 channelId = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(45)),
+            address(contractSigner)
+        );
+
+        // Settle partial
+        uint128 amt1 = 300_000;
+        bytes32 digest1 = channel.getVoucherDigest(channelId, amt1);
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(adminSignerKey, digest1);
+        vm.prank(payee);
+        channel.settle(channelId, amt1, abi.encodePacked(r1, s1, v1));
+
+        // Close with final voucher
+        uint128 finalAmt = 800_000;
+        bytes32 digest2 = channel.getVoucherDigest(channelId, finalAmt);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(adminSignerKey, digest2);
+        vm.prank(payee);
+        channel.close(channelId, finalAmt, abi.encodePacked(r2, s2, v2));
+
+        assertTrue(channel.getChannel(channelId).finalized);
+        assertEq(token.balanceOf(payee), finalAmt);
+    }
+
+    function test_erc1271_existingEOATestsStillPass() public {
+        // Verify that existing EOA-based authorized signer still works
+        // (backward compatibility)
+        (address delegateSigner, uint256 delegateKey) = makeAddrAndKey("compat");
+
+        vm.prank(payer);
+        bytes32 channelId = channel.open(
+            payee, address(token), DEPOSIT, bytes32(uint256(46)), delegateSigner
+        );
+
+        bytes32 digest = channel.getVoucherDigest(channelId, 500_000);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(delegateKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.prank(payee);
+        channel.settle(channelId, 500_000, sig);
+
+        assertEq(channel.getChannel(channelId).settled, 500_000);
     }
 
 }

--- a/tips/ref-impls/test/mocks/MockERC1271Signer.sol
+++ b/tips/ref-impls/test/mocks/MockERC1271Signer.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { ECDSA } from "solady/utils/ECDSA.sol";
+import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+
+/// @notice Mock ERC-1271 smart contract signer.
+///         Delegates signature validation to an EOA key.
+///         Simulates a vault or smart wallet that signs vouchers.
+contract MockERC1271Signer {
+    address public immutable signer;
+
+    constructor(address signer_) {
+        signer = signer_;
+    }
+
+    /// @dev ERC-1271: validate signature by checking the delegated EOA.
+    function isValidSignature(
+        bytes32 hash,
+        bytes memory signature
+    ) external view returns (bytes4) {
+        address recovered = ECDSA.recover(hash, signature);
+        if (recovered == signer) {
+            return 0x1626ba7e; // ERC-1271 magic value
+        }
+        return 0xffffffff;
+    }
+
+    /// @dev Allow this contract to approve token spending.
+    function approveToken(
+        address token,
+        address spender,
+        uint256 amount
+    ) external {
+        ITIP20(token).approve(spender, amount);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `ECDSA.recoverCalldata` with `SignatureCheckerLib.isValidSignatureNowCalldata` in `settle()` and `close()` to support smart contract signers (ERC-1271)
- Extract shared `_verifyVoucher()` helper to reduce code duplication
- Add `MockERC1271Signer` test mock and 5 new tests

## Motivation

Smart contracts (ERC4626 vaults, multisigs, AA wallets) cannot currently be `authorizedSigner` or act as payers that sign vouchers on payment channels. This blocks use cases like:

- **Lending vaults** that open channels on behalf of AI agents (vault is payer, admin key signs vouchers via ERC-1271)
- **Multisig wallets** that authorize streaming payments
- **Account abstraction wallets** that use contract-based signatures

## Change

One function swap — `SignatureCheckerLib` from solady (already a dependency):

```diff
- address signer = ECDSA.recoverCalldata(digest, signature);
- if (signer != expectedSigner) revert InvalidSignature();

+ if (!SignatureCheckerLib.isValidSignatureNowCalldata(expectedSigner, digest, signature))
+     revert InvalidSignature();
```

`SignatureCheckerLib.isValidSignatureNowCalldata`:
1. Tries `ecrecover` first (EOA — identical to current behavior)
2. Falls back to `IERC1271.isValidSignature()` (contract signers)

**Fully backward compatible.** Every existing EOA signature works exactly as before.

## Tests

5 new tests added to `TempoStreamChannel.t.sol`:

| Test | What it proves |
|------|---------------|
| `test_erc1271_contractPayer_eoaSigner` | Contract pays, EOA signs (vault + admin key) |
| `test_erc1271_contractAsSigner` | Contract is authorizedSigner, delegates to EOA via isValidSignature |
| `test_erc1271_rejectsWrongKey` | Wrong EOA key rejected by contract's isValidSignature |
| `test_erc1271_closeWithContractSigner` | Close with partial settle + final voucher via ERC-1271 |
| `test_erc1271_existingEOATestsStillPass` | Backward compatibility — existing EOA flow unchanged |

## Context

Built during the Tempo hackathon while building an [Agent Credit Protocol](https://github.com/Fbartoli/tempo-hack) — an ERC4626 vault that lends USDC.e to AI agents for MPP service consumption. The vault needed to open payment channels as payer, which required ERC-1271 support on the escrow.