### PR TITLE
docs: fix xtask subcommands list

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -2,6 +2,11 @@
 
 A polyfill to perform various operations on the codebase.
 
-Subcommands currently supported:
+Subcommands (see `cargo xtask --help`):
 
-+ `generate-config`: generates a set of validators to run a local network.
+- `generate-genesis` — write `genesis.json` (and optional validator artifacts) under `--output`
+- `generate-localnet` — genesis plus per-validator dirs and keys for a local multi-validator setup
+- `generate-devnet` — devnet-style layout (see `--help`)
+- `generate-add-peer` — emit config for adding a peer to an existing network
+- `generate-state-bloat` — produce a TIP-20 state bloat binary for testing
+- `get-dkg-outcome` — read DKG outcome from an RPC block / epoch


### PR DESCRIPTION
Problem:
The README mentions a non-existent command, `generate-config`.

Solution:
- Removed the `generate-config` command
- Added `cargo xtask --help`
- Removed the reference to `generate-config`
- Added the commands found in `xtask/src/main.rs`

The list now corresponds to the actual subcommands.