### PR TITLE
refactor: reduce boilerplate required for new hardforks

### DIFF
--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -193,24 +193,22 @@ impl TempoHardfork {
     /// - T1+: 20 billion attodollars per gas (targets ~0.1 cent per TIP-20 transfer)
     ///
     /// Economic conversion: ceil(basefee × gas_used / 10^12) = cost in microdollars (TIP-20 tokens)
-    pub const fn base_fee(&self) -> u64 {
-        match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
-                crate::spec::TEMPO_T1_BASE_FEE
-            }
-            Self::T0 | Self::Genesis => crate::spec::TEMPO_T0_BASE_FEE,
+    pub fn base_fee(&self) -> u64 {
+        if *self >= Self::T1 {
+            crate::spec::TEMPO_T1_BASE_FEE
+        } else {
+            crate::spec::TEMPO_T0_BASE_FEE
         }
     }
 
     /// Returns the fixed general gas limit for T1+, or None for pre-T1.
     /// - Pre-T1: None
     /// - T1+: 30M gas (fixed)
-    pub const fn general_gas_limit(&self) -> Option<u64> {
-        match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
-                Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT)
-            }
-            Self::T0 | Self::Genesis => None,
+    pub fn general_gas_limit(&self) -> Option<u64> {
+        if *self >= Self::T1 {
+            Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT)
+        } else {
+            None
         }
     }
 
