### PR TITLE
chore(bench): split B-F-F-B runs into separate workflow steps

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -545,22 +545,23 @@ jobs:
             core.setOutput('feature-ref', featureRef);
             core.setOutput('feature-name', featureName);
 
-      - name: Update status (running benchmark)
+      - name: Update status (setting up benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running benchmark...'});
+            await s({github, context, status: 'Setting up benchmark...'});
 
-      - name: Run benchmark
-        id: bench
+      - name: Setup benchmark
+        id: bench-setup
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          nu tempo.nu bench \
+          OUTPUT=$(nu tempo.nu bench \
+            --setup-only \
             --preset "$BENCH_PRESET" \
             --mode dev \
             --bloat "$BENCH_BLOAT" \
@@ -573,7 +574,66 @@ jobs:
             --tune \
             $([ "$BENCH_SAMPLY" = "true" ] && echo "--samply" || true) \
             $([ "$BENCH_TRACY" != "off" ] && echo "--tracy $BENCH_TRACY --tracy-seconds $BENCH_TRACY_SECONDS --tracy-offset $BENCH_TRACY_OFFSET" || true) \
-            $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true)
+            $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true) \
+            2>&1 | tee /dev/stderr)
+          CONFIG=$(echo "$OUTPUT" | grep '^BENCH_CONFIG_PATH=' | cut -d= -f2-)
+          echo "config=$CONFIG" >> "$GITHUB_OUTPUT"
+
+      - name: "Update status: baseline (1/2)"
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running baseline benchmark (1/2)...'});
+
+      - name: "Run benchmark: baseline (1/2)"
+        id: run-baseline-1
+        run: nu tempo.nu bench-run-single --config "${{ steps.bench-setup.outputs.config }}" --label baseline-1
+
+      - name: "Update status: feature (1/2)"
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running feature benchmark (1/2)...'});
+
+      - name: "Run benchmark: feature (1/2)"
+        id: run-feature-1
+        run: nu tempo.nu bench-run-single --config "${{ steps.bench-setup.outputs.config }}" --label feature-1
+
+      - name: "Update status: feature (2/2)"
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running feature benchmark (2/2)...'});
+
+      - name: "Run benchmark: feature (2/2)"
+        id: run-feature-2
+        run: nu tempo.nu bench-run-single --config "${{ steps.bench-setup.outputs.config }}" --label feature-2
+
+      - name: "Update status: baseline (2/2)"
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Running baseline benchmark (2/2)...'});
+
+      - name: "Run benchmark: baseline (2/2)"
+        id: run-baseline-2
+        run: nu tempo.nu bench-run-single --config "${{ steps.bench-setup.outputs.config }}" --label baseline-2
+
+      - name: Finalize benchmark
+        if: success()
+        run: nu tempo.nu bench-finalize --config "${{ steps.bench-setup.outputs.config }}"
 
       - name: Find results directory
         id: results-dir
