### PR TITLE
fix: add missing `localnet` recipe to Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,3 +9,7 @@ mod scripts
 [group('dev')]
 tempo-dev-up: scripts::tempo-dev-up
 tempo-dev-down: scripts::tempo-dev-down
+
+# Start a local dev node (Nushell). Extra flags are forwarded to `tempo.nu` (e.g. `just localnet -- --accounts 50000`).
+localnet *ARGS:
+    nu ./tempo.nu localnet {{ ARGS }}


### PR DESCRIPTION
## Summary

Adds a missing `localnet` recipe to the Justfile to match the command documented in the README.

## Problem

The README instructs developers to start a local network using:

    just localnet

However, the `Justfile` did not define a `localnet` recipe.

## Solution

Added a `localnet` recipe that forwards execution to the existing Nushell script:

    localnet *ARGS:
        nu ./tempo.nu localnet {{ ARGS }}

This keeps the implementation consistent with existing scripts and supports passing additional arguments.