### PR TITLE
fix: update fee payer fallback

### DIFF
--- a/crates/alloy/src/rpc/compat.rs
+++ b/crates/alloy/src/rpc/compat.rs
@@ -103,13 +103,13 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
         let fee_payer = if self.fee_payer_signature.is_some() {
             // Try to recover the fee payer address from the signature.
             // If recovery fails (e.g. dummy signature during gas estimation / fill),
-            // keep it unresolved so estimation/fill can continue with sender-paid semantics.
+            // fall back to sender-paid semantics (None) so gas estimation still works.
             let recovered = self
                 .clone()
                 .build_aa()
                 .ok()
                 .and_then(|tx| tx.recover_fee_payer(caller_addr).ok());
-            Some(recovered)
+            recovered.map(Some)
         } else {
             None
         };
@@ -531,7 +531,7 @@ mod tests {
     }
 
     #[test]
-    fn test_estimate_gas_invalid_fee_payer_signature_keeps_unresolved_fee_payer() {
+    fn test_estimate_gas_invalid_fee_payer_signature_falls_back_to_sender_paid() {
         let sender = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let target = address!("0x2222222222222222222222222222222222222222");
 
@@ -558,9 +558,8 @@ mod tests {
             "fee_payer_signature alone must produce an AA tx env"
         );
         assert_eq!(
-            tx_env.fee_payer,
-            Some(None),
-            "invalid fee_payer_signature should remain unresolved"
+            tx_env.fee_payer, None,
+            "invalid fee_payer_signature should fall back to sender-paid (None)"
         );
     }
 

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -257,14 +257,24 @@ where
             }
 
             // Check 2: Spending limit updates
-            // Only evict if the transaction's fee token matches the token whose limit changed.
+            // Only evict sender-paid keychain txs whose fee token matches the changed limit.
+            // Sponsored txs (fee payer != sender) are not subject to the sender's spending
+            // limit, so evicting them here would be a false positive.
             if !updates.spending_limit_changes.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_changes)
             {
-                to_remove.push(*tx.hash());
-                spending_limit_count += 1;
-                continue;
+                let sender = *tx.transaction.sender_ref();
+                let sender_paid = tx
+                    .transaction
+                    .inner()
+                    .fee_payer(sender)
+                    .map_or(true, |fee_payer| fee_payer == sender);
+                if sender_paid {
+                    to_remove.push(*tx.hash());
+                    spending_limit_count += 1;
+                    continue;
+                }
             }
 
             // Check 2b: Spending limit spends
@@ -272,15 +282,24 @@ where
             // remaining limit but emits no event. We re-read the current remaining limit
             // from state for affected (account, key_id, fee_token) combos and evict if
             // the pending tx's fee cost now exceeds the remaining limit.
+            // Same as Check 2: only applies to sender-paid transactions.
             if !updates.spending_limit_spends.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_spends)
                 && let Some(ref mut provider) = state_provider
                 && exceeds_spending_limit(provider, subject, tx.transaction.fee_token_cost())
             {
-                to_remove.push(*tx.hash());
-                spending_limit_spend_count += 1;
-                continue;
+                let sender = *tx.transaction.sender_ref();
+                let sender_paid = tx
+                    .transaction
+                    .inner()
+                    .fee_payer(sender)
+                    .map_or(true, |fee_payer| fee_payer == sender);
+                if sender_paid {
+                    to_remove.push(*tx.hash());
+                    spending_limit_spend_count += 1;
+                    continue;
+                }
             }
 
             // Check 3: Validator token changes (re-check liquidity for all transactions)


### PR DESCRIPTION
Restores sender-paid fallback in `compat.rs` when fee-payer signature recovery fails to fix `eth_estimateGas` functionality. 