### PR TITLE
ci: add upstream reth diff summary to deps update PR

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -319,16 +319,20 @@ jobs:
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          OLD_REV="${{ steps.update.outputs.old_rev }}"
-          NEW_REV="${{ steps.update.outputs.new_rev }}"
           TITLE="deps: update reth from main ($DATE)"
+
+          # Always compute revs by reading Cargo.toml on each branch.
+          # steps.update.outputs.old_rev/new_rev are empty when no bump was
+          # needed this run (branch already had the latest rev).
+          OLD_REV=$(git show origin/main:Cargo.toml | grep -m1 'paradigmxyz/reth' | sed 's/.*rev = "\([^"]*\)".*/\1/')
+          NEW_REV=$(grep -m1 'paradigmxyz/reth' Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/')
 
           # Build PR body in a temp file to avoid shell quoting issues
           {
             echo "Automated nightly update of reth dependencies from \`paradigmxyz/reth\` main branch."
             echo ""
 
-            if [ -n "$OLD_REV" ] && [ -n "$NEW_REV" ]; then
+            if [ -n "$OLD_REV" ] && [ -n "$NEW_REV" ] && [ "$OLD_REV" != "$NEW_REV" ]; then
               # Summarize upstream reth changes
               echo "## Upstream reth changes"
               echo ""


### PR DESCRIPTION
Adds an "Upstream reth changes" section to the auto-generated reth deps update PR body. Uses `gh api` to fetch the commit log between old and new reth revs, then Amp summarizes them into a grouped bullet list by area (engine, rpc, trie, etc).

Example PR: https://github.com/tempoxyz/tempo/pull/3245

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey