### PR TITLE
feat: reject history pruning on validator nodes

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -391,8 +391,8 @@ fn main() -> eyre::Result<()> {
             .public_key()?
             .map(|key| B256::from_slice(key.as_ref()));
 
-        // Validators must not prune account or storage history — they need full
-        // state to participate in consensus and serve historical queries.
+        // Validators must not prune account or storage history — the consensus
+        // implementation relies on historical state to fetch the validator set.
         if validator_key.is_some()
             && let Some(prune_config) = builder.config().prune_config()
         {


### PR DESCRIPTION
Checks prune config at startup and exits with a clear error if a validator
node (one with a consensus signing key) is configured to prune account or
storage history. Validators need full history for consensus and serving
historical queries.

Prompted by: klkvr