@@ -219,32 +217,29 @@ impl TempoHardfork {
     /// - T1A+: 30M gas (allows maximum-sized contract deployments under [TIP-1000] state creation)
     ///
     /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
-    pub const fn tx_gas_limit_cap(&self) -> Option<u64> {
-        match self {
-            Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
-                Some(crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP)
-            }
-            Self::T0 | Self::Genesis | Self::T1 => Some(MAX_TX_GAS_LIMIT_OSAKA),
+    pub fn tx_gas_limit_cap(&self) -> u64 {
+        if *self >= Self::T1A {
+            crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP
+        } else {
+            MAX_TX_GAS_LIMIT_OSAKA
         }
     }
 
     /// Gas cost for using an existing 2D nonce key
-    pub const fn gas_existing_nonce_key(&self) -> u64 {
-        match self {
-            Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
-                crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
-            }
-            Self::T2 => crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS,
+    pub fn gas_existing_nonce_key(&self) -> u64 {
+        if *self >= Self::T2 {
+            crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS
+        } else {
+            crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
         }
     }
 
     /// Gas cost for using a new 2D nonce key
-    pub const fn gas_new_nonce_key(&self) -> u64 {
-        match self {
-            Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
-                crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
-            }
-            Self::T2 => crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS,
+    pub fn gas_new_nonce_key(&self) -> u64 {
+        if *self >= Self::T2 {
+            crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS
+        } else {
+            crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
         }
     }
 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -459,14 +459,14 @@ mod tests {
     #[test]
     fn test_tempo_evm_respects_gas_cap() {
         let mut env = evm_env_with_spec(TempoHardfork::T1);
-        env.cfg_env.tx_gas_limit_cap = TempoHardfork::T1.tx_gas_limit_cap();
+        env.cfg_env.tx_gas_limit_cap = Some(TempoHardfork::T1.tx_gas_limit_cap());
 
         let evm = TempoEvm::new(EmptyDB::default(), env);
 
         // Verify gas limit cap is preserved
         assert_eq!(
             evm.ctx().cfg.tx_gas_limit_cap,
-            TempoHardfork::T1.tx_gas_limit_cap(),
+            Some(TempoHardfork::T1.tx_gas_limit_cap()),
             "TempoEvm should preserve the gas limit cap from input"
         );
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -134,7 +134,7 @@ impl ConfigureEvm for TempoEvmConfig {
 
         // Apply TIP-1000 gas params for T1 hardfork.
         let mut cfg_env = cfg_env.with_spec_and_gas_params(spec, tempo_gas_params(spec));
-        cfg_env.tx_gas_limit_cap = spec.tx_gas_limit_cap();
+        cfg_env.tx_gas_limit_cap = Some(spec.tx_gas_limit_cap());
 
         Ok(EvmEnv {
             cfg_env,
@@ -171,7 +171,7 @@ impl ConfigureEvm for TempoEvmConfig {
 
         // Apply TIP-1000 gas params for T1 hardfork.
         let mut cfg_env = cfg_env.with_spec_and_gas_params(spec, tempo_gas_params(spec));
-        cfg_env.tx_gas_limit_cap = spec.tx_gas_limit_cap();
+        cfg_env.tx_gas_limit_cap = Some(spec.tx_gas_limit_cap());
 
         Ok(EvmEnv {
             cfg_env,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -3356,8 +3356,6 @@ mod tests {
         const TEST_TARGET: Address = Address::new([0xAA; 20]);
         const TEST_NONCE_KEY: U256 = U256::from_limbs([42, 0, 0, 0]);
         const SPEC: TempoHardfork = TempoHardfork::T1;
-        const NEW_NONCE_KEY_GAS: u64 = SPEC.gas_new_nonce_key();
-        const EXISTING_NONCE_KEY_GAS: u64 = SPEC.gas_existing_nonce_key();
 
         // Create T1 config with TIP-1000 gas params
         let mut cfg = CfgEnv::<TempoHardfork>::default();
@@ -3416,7 +3414,7 @@ mod tests {
         // Delta-based assertion: the difference should be new_account_cost - EXISTING_NONCE_KEY_GAS
         // nonce=0 charges 250k (new account), nonce>0 charges 5k (existing key update)
         let gas_delta = gas_nonce_zero.initial_gas - gas_nonce_five.initial_gas;
-        let expected_delta = new_account_cost - EXISTING_NONCE_KEY_GAS;
+        let expected_delta = new_account_cost - SPEC.gas_existing_nonce_key();
         assert_eq!(
             gas_delta, expected_delta,
             "T1 gas difference between nonce=0 and nonce>0 should be {expected_delta} (new_account_cost - EXISTING_NONCE_KEY_GAS), got {gas_delta}"
@@ -3424,8 +3422,9 @@ mod tests {
 
         // Verify it's NOT using the pre-T1 NEW_NONCE_KEY_GAS (22,100)
         assert_ne!(
-            gas_delta, NEW_NONCE_KEY_GAS,
-            "T1 should NOT use pre-T1 NEW_NONCE_KEY_GAS ({NEW_NONCE_KEY_GAS}) for nonce=0 transactions"
+            gas_delta,
+            SPEC.gas_new_nonce_key(),
+            "T1 should NOT use pre-T1 NEW_NONCE_KEY_GAS for nonce=0 transactions"
         );
 
         // Case 3: nonce == 0 with regular nonce (nonce_key=0) -> same +250k charge
@@ -3459,7 +3458,6 @@ mod tests {
         const TEST_TARGET: Address = Address::new([0xBB; 20]);
         const TEST_NONCE_KEY: U256 = U256::from_limbs([99, 0, 0, 0]);
         const SPEC: TempoHardfork = TempoHardfork::T1;
-        const EXISTING_NONCE_KEY_GAS: u64 = SPEC.gas_existing_nonce_key();
 
         let mut cfg = CfgEnv::<TempoHardfork>::default();
         cfg.spec = SPEC;
@@ -3502,8 +3500,8 @@ mod tests {
 
         assert_eq!(
             gas_existing.initial_gas,
-            BASE_INTRINSIC_GAS + EXISTING_NONCE_KEY_GAS,
-            "T1 existing 2D nonce key (nonce>0) should charge BASE + EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
+            BASE_INTRINSIC_GAS + SPEC.gas_existing_nonce_key(),
+            "T1 existing 2D nonce key (nonce>0) should charge BASE + EXISTING_NONCE_KEY_GAS"
         );
 
         // Case 2: Regular nonce (nonce_key = 0) with nonce > 0 should NOT charge extra gas
@@ -3518,8 +3516,9 @@ mod tests {
         // Verify the delta between 2D and regular nonce is exactly EXISTING_NONCE_KEY_GAS
         let gas_delta = gas_existing.initial_gas - gas_regular.initial_gas;
         assert_eq!(
-            gas_delta, EXISTING_NONCE_KEY_GAS,
-            "Difference between existing 2D nonce and regular nonce should be EXISTING_NONCE_KEY_GAS ({EXISTING_NONCE_KEY_GAS})"
+            gas_delta,
+            SPEC.gas_existing_nonce_key(),
+            "Difference between existing 2D nonce and regular nonce should be EXISTING_NONCE_KEY_GAS"
         );
     }
 }


### PR DESCRIPTION
Refactors match statements on chainspec to not be exhaustive and instead operate on hardfork boundaries so that adding new hardforks does not require changing and reviewing changes to them