### PR TITLE
feat(payload): add span attributes for builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
+checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -251,7 +251,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,9 +1496,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -1929,19 +1929,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -2122,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3542,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -3779,7 +3780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,8 +4219,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4768,7 +4769,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5050,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -5148,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof"
@@ -5439,9 +5440,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -6168,7 +6169,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6264,9 +6265,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -6274,9 +6275,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6527,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -6936,9 +6937,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -7762,7 +7763,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7786,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7818,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7838,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7851,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7934,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7944,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7964,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7984,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7994,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8010,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8023,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8036,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8062,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8090,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8119,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8149,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8164,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8189,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8213,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8237,7 +8238,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8272,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8329,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8357,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8380,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8405,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8443,6 +8444,7 @@ dependencies = [
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
+ "reth-storage-api",
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
@@ -8461,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8489,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8504,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8520,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8542,7 +8544,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8553,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8581,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8602,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8643,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "clap",
  "eyre",
@@ -8666,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8682,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8700,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8713,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8742,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8756,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8766,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8790,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8810,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8823,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8841,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8879,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8893,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8903,7 +8905,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8931,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "bytes",
  "futures",
@@ -8951,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8968,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "bindgen",
  "cc",
@@ -8977,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "futures",
  "metrics",
@@ -8989,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8998,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9012,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9069,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9094,7 +9096,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9117,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9132,7 +9134,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9146,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9163,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9187,7 +9189,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9255,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9310,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9348,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9372,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "bytes",
  "eyre",
@@ -9425,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9437,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9458,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9470,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9493,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9503,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9538,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9584,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9613,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9629,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9642,7 +9644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9720,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9751,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9794,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9814,7 +9816,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9845,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9889,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9937,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9951,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9967,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10019,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10046,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10060,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10080,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10095,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10119,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10136,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10157,7 +10159,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10173,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10183,7 +10185,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "clap",
  "eyre",
@@ -10202,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "clap",
  "eyre",
@@ -10220,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10264,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10317,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10337,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10361,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10383,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
+source = "git+https://github.com/paradigmxyz/reth?rev=ad8f93af1#ad8f93af1f834605864b5f611ab3f62c82045bd8"
 dependencies = [
  "zstd",
 ]
@@ -10850,7 +10852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10930,7 +10932,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11278,9 +11280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11297,11 +11299,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11532,7 +11534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11752,9 +11754,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -11771,7 +11773,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12685,9 +12687,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -12803,7 +12805,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -12817,39 +12819,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tonic"
@@ -13735,7 +13737,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14250,6 +14252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14477,18 +14488,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,53 +120,53 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a0b0d88", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ad8f93af1", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -512,6 +512,7 @@ where
             evm_config,
             self.state_provider_metrics,
             self.disable_state_cache,
+            Default::default(),
         ))
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -631,8 +631,11 @@ where
         } = builder.finish(instrumented_provider)?;
         if tracing::enabled!(target: "payload_builder", Level::DEBUG) {
             finish_span.record("accounts_changed", hashed_state.accounts.len());
-            let storage_slots_changed: usize =
-                hashed_state.storages.values().map(|s| s.storage.len()).sum();
+            let storage_slots_changed: usize = hashed_state
+                .storages
+                .values()
+                .map(|s| s.storage.len())
+                .sum();
             finish_span.record("storage_slots_changed", storage_slots_changed);
         }
         drop(finish_span);

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -224,6 +224,7 @@ where
     where
         Txs: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
     {
+        let build_span = Span::current();
         let BuildArguments {
             mut cached_reads,
             config,
@@ -628,14 +629,12 @@ where
             hashed_state,
             trie_updates,
         } = builder.finish(instrumented_provider)?;
-        let accounts_changed = hashed_state.accounts.len();
-        let storage_slots_changed: usize = hashed_state
-            .storages
-            .values()
-            .map(|s| s.storage.len())
-            .sum();
-        finish_span.record("accounts_changed", accounts_changed);
-        finish_span.record("storage_slots_changed", storage_slots_changed);
+        if tracing::enabled!(target: "payload_builder", Level::DEBUG) {
+            finish_span.record("accounts_changed", hashed_state.accounts.len());
+            let storage_slots_changed: usize =
+                hashed_state.storages.values().map(|s| s.storage.len()).sum();
+            finish_span.record("storage_slots_changed", storage_slots_changed);
+        }
         drop(finish_span);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics
@@ -693,9 +692,8 @@ where
             .rlp_block_size_bytes_last
             .set(rlp_length as f64);
 
-        let span = Span::current();
-        span.record("total_txs", total_transactions);
-        span.record("gas_used", gas_used);
+        build_span.record("total_txs", total_transactions);
+        build_span.record("gas_used", gas_used);
 
         info!(
             parent_hash = ?sealed_block.parent_hash(),

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -541,12 +541,12 @@ where
             subblock_txs = tracing::field::Empty,
         )
         .entered();
-        let subblocks_count = subblocks.len();
-        let mut subblock_transactions = 0u64;
+        let subblocks_count = subblocks.len() as f64;
+        let mut subblock_transactions = 0f64;
         // Apply subblock transactions
         for subblock in &subblocks {
             let subblock_start = Instant::now();
-            let mut subblock_tx_count = 0u64;
+            let mut subblock_tx_count = 0f64;
 
             for tx in subblock.transactions_recovered() {
                 if let Err(err) = builder.execute_transaction(tx.cloned()) {
@@ -567,7 +567,7 @@ where
                     }
                 }
 
-                subblock_tx_count += 1;
+                subblock_tx_count += 1.0;
             }
 
             self.metrics
@@ -575,23 +575,23 @@ where
                 .record(subblock_start.elapsed());
             self.metrics
                 .subblock_transaction_count
-                .record(subblock_tx_count as f64);
+                .record(subblock_tx_count);
             subblock_transactions += subblock_tx_count;
         }
-        _subblock_txs_span.record("subblock_txs", subblock_transactions);
+        _subblock_txs_span.record("subblock_txs", subblock_transactions as u64);
         drop(_subblock_txs_span);
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
             .record(total_subblock_transaction_execution_elapsed);
-        self.metrics.subblocks.record(subblocks_count as f64);
-        self.metrics.subblocks_last.set(subblocks_count as f64);
+        self.metrics.subblocks.record(subblocks_count);
+        self.metrics.subblocks_last.set(subblocks_count);
         self.metrics
             .subblock_transactions
-            .record(subblock_transactions as f64);
+            .record(subblock_transactions);
         self.metrics
             .subblock_transactions_last
-            .set(subblock_transactions as f64);
+            .set(subblock_transactions);
 
         // Apply system transactions
         let system_txs_execution_start = Instant::now();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -540,12 +540,12 @@ where
             subblock_txs = tracing::field::Empty,
         )
         .entered();
-        let subblocks_count = subblocks.len() as f64;
-        let mut subblock_transactions = 0f64;
+        let subblocks_count = subblocks.len();
+        let mut subblock_transactions = 0u64;
         // Apply subblock transactions
         for subblock in &subblocks {
             let subblock_start = Instant::now();
-            let mut subblock_tx_count = 0f64;
+            let mut subblock_tx_count = 0u64;
 
             for tx in subblock.transactions_recovered() {
                 if let Err(err) = builder.execute_transaction(tx.cloned()) {
@@ -566,7 +566,7 @@ where
                     }
                 }
 
-                subblock_tx_count += 1.0;
+                subblock_tx_count += 1;
             }
 
             self.metrics
@@ -574,23 +574,23 @@ where
                 .record(subblock_start.elapsed());
             self.metrics
                 .subblock_transaction_count
-                .record(subblock_tx_count);
+                .record(subblock_tx_count as f64);
             subblock_transactions += subblock_tx_count;
         }
-        _subblock_txs_span.record("subblock_txs", subblock_transactions as u64);
+        _subblock_txs_span.record("subblock_txs", subblock_transactions);
         drop(_subblock_txs_span);
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
             .record(total_subblock_transaction_execution_elapsed);
