### PR TITLE
fix: restore sender-paid fallback

### DIFF
--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -30,10 +30,7 @@ use reth_ethereum::tasks::{
     Runtime,
     pool::{BlockingTaskGuard, BlockingTaskPool},
 };
-use reth_evm::{
-    EvmEnvFor, TxEnvFor,
-    revm::{Database, context::result::EVMError},
-};
+use reth_evm::{EvmEnvFor, TxEnvFor, revm::Database};
 use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, PrimitivesTy};
 use reth_node_builder::{
     NodeAdapter,
@@ -279,9 +276,10 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
         evm_env: &EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
     ) -> Result<u64, Self::Error> {
-        let fee_payer = tx_env
-            .fee_payer()
-            .map_err(EVMError::<ProviderError, _>::from)?;
+        // Defensive: create_txn_env already normalizes Some(None) → None for
+        // unresolvable placeholder signatures, but fall back to caller here too
+        // in case fee_payer() errors for any other reason during estimation.
+        let fee_payer = tx_env.fee_payer().unwrap_or(tx_env.caller);
 
         let fee_token = db
             .get_fee_token(tx_env, fee_payer, evm_env.cfg_env.spec)
@@ -323,7 +321,16 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
             request.nonce = Some(nonce);
         }
 
-        Ok(self.inner.create_txn_env(evm_env, request, db)?)
+        let mut tx_env = self.inner.create_txn_env(evm_env, request, db)?;
+
+        // If a fee-payer signature was present but recovery failed (e.g. placeholder
+        // signature during gas estimation / fill), clear the unresolved fee payer so
+        // the EVM falls back to sender-paid semantics instead of erroring.
+        if tx_env.fee_payer == Some(None) {
+            tx_env.fee_payer = None;
+        }
+
+        Ok(tx_env)
     }
 }
 

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -338,6 +338,7 @@ fn gas_estimation_cases() -> Vec<GasCase> {
                     auth: auth_def.auth.clone(),
                     payload: payload.clone(),
                     expected: expected.clone(),
+                    placeholder_fee_payer: false,
                 });
             }
 
@@ -346,6 +347,40 @@ fn gas_estimation_cases() -> Vec<GasCase> {
                 auth: auth_def.auth.clone(),
                 payload: payload.clone(),
                 expected,
+                placeholder_fee_payer: false,
+            });
+        }
+    }
+
+    // --- Sponsored estimation cases (placeholder fee_payer_signature) ---
+    // The SDK calls eth_estimateGas with a dummy fee_payer_signature before the
+    // sponsor has signed. The RPC must fall back to sender-paid semantics and
+    // return a gas estimate comparable to the unsponsored counterpart.
+    let sponsored_auths: &[(&str, AuthKind)] = &[
+        ("secp256k1", AuthKind::Baseline),
+        (
+            "keychain_secp256k1",
+            AuthKind::Keychain {
+                key_type: None,
+                num_limits: 0,
+            },
+        ),
+    ];
+    for &(name, ref auth) in sponsored_auths {
+        for &(payload_name, ref payload) in payloads {
+            // After normalization the EVM sees the same sender-paid semantics,
+            // so gas should equal the unsponsored same-auth same-payload case.
+            let unsponsored_ref = if name == "secp256k1" && payload_name == "noop" {
+                "baseline".into()
+            } else {
+                format!("{name}::{payload_name}")
+            };
+            cases.push(GasCase {
+                name: format!("sponsored_{name}::{payload_name}"),
+                auth: auth.clone(),
+                payload: payload.clone(),
+                expected: ExpectedGasDiff::SameAs(unsponsored_ref),
+                placeholder_fee_payer: true,
             });
         }
     }
@@ -451,6 +486,17 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
             }
         }
 
+        // Attach a placeholder (all-zero) fee_payer_signature when the case
+        // simulates pre-sponsor estimation. Recovery will fail, so the RPC must
+        // fall back to sender-paid semantics.
+        if test_case.placeholder_fee_payer {
+            request.fee_payer_signature = Some(alloy::primitives::Signature::new(
+                U256::ZERO,
+                U256::ZERO,
+                false,
+            ));
+        }
+
         let gas = estimate_gas(provider, &request).await?;
         println!("  gas: {gas}");
 
@@ -483,6 +529,17 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
                     test_case.name,
                 );
                 println!("  ✓ gas {gas} > {ref_name} gas {ref_gas}");
+            }
+            ExpectedGasDiff::SameAs(ref_name) => {
+                let ref_gas = *results
+                    .get(ref_name.as_str())
+                    .unwrap_or_else(|| panic!("missing reference gas case '{ref_name}'"));
+                assert_eq!(
+                    gas, ref_gas,
+                    "[{}] expected same gas as {ref_name} ({ref_gas}), got {gas}",
+                    test_case.name,
+                );
+                println!("  ✓ gas {gas} == {ref_name} gas {ref_gas}");
             }
         }
 

--- a/crates/node/tests/it/tempo_transaction/snapshots/it__tempo_transaction__gas_estimation_snapshots.snap
+++ b/crates/node/tests/it/tempo_transaction/snapshots/it__tempo_transaction__gas_estimation_snapshots.snap
@@ -9,6 +9,12 @@ baseline: 274318
 "secp256k1::batch_5_transfers": 578624
 "secp256k1::batch_10_transfers": 610586
 "secp256k1::contract_creation": 779451