@@ -714,12 +774,21 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
+            const steps_status = [
+              ['setting up benchmark', '${{ steps.bench-setup.outcome }}'],
+              ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
+              ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
+              ['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}'],
+              ['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}'],
+            ];
+            const failed = steps_status.find(([, o]) => o === 'failure');
+            const failedStep = failed ? failed[0] : 'unknown step';
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed. [View logs](${jobUrl})`,
+              body: `cc @${process.env.BENCH_ACTOR}\n\n❌ Benchmark failed while ${failedStep}. [View logs](${jobUrl})`,
             });
 
       - name: Update status (cancelled)

--- a/tempo.nu
+++ b/tempo.nu
@@ -1979,7 +1979,7 @@ def "main bench" [
         }
 
         # Load the saved config and run B-F-F-B passes
-        let bench_cfg = (open $config_path | from json)
+        let bench_cfg = (open $config_path)
         for run in $runs {
             do-bench-run $bench_cfg $run.label
         }
@@ -2165,7 +2165,7 @@ def "main bench-run-single" [
     --config: string                                # Path to bench-config.json from bench --setup-only
     --label: string                                 # Run label: baseline-1, feature-1, feature-2, baseline-2
 ] {
-    let cfg = (open $config | from json)
+    let cfg = (open $config)
     do-bench-run $cfg $label
 }
 
@@ -2173,7 +2173,7 @@ def "main bench-run-single" [
 def "main bench-finalize" [
     --config: string                                # Path to bench-config.json from bench --setup-only
 ] {
-    let cfg = (open $config | from json)
+    let cfg = (open $config)
     do-bench-finalize $cfg
     print $"\nBenchmark finalized! Results: ($cfg.results_dir)/"
 }

--- a/tempo.nu
+++ b/tempo.nu
@@ -1978,53 +1978,13 @@ def "main bench" [
             return
         }
 
+        # Load the saved config and run B-F-F-B passes
+        let bench_cfg = (open $config_path | from json)
         for run in $runs {
-            # bench-recover restores the entire schelk volume to the promoted
-            # virgin state. In dual-hardfork mode this resets both baseline-db
-            # and feature-db subdirs at once.
-            bench-recover $datadir
-            run-bench-single $run.tempo $baseline_bench_bin $run.genesis $run.datadir $run.label $results_dir $tps $duration $accounts $max_concurrent_requests $weights $preset $bench_args $loud $node_args $bloat $run.git_ref $benchmark_id $reference_epoch $samply $samply_args_list $tracy $tracy_filter $tracy_seconds $tracy_offset $tracing_otlp
+            do-bench-run $bench_cfg $run.label
         }
 
-        # Generate summary report
-        let baseline_label = if $dual_hardfork { $"($baseline) \(($baseline_hardfork | str upcase)\)" } else { $baseline }
-        let feature_label = if $dual_hardfork { $"($feature) \(($feature_hardfork | str upcase)\)" } else { $feature }
-        generate-summary $results_dir $baseline_label $feature_label $bloat $preset $tps $duration --benchmark-id $benchmark_id --reference-epoch $reference_epoch
-
-        # Cleanup worktrees (only those we created)
-        if $baseline != "local" or $feature != "local" {
-            print "Cleaning up worktrees..."
-        }
-        if $baseline != "local" { try { git worktree remove --force $baseline_wt } catch { } }
-        if $feature != "local" { try { git worktree remove --force $feature_wt } catch { } }
-
-        if not $no_infra {
-            docker compose -f $"($BENCH_DIR)/docker-compose.yml" down
-        }
-
-        # Upload samply profiles to Firefox Profiler
-        if $samply {
-            print "\nUploading samply profiles to Firefox Profiler..."
-            for run in $runs {
-                let profile = $"($results_dir)/profile-($run.label).json.gz"
-                let url = (upload-samply-profile $profile)
-                if $url != null {
-                    $url | save -f $"($results_dir)/profile-($run.label)-url.txt"
-                }
-            }
-        }
-
-        # Upload tracy profiles to R2
-        if $tracy != "off" {
-            print "\nUploading tracy profiles to R2..."
-            for run in $runs {
-                let profile = $"($results_dir)/tracy-profile-($run.label).tracy"
-                let viewer_url = (upload-tracy-profile $profile $run.label $run.git_ref)
-                if $viewer_url != null {
-                    $viewer_url | save -f $"($results_dir)/tracy-($run.label)-url.txt"
-                }
-            }
-        }
+        do-bench-finalize $bench_cfg
 
         restore-system-tuning $tuning_state
         print $"\nComparison complete! Results: ($results_dir)/"
@@ -2145,12 +2105,8 @@ def "main bench" [
     print "Done."
 }
 
-# Run a single benchmark pass (used by CI to split B-F-F-B into separate steps)
-def "main bench-run-single" [
-    --config: string                                # Path to bench-config.json from bench --setup-only
-    --label: string                                 # Run label: baseline-1, feature-1, feature-2, baseline-2
-] {
-    let cfg = (open $config | from json)
+# Run a single benchmark pass from a config record
+def do-bench-run [cfg: record, label: string] {
     let matched = ($cfg.runs | where label == $label)
     if ($matched | length) == 0 {
         print $"Error: unknown run label '($label)'. Valid: ($cfg.runs | get label | str join ', ')"
@@ -2162,12 +2118,8 @@ def "main bench-run-single" [
     run-bench-single $run.tempo $cfg.baseline_bench_bin $run.genesis $run.datadir $run.label $cfg.results_dir $cfg.tps $cfg.duration $cfg.accounts $cfg.max_concurrent_requests $cfg.weights $cfg.preset $cfg.bench_args $cfg.loud $cfg.node_args $cfg.bloat $run.git_ref $cfg.benchmark_id $cfg.reference_epoch $cfg.samply $cfg.samply_args $cfg.tracy $cfg.tracy_filter $cfg.tracy_seconds $cfg.tracy_offset $cfg.tracing_otlp
 }
 
-# Generate summary report after all bench runs complete
-def "main bench-finalize" [
-    --config: string                                # Path to bench-config.json from bench --setup-only
-] {
-    let cfg = (open $config | from json)
-
+# Finalize benchmark: generate summary, upload profiles, clean up worktrees
+def do-bench-finalize [cfg: record] {
     let baseline_label = if $cfg.dual_hardfork { $"($cfg.baseline) \(($cfg.baseline_hardfork | str upcase)\)" } else { $cfg.baseline }
     let feature_label = if $cfg.dual_hardfork { $"($cfg.feature) \(($cfg.feature_hardfork | str upcase)\)" } else { $cfg.feature }
     generate-summary $cfg.results_dir $baseline_label $feature_label $cfg.bloat $cfg.preset $cfg.tps $cfg.duration --benchmark-id $cfg.benchmark_id --reference-epoch $cfg.reference_epoch
@@ -2206,7 +2158,23 @@ def "main bench-finalize" [
             }
         }
     }
+}
 
+# Run a single benchmark pass (used by CI to split B-F-F-B into separate steps)
+def "main bench-run-single" [
+    --config: string                                # Path to bench-config.json from bench --setup-only
+    --label: string                                 # Run label: baseline-1, feature-1, feature-2, baseline-2
+] {
+    let cfg = (open $config | from json)
+    do-bench-run $cfg $label
+}
+
+# Generate summary report after all bench runs complete
+def "main bench-finalize" [
+    --config: string                                # Path to bench-config.json from bench --setup-only
+] {
+    let cfg = (open $config | from json)
+    do-bench-finalize $cfg
     print $"\nBenchmark finalized! Results: ($cfg.results_dir)/"
 }
 

--- a/tempo.nu
+++ b/tempo.nu
@@ -1460,6 +1460,7 @@ def "main bench" [
     --tracing-otlp: string = ""                     # OTLP endpoint for tracing (auto-derived from TEMPO_TELEMETRY_URL if not set)
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
+    --setup-only                                    # Exit after setup (build + init), saving config for bench-run-single
 ] {
     validate-mode $mode
 
@@ -1926,6 +1927,57 @@ def "main bench" [
             ]
         }
 
+        # Save bench config for use by bench-run-single / bench-finalize
+        let abs_runs = ($runs | each { |r| {
+            label: $r.label
+            tempo: ($r.tempo | path expand)
+            git_ref: $r.git_ref
+            genesis: $r.genesis
+            datadir: $r.datadir
+        }})
+        let bench_config = {
+            results_dir: ($results_dir | path expand)
+            datadir: $datadir
+            benchmark_id: $benchmark_id
+            reference_epoch: $reference_epoch
+            preset: $preset
+            tps: $tps
+            duration: $duration
+            accounts: $accounts
+            max_concurrent_requests: $max_concurrent_requests
+            weights: $weights
+            bench_args: $bench_args
+            loud: $loud
+            node_args: $node_args
+            bloat: $bloat
+            samply: $samply
+            samply_args: $samply_args_list
+            tracy: $tracy
+            tracy_filter: $tracy_filter
+            tracy_seconds: $tracy_seconds
+            tracy_offset: $tracy_offset
+            tracing_otlp: $tracing_otlp
+            baseline_sha: $baseline_sha
+            feature_sha: $feature_sha
+            baseline: $baseline
+            feature: $feature
+            baseline_hardfork: $baseline_hardfork
+            feature_hardfork: $feature_hardfork
+            dual_hardfork: $dual_hardfork
+            runs: $abs_runs
+            baseline_bench_bin: ($baseline_bench_bin | path expand)
+            no_infra: $no_infra
+        }
+        let config_path = $"($results_dir)/bench-config.json"
+        $bench_config | to json | save -f $config_path
+        print $"BENCH_CONFIG_PATH=($config_path)"
+
+        if $setup_only {
+            print "Setup complete. Use 'bench-run-single' to run individual passes."
+            restore-system-tuning $tuning_state
+            return
+        }
+
         for run in $runs {
             # bench-recover restores the entire schelk volume to the promoted
             # virgin state. In dual-hardfork mode this resets both baseline-db
@@ -2091,6 +2143,71 @@ def "main bench" [
 
     restore-system-tuning $tuning_state
     print "Done."
+}
+
+# Run a single benchmark pass (used by CI to split B-F-F-B into separate steps)
+def "main bench-run-single" [
+    --config: string                                # Path to bench-config.json from bench --setup-only
+    --label: string                                 # Run label: baseline-1, feature-1, feature-2, baseline-2
+] {
+    let cfg = (open $config | from json)
+    let matched = ($cfg.runs | where label == $label)
+    if ($matched | length) == 0 {
+        print $"Error: unknown run label '($label)'. Valid: ($cfg.runs | get label | str join ', ')"
+        exit 1
+    }
+    let run = ($matched | first)
+
+    bench-recover $cfg.datadir
+    run-bench-single $run.tempo $cfg.baseline_bench_bin $run.genesis $run.datadir $run.label $cfg.results_dir $cfg.tps $cfg.duration $cfg.accounts $cfg.max_concurrent_requests $cfg.weights $cfg.preset $cfg.bench_args $cfg.loud $cfg.node_args $cfg.bloat $run.git_ref $cfg.benchmark_id $cfg.reference_epoch $cfg.samply $cfg.samply_args $cfg.tracy $cfg.tracy_filter $cfg.tracy_seconds $cfg.tracy_offset $cfg.tracing_otlp
+}
+
+# Generate summary report after all bench runs complete
+def "main bench-finalize" [
+    --config: string                                # Path to bench-config.json from bench --setup-only
+] {
+    let cfg = (open $config | from json)
+
+    let baseline_label = if $cfg.dual_hardfork { $"($cfg.baseline) \(($cfg.baseline_hardfork | str upcase)\)" } else { $cfg.baseline }
+    let feature_label = if $cfg.dual_hardfork { $"($cfg.feature) \(($cfg.feature_hardfork | str upcase)\)" } else { $cfg.feature }
+    generate-summary $cfg.results_dir $baseline_label $feature_label $cfg.bloat $cfg.preset $cfg.tps $cfg.duration --benchmark-id $cfg.benchmark_id --reference-epoch $cfg.reference_epoch
+
+    # Cleanup worktrees (only those we created)
+    let baseline_wt = $"($BENCH_WORKTREES_DIR)/baseline"
+    let feature_wt = $"($BENCH_WORKTREES_DIR)/feature"
+    if $cfg.baseline != "local" { try { git worktree remove --force $baseline_wt } catch { } }
+    if $cfg.feature != "local" { try { git worktree remove --force $feature_wt } catch { } }
+
+    # Stop observability stack if it was started
+    if not $cfg.no_infra {
+        docker compose -f $"($BENCH_DIR)/docker-compose.yml" down
+    }
+
+    # Upload samply profiles
+    if $cfg.samply {
+        print "\nUploading samply profiles to Firefox Profiler..."
+        for run in $cfg.runs {
+            let profile = $"($cfg.results_dir)/profile-($run.label).json.gz"
+            let url = (upload-samply-profile $profile)
+            if $url != null {
+                $url | save -f $"($cfg.results_dir)/profile-($run.label)-url.txt"
+            }
+        }
+    }
+
+    # Upload tracy profiles
+    if $cfg.tracy != "off" {
+        print "\nUploading tracy profiles to R2..."
+        for run in $cfg.runs {
+            let profile = $"($cfg.results_dir)/tracy-profile-($run.label).tracy"
+            let viewer_url = (upload-tracy-profile $profile $run.label $run.git_ref)
+            if $viewer_url != null {
+                $viewer_url | save -f $"($cfg.results_dir)/tracy-($run.label)-url.txt"
+            }
+        }
+    }
+
+    print $"\nBenchmark finalized! Results: ($cfg.results_dir)/"
 }
 
 # Wait for an RPC endpoint to be ready and chain advancing


### PR DESCRIPTION
Adds `--setup-only` flag to `bench` and new `bench-run-single` / `bench-finalize` subcommands so each of the 4 interleaved runs (baseline-1, feature-1, feature-2, baseline-2) is a separate GitHub Actions step with its own status update in the PR comment.

The CI workflow now shows progress like "Running baseline benchmark (1/2)..." → "Running feature benchmark (1/2)..." etc. instead of a single "Running benchmark..." for the entire ~20 min run. The failure message also identifies which specific step failed.

`bench --setup-only` saves a JSON config after building binaries and initializing the snapshot, then `bench-run-single --config <path> --label <label>` runs one pass, and `bench-finalize --config <path>` generates the summary and cleans up.

The existing `bench` command (without `--setup-only`) is unchanged — the config is always saved but the loop still runs inline.

Prompted by: alexey