-        self.metrics.subblocks.record(subblocks_count);
-        self.metrics.subblocks_last.set(subblocks_count);
+        self.metrics.subblocks.record(subblocks_count as f64);
+        self.metrics.subblocks_last.set(subblocks_count as f64);
         self.metrics
             .subblock_transactions
-            .record(subblock_transactions);
+            .record(subblock_transactions as f64);
         self.metrics
             .subblock_transactions_last
-            .set(subblock_transactions);
+            .set(subblock_transactions as f64);
 
         // Apply system transactions
         let system_txs_execution_start = Instant::now();

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -16,7 +16,7 @@ use reth_basic_payload_builder::{
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
-use reth_engine_tree::tree::instrumented_state::InstrumentedStateProvider;
+use reth_engine_tree::tree::{SharedPreservedSparseTrie, instrumented_state::InstrumentedStateProvider};
 use reth_errors::{ConsensusError, ProviderError};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
@@ -90,6 +90,8 @@ pub struct TempoPayloadBuilder<Provider> {
     state_provider_metrics: bool,
     /// Whether to disable state cache.
     disable_state_cache: bool,
+    /// Engine sparse trie (Arc-backed, cheap to clone). Used for sparse trie-based state root.
+    sparse_trie: SharedPreservedSparseTrie,
 }
 
 impl<Provider> TempoPayloadBuilder<Provider> {
@@ -99,6 +101,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         evm_config: TempoEvmConfig,
         state_provider_metrics: bool,
         disable_state_cache: bool,
+        sparse_trie: SharedPreservedSparseTrie,
     ) -> Self {
         Self {
             pool,
@@ -108,6 +111,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             highest_invalid_subblock: Default::default(),
             state_provider_metrics,
             disable_state_cache,
+            sparse_trie,
         }
     }
 }
@@ -622,6 +626,7 @@ where
         let instrumented_provider = InstrumentedFinishProvider {
             inner: &*state_provider,
             metrics: self.metrics.clone(),
+            sparse_trie: self.sparse_trie.clone(),
         };
         let BlockBuilderOutcome {
             execution_result,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -60,7 +60,7 @@ use tempo_transaction_pool::{
     TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
-use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
+use tracing::{Level, Span, debug, debug_span, error, info, instrument, trace, warn};
 
 /// Returns true if a subblock has any expired transactions for the given timestamp.
 fn has_expired_transactions(subblock: &RecoveredSubBlock, timestamp: u64) -> bool {
@@ -210,7 +210,9 @@ where
         fields(
             id = %args.config.attributes.payload_id(),
             parent_number = %args.config.parent_header.number(),
-            parent_hash = %args.config.parent_header.hash()
+            parent_hash = %args.config.parent_header.hash(),
+            total_txs = tracing::field::Empty,
+            gas_used = tracing::field::Empty,
         )
     )]
     fn build_payload<Txs>(
@@ -381,7 +383,13 @@ where
             .record(pool_fetch_start.elapsed());
 
         let execution_start = Instant::now();
-        let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
+        let block_fill_span = debug_span!(target: "payload_builder", "block_fill",
+            pool_txs = tracing::field::Empty,
+            payment_txs = tracing::field::Empty,
+            cumulative_gas_used = tracing::field::Empty,
+        )
+        .entered();
+        let mut pool_tx_count = 0u64;
         while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
@@ -495,8 +503,12 @@ where
                 non_payment_gas_used += gas_used;
             }
             block_size_used += tx_rlp_length;
+            pool_tx_count += 1;
         }
-        drop(_block_fill_span);
+        block_fill_span.record("pool_txs", pool_tx_count);
+        block_fill_span.record("payment_txs", payment_transactions);
+        block_fill_span.record("cumulative_gas_used", cumulative_gas_used);
+        drop(block_fill_span);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds
@@ -523,8 +535,11 @@ where
         }
 
         let subblocks_start = Instant::now();
