### PR TITLE
tip: TIP-1020 Signature Verification Precompile

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -104,5 +104,5 @@ It is expected that this precompile will be updated when other account types are
 | **SV2** | P256 and ECDSA signature malleability resistance | P256 and ECDSA signatures MUST satisfy the low-s requirement (`s <= n/2`). Signatures with high-s values MUST be rejected. |
 | **SV3** | WebAuthn bounds enforcement | WebAuthn signature parsing MUST enforce the length bounds and structural validity checks used by Tempo transaction verification, preventing out-of-bounds reads and pathological resource usage. |
 | **SV4** | Revert on failure | On any invalid signature, invalid encoding, unsupported type, or signer mismatch, the precompile MUST revert. |
-| **SV5** | Gas schedule consistency | Gas charged MUST follow the Tempo Transaction Signature Gas Schedule. |
+| **SV5** | Gas schedule consistency | Gas charged MUST follow the gas schedule listed above. |
 | **SV6** | Signature type disambiguation | Exactly 65 bytes MUST be interpreted as secp256k1 (no prefix). Any non-65-byte signature MUST be interpreted using the leading type byte. Unknown type identifiers MUST revert. |


### PR DESCRIPTION
## Summary

Adds the TIP-1020 spec for a signature verification precompile at `0x5165300000000000000000000000000000000000`.

Enables contracts to verify Tempo signature types (secp256k1, P256, WebAuthn) onchain by reusing the existing audited verification logic from Tempo transaction processing.

Key design decisions:
- **Same gas schedule** as transaction signatures (3k secp256k1, 8k P256/WebAuthn)
- **Revert on invalid** rather than returning false (fail-fast)
- **No Keychain in precompile** — instead, the spec documents how contracts can verify Keychain signatures themselves by combining this precompile (inner signature verification) with the AccountKeychain precompile (access key validation)
- **No double-charge** for WebAuthn calldata gas (EVM already charges it)

Spec-only change — no code changes.

Implementation: https://github.com/tempoxyz/tempo/pull/2438

---
_Continues from #2633 (branch renamed from TIP/1020 to tip/1020)._