### PR TITLE
Fix: `tempo-bench` example flags in README

### DIFF
--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -146,16 +146,16 @@ Run 15 second benchmark with 20k TPS:
 tempo-bench run-max-tps --duration 15 --tps 20000
 ```
 
-Run benchmark on MacOS:
+On machines with tight file-descriptor or connection limits, lower concurrent HTTP usage:
 
 ```bash
-tempo-bench run-max-tps --duration 15 --tps 20000 --disable-thread-pinning
+tempo-bench run-max-tps --duration 15 --tps 20000 --max-concurrent-requests 50
 ```
 
-Run benchmark with less workers than the default:
+Run benchmark with less concurrency than the default:
 
 ```bash
-tempo-bench run-max-tps --duration 15 --tps 20 -w 1
+tempo-bench run-max-tps --duration 15 --tps 20 --max-concurrent-requests 1
 ```
 
 Run benchmark with more accounts than the default:


### PR DESCRIPTION
Updated example commands in bin/tempo-bench/README.md to match actual CLI flags in bin/tempo-bench/src/cmd/max_tps.rs.

Replaced `--disable-thread-pinning` with `--max-concurrent-requests 50`. Replaced `-w 1` with `--max-concurrent-requests 1`.

Files affected:

`bin/tempo-bench/README.md` (examples section)
CLI definitions in `bin/tempo-bench/src/cmd/max_tps.rs` verified via [`MaxTpsArgs`](https://github.com/tempoxyz/tempo/blob/main/bin/tempo-bench/src/cmd/max_tps.rs#L77-L202) struct.

Rationale:
Previous examples referenced non-existent flags (`--disable-thread-pinning`, `-w`).