### PR TITLE
fix: handle invalid PolicyType instead of unreachable panic in is_simple

### DIFF
--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -617,7 +617,9 @@ impl TIP403Registry {
             PolicyType::WHITELIST => Ok(is_in_set),
             PolicyType::BLACKLIST => Ok(!is_in_set),
             PolicyType::COMPOUND => Err(TIP403RegistryError::incompatible_policy_type().into()),
-            PolicyType::__Invalid => unreachable!(),
+            PolicyType::__Invalid => {
+                Err(TIP403RegistryError::invalid_policy_type().into())
+            },
         }
     }
 


### PR DESCRIPTION
Previously, `PolicyType::__Invalid` in `is_simple` was handled via `unreachable!()`, implicitly assuming that `PolicyData::policy_type()` would never return an invalid value.

However, this assumption is not strictly guaranteed. `policy_type()` may return `Ok(PolicyType::__Invalid)` in cases of:
- corrupted or inconsistent on-chain storage
- legacy or migrated data
- unexpected enum values due to version mismatches

In such scenarios, the existing implementation would trigger a runtime panic, potentially crashing execution.

Changes:

Replaced `unreachable!()` with explicit error handling:
```rust
PolicyType::__Invalid => Err(TIP403RegistryError::invalid_policy_type().into())
```
Rationale:
- Prevents panic on malformed or unexpected input
- Ensures deterministic and safe error propagation
- Aligns with defensive programming practices for externally-influenced data

This change makes the system more robust without altering expected behavior for valid inputs.