### PR TITLE
ci: let cargo clippy resolve deps in update-reth workflow

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -162,10 +162,6 @@ jobs:
           find . -name 'Cargo.toml' -exec sed -i "s|paradigmxyz/reth\", rev = \"${CURRENT_REV}\"|paradigmxyz/reth\", rev = \"${NEW_REV}\"|g" {} +
           echo "Updated reth rev: $CURRENT_REV -> $NEW_REV"
 
-          # Update a single reth dependency, which in turn will update all dependencies with the same `git` source.
-          # We can't just do `cargo update` because it will also do unwanted bumps.
-          cargo update -p reth-engine-tree
-
       # ── commit rev bump if changed ──────────────────────────────
       - name: Commit reth rev bump
         if: steps.update.outputs.bumped == 'true'
@@ -181,7 +177,7 @@ jobs:
         run: |
           echo "::group::Initial cargo clippy"
           set +e
-          cargo clippy --all-targets --all-features --locked 2>&1
+          cargo clippy --all-targets --all-features 2>&1
           clippy_exit=$?
           set -e
           echo "::endgroup::"
@@ -192,9 +188,9 @@ jobs:
           fi
 
           AMP_PROMPT="This Rust workspace just had its reth dependencies updated to the latest commit \
-          on the paradigmxyz/reth main branch. \`cargo clippy --all-targets --all-features --locked\` is now failing with compilation errors.
+          on the paradigmxyz/reth main branch. \`cargo clippy --all-targets --all-features\` is now failing with compilation errors.
 
-          Run \`cargo clippy --all-targets --all-features --locked\` to see the errors, then fix the Rust source code and repeat \
+          Run \`cargo clippy --all-targets --all-features\` to see the errors, then fix the Rust source code and repeat \
           until cargo clippy passes. You may also bump non-reth dependency versions in Cargo.toml files \
           if needed (e.g. revm, alloy), but do NOT modify the reth rev or git source specifications \
           in any Cargo.toml — those have already been updated by the workflow.
@@ -220,7 +216,7 @@ jobs:
 
             echo "::group::Verify cargo clippy"
             set +e
-            cargo clippy --all-targets --all-features --locked 2>&1
+            cargo clippy --all-targets --all-features 2>&1
             clippy_exit=$?
             set -e
             echo "::endgroup::"


### PR DESCRIPTION
Removes `cargo update -p reth-engine-tree` and drops `--locked` from clippy. Cargo clippy resolves deps itself, so Amp can fix feature/API breakage in the existing fix loop instead of the workflow failing before Amp runs.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey