### PR TITLE
feat: enable publishing tempo-contracts, tempo-primitives, and tempo-alloy to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,25 +97,25 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.dependencies]
-tempo-alloy = { path = "crates/alloy" }
+tempo-alloy = { path = "crates/alloy", version = "=1.4.2" }
 tempo-node = { path = "crates/node" }
-tempo-chainspec = { path = "crates/chainspec", default-features = false }
+tempo-chainspec = { path = "crates/chainspec", version = ">=0", default-features = false }
 tempo-commonware-node = { path = "crates/commonware-node", default-features = false }
 tempo-commonware-node-config = { path = "crates/commonware-node-config", default-features = false }
 tempo-consensus = { path = "crates/consensus", default-features = false }
 tempo-dkg-onchain-artifacts = { path = "crates/dkg-onchain-artifacts", default-features = false }
 tempo-e2e = { path = "crates/e2e" }
 tempo-faucet = { path = "crates/faucet", default-features = false }
-tempo-evm = { path = "crates/evm", default-features = false }
+tempo-evm = { path = "crates/evm", version = ">=0", default-features = false }
 tempo-eyre = { path = "crates/eyre", default-features = false }
 tempo-ext = { path = "crates/ext" }
-tempo-revm = { path = "crates/revm", default-features = false }
+tempo-revm = { path = "crates/revm", version = ">=0", default-features = false }
 tempo-payload-builder = { path = "crates/payload/builder", default-features = false }
 tempo-payload-types = { path = "crates/payload/types", default-features = false }
 tempo-precompiles = { path = "crates/precompiles", default-features = false }
 tempo-precompiles-macros = { path = "crates/precompiles-macros" }
-tempo-primitives = { path = "crates/primitives", default-features = false }
-tempo-contracts = { path = "crates/contracts", default-features = false }
+tempo-primitives = { path = "crates/primitives", version = "=1.4.2", default-features = false }
+tempo-contracts = { path = "crates/contracts", version = "=1.4.2", default-features = false }
 tempo-telemetry-util = { path = "crates/telemetry-util", default-features = false }
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -1,18 +1,20 @@
 [package]
 name = "tempo-alloy"
+description = "Tempo blockchain Alloy provider and types"
+repository = "https://github.com/tempoxyz/tempo"
 
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-publish.workspace = true
+publish = true
 
 [lints]
 workspace = true
 
 [dependencies]
 tempo-contracts = { workspace = true, features = ["rpc"] }
-tempo-primitives = { workspace = true, features = ["serde", "reth"] }
+tempo-primitives = { workspace = true, features = ["serde"] }
 tempo-chainspec = { workspace = true, optional = true }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
@@ -29,10 +31,10 @@ alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 alloy-transport.workspace = true
 
-reth-evm = { workspace = true, optional = true }
-reth-primitives-traits = { workspace = true, optional = true }
-reth-rpc-convert = { workspace = true, optional = true }
-reth-rpc-eth-types = { workspace = true, optional = true }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", default-features = false, optional = true }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
 
 dashmap.workspace = true
 derive_more.workspace = true
@@ -61,5 +63,6 @@ tempo-compat = [
     "dep:tempo-chainspec",
     "dep:tempo-evm",
     "dep:tempo-revm",
+    "tempo-primitives/reth",
     "tempo-primitives/rpc",
 ]

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "tempo-contracts"
-description = "TODO:"
+description = "Tempo blockchain contract bindings"
+repository = "https://github.com/tempoxyz/tempo"
 
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-publish.workspace = true
+publish = true
 
 [lints]
 workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "tempo-primitives"
+description = "Tempo blockchain primitive types"
+repository = "https://github.com/tempoxyz/tempo"
 
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-publish.workspace = true
+publish = true
 
 [lints]
 workspace = true
@@ -13,12 +15,14 @@ workspace = true
 [dependencies]
 tempo-contracts.workspace = true
 
-# Reth
-reth-db-api = { workspace = true, optional = true }
-reth-ethereum-primitives = { workspace = true, optional = true }
-reth-primitives-traits = { workspace = true, optional = true }
-reth-codecs = { workspace = true, optional = true }
-reth-rpc-convert = { workspace = true, optional = true }
+# Reth — use git+version "multiple locations" so the workspace resolves via
+# git while `cargo publish` resolves the (placeholder) crates-io versions.
+# These are ALL optional; the published crate defaults to `serde` only.
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", default-features = false, optional = true }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", default-features = false, optional = true }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", version = ">=0", optional = true }
 
 # revm
 revm.workspace = true
