### PR TITLE
docs(tip-1037): extended memo support

### DIFF
--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 1024 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The existing 32-byte `WithMemo` functions remain unchanged.
+TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 256 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The memo cap is set to 256 bytes — large enough for structured payment references and human-readable notes, but too small for image or media inscriptions that could attract ordinals-style abuse. The existing 32-byte `WithMemo` functions remain unchanged.
 
 ## Motivation
 
@@ -24,11 +24,13 @@ The current `bytes32` memo is sufficient for compact identifiers (invoice IDs, r
 
 2. **`transferWithLongMemo(bytes128)`**: Fixed-size extension. Rejected because any fixed size is either too large (wasted calldata for short memos) or too small (not future-proof). A dynamic `bytes` with an enforced cap is strictly more flexible at similar gas cost for typical payloads.
 
+3. **Larger caps (1024+ bytes)**: Rejected because memos large enough to hold images, SVGs, or base64-encoded media would make the chain an attractive target for ordinals-style inscription protocols. A 256-byte cap is sufficient for all legitimate payment metadata while being too small for meaningful media inscriptions.
+
 ## Assumptions
 
 - The existing `bytes32` memo functions (`transferWithMemo`, etc.) remain the recommended path for short, fixed-size identifiers. This TIP does not deprecate them.
 - Callers are responsible for choosing the encoding of the memo blob (UTF-8 text, ABI-encoded struct, etc.). The protocol treats it as opaque bytes.
-- The 1024-byte cap is chosen to keep calldata costs reasonable (~16k gas for a full memo) while covering foreseeable use cases. It can be adjusted via a future TIP if needed.
+- The 256-byte cap is chosen to cover legitimate payment metadata while discouraging ordinals-style inscription abuse. It can be adjusted via a future TIP if needed.
 
 ---
 
@@ -42,17 +44,17 @@ The following functions are added to the `ITIP20` interface:
 /// @notice Transfers tokens with a variable-length memo.
 /// @param to The recipient address.
 /// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
 
 /// @notice Transfers tokens from one address to another with a variable-length memo, using allowance.
 /// @param from The address to transfer from.
 /// @param to The recipient address.
 /// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 1024 bytes).
+/// @param memo The memo to attach (max 256 bytes).
 /// @return success True if the transfer was successful.
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function transferFromWithLongMemo(
     address from,
     address to,
@@ -63,14 +65,14 @@ function transferFromWithLongMemo(
 /// @notice Mints tokens with a variable-length memo.
 /// @param to The address to mint tokens to.
 /// @param amount The amount of tokens to mint.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
 
 /// @notice Burns tokens with a variable-length memo.
 /// @param amount The amount of tokens to burn.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
 ```
 
@@ -103,13 +105,13 @@ event TransferWithLongMemo(
 
 | Name | Value | Description |
 |------|-------|-------------|
-| `MAX_MEMO_LENGTH` | 1024 | Maximum memo length in bytes |
+| `MAX_MEMO_LENGTH` | 256 | Maximum memo length in bytes |
 
 ## Behavior
 
 ### Memo Validation
 
-All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > MAX_MEMO_LENGTH`. Empty memos (`memo.length == 0`) are permitted.
+All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > 256`. Empty memos (`memo.length == 0`) are permitted.
 
 ### Transfer Logic
 
@@ -132,7 +134,7 @@ The gas overhead relative to a standard transfer is:
 - `keccak256` hash: 30 gas + 6 gas per 32-byte word
 - Log emission: 375 gas base + 8 gas per byte of log data + 375 gas per indexed topic
 
-For a 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
+For a max-length 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
 
 ### Interaction with Existing Functions
 
@@ -142,7 +144,7 @@ The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged
 
 # Invariants
 
-1. **Memo Length Invariant**: Any call with `memo.length > 1024` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
+1. **Memo Length Invariant**: Any call with `memo.length > 256` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
 
 2. **Hash Integrity Invariant**: The `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)` where `memo` is the raw bytes in the same event's data field.
 
@@ -154,8 +156,8 @@ The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged
 
 1. **Basic long memo transfer**: `transferWithLongMemo` with a 256-byte memo succeeds and emits `TransferWithLongMemo` with correct `memoHash` and `memo`
 2. **Empty memo**: `transferWithLongMemo` with zero-length memo succeeds
-3. **Max length**: `transferWithLongMemo` with exactly 1024 bytes succeeds
-4. **Exceeds max**: `transferWithLongMemo` with 1025 bytes reverts with `MemoTooLong()`
+3. **Max length**: `transferWithLongMemo` with exactly 256 bytes succeeds
+4. **Exceeds max**: `transferWithLongMemo` with 257 bytes reverts with `MemoTooLong()`
 5. **Hash correctness**: `memoHash` in emitted event equals `keccak256(memo)` for various memo lengths
 6. **Allowance enforcement**: `transferFromWithLongMemo` correctly checks and deducts allowance
 7. **Policy enforcement**: `transferWithLongMemo` respects transfer policies (blocked by policy → revert)


### PR DESCRIPTION
Adds TIP-1037: Extended Memo Support. Introduces `WithLongMemo` variants of transfer, transferFrom, mint, and burn that accept dynamic `bytes memo` (up to 1024 bytes). Events emit both `bytes32 indexed memoHash` for topic filtering and raw `bytes memo` for readability.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan