### PR TITLE
feat(xtask): add check-v1-migration subcommand

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,6 +26,7 @@ alloy = { workspace = true, features = [
   "providers",
   "reqwest",
   "reqwest-rustls-tls",
+  "rpc-types",
   "signers",
   "signer-local",
   "signer-mnemonic",

--- a/xtask/src/check_v1_migration.rs
+++ b/xtask/src/check_v1_migration.rs
@@ -1,0 +1,129 @@
+//! Pre-flight check for V1→V2 validator migration.
+//!
+//! Reads all V1 validators and reports which ones would be skipped or cause a revert
+//! during `ValidatorConfigV2.migrateValidator`.
+//!
+//! Migration heuristics (from ValidatorConfigV2.migrateValidator):
+//!   SKIP   1. publicKey == 0 OR validatorAddress == address(0)
+//!   SKIP   2. Duplicate publicKey (already seen earlier in the array)
+//!   SKIP   3. Active validator whose ingress hash (full ip:port) collides with an earlier active
+//!   REVERT 4. Duplicate active validatorAddress (AddressAlreadyHasValidator)
+
+use std::collections::HashSet;
+
+use alloy::{
+    primitives::{Address, B256, keccak256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    sol_types::SolCall,
+};
+use eyre::Context;
+use tempo_contracts::precompiles::{
+    IValidatorConfig::getValidatorsCall, VALIDATOR_CONFIG_ADDRESS,
+};
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct CheckV1Migration {
+    /// RPC endpoint URL
+    #[arg(long)]
+    rpc_url: String,
+}
+
+impl CheckV1Migration {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let provider = ProviderBuilder::new()
+            .connect(&self.rpc_url)
+            .await
+            .wrap_err("failed to connect to RPC")?;
+
+        let call = getValidatorsCall {};
+        let tx = TransactionRequest::default()
+            .to(VALIDATOR_CONFIG_ADDRESS)
+            .input(call.abi_encode().into());
+
+        let result = provider
+            .call(tx)
+            .await
+            .wrap_err("getValidators() call failed")?;
+
+        let validators = getValidatorsCall::abi_decode_returns(&result)
+            .wrap_err("failed to decode getValidators() return data")?;
+
+        println!("=== V1 Validator Migration Pre-Flight ===");
+        println!("Total V1 validators: {}", validators.len());
+        println!();
+
+        let mut skip_count: usize = 0;
+        let mut revert_count: usize = 0;
+        let mut ok_count: usize = 0;
+
+        let mut seen_pubkeys = HashSet::<B256>::new();
+        let mut active_addresses = HashSet::<Address>::new();
+        let mut active_ingress_hashes = HashSet::<B256>::new();
+
+        // Process in reverse order (migration iterates N-1 down to 0)
+        for ri in 0..validators.len() {
+            let i = validators.len() - 1 - ri;
+            let v = &validators[i];
+
+            // Check 1: zero pubkey or zero address
+            if v.publicKey == B256::ZERO || v.validatorAddress == Address::ZERO {
+                println!("SKIP  [idx {i}] zero pubkey or zero address");
+                println!("  addr={}", v.validatorAddress);
+                println!("  pubkey={}", v.publicKey);
+                skip_count += 1;
+                continue;
+            }
+
+            // Check 2: duplicate pubkey
+            if !seen_pubkeys.insert(v.publicKey) {
+                println!("SKIP  [idx {i}] duplicate publicKey");
+                println!("  addr={}", v.validatorAddress);
+                println!("  pubkey={}", v.publicKey);
+                skip_count += 1;
+                continue;
+            }
+
+            // Check 4 (before 3): duplicate active address → REVERT
+            if active_addresses.contains(&v.validatorAddress) {
+                println!("REVERT [idx {i}] AddressAlreadyHasValidator (dup active address)");
+                println!("  addr={}", v.validatorAddress);
+                revert_count += 1;
+                continue;
+            }
+
+            // Check 3: active validator with duplicate ingress hash
+            if v.active {
+                let ingress_hash = keccak256(v.inboundAddress.as_bytes());
+                if !active_ingress_hashes.insert(ingress_hash) {
+                    println!("SKIP  [idx {i}] duplicate active ingress");
+                    println!("  addr={}", v.validatorAddress);
+                    println!("  ingress={}", v.inboundAddress);
+                    skip_count += 1;
+                    continue;
+                }
+                active_addresses.insert(v.validatorAddress);
+            }
+
+            println!("OK    [idx {i}] {}", v.validatorAddress);
+            println!("  active={} ingress={}", v.active, v.inboundAddress);
+            ok_count += 1;
+        }
+
+        println!();
+        println!("=== Summary ===");
+        println!("OK    : {ok_count}");
+        println!("SKIP  : {skip_count}");
+        println!("REVERT: {revert_count}");
+
+        if revert_count > 0 {
+            println!();
+            println!(
+                "WARNING: {revert_count} validator(s) would cause migration to REVERT."
+            );
+            println!("These must be resolved in V1 before migration can proceed.");
+        }
+
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,9 +2,9 @@
 use std::net::SocketAddr;
 
 use crate::{
-    generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
-    generate_localnet::GenerateLocalnet, generate_state_bloat::GenerateStateBloat,
-    get_dkg_outcome::GetDkgOutcome,
+    check_v1_migration::CheckV1Migration, generate_devnet::GenerateDevnet,
+    generate_genesis::GenerateGenesis, generate_localnet::GenerateLocalnet,
+    generate_state_bloat::GenerateStateBloat, get_dkg_outcome::GetDkgOutcome,
 };
 
 use alloy::signers::{local::MnemonicBuilder, utils::secret_key_to_address};
@@ -12,6 +12,7 @@ use clap::Parser as _;
 use commonware_codec::DecodeExt;
 use eyre::Context;
 
+mod check_v1_migration;
 mod generate_devnet;
 mod generate_genesis;
 mod generate_localnet;
@@ -23,6 +24,10 @@ mod get_dkg_outcome;
 async fn main() -> eyre::Result<()> {
     let args = Args::parse();
     match args.action {
+        Action::CheckV1Migration(args) => args
+            .run()
+            .await
+            .wrap_err("failed to check V1 migration"),
         Action::GetDkgOutcome(args) => args.run().await.wrap_err("failed to get DKG outcome"),
         Action::GenerateGenesis(args) => args.run().await.wrap_err("failed generating genesis"),
         Action::GenerateDevnet(args) => args
@@ -53,6 +58,7 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Action {
+    CheckV1Migration(CheckV1Migration),
     GetDkgOutcome(GetDkgOutcome),
     GenerateGenesis(GenerateGenesis),
     GenerateDevnet(GenerateDevnet),


### PR DESCRIPTION
Oxidizes `tips/ref-impls/script/CheckV1Migration.s.sol` into a native xtask subcommand. Connects to an RPC endpoint, calls `getValidators()` on the V1 ValidatorConfig precompile, and runs the same four migration heuristic checks (zero pubkey/address, duplicate pubkey, duplicate active ingress, duplicate active address) to report which validators would be skipped or cause a revert during the V2 migration.

Usage: `cargo xtask check-v1-migration --rpc-url https://rpc.tempo.xyz`

Co-Authored-By: Richard Janis Goldschmidt <701177+SuperFluffy@users.noreply.github.com>

Prompted by: janis