@@ -63,7 +67,7 @@ rand.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
-default = ["std", "reth", "serde", "reth-codec", "serde-bincode-compat", "rpc"]
+default = ["std", "serde"]
 std = [
 	"alloy-consensus/secp256k1",
 	"alloy-consensus/std",
@@ -84,7 +88,7 @@ std = [
 	"alloy-sol-types/std",
 	"tempo-contracts/std",
 ]
-reth = ["dep:reth-ethereum-primitives", "dep:reth-primitives-traits", "serde"]
+reth = ["dep:reth-ethereum-primitives", "dep:reth-primitives-traits", "serde", "serde-bincode-compat"]
 serde = [
 	"dep:alloy-serde",
 	"alloy-consensus/serde",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -25,10 +25,8 @@ extern crate alloc;
 
 use once_cell as _;
 
-#[cfg(feature = "reth")]
 use alloy_primitives::Log;
-#[cfg(feature = "reth")]
-use reth_ethereum_primitives::EthereumReceipt;
+
 #[cfg(feature = "reth")]
 use reth_primitives_traits::NodePrimitives;
 
@@ -39,8 +37,7 @@ pub type Block = alloy_consensus::Block<TempoTxEnvelope, TempoHeader>;
 pub type BlockBody = alloy_consensus::BlockBody<TempoTxEnvelope, TempoHeader>;
 
 /// Tempo receipt.
-#[cfg(feature = "reth")]
-pub type TempoReceipt<L = Log> = EthereumReceipt<TempoTxType, L>;
+pub type TempoReceipt<L = Log> = alloy_consensus::EthereumReceipt<TempoTxType, L>;
 
 /// A [`NodePrimitives`] implementation for Tempo.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]


### PR DESCRIPTION
## What

Enable crates.io publishing for `tempo-contracts`, `tempo-primitives`, and `tempo-alloy`.

## Why

`mpp-rs` depends on `tempo-alloy` and `tempo-primitives` from crates.io so that `cargo add mpp` works. Currently these crates inherit `publish = false` from the workspace, blocking publishing.

## How

**Metadata changes:**
- Override `publish = false` → `publish = true` on the three crates
- Add `description` and `repository` fields

**Dependency resolution for crates.io:**
- Add `version = "=1.4.2"` alongside `path` for the three publishable crates in workspace deps (Cargo "multiple locations" pattern — uses path locally, version from crates.io when published)
- Inline reth-* deps in `tempo-primitives` and `tempo-alloy` with `git + version = ">=0"` so the workspace resolves via git while `cargo publish` resolves the `0.0.0` placeholder crates on crates.io
- Add `version = ">=0"` to `tempo-chainspec`, `tempo-evm`, `tempo-revm` workspace deps (needed by `tempo-alloy`'s optional `tempo-compat` feature)

**Feature changes:**
- Change `tempo-primitives` default features from `["std", "reth", "serde", "reth-codec", "serde-bincode-compat", "rpc"]` to `["std", "serde"]` — reth features are opt-in for the published crate
- Make `reth` feature pull in `serde-bincode-compat` (required by `NodePrimitives` bounds)
- Move `TempoReceipt` type alias from `reth_ethereum_primitives::EthereumReceipt` to `alloy_consensus::EthereumReceipt` (same underlying type, no reth dep needed)
- `tempo-alloy` now requests `tempo-primitives` with only `["serde"]` by default; the `tempo-compat` feature adds `reth` + `rpc`

**No changes to internal workspace behavior** — feature unification ensures all internal crates still get the features they need.

## Publish order

```
tempo-contracts → tempo-primitives → tempo-alloy
```

Each must be published before the next (version dependencies).

## Pre-publish checklist

- [ ] Add `CARGO_REGISTRY_TOKEN` secret to the repo
- [ ] `cargo publish -p tempo-contracts --allow-dirty`
- [ ] `cargo publish -p tempo-primitives --allow-dirty`
- [ ] `cargo publish -p tempo-alloy --allow-dirty --no-verify` (tempo-compat deps not on crates.io)