-        let _subblock_txs_span =
-            debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
+        let _subblock_txs_span = debug_span!(target: "payload_builder", "execute_subblock_txs",
+            subblocks = subblocks.len(),
+            subblock_txs = tracing::field::Empty,
+        )
+        .entered();
         let subblocks_count = subblocks.len() as f64;
         let mut subblock_transactions = 0f64;
         // Apply subblock transactions
@@ -562,6 +577,7 @@ where
                 .record(subblock_tx_count);
             subblock_transactions += subblock_tx_count;
         }
+        _subblock_txs_span.record("subblock_txs", subblock_transactions as u64);
         drop(_subblock_txs_span);
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics
@@ -597,7 +613,11 @@ where
             .record(total_transaction_execution_elapsed);
 
         let builder_finish_start = Instant::now();
-        let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
+        let finish_span = debug_span!(target: "payload_builder", "finish_block",
+            accounts_changed = tracing::field::Empty,
+            storage_slots_changed = tracing::field::Empty,
+        )
+        .entered();
         let instrumented_provider = InstrumentedFinishProvider {
             inner: &*state_provider,
             metrics: self.metrics.clone(),
@@ -608,7 +628,15 @@ where
             hashed_state,
             trie_updates,
         } = builder.finish(instrumented_provider)?;
-        drop(_finish_span);
+        let accounts_changed = hashed_state.accounts.len();
+        let storage_slots_changed: usize = hashed_state
+            .storages
+            .values()
+            .map(|s| s.storage.len())
+            .sum();
+        finish_span.record("accounts_changed", accounts_changed);
+        finish_span.record("storage_slots_changed", storage_slots_changed);
+        drop(finish_span);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics
             .payload_finalization_duration_seconds
@@ -664,6 +692,10 @@ where
         self.metrics
             .rlp_block_size_bytes_last
             .set(rlp_length as f64);
+
+        let span = Span::current();
+        span.record("total_txs", total_transactions);
+        span.record("gas_used", gas_used);
 
         info!(
             parent_hash = ?sealed_block.parent_hash(),

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -142,11 +142,6 @@ reth_storage_api::delegate_impls_to_as_ref!(
     BytecodeReader {
         fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
     }
-    StorageRootProvider {
-        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
-        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
-        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
-    }
     StateProofProvider {
         fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
         fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
@@ -154,12 +149,51 @@ reth_storage_api::delegate_impls_to_as_ref!(
     }
 );
 
+impl StorageRootProvider for InstrumentedFinishProvider<'_> {
+    fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
+        let slots = storage.storage.len();
+        let _span = debug_span!(
+            target: "payload_builder",
+            "storage_root",
+            %address,
+            slots,
+        )
+        .entered();
+        self.inner.storage_root(address, storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        self.inner.storage_proof(address, slot, storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.inner.storage_multiproof(address, slots, storage)
+    }
+}
+
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
     fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
         let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
+        let span = debug_span!(target: "payload_builder", "hashed_post_state",
+            accounts = tracing::field::Empty,
+            storage_slots = tracing::field::Empty,
+        )
+        .entered();
         let result = self.inner.hashed_post_state(bundle_state);
-        drop(_span);
+        span.record("accounts", result.accounts.len());
+        let storage_slots: usize = result.storages.values().map(|s| s.storage.len()).sum();
+        span.record("storage_slots", storage_slots);
+        drop(span);
         self.metrics
             .hashed_post_state_duration_seconds
             .record(start.elapsed());
@@ -188,9 +222,15 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
+        let span = debug_span!(target: "payload_builder", "state_root_with_updates",
+            storage_tries = tracing::field::Empty,
+        )
+        .entered();
         let result = self.inner.state_root_with_updates(hashed_state);
-        drop(_span);
+        if let Ok((_, ref trie_updates)) = result {
+            span.record("storage_tries", trie_updates.storage_tries_ref().len());
+        }
+        drop(span);
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -160,17 +160,13 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
         let span = debug_span!(target: "payload_builder", "hashed_post_state",
             accounts = tracing::field::Empty,
             storage_slots = tracing::field::Empty,
-        );
-        let result = {
-            let _guard = span.enter();
-            self.inner.hashed_post_state(bundle_state)
-        };
-        if !span.is_disabled() {
-            span.record("accounts", result.accounts.len());
-            let storage_slots: usize =
-                result.storages.values().map(|s| s.storage.len()).sum();
-            span.record("storage_slots", storage_slots);
-        }
+        )
+        .entered();
+        let result = self.inner.hashed_post_state(bundle_state);
+        span.record("accounts", result.accounts.len());
+        span.record("storage_slots",
+            result.storages.values().map(|s| s.storage.len()).sum::<usize>());
+        drop(span);
         self.metrics
             .hashed_post_state_duration_seconds
             .record(start.elapsed());
@@ -201,14 +197,13 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         let start = Instant::now();
         let span = debug_span!(target: "payload_builder", "state_root_with_updates",
             storage_tries = tracing::field::Empty,
-        );
-        let result = {
-            let _guard = span.enter();
-            self.inner.state_root_with_updates(hashed_state)
-        };
+        )
+        .entered();
+        let result = self.inner.state_root_with_updates(hashed_state);
         if let Ok((_, ref trie_updates)) = result {
             span.record("storage_tries", trie_updates.storage_tries_ref().len());
         }
