### PR TITLE
feat(payload): enrich tracing spans with actionable attributes for BlockScope

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -210,7 +210,9 @@ where
         fields(
             id = %args.config.attributes.payload_id(),
             parent_number = %args.config.parent_header.number(),
-            parent_hash = %args.config.parent_header.hash()
+            parent_hash = %args.config.parent_header.hash(),
+            total_txs = tracing::field::Empty,
+            gas_used = tracing::field::Empty,
         )
     )]
     fn build_payload<Txs>(
@@ -233,6 +235,7 @@ where
             attributes,
         } = config;
 
+        let build_payload_span = tracing::Span::current();
         let start = Instant::now();
 
         let block_time_millis =
@@ -381,7 +384,15 @@ where
             .record(pool_fetch_start.elapsed());
 
         let execution_start = Instant::now();
-        let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
+        let block_fill_span = debug_span!(
+            target: "payload_builder",
+            "block_fill",
+            pool_txs = tracing::field::Empty,
+            payment_txs = tracing::field::Empty,
+            cumulative_gas_used = tracing::field::Empty,
+        );
+        let _block_fill_entered = block_fill_span.enter();
+        let mut pool_transactions = 0u64;
         while let Some(pool_tx) = best_txs.next() {
             // Ensure we still have capacity for this transaction within the non-shared gas limit.
             // The remaining `shared_gas_limit` is reserved for validator subblocks and must not
@@ -428,9 +439,6 @@ where
             }
 
             let is_payment = pool_tx.transaction.is_payment();
-            if is_payment {
-                payment_transactions += 1;
-            }
 
             let tx_rlp_length = pool_tx.transaction.inner().length();
             let estimated_block_size_with_tx = block_size_used + tx_rlp_length;
@@ -489,6 +497,10 @@ where
             trace!(?elapsed, "Transaction executed");
 
             // update and add to total fees
+            pool_transactions += 1;
+            if is_payment {
+                payment_transactions += 1;
+            }
             total_fees += calc_gas_balance_spending(gas_used, effective_gas_price);
             cumulative_gas_used += gas_used;
             if !is_payment {
@@ -496,7 +508,10 @@ where
             }
             block_size_used += tx_rlp_length;
         }
-        drop(_block_fill_span);
+        block_fill_span.record("pool_txs", pool_transactions);
+        block_fill_span.record("payment_txs", payment_transactions);
+        block_fill_span.record("cumulative_gas_used", cumulative_gas_used);
+        drop(_block_fill_entered);
         let total_normal_transaction_execution_elapsed = execution_start.elapsed();
         self.metrics
             .total_normal_transaction_execution_duration_seconds
@@ -523,14 +538,19 @@ where
         }
 
         let subblocks_start = Instant::now();
-        let _subblock_txs_span =
-            debug_span!(target: "payload_builder", "execute_subblock_txs").entered();
-        let subblocks_count = subblocks.len() as f64;
-        let mut subblock_transactions = 0f64;
+        let subblock_txs_span = debug_span!(
+            target: "payload_builder",
+            "execute_subblock_txs",
+            subblocks = tracing::field::Empty,
+            subblock_txs = tracing::field::Empty,
+        );
+        let _subblock_txs_entered = subblock_txs_span.enter();
+        let subblocks_count = subblocks.len() as u64;
+        let mut subblock_transactions = 0u64;
         // Apply subblock transactions
         for subblock in &subblocks {
             let subblock_start = Instant::now();
-            let mut subblock_tx_count = 0f64;
+            let mut subblock_tx_count = 0u64;
 
             for tx in subblock.transactions_recovered() {
                 if let Err(err) = builder.execute_transaction(tx.cloned()) {
@@ -551,7 +571,7 @@ where
                     }
                 }
 
-                subblock_tx_count += 1.0;
+                subblock_tx_count += 1;
             }
 
             self.metrics
@@ -559,22 +579,24 @@ where
                 .record(subblock_start.elapsed());
             self.metrics
                 .subblock_transaction_count
-                .record(subblock_tx_count);
+                .record(subblock_tx_count as f64);
             subblock_transactions += subblock_tx_count;
         }
-        drop(_subblock_txs_span);
+        subblock_txs_span.record("subblocks", subblocks_count);
+        subblock_txs_span.record("subblock_txs", subblock_transactions);
+        drop(_subblock_txs_entered);
         let total_subblock_transaction_execution_elapsed = subblocks_start.elapsed();
         self.metrics
             .total_subblock_transaction_execution_duration_seconds
             .record(total_subblock_transaction_execution_elapsed);
-        self.metrics.subblocks.record(subblocks_count);
-        self.metrics.subblocks_last.set(subblocks_count);
+        self.metrics.subblocks.record(subblocks_count as f64);
+        self.metrics.subblocks_last.set(subblocks_count as f64);
         self.metrics
             .subblock_transactions
-            .record(subblock_transactions);
+            .record(subblock_transactions as f64);
         self.metrics
             .subblock_transactions_last
-            .set(subblock_transactions);
+            .set(subblock_transactions as f64);
 
         // Apply system transactions
         let system_txs_execution_start = Instant::now();
@@ -597,7 +619,13 @@ where
             .record(total_transaction_execution_elapsed);
 
         let builder_finish_start = Instant::now();
