### PR TITLE
Fix(link): broken links in `tip-1005` guide

### DIFF
--- a/tips/tip-1005.md
+++ b/tips/tip-1005.md
@@ -54,9 +54,9 @@ The fix requires:
 
 ## Reference implementation changes
 
-The fix requires changes to two functions in [`docs/specs/src/StablecoinDEX.sol`](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol):
+The fix requires changes to two functions in [`tips/ref-impls/src/StablecoinDEX.sol`](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol):
 
-### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L551-L556))
+### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol#L551-L556))
 
 Add an optional `quoteOverride` parameter. When non-zero and the order is an ask, use `quoteOverride` directly for the maker's balance increment instead of computing `ceil(fillAmount * price)`.
 
@@ -73,7 +73,7 @@ uint128 quoteAmount = quoteOverride > 0
 balances[order.maker][book.quote] += quoteAmount;
 ```
 
-### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L923-L926))
+### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol#L923-L926))
 
 In the partial fill branch for asks, pass `remainingIn` as the quote override:
 


### PR DESCRIPTION
The links in the `tip-1005` guide are broken:
`docs/specs/src/StablecoinDEX.sol`
Changed to:
`tips/ref-impls`

Essentially, this change has minimal impact, as it only improves the experience for readers of `tip-1005`.