### PR TITLE
feat(chainspec): add T3 hardfork plumbing

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -26,6 +26,7 @@
     "t1bTime": 0,
     "t1cTime": 0,
     "t2Time": 0,
+    "t3Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -182,6 +182,8 @@ tempo_hardfork! (
         ///
         /// [TIP-1015]: <https://docs.tempo.xyz/protocol/tips/tip-1015>
         T2,
+        /// T3 hardfork
+        T3,
     }
 );
 
@@ -195,7 +197,7 @@ impl TempoHardfork {
     /// Economic conversion: ceil(basefee × gas_used / 10^12) = cost in microdollars (TIP-20 tokens)
     pub const fn base_fee(&self) -> u64 {
         match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
+            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
                 crate::spec::TEMPO_T1_BASE_FEE
             }
             Self::T0 | Self::Genesis => crate::spec::TEMPO_T0_BASE_FEE,
@@ -207,7 +209,7 @@ impl TempoHardfork {
     /// - T1+: 30M gas (fixed)
     pub const fn general_gas_limit(&self) -> Option<u64> {
         match self {
-            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
+            Self::T1 | Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
                 Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT)
             }
             Self::T0 | Self::Genesis => None,
@@ -221,7 +223,7 @@ impl TempoHardfork {
     /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     pub const fn tx_gas_limit_cap(&self) -> Option<u64> {
         match self {
-            Self::T1A | Self::T1B | Self::T1C | Self::T2 => {
+            Self::T1A | Self::T1B | Self::T1C | Self::T2 | Self::T3 => {
                 Some(crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP)
             }
             Self::T0 | Self::Genesis | Self::T1 => Some(MAX_TX_GAS_LIMIT_OSAKA),
@@ -234,7 +236,7 @@ impl TempoHardfork {
             Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
                 crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
             }
-            Self::T2 => crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS,
+            Self::T2 | Self::T3 => crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS,
         }
     }
 
@@ -244,7 +246,7 @@ impl TempoHardfork {
             Self::Genesis | Self::T0 | Self::T1 | Self::T1A | Self::T1B | Self::T1C => {
                 crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
             }
-            Self::T2 => crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS,
+            Self::T2 | Self::T3 => crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -94,6 +94,9 @@ pub struct TempoGenesisInfo {
     /// Activation timestamp for T2 hardfork.
     #[serde(skip_serializing_if = "Option::is_none")]
     t2_time: Option<u64>,
+    /// Activation timestamp for T3 hardfork.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    t3_time: Option<u64>,
 }
 
 impl TempoGenesisInfo {
@@ -120,6 +123,7 @@ impl TempoGenesisInfo {
             TempoHardfork::T1B => self.t1b_time,
             TempoHardfork::T1C => self.t1c_time,
             TempoHardfork::T2 => self.t2_time,
+            TempoHardfork::T3 => self.t3_time,
         }
     }
 }

--- a/tempo.nu
+++ b/tempo.nu
@@ -251,7 +251,7 @@ def write-bench-marker [bloat: int, accounts: int, datadir: string] {
 # ============================================================================
 
 # Ordered list of all Tempo hardforks (must match TempoHardfork enum in crates/chainspec)
-const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2"]
+const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2" "T3"]
 
 # Map a hardfork name to generate-genesis CLI args.
 # Forks up to and including the given fork are active at genesis (time=0).

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -169,6 +169,10 @@ pub(crate) struct GenesisArgs {
     #[arg(long, default_value = "0")]
     t2_time: u64,
 
+    /// T3 hardfork activation time.
+    #[arg(long, default_value = "0")]
+    t3_time: u64,
+
     /// Whether to skip initializing validator config v1
     #[arg(long)]
     no_initialize_validator_config_v1: bool,
@@ -537,6 +541,9 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("t2Time".to_string(), self.t2_time)?;
+        chain_config
+            .extra_fields
+            .insert_value("t3Time".to_string(), self.t3_time)?;
         let mut extra_data = Bytes::from_static(b"tempo-genesis");
 
         if let Some(consensus_config) = &consensus_config {


### PR DESCRIPTION
Adds the T3 hardfork variant and all plumbing — enum, genesis info field, fork_time arm, dev.json activation, xtask arg, and tempo.nu hardfork list. T3 inherits T2 behavior for base fee, gas limits, and nonce key gas.

Not added to moderato or presto genesis files yet — activation timestamps to be set when T3 is scheduled.

Prompted by: rusowsky