-        let _finish_span = debug_span!(target: "payload_builder", "finish_block").entered();
+        let finish_span = debug_span!(
+            target: "payload_builder",
+            "finish_block",
+            accounts_changed = tracing::field::Empty,
+            storage_slots_changed = tracing::field::Empty,
+        );
+        let _finish_entered = finish_span.enter();
         let instrumented_provider = InstrumentedFinishProvider {
             inner: &*state_provider,
             metrics: self.metrics.clone(),
@@ -608,13 +636,25 @@ where
             hashed_state,
             trie_updates,
         } = builder.finish(instrumented_provider)?;
-        drop(_finish_span);
+        finish_span.record("accounts_changed", hashed_state.accounts.len() as u64);
+        finish_span.record(
+            "storage_slots_changed",
+            hashed_state
+                .storages
+                .values()
+                .map(|s| s.storage.len() as u64)
+                .sum::<u64>(),
+        );
+        drop(_finish_entered);
         let builder_finish_elapsed = builder_finish_start.elapsed();
         self.metrics
             .payload_finalization_duration_seconds
             .record(builder_finish_elapsed);
 
         let total_transactions = block.transaction_count();
+        let gas_used = block.gas_used();
+        build_payload_span.record("total_txs", total_transactions);
+        build_payload_span.record("gas_used", gas_used);
         self.metrics
             .total_transactions
             .record(total_transactions as f64);
@@ -622,7 +662,6 @@ where
             .total_transactions_last
             .set(total_transactions as f64);
 
-        let gas_used = block.gas_used();
         self.metrics.gas_used.record(gas_used as f64);
         self.metrics.gas_used_last.set(gas_used as f64);
         self.metrics

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -142,11 +142,6 @@ reth_storage_api::delegate_impls_to_as_ref!(
     BytecodeReader {
         fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>>;
     }
-    StorageRootProvider {
-        fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256>;
-        fn storage_proof(&self, address: Address, slot: B256, storage: HashedStorage) -> ProviderResult<StorageProof>;
-        fn storage_multiproof(&self, address: Address, slots: &[B256], storage: HashedStorage) -> ProviderResult<StorageMultiProof>;
-    }
     StateProofProvider {
         fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
         fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
@@ -154,12 +149,55 @@ reth_storage_api::delegate_impls_to_as_ref!(
     }
 );
 
+impl StorageRootProvider for InstrumentedFinishProvider<'_> {
+    fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
+        let slots = storage.storage.len() as u64;
+        let _span = debug_span!(
+            target: "payload_builder",
+            "storage_root",
+            %address,
+            slots,
+        )
+        .entered();
+        self.inner.storage_root(address, storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        self.inner.storage_proof(address, slot, storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.inner.storage_multiproof(address, slots, storage)
+    }
+}
+
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
     fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
         let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
+        let span = debug_span!(
+            target: "payload_builder",
+            "hashed_post_state",
+            accounts = tracing::field::Empty,
+            storage_slots = tracing::field::Empty,
+        );
+        let _entered = span.enter();
         let result = self.inner.hashed_post_state(bundle_state);
-        drop(_span);
+        span.record("accounts", result.accounts.len() as u64);
+        span.record(
+            "storage_slots",
+            result.storages.values().map(|s| s.storage.len() as u64).sum::<u64>(),
+        );
+        drop(_entered);
         self.metrics
             .hashed_post_state_duration_seconds
             .record(start.elapsed());
@@ -170,9 +208,10 @@ impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
 impl StateRootProvider for InstrumentedFinishProvider<'_> {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "state_root").entered();
+        let span = debug_span!(target: "payload_builder", "state_root");
+        let _entered = span.enter();
         let result = self.inner.state_root(hashed_state);
-        drop(_span);
+        drop(_entered);
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());
@@ -188,9 +227,17 @@ impl StateRootProvider for InstrumentedFinishProvider<'_> {
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         let start = Instant::now();
-        let _span = debug_span!(target: "payload_builder", "state_root_with_updates").entered();
+        let span = debug_span!(
+            target: "payload_builder",
+            "state_root_with_updates",
+            storage_tries = tracing::field::Empty,
+        );
+        let _entered = span.enter();
         let result = self.inner.state_root_with_updates(hashed_state);
-        drop(_span);
+        if let Ok((_, ref trie_updates)) = result {
+            span.record("storage_tries", trie_updates.storage_tries.len() as u64);
+        }
+        drop(_entered);
         self.metrics
             .state_root_with_updates_duration_seconds
             .record(start.elapsed());


### PR DESCRIPTION
Records actionable fields on payload builder tracing spans and instruments
`storage_root` with real address + slot count so BlockScope can display
useful data instead of noise like `busy_ns` and `hashed_address`.

Spans enriched:

| Span | New fields |
|---|---|
| `build_payload` | `total_txs`, `gas_used` |
| `block_fill` | `pool_txs`, `payment_txs`, `cumulative_gas_used` |
| `execute_subblock_txs` | `subblocks`, `subblock_txs` |
| `finish_block` | `accounts_changed`, `storage_slots_changed` |
| `hashed_post_state` | `accounts`, `storage_slots` |
| `state_root_with_updates` | `storage_tries` |
| `storage_root` | `address`, `slots` (manual impl replacing delegate) |

The `storage_root` span wraps each per-account trie computation with the
real address and slot count, giving BlockScope a parent span with
actionable data around the noisy child `storage_trie` spans.

Also changes `subblock_transactions` / `subblock_tx_count` from `f64` to
`u64` locally, casting to `f64` only at the metrics boundary. Moves
`payment_transactions` increment to after successful execution so the
count is accurate.

Supersedes #3233 and #3235.

Prompted by: yk