+"sponsored_secp256k1::noop": 274318
+"sponsored_secp256k1::transfer": 553055
+"sponsored_secp256k1::batch_2_transfers": 559447
+"sponsored_secp256k1::batch_5_transfers": 578624
+"sponsored_secp256k1::batch_10_transfers": 610586
+"sponsored_secp256k1::contract_creation": 779451
 "p256::noop": 279358
 "p256::transfer": 558095
 "p256::batch_2_transfers": 564487
@@ -81,6 +87,12 @@ baseline: 274318
 "keychain_secp256k1::batch_5_transfers": 841796
 "keychain_secp256k1::batch_10_transfers": 874766
 "keychain_secp256k1::contract_creation": 1041616
+"sponsored_keychain_secp256k1::noop": 536482
+"sponsored_keychain_secp256k1::transfer": 815421
+"sponsored_keychain_secp256k1::batch_2_transfers": 822015
+"sponsored_keychain_secp256k1::batch_5_transfers": 841796
+"sponsored_keychain_secp256k1::batch_10_transfers": 874766
+"sponsored_keychain_secp256k1::contract_creation": 1041616
 "keychain_p256::noop": 541522
 "keychain_p256::transfer": 820460
 "keychain_p256::batch_2_transfers": 827054

--- a/crates/node/tests/it/tempo_transaction/types.rs
+++ b/crates/node/tests/it/tempo_transaction/types.rs
@@ -736,6 +736,8 @@ pub(crate) enum GasPayload {
 pub(crate) enum ExpectedGasDiff {
     Range(std::ops::RangeInclusive<u64>),
     GreaterThan(String),
+    /// Gas must equal the referenced case exactly.
+    SameAs(String),
 }
 
 pub(crate) struct GasCase {
@@ -743,4 +745,7 @@ pub(crate) struct GasCase {
     pub auth: AuthKind,
     pub payload: GasPayload,
     pub expected: ExpectedGasDiff,
+    /// When true, attach a placeholder (all-zero) fee_payer_signature to
+    /// simulate the SDK's `eth_estimateGas` call before the sponsor has signed.
+    pub placeholder_fee_payer: bool,
 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -107,6 +107,12 @@ impl TempoTxEnvelope {
         }
     }
 
+    /// Returns `true` if the transaction is self-funded (no sponsor or recovery failed).
+    pub fn is_self_funded(&self, sender: Address) -> bool {
+        self.fee_payer(sender)
+            .map_or(true, |fee_payer| fee_payer == sender)
+    }
+
     /// Return the [`TempoTxType`] of the inner txn.
     pub const fn tx_type(&self) -> TempoTxType {
         match self {

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -225,12 +225,7 @@ impl PausedFeeTokenPool {
                     subject.matches_spending_limit_update(spending_limit_spends);
                 let sender_paid = if matches_limit_update || matches_limit_spend {
                     let sender = *entry.tx.transaction.sender_ref();
-                    entry
-                        .tx
-                        .transaction
-                        .inner()
-                        .fee_payer(sender)
-                        .map_or(true, |fee_payer| fee_payer == sender)
+                    entry.tx.transaction.inner().is_self_funded(sender)
                 } else {
                     false
                 };

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -257,10 +257,16 @@ where
             }
 
             // Check 2: Spending limit updates
-            // Only evict if the transaction's fee token matches the token whose limit changed.
+            // Only evict if the transaction's fee token matches the token whose limit changed
+            // AND the sender is paying their own fees. Sponsored transactions are unaffected
+            // by the sender's spending-limit changes (the sponsor's limits apply instead).
             if !updates.spending_limit_changes.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_changes)
+                && tx
+                    .transaction
+                    .inner()
+                    .is_self_funded(tx.transaction.sender())
             {
                 to_remove.push(*tx.hash());
                 spending_limit_count += 1;
@@ -272,9 +278,15 @@ where
             // remaining limit but emits no event. We re-read the current remaining limit
             // from state for affected (account, key_id, fee_token) combos and evict if
             // the pending tx's fee cost now exceeds the remaining limit.
+            // Same sender-paid guard as Check 2 — sponsored txs are not subject to the
+            // sender's spending limits.
             if !updates.spending_limit_spends.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_spends)
+                && tx
+                    .transaction
+                    .inner()
+                    .is_self_funded(tx.transaction.sender())
                 && let Some(ref mut provider) = state_provider
                 && exceeds_spending_limit(provider, subject, tx.transaction.fee_token_cost())
             {


### PR DESCRIPTION
fixes two issues introduced/exposed by #3200:

1. RPC estimation regression: placeholder fee-payer signatures during eth_estimateGas now fail with InvalidFeePayerSignature instead of falling back to sender-paid semantics. Resolve Some(None) to None in create_txn_env (RPC-only) and fall back to caller in caller_gas_allowance. load_fee_fields stays strict for consensus.

2. Main pool false-eviction: spending-limit eviction in the main pool unconditionally evicts keychain txs whose fee token matches a changed limit, even when a sponsor is paying. Add the same sender-paid guard the paused pool uses — only evict if fee_payer == sender.