### PR TITLE
chore(deps): allow aws-lc advisories and bump rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,7 +3304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10942,9 +10942,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -13148,7 +13148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,10 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0044 aws-lc-sys upgrade requires a commonware bump
+  "RUSTSEC-2026-0044",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0048 aws-lc-sys upgrade requires a commonware bump
+  "RUSTSEC-2026-0048",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Temporarily allow the new `aws-lc-sys` advisories while `commonware` still pins the older AWS-LC stack.

Bump `rustls-webpki` to 0.103.10 so the new Rustls CRL advisory is resolved in the meantime.

The remaining `cargo deny` failure is the pre-existing `lru` unsound advisory from the reth/discv5 dependency path.