+        drop(span);
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -164,8 +164,14 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
         .entered();
         let result = self.inner.hashed_post_state(bundle_state);
         span.record("accounts", result.accounts.len());
-        span.record("storage_slots",
-            result.storages.values().map(|s| s.storage.len()).sum::<usize>());
+        span.record(
+            "storage_slots",
+            result
+                .storages
+                .values()
+                .map(|s| s.storage.len())
+                .sum::<usize>(),
+        );
         drop(span);
         self.metrics
             .hashed_post_state_duration_seconds

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -160,13 +160,17 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
         let span = debug_span!(target: "payload_builder", "hashed_post_state",
             accounts = tracing::field::Empty,
             storage_slots = tracing::field::Empty,
-        )
-        .entered();
-        let result = self.inner.hashed_post_state(bundle_state);
-        span.record("accounts", result.accounts.len());
-        let storage_slots: usize = result.storages.values().map(|s| s.storage.len()).sum();
-        span.record("storage_slots", storage_slots);
-        drop(span);
+        );
+        let result = {
+            let _guard = span.enter();
+            self.inner.hashed_post_state(bundle_state)
+        };
+        if !span.is_disabled() {
+            span.record("accounts", result.accounts.len());
+            let storage_slots: usize =
+                result.storages.values().map(|s| s.storage.len()).sum();
+            span.record("storage_slots", storage_slots);
+        }
         self.metrics
             .hashed_post_state_duration_seconds
             .record(start.elapsed());
@@ -197,13 +201,14 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         let start = Instant::now();
         let span = debug_span!(target: "payload_builder", "state_root_with_updates",
             storage_tries = tracing::field::Empty,
-        )
-        .entered();
-        let result = self.inner.state_root_with_updates(hashed_state);
+        );
+        let result = {
+            let _guard = span.enter();
+            self.inner.state_root_with_updates(hashed_state)
+        };
         if let Ok((_, ref trie_updates)) = result {
             span.record("storage_tries", trie_updates.storage_tries_ref().len());
         }
-        drop(span);
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -142,44 +142,17 @@ reth_storage_api::delegate_impls_to_as_ref!(
     BytecodeReader {
         fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
     }
+    StorageRootProvider {
+        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
+        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
+        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
+    }
     StateProofProvider {
         fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
         fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
         fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
     }
 );
