### PR TITLE
Clarify generate-genesis output path and header in README

### DIFF
--- a/bin/tempo-bench/README.md
+++ b/bin/tempo-bench/README.md
@@ -174,10 +174,12 @@ The benchmark will continuously output performance metrics including transaction
 
 ## Quick Start
 
-### 1. Generate genesis.json
+### 1. Generate genesis
+
+`generate-genesis` expects a **directory**; it writes `genesis.json` inside it (plus validator keys when applicable):
 
 ```bash
-cargo x generate-genesis --accounts 50000 --output genesis.json
+cargo x generate-genesis --accounts 50000 --output ./bench-genesis
 ```
 
 ### 2. Start the Node


### PR DESCRIPTION
Update README in bin/tempo-bench/README.md to correctly reflect how cargo x generate-genesis handles the --output flag and improve section header clarity. #### Header updated:
```diff
- ### 1. Generate genesis.json
+ ### 1. Generate genesis
```
#### Command updated:
```diff
- cargo x generate-genesis --accounts 50000 --output genesis.json
+ cargo x generate-genesis --accounts 50000 --output ./bench-genesis
```
#### Added clarification:
```
`generate-genesis` expects a **directory**; it writes `genesis.json` inside it (plus validator keys when applicable)
```

#### Reasoning / Files:

`xtask/src/generate_genesis.rs` expects `--output` to be a directory, not a file. Ensures generated files go to the correct path and avoids confusion.