### PR TITLE
fix: lift storage cursor out of inner loop, fix minor issues

### DIFF
--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -82,7 +82,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
         let mut reader = BufReader::with_capacity(64 * 1024 * 1024, file);
 
         let mut total_entries = 0u64;
-        let mut total_tokens = 0u64;
+        let mut total_blocks = 0u64;
         let mut total_commits = 0u64;
 
         // Track addresses for account hashing (small — only token addresses)
@@ -136,7 +136,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
             if batch_address.is_some() && batch_address != Some(address) && !batch.is_empty() {
                 let flush_addr = batch_address.unwrap();
                 provider_rw
-                    .insert_storage_for_hashing([(flush_addr, batch.drain(..).into_iter())])?;
+                    .insert_storage_for_hashing([(flush_addr, batch.drain(..))])?;
                 provider_rw.commit()?;
                 provider_rw = provider_factory.database_provider_rw()?;
                 total_commits += 1;
@@ -159,6 +159,12 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
             let start = std::time::Instant::now();
             let mut last_log = start;
 
+            // Open storage cursor once for the entire block
+            let mut storage_cursor = {
+                let tx = provider_rw.tx_ref();
+                tx.cursor_dup_write::<tables::PlainStorageState>()?
+            };
+
             for i in 0..pair_count {
                 reader
                     .read_exact(&mut entry_buf)
@@ -175,11 +181,7 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 let entry = StorageEntry { key: slot, value };
 
                 // Insert into plain storage state
-                {
-                    let tx = provider_rw.tx_ref();
-                    let mut storage_cursor = tx.cursor_dup_write::<tables::PlainStorageState>()?;
-                    storage_cursor.upsert(address, &entry)?;
-                }
+                storage_cursor.upsert(address, &entry)?;
 
                 // Collect for hashed storage
                 batch.push(entry);
@@ -187,18 +189,30 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
                 // Flush batch when it reaches the threshold
                 if batch.len() >= HASHING_BATCH_SIZE {
+                    // Drop cursor before commit
+                    drop(storage_cursor);
+
                     provider_rw
-                        .insert_storage_for_hashing([(address, batch.drain(..).into_iter())])?;
+                        .insert_storage_for_hashing([(address, batch.drain(..))])?;
                     provider_rw.commit()?;
                     provider_rw = provider_factory.database_provider_rw()?;
                     total_commits += 1;
 
                     // Re-ensure account exists after reopen (idempotent)
-                    let tx = provider_rw.tx_ref();
-                    let mut account_cursor = tx.cursor_write::<tables::PlainAccountState>()?;
-                    if account_cursor.seek_exact(address)?.is_none() {
-                        account_cursor.upsert(address, &Account::default())?;
+                    {
+                        let tx = provider_rw.tx_ref();
+                        let mut account_cursor =
+                            tx.cursor_write::<tables::PlainAccountState>()?;
+                        if account_cursor.seek_exact(address)?.is_none() {
+                            account_cursor.upsert(address, &Account::default())?;
+                        }
                     }
+
+                    // Re-open storage cursor after commit
+                    storage_cursor = {
+                        let tx = provider_rw.tx_ref();
+                        tx.cursor_dup_write::<tables::PlainStorageState>()?
+                    };
                 }
 
                 let now = std::time::Instant::now();
@@ -220,21 +234,22 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                 }
             }
 
-            total_tokens += 1;
+            total_blocks += 1;
         }
 
         // Flush any remaining batch entries
         if let Some(addr) = batch_address {
             if !batch.is_empty() {
-                provider_rw.insert_storage_for_hashing([(addr, batch.drain(..).into_iter())])?;
+                provider_rw.insert_storage_for_hashing([(addr, batch.drain(..))])?;
             }
         }
 
         info!(
             target: "tempo::cli",
-            total_tokens,
+            total_blocks,
             total_entries,
             total_commits,
+            tokens = addresses_seen.len(),
             "Plain and hashed storage written, writing hashed accounts..."
         );
 
@@ -257,9 +272,10 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
 
         info!(
             target: "tempo::cli",
-            total_tokens,
+            total_blocks,
             total_entries,
             total_commits = total_commits + 1,
+            tokens = addresses_seen.len(),
             "Binary state dump loaded successfully"
         );
 

--- a/xtask/src/generate_state_bloat.rs
+++ b/xtask/src/generate_state_bloat.rs
@@ -159,7 +159,7 @@ impl GenerateStateBloat {
                 .expect("valid template"),
         );
 
-        let mut chunk_buf = Vec::with_capacity(chunk_size.min(DEFAULT_CHUNK_SIZE) * 64);
+        let mut chunk_buf = Vec::with_capacity(chunk_size * 64);
 
         for chunk_idx in 0..num_chunks {
             let chunk_start = chunk_idx * chunk_size;


### PR DESCRIPTION
Follow-up to #3280. Fixes review findings:

- Hoist `PlainStorageState` cursor outside the per-entry loop — was creating/dropping it per entry (~250k FFI round-trips per chunk), now once per block with explicit drop/reopen around commits.
- Use `chunk_size` directly for `chunk_buf` pre-allocation instead of capping at `DEFAULT_CHUNK_SIZE`, which caused unnecessary reallocations for larger chunk sizes.
- Rename `total_tokens` to `total_blocks` since the counter tracks binary format blocks, not distinct tokens. Added separate `tokens` field using `addresses_seen.len()`.
- Remove redundant `.into_iter()` on `.drain(..)`.

Prompted by: yk