### PR TITLE
docs(foundry): add TIP-20 deployment example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Tempo has several SDKs to help you get started building on Tempo:
 - [Rust](https://docs.tempo.xyz/sdk/rust)
 - [Go](https://docs.tempo.xyz/sdk/go)
 - [Foundry](https://docs.tempo.xyz/sdk/foundry)
+- [Foundry TIP-20 deployment example](./examples/foundry/README.md)
 
 Want to contribute?
 

--- a/examples/foundry/README.md
+++ b/examples/foundry/README.md
@@ -9,8 +9,13 @@ mint an initial supply, and verify the deployed address in the explorer.
 
 ## Prerequisites
 
-1. Foundry installed (`forge`, `cast`).
-2. `forge-std` installed in your Foundry project.
+1. Tempo's Foundry fork installed (`forge`, `cast`), for example:
+   ```bash
+   foundryup -n tempo
+   forge -V
+   ```
+   Ensure `forge -V` contains `-tempo`.
+2. A Tempo-enabled Foundry project (for example created with `forge init -n tempo`).
 3. A funded Tempo testnet account.
 
 Get testnet funds:

--- a/examples/foundry/README.md
+++ b/examples/foundry/README.md
@@ -1,0 +1,50 @@
+# Foundry TIP-20 Deployment Example
+
+This example shows how to deploy a basic TIP-20 token on Tempo Moderato testnet,
+mint an initial supply, and verify the deployed address in the explorer.
+
+## Script
+
+`scripts/DeployTip20Example.s.sol`
+
+## Prerequisites
+
+1. Foundry installed (`forge`, `cast`).
+2. `forge-std` installed in your Foundry project.
+3. A funded Tempo testnet account.
+
+Get testnet funds:
+
+```bash
+cast rpc tempo_fundAddress <YOUR_ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz
+```
+
+## Run
+
+Copy the script into your Foundry project (example destination: `script/DeployTip20Example.s.sol`):
+
+```bash
+cp examples/foundry/scripts/DeployTip20Example.s.sol /path/to/your-foundry-project/script/
+```
+
+Export your private key:
+
+```bash
+export PRIVATE_KEY=<YOUR_PRIVATE_KEY_HEX>
+```
+
+From your Foundry project root, execute the script:
+
+```bash
+forge script script/DeployTip20Example.s.sol:DeployTip20Example \
+  --rpc-url https://rpc.moderato.tempo.xyz \
+  --broadcast
+```
+
+## Verify on Explorer
+
+After broadcast, the script prints the token address and:
+
+`https://explore.tempo.xyz/address/<TOKEN_ADDRESS>`
+
+Open that URL to verify deployment and transaction activity.

--- a/examples/foundry/scripts/DeployTip20Example.s.sol
+++ b/examples/foundry/scripts/DeployTip20Example.s.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { Script, console2 } from "forge-std/Script.sol";
+
+interface ITIP20 {
+    function ISSUER_ROLE() external view returns (bytes32);
+    function grantRole(bytes32 role, address account) external;
+    function mint(address to, uint256 amount) external;
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface ITIP20Factory {
+    function createToken(
+        string calldata name,
+        string calldata symbol,
+        string calldata currency,
+        ITIP20 quoteToken,
+        address admin,
+        bytes32 salt
+    )
+        external
+        returns (address);
+}
+
+contract DeployTip20Example is Script {
+    ITIP20Factory internal constant TIP20_FACTORY =
+        ITIP20Factory(0x20FC000000000000000000000000000000000000);
+
+    ITIP20 internal constant PATH_USD = ITIP20(0x20C0000000000000000000000000000000000000);
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address admin = vm.addr(deployerPrivateKey);
+
+        bytes32 salt = keccak256(abi.encodePacked(admin, block.timestamp));
+        uint256 initialSupply = 1_000_000 * 1e6; // TIP-20 tokens use 6 decimals.
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        address tokenAddress = TIP20_FACTORY.createToken(
+            "My Tempo Stable Token",
+            "MTST",
+            "USD",
+            PATH_USD,
+            admin,
+            salt
+        );
+
+        ITIP20 token = ITIP20(tokenAddress);
+        token.grantRole(token.ISSUER_ROLE(), admin);
+        token.mint(admin, initialSupply);
+
+        vm.stopBroadcast();
+
+        console2.log("TIP-20 deployed at:", tokenAddress);
+        console2.log("Admin address:", admin);
+        console2.log("Minted amount (base units):", token.balanceOf(admin));
+        console2.log(
+            "Explorer URL:",
+            string.concat("https://explore.tempo.xyz/address/", vm.toString(tokenAddress))
+        );
+    }
+}

--- a/examples/foundry/scripts/DeployTip20Example.s.sol
+++ b/examples/foundry/scripts/DeployTip20Example.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { Script, console2 } from "forge-std/Script.sol";
+import {Script, console2} from "forge-std/Script.sol";
 
 interface ITIP20 {
     function ISSUER_ROLE() external view returns (bytes32);
@@ -18,14 +18,11 @@ interface ITIP20Factory {
         ITIP20 quoteToken,
         address admin,
         bytes32 salt
-    )
-        external
-        returns (address);
+    ) external returns (address);
 }
 
 contract DeployTip20Example is Script {
-    ITIP20Factory internal constant TIP20_FACTORY =
-        ITIP20Factory(0x20FC000000000000000000000000000000000000);
+    ITIP20Factory internal constant TIP20_FACTORY = ITIP20Factory(0x20Fc000000000000000000000000000000000000);
 
     ITIP20 internal constant PATH_USD = ITIP20(0x20C0000000000000000000000000000000000000);
 
@@ -38,14 +35,7 @@ contract DeployTip20Example is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        address tokenAddress = TIP20_FACTORY.createToken(
-            "My Tempo Stable Token",
-            "MTST",
-            "USD",
-            PATH_USD,
-            admin,
-            salt
-        );
+        address tokenAddress = TIP20_FACTORY.createToken("My Tempo Stable Token", "MTST", "USD", PATH_USD, admin, salt);
 
         ITIP20 token = ITIP20(tokenAddress);
         token.grantRole(token.ISSUER_ROLE(), admin);
@@ -56,9 +46,6 @@ contract DeployTip20Example is Script {
         console2.log("TIP-20 deployed at:", tokenAddress);
         console2.log("Admin address:", admin);
         console2.log("Minted amount (base units):", token.balanceOf(admin));
-        console2.log(
-            "Explorer URL:",
-            string.concat("https://explore.tempo.xyz/address/", vm.toString(tokenAddress))
-        );
+        console2.log("Explorer URL:", string.concat("https://explore.tempo.xyz/address/", vm.toString(tokenAddress)));
     }
 }


### PR DESCRIPTION
Closes #3027

Adds a runnable Foundry script example for deploying and minting a TIP-20 token on Moderato testnet, and links it from the root README for easier discovery.