-
-impl StorageRootProvider for InstrumentedFinishProvider<'_> {
-    fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
-        let slots = storage.storage.len();
-        let _span = debug_span!(
-            target: "payload_builder",
-            "storage_root",
-            %address,
-            slots,
-        )
-        .entered();
-        self.inner.storage_root(address, storage)
-    }
-
-    fn storage_proof(
-        &self,
-        address: Address,
-        slot: B256,
-        storage: HashedStorage,
-    ) -> ProviderResult<StorageProof> {
-        self.inner.storage_proof(address, slot, storage)
-    }
-
-    fn storage_multiproof(
-        &self,
-        address: Address,
-        slots: &[B256],
-        storage: HashedStorage,
-    ) -> ProviderResult<StorageMultiProof> {
-        self.inner.storage_multiproof(address, slots, storage)
-    }
-}
 
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
     fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -11,8 +11,9 @@ use reth_trie_common::{
     AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
     StorageProof, TrieInput, updates::TrieUpdates,
 };
+use reth_engine_tree::tree::SharedPreservedSparseTrie;
 use std::time::Instant;
-use tracing::debug_span;
+use tracing::{debug_span, warn};
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_payload_builder")]
@@ -87,6 +88,8 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) hashed_post_state_duration_seconds: Histogram,
     /// Time to compute the state root and trie updates via `state_root_with_updates`.
     pub(crate) state_root_with_updates_duration_seconds: Histogram,
+    /// Whether the sparse trie was used for state root (1 = hit, 0 = no/fallback).
+    pub(crate) sparse_trie_state_root_hit: Gauge,
 }
 
 impl TempoPayloadBuilderMetrics {
@@ -116,9 +119,11 @@ impl TempoPayloadBuilderMetrics {
 
 /// Wraps a [`StateProvider`] reference to instrument `hashed_post_state` and
 /// `state_root_with_updates` with tracing spans and histogram metrics during `builder.finish()`.
+/// When a shared sparse trie is available, attempts sparse trie-based state root first.
 pub(crate) struct InstrumentedFinishProvider<'a> {
     pub(crate) inner: &'a dyn StateProvider,
     pub(crate) metrics: TempoPayloadBuilderMetrics,
+    pub(crate) sparse_trie: SharedPreservedSparseTrie,
 }
 
 impl<'a> AsRef<dyn StateProvider + 'a> for InstrumentedFinishProvider<'a> {
@@ -201,6 +206,29 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let start = Instant::now();
+
+        // Try sparse trie first
+        if let Some(result) =
+            self.sparse_trie.compute_state_root(self.inner, hashed_state.clone())
+        {
+            match result {
+                Ok(outcome) => {
+                    self.metrics
+                        .state_root_with_updates_duration_seconds
+                        .record(start.elapsed());
+                    self.metrics.sparse_trie_state_root_hit.set(1.0);
+                    return Ok(outcome);
+                }
+                Err(e) => {
+                    warn!(target: "payload_builder", %e, "sparse trie state root failed, falling back");
+                    self.metrics.sparse_trie_state_root_hit.set(0.0);
+                }
+            }
+        } else {
+            self.metrics.sparse_trie_state_root_hit.set(0.0);
+        }
+
+        // Fall back to standard computation
         let span = debug_span!(target: "payload_builder", "state_root_with_updates",
             storage_tries = tracing::field::Empty,
         )


### PR DESCRIPTION
## Summary

Adds structured fields to payload builder tracing spans so BlockScope shows actionable data instead of just `busy_ns` and hashed addresses.

| Span | New fields | Why |
|---|---|---|
| `build_payload` | `total_txs`, `gas_used` | See final block stats at a glance without expanding child spans |
| `block_fill` | `pool_txs`, `payment_txs`, `cumulative_gas_used` | Distinguish pool vs payment tx counts; spot gas-heavy blocks |
| `execute_subblock_txs` | `subblocks`, `subblock_txs` | Know how many subblocks/txs were processed without counting children |
| `finish_block` | `accounts_changed`, `storage_slots_changed` | Correlate finalization time with state-diff size |
| `hashed_post_state` | `accounts`, `storage_slots` | Understand hashing cost relative to changed state |
| `state_root_with_updates` | `storage_tries` | Correlate trie computation time with number of storage tries |