### PR TITLE
fix(rpc): return InsufficientFunds when fee token balance is zero in eth_estimateGas

### DIFF
--- a/crates/node/src/rpc/error.rs
+++ b/crates/node/src/rpc/error.rs
@@ -1,26 +1,71 @@
 use std::convert::Infallible;
 
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes, U256};
 use reth_errors::ProviderError;
 use reth_evm::revm::context::result::EVMError;
 use reth_node_core::rpc::result::rpc_err;
 use reth_rpc_eth_api::AsEthApiError;
 use reth_rpc_eth_types::{
-    EthApiError,
+    EthApiError, RpcInvalidTransactionError,
     error::api::{FromEvmHalt, FromRevert},
 };
 use tempo_evm::TempoHaltReason;
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InsufficientFeeTokenFundsData {
+    fee_token: Address,
+    cost: String,
+    balance: String,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum TempoEthApiError {
     #[error(transparent)]
     EthApiError(EthApiError),
+    #[error("insufficient funds for gas * price + value: have {balance} want {cost}")]
+    InsufficientFeeTokenFunds {
+        cost: U256,
+        balance: U256,
+        fee_token: Address,
+        eth_api_error: Box<EthApiError>,
+    },
+}
+
+impl TempoEthApiError {
+    pub fn insufficient_fee_token_funds(cost: U256, balance: U256, fee_token: Address) -> Self {
+        Self::InsufficientFeeTokenFunds {
+            cost,
+            balance,
+            fee_token,
+            eth_api_error: Box::new(EthApiError::InvalidTransaction(
+                RpcInvalidTransactionError::InsufficientFunds { cost, balance },
+            )),
+        }
+    }
 }
 
 impl From<TempoEthApiError> for jsonrpsee::types::error::ErrorObject<'static> {
     fn from(error: TempoEthApiError) -> Self {
         match error {
             TempoEthApiError::EthApiError(err) => err.into(),
+            TempoEthApiError::InsufficientFeeTokenFunds {
+                cost,
+                balance,
+                fee_token,
+                ..
+            } => {
+                let err = RpcInvalidTransactionError::InsufficientFunds { cost, balance };
+                jsonrpsee::types::error::ErrorObject::owned(
+                    err.error_code(),
+                    err.to_string(),
+                    Some(InsufficientFeeTokenFundsData {
+                        fee_token,
+                        cost: format!("0x{cost:x}"),
+                        balance: format!("0x{balance:x}"),
+                    }),
+                )
+            }
         }
     }
 }
@@ -34,6 +79,7 @@ impl AsEthApiError for TempoEthApiError {
     fn as_err(&self) -> Option<&EthApiError> {
         match self {
             Self::EthApiError(err) => Some(err),
+            Self::InsufficientFeeTokenFunds { eth_api_error, .. } => Some(eth_api_error.as_ref()),
         }
     }
 }
@@ -75,5 +121,45 @@ impl FromRevert for TempoEthApiError {
             )))),
             None => Self::EthApiError(EthApiError::from_revert(revert)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insufficient_fee_token_funds_keeps_standard_error_and_includes_fee_token_data() {
+        let cost = U256::from(21_000u64);
+        let balance = U256::ZERO;
+        let fee_token = Address::with_last_byte(0x42);
+
+        let err = TempoEthApiError::insufficient_fee_token_funds(cost, balance, fee_token);
+
+        let eth_err = err.as_err().expect("must expose core EthApiError");
+        assert!(matches!(
+            eth_err,
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::InsufficientFunds {
+                cost: c,
+                balance: b,
+            }) if *c == cost && *b == balance
+        ));
+
+        let rpc_err: jsonrpsee::types::error::ErrorObject<'static> = err.into();
+        assert_eq!(
+            rpc_err.code(),
+            RpcInvalidTransactionError::InsufficientFunds { cost, balance }.error_code()
+        );
+        assert_eq!(
+            rpc_err.message(),
+            "insufficient funds for gas * price + value: have 0 want 21000"
+        );
+
+        let data = rpc_err.data().expect("must include structured error data");
+        let data: serde_json::Value =
+            serde_json::from_str(data.get()).expect("error data must be valid JSON");
+        assert_eq!(data["feeToken"], serde_json::json!(fee_token));
+        assert_eq!(data["cost"], "0x5208");
+        assert_eq!(data["balance"], "0x0");
     }
 }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -21,7 +21,7 @@ pub use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_chainspec::TempoChainSpec;
 use tempo_evm::TempoStateAccess;
 use tempo_precompiles::{NONCE_PRECOMPILE_ADDRESS, nonce::NonceManager};
-use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
+use tempo_primitives::transaction::{TEMPO_EXPIRING_NONCE_KEY, calc_gas_balance_spending};
 pub use token::{TempoToken, TempoTokenApiServer};
 
 use crate::{node::TempoNode, rpc::error::TempoEthApiError};
@@ -272,7 +272,7 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
         self.inner.evm_memory_limit()
     }
 
-    /// Returns the max gas limit that the caller can afford given a transaction environment.
+    /// Returns the max gas limit that the caller can afford based on their fee token balance.
     fn caller_gas_allowance(
         &self,
         mut db: impl Database<Error: Into<EthApiError>>,
@@ -289,6 +289,14 @@ impl<N: FullNodeTypes<Types = TempoNode>> Call for TempoEthApi<N> {
         let fee_token_balance = db
             .get_token_balance(fee_token, fee_payer, evm_env.cfg_env.spec)
             .map_err(ProviderError::other)?;
+
+        if fee_token_balance.is_zero() {
+            return Err(TempoEthApiError::insufficient_fee_token_funds(
+                calc_gas_balance_spending(tx_env.gas_limit, tx_env.inner.gas_price),
+                U256::ZERO,
+                fee_token,
+            ));
+        }
 
         Ok(fee_token_balance
             // multiply by the scaling factor

--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -6,7 +6,7 @@ use alloy::{
         Filter, TransactionRequest,
         trace::parity::{ChangedType, Delta},
     },
-    signers::local::MnemonicBuilder,
+    signers::local::{MnemonicBuilder, PrivateKeySigner},
     sol_types::{SolCall, SolError, SolEvent},
 };
 use alloy_eips::BlockId;
@@ -581,6 +581,88 @@ async fn test_eth_estimate_gas_preseeded_zero_address_validator_token() -> eyre:
     assert!(
         gas > 0,
         "gas estimation must succeed with pre-seeded validatorTokens[address(0)]"
+    );
+
+    Ok(())
+}
+
+/// Regression test: if a user holds a valid fee token but has not set `userTokens[sender]`,
+/// zero-value basic transfer estimation falls back to PathUSD. When PathUSD balance is zero,
+/// `eth_estimateGas` with a non-zero fee cap must return `insufficient funds` instead of the
+/// confusing intrinsic gas error caused by a zero gas allowance cap.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_estimate_gas_zero_value_transfer_returns_insufficient_funds() -> eyre::Result<()>
+{
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let http_url = setup.http_url;
+
+    let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
+    let wallet_address = wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(http_url.clone());
+
+    let user = PrivateKeySigner::random();
+    let user_address = user.address();
+    let user_provider = ProviderBuilder::new().wallet(user).connect_http(http_url);
+
+    let fee_manager =
+        IFeeManager::new(tempo_precompiles::TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let path_usd = ITIP20::new(PATH_USD_ADDRESS, provider.clone());
+    let alternate_fee_token = setup_test_token(provider.clone(), wallet_address).await?;
+
+    alternate_fee_token
+        .mint(user_address, U256::from(1_000_000u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    assert_eq!(
+        fee_manager.userTokens(user_address).call().await?,
+        Address::ZERO
+    );
+    assert_eq!(path_usd.balanceOf(user_address).call().await?, U256::ZERO);
+    assert_eq!(
+        alternate_fee_token.balanceOf(user_address).call().await?,
+        U256::from(1_000_000u64)
+    );
+
+    let gas: String = user_provider
+        .raw_request(
+            "eth_estimateGas".into(),
+            [serde_json::json!({
+                "from": user_address,
+                "to": user_address,
+                "value": "0x0",
+            })],
+        )
+        .await?;
+    assert!(u64::from_str_radix(gas.trim_start_matches("0x"), 16)? > 0);
+
+    let err = user_provider
+        .raw_request::<_, String>(
+            "eth_estimateGas".into(),
+            [serde_json::json!({
+                "from": user_address,
+                "to": user_address,
+                "value": "0x0",
+                "maxFeePerGas": format!("0x{:x}", TEMPO_T1_BASE_FEE),
+            })],
+        )
+        .await
+        .unwrap_err();
+
+    let err = err.to_string();
+    assert!(
+        err.contains("insufficient funds for gas * price + value"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !err.contains("gas_limit 0 < intrinsic_gas 21000"),
+        "unexpected error: {err}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

When `eth_estimateGas` is called with `maxFeePerGas` and the resolved fee token has zero balance, return a standard `InsufficientFunds` error with the fee token address in `error.data`, instead of the confusing `"gas_limit 0 < intrinsic_gas 21000"`.

## Before / After

```json
// Before
{"code":-32603,"message":"Revm error: insufficient gas for intrinsic cost: gas_limit 0 < intrinsic_gas 21000"}

// After
{"code":-32003,
 "message":"insufficient funds for gas * price + value: have 0 want 10000000",
 "data":{"feeToken":"0x20c0000000000000000000000000000000000000","cost":"0x989680","balance":"0x0"}}
```

## Context

Foundry's `cast send` fills `maxFeePerGas` before calling `eth_estimateGas`. For transactions without calldata (e.g. zero-value transfers), `get_fee_token` can't infer the fee token from calldata, so it falls back to PathUSD. If the user holds a different USD token but not PathUSD, `caller_gas_allowance` sees balance=0 and caps the gas search to 0, which then fails with `"gas_limit 0 < intrinsic_gas 21000"` — an unrelated error that tells the user nothing useful.

The PathUSD fallback is intentional (there's no deterministic way to pick the right token without calldata or user preference). The problem is just the error: it should say "insufficient funds" not "gas limit too low".

## Design

Keep the standard `InsufficientFunds` error code and message so existing tools (Foundry, ethers.js) can parse it normally. Put the fee token address in `error.data` for clients that want to know which token to fund or change via `setUserToken`.

`cost` is an upper bound based on the gas limit at the start of estimation (typically block gas limit), not the final estimated cost.
