### PR TITLE
chore(ci): bench OOM fix + timeout bump (Diagnosis)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -381,7 +381,7 @@ jobs:
     needs: tempo-bench-ack
     name: tempo-bench
     runs-on: [self-hosted, Linux, X64, bare-metal]
-    timeout-minutes: 300
+    timeout-minutes: 1500
     env:
       BENCH_PR: ${{ needs.tempo-bench-ack.outputs.pr }}
       BENCH_ACTOR: ${{ needs.tempo-bench-ack.outputs.actor }}
@@ -559,6 +559,23 @@ jobs:
             core.setOutput('feature-ref', featureRef);
             core.setOutput('feature-name', featureName);
 
+      - name: Update status (generating state)
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const s = require('./.github/scripts/bench-update-status.js');
+            await s({github, context, status: 'Generating state...'});
+
+      - name: Generate state
+        id: gen
+        timeout-minutes: 900
+        run: |
+          nu tempo.nu bench-init \
+            --bloat "$BENCH_BLOAT" \
+            --bench-datadir /reth-bench
+
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
@@ -570,6 +587,7 @@ jobs:
 
       - name: Run benchmark
         id: bench
+        timeout-minutes: 300
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -381,7 +381,7 @@ jobs:
     needs: tempo-bench-ack
     name: tempo-bench
     runs-on: [self-hosted, Linux, X64, bare-metal]
-    timeout-minutes: 900
+    timeout-minutes: 1500
     env:
       BENCH_PR: ${{ needs.tempo-bench-ack.outputs.pr }}
       BENCH_ACTOR: ${{ needs.tempo-bench-ack.outputs.actor }}
@@ -559,36 +559,6 @@ jobs:
             core.setOutput('feature-ref', featureRef);
             core.setOutput('feature-name', featureName);
 
-      - name: Update status (generating state)
-        if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.DEREK_PAT }}
-          script: |
-            const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Generating state...'});
-
-      - name: Generate state
-        id: gen
-        timeout-minutes: 600
-        env:
-          BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
-          FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
-        run: |
-          nu tempo.nu bench \
-            --init-only \
-            --preset "$BENCH_PRESET" \
-            --mode dev \
-            --bloat "$BENCH_BLOAT" \
-            --duration "$BENCH_DURATION" \
-            --tps "$BENCH_TPS" \
-            --no-infra \
-            --baseline "$BASELINE_REF" \
-            --feature "$FEATURE_REF" \
-            --bench-datadir /reth-bench \
-            --tune \
-            $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true)
-
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
@@ -600,7 +570,6 @@ jobs:
 
       - name: Run benchmark
         id: bench
-        timeout-minutes: 300
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -571,10 +571,23 @@ jobs:
       - name: Generate state
         id: gen
         timeout-minutes: 600
+        env:
+          BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
+          FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          nu tempo.nu bench-init \
+          nu tempo.nu bench \
+            --init-only \
+            --preset "$BENCH_PRESET" \
+            --mode dev \
             --bloat "$BENCH_BLOAT" \
-            --bench-datadir /reth-bench
+            --duration "$BENCH_DURATION" \
+            --tps "$BENCH_TPS" \
+            --no-infra \
+            --baseline "$BASELINE_REF" \
+            --feature "$FEATURE_REF" \
+            --bench-datadir /reth-bench \
+            --tune \
+            $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true)
 
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -381,7 +381,7 @@ jobs:
     needs: tempo-bench-ack
     name: tempo-bench
     runs-on: [self-hosted, Linux, X64, bare-metal]
-    timeout-minutes: 1500
+    timeout-minutes: 900
     env:
       BENCH_PR: ${{ needs.tempo-bench-ack.outputs.pr }}
       BENCH_ACTOR: ${{ needs.tempo-bench-ack.outputs.actor }}
@@ -570,7 +570,7 @@ jobs:
 
       - name: Generate state
         id: gen
-        timeout-minutes: 900
+        timeout-minutes: 600
         run: |
           nu tempo.nu bench-init \
             --bloat "$BENCH_BLOAT" \

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -315,6 +315,12 @@ impl MaxTpsArgs {
         // Grab first provider to call some RPC methods
         let provider = signer_providers[0].1.clone();
 
+        // Wait for block timestamp to catch up to wall clock (within 30s).
+        // After large state bloat loading, the node's block timestamp can lag
+        // behind wall clock by minutes, causing expiring nonce validation to
+        // reject faucet transactions.
+        wait_for_block_timestamp_sync(&provider).await?;
+
         // Fund accounts from faucet if requested
         if self.faucet {
             let faucet_provider: DynProvider<TempoNetwork> =
@@ -855,6 +861,49 @@ fn generate_transactions<F: TxFiller<TempoNetwork> + 'static>(
             eyre::Ok(unsigned.into_envelope(sig).encoded_2718())
         }
     })
+}
+
+/// Waits until the latest block timestamp is within 30s of wall clock time.
+///
+/// After large state bloat loading, the node's first blocks can have timestamps
+/// minutes behind wall clock. The faucet's expiring nonce filler uses
+/// `SystemTime::now()` to set `valid_before`, which then gets rejected because
+/// it's "too far in the future" relative to the block timestamp.
+async fn wait_for_block_timestamp_sync(provider: &DynProvider<TempoNetwork>) -> eyre::Result<()> {
+    let max_drift_secs = 30u64;
+    let poll_interval = Duration::from_secs(2);
+    let max_wait = Duration::from_secs(600);
+    let start = std::time::Instant::now();
+
+    loop {
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        if let Some(block) = provider.get_block(alloy::eips::BlockId::latest()).await? {
+            let block_ts = block.header.timestamp();
+            let drift = now_secs.saturating_sub(block_ts);
+            if drift <= max_drift_secs {
+                info!(block_ts, now_secs, drift, "Block timestamp synced with wall clock");
+                return Ok(());
+            }
+            info!(
+                block_ts,
+                now_secs,
+                drift,
+                "Waiting for block timestamp to catch up ({drift}s behind)"
+            );
+        }
+
+        if start.elapsed() > max_wait {
+            eyre::bail!(
+                "Block timestamp did not sync within {}s",
+                max_wait.as_secs()
+            );
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
 }
 
 /// Funds accounts from the faucet using `temp_fundAddress` RPC.

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -863,14 +863,16 @@ fn generate_transactions<F: TxFiller<TempoNetwork> + 'static>(
     })
 }
 
-/// Waits until the latest block timestamp is within 30s of wall clock time.
+/// Waits until the latest block timestamp is within 2s of wall clock time.
 ///
 /// After large state bloat loading, the node's first blocks can have timestamps
 /// minutes behind wall clock. The faucet's expiring nonce filler uses
-/// `SystemTime::now()` to set `valid_before`, which then gets rejected because
-/// it's "too far in the future" relative to the block timestamp.
+/// `SystemTime::now() + expiry_secs` to set `valid_before`, which then gets
+/// rejected because it's "too far in the future" relative to the block
+/// timestamp (protocol enforces `valid_before <= block_timestamp + 30s`).
+/// We wait for near-zero drift to avoid any off-by-one edge cases.
 async fn wait_for_block_timestamp_sync(provider: &DynProvider<TempoNetwork>) -> eyre::Result<()> {
-    let max_drift_secs = 30u64;
+    let max_drift_secs = 2u64;
     let poll_interval = Duration::from_secs(2);
     let max_wait = Duration::from_secs(600);
     let start = std::time::Instant::now();

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -885,14 +885,15 @@ async fn wait_for_block_timestamp_sync(provider: &DynProvider<TempoNetwork>) -> 
             let block_ts = block.header.timestamp();
             let drift = now_secs.saturating_sub(block_ts);
             if drift <= max_drift_secs {
-                info!(block_ts, now_secs, drift, "Block timestamp synced with wall clock");
+                info!(
+                    block_ts,
+                    now_secs, drift, "Block timestamp synced with wall clock"
+                );
                 return Ok(());
             }
             info!(
                 block_ts,
-                now_secs,
-                drift,
-                "Waiting for block timestamp to catch up ({drift}s behind)"
+                now_secs, drift, "Waiting for block timestamp to catch up ({drift}s behind)"
             );
         }
 

--- a/bin/tempo/src/init_state.rs
+++ b/bin/tempo/src/init_state.rs
@@ -7,7 +7,10 @@ use std::{
     fs::File,
     io::{BufReader, Read},
     path::PathBuf,
-    sync::mpsc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        mpsc,
+    },
     time::{Duration, Instant},
 };
 
@@ -45,6 +48,61 @@ const WORKER_CHUNK_SIZE: usize = 100;
 
 /// Maximum number of channels that can exist in memory before draining.
 const MAXIMUM_CHANNELS: usize = 10_000;
+
+/// Peak RssAnon in KiB, updated atomically from progress logging.
+static PEAK_RSS_ANON_KB: AtomicU64 = AtomicU64::new(0);
+
+/// Memory stats from /proc/self/status (Linux only).
+#[derive(Debug, Default)]
+struct MemStats {
+    rss_kb: u64,
+    rss_anon_kb: u64,
+    rss_file_kb: u64,
+    vm_hwm_kb: u64,
+}
+
+impl MemStats {
+    /// Read current memory stats from /proc/self/status.
+    /// Returns default (zeros) on non-Linux or if parsing fails.
+    fn read() -> Self {
+        Self::try_read().unwrap_or_default()
+    }
+
+    fn try_read() -> Option<Self> {
+        let data = std::fs::read_to_string("/proc/self/status").ok()?;
+        let mut stats = Self::default();
+        for line in data.lines() {
+            let (key, val) = line.split_once(':')?;
+            let kb = || val.trim().strip_suffix(" kB")?.trim().parse::<u64>().ok();
+            match key.trim() {
+                "VmRSS" => stats.rss_kb = kb()?,
+                "RssAnon" => stats.rss_anon_kb = kb()?,
+                "RssFile" => stats.rss_file_kb = kb()?,
+                "VmHWM" => stats.vm_hwm_kb = kb()?,
+                _ => {}
+            }
+        }
+        // Update peak RssAnon
+        PEAK_RSS_ANON_KB.fetch_max(stats.rss_anon_kb, Ordering::Relaxed);
+        Some(stats)
+    }
+
+    fn rss_mb(&self) -> u64 {
+        self.rss_kb / 1024
+    }
+    fn rss_anon_mb(&self) -> u64 {
+        self.rss_anon_kb / 1024
+    }
+    fn rss_file_mb(&self) -> u64 {
+        self.rss_file_kb / 1024
+    }
+    fn vm_hwm_mb(&self) -> u64 {
+        self.vm_hwm_kb / 1024
+    }
+    fn peak_rss_anon_mb() -> u64 {
+        PEAK_RSS_ANON_KB.load(Ordering::Relaxed) / 1024
+    }
+}
 
 /// Initialize state from a binary dump file.
 #[derive(Debug, Parser)]
@@ -218,12 +276,17 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
                     let pct = ((i + 1) as f64 / pair_count as f64) * 100.0;
                     let elapsed = start.elapsed();
                     let pairs_per_sec = (i + 1) as f64 / elapsed.as_secs_f64();
+                    let mem = MemStats::read();
                     info!(
                         target: "tempo::cli",
                         %address,
                         progress = format_args!("{}/{} ({pct:.0}%)", i + 1, pair_count),
                         elapsed = ?elapsed,
                         pairs_per_sec = pairs_per_sec as u64,
+                        rss_mb = mem.rss_mb(),
+                        rss_anon_mb = mem.rss_anon_mb(),
+                        rss_file_mb = mem.rss_file_mb(),
+                        peak_rss_anon_mb = MemStats::peak_rss_anon_mb(),
                         "Collecting storage"
                     );
                     last_log = now;
@@ -257,10 +320,16 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
         // Drain all remaining channels
         collect_hashed(&mut pending_channels, &mut hashed_collector)?;
 
+        let mem = MemStats::read();
         info!(
             target: "tempo::cli",
             total_blocks,
             total_entries,
+            rss_mb = mem.rss_mb(),
+            rss_anon_mb = mem.rss_anon_mb(),
+            rss_file_mb = mem.rss_file_mb(),
+            peak_rss_anon_mb = MemStats::peak_rss_anon_mb(),
+            vm_hwm_mb = mem.vm_hwm_mb(),
             "Entries collected, merging genesis storage into ETL collectors..."
         );
 
@@ -407,10 +476,16 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
         }
         drop(hashed_cursor);
 
+        let mem = MemStats::read();
         info!(
             target: "tempo::cli",
             total_plain,
             total_hashes,
+            rss_mb = mem.rss_mb(),
+            rss_anon_mb = mem.rss_anon_mb(),
+            rss_file_mb = mem.rss_file_mb(),
+            peak_rss_anon_mb = MemStats::peak_rss_anon_mb(),
+            vm_hwm_mb = mem.vm_hwm_mb(),
             "Storage written, writing hashed accounts..."
         );
 
@@ -445,10 +520,15 @@ impl<C: reth_cli::chainspec::ChainSpecParser<ChainSpec: EthChainSpec + EthereumH
         // Commit the transaction
         provider_rw.commit()?;
 
+        let mem = MemStats::read();
         info!(
             target: "tempo::cli",
             total_blocks,
             total_entries,
+            rss_mb = mem.rss_mb(),
+            rss_anon_mb = mem.rss_anon_mb(),
+            peak_rss_anon_mb = MemStats::peak_rss_anon_mb(),
+            vm_hwm_mb = mem.vm_hwm_mb(),
             "Binary state dump loaded successfully"
         );
 

--- a/tempo.nu
+++ b/tempo.nu
@@ -1461,6 +1461,7 @@ def "main bench" [
     --tracing-otlp: string = ""                     # OTLP endpoint for tracing (auto-derived from TEMPO_TELEMETRY_URL if not set)
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
+    --init-only                                     # Only build binaries and initialize state snapshot, skip benchmark runs
 ] {
     validate-mode $mode
 
@@ -1890,6 +1891,12 @@ def "main bench" [
 
         # Resolve per-run genesis/datadir based on mode
         let genesis_path = if $dual_hardfork { "" } else { $"($abs_localnet)/genesis.json" }
+
+        if $init_only {
+            print "State initialization complete (--init-only). Skipping benchmark runs."
+            restore-system-tuning $tuning_state
+            return
+        }
 
         # Start observability stack
         if not $no_infra {

--- a/tempo.nu
+++ b/tempo.nu
@@ -1866,11 +1866,11 @@ def "main bench" [
                 }
 
                 print $"Initializing database at ($datadir)..."
-                run-external $baseline_tempo "init" "--chain" $genesis_path_std "--datadir" $datadir
+                run-external $feature_tempo "init" "--chain" $genesis_path_std "--datadir" $datadir
 
                 if $bloat > 0 {
                     print $"Loading state bloat into ($datadir)..."
-                    run-external $baseline_tempo "init-from-binary-dump" "--chain" $genesis_path_std "--datadir" $datadir $bloat_file | complete
+                    run-external $feature_tempo "init-from-binary-dump" "--chain" $genesis_path_std "--datadir" $datadir $bloat_file | complete
                 }
 
                 mkdir $meta_dir

--- a/tempo.nu
+++ b/tempo.nu
@@ -1418,7 +1418,7 @@ def "main bench-init" [
 
     if $bloat > 0 {
         print $"Loading state bloat into ($datadir)..."
-        run-external $tempo_bin "init-from-binary-dump" "--chain" $genesis_path "--datadir" $datadir $bloat_file | complete
+        run-external $tempo_bin "init-from-binary-dump" "--chain" $genesis_path "--datadir" $datadir $bloat_file
     }
 
     # Save genesis + bloat to volume meta dir (survives schelk recover)
@@ -1803,7 +1803,7 @@ def "main bench" [
 
                     if $bloat > 0 {
                         print $"Loading state bloat into ($side.name)..."
-                        run-external $side.tempo "init-from-binary-dump" "--chain" $side.genesis "--datadir" $side.dd $bloat_file | complete
+                        run-external $side.tempo "init-from-binary-dump" "--chain" $side.genesis "--datadir" $side.dd $bloat_file
                     }
                     }
                 }
@@ -1904,7 +1904,7 @@ def "main bench" [
 
                 if $bloat > 0 {
                     print $"Loading state bloat into ($datadir)..."
-                    run-external $feature_tempo "init-from-binary-dump" "--chain" $genesis_path_std "--datadir" $datadir $bloat_file | complete
+                    run-external $feature_tempo "init-from-binary-dump" "--chain" $genesis_path_std "--datadir" $datadir $bloat_file
                 }
                 }
 

--- a/tempo.nu
+++ b/tempo.nu
@@ -1461,7 +1461,6 @@ def "main bench" [
     --tracing-otlp: string = ""                     # OTLP endpoint for tracing (auto-derived from TEMPO_TELEMETRY_URL if not set)
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
-    --init-only                                     # Only build binaries and initialize state snapshot, skip benchmark runs
 ] {
     validate-mode $mode
 
@@ -1891,11 +1890,6 @@ def "main bench" [
 
         # Resolve per-run genesis/datadir based on mode
         let genesis_path = if $dual_hardfork { "" } else { $"($abs_localnet)/genesis.json" }
-
-        if $init_only {
-            print "State initialization complete (--init-only). Skipping benchmark runs."
-            return
-        }
 
         # Start observability stack
         if not $no_infra {

--- a/tempo.nu
+++ b/tempo.nu
@@ -16,6 +16,19 @@ const METRICS_LABELS_FILE = "/tmp/bench-metrics-labels.json"
 const MINIO_BUCKET = "minio/tempo-binaries"
 const BENCH_META_SUBDIR = ".bench-meta"
 
+# Emit GitHub Actions log groups for CI visibility.
+# Usage: ci-group "Phase name" { ... }
+def ci-group [title: string, body: closure] {
+    print $"::group::($title)"
+    try {
+        do $body
+        print "::endgroup::"
+    } catch { |e|
+        print "::endgroup::"
+        error make { msg: $e.msg }
+    }
+}
+
 # Preset weight configurations: [tip20, erc20, swap, order]
 const PRESETS = {
     tip20: [1.0, 0.0, 0.0, 0.0],
@@ -1598,6 +1611,7 @@ def "main bench" [
         )
 
         # Prune worktree registrations where the directory no longer exists
+        ci-group "Setting up worktrees" {
         git worktree prune
 
         for wt in [$baseline_wt $feature_wt] {
@@ -1616,6 +1630,7 @@ def "main bench" [
         if $feature != "local" {
             git worktree add $feature_wt $feature_sha
         }
+        }
 
         # Build binaries (apply tracy build config if needed)
         let tbc = (tracy-build-config $features $tracy)
@@ -1625,6 +1640,7 @@ def "main bench" [
         let effective_no_cache = $no_cache or ($tracy != "off")
 
         if $baseline == "local" or $feature == "local" {
+            ci-group "Building local binaries" {
             print "Building local binaries..."
             if $tracy != "off" {
                 # Build tempo (with tracy) and tempo-bench (without) separately
@@ -1633,19 +1649,24 @@ def "main bench" [
             } else {
                 build-tempo ["tempo" "tempo-bench"] $profile $effective_features
             }
+            }
         }
         if $baseline != "local" {
+            ci-group $"Building baseline binary \(($baseline)\)" {
             if $effective_no_cache {
                 build-in-worktree --no-cache --extra-rustflags $effective_extra_rustflags --bench-features $features $baseline_wt $baseline $profile $effective_features $baseline_sha
             } else {
                 build-in-worktree $baseline_wt $baseline $profile $effective_features $baseline_sha
             }
+            }
         }
         if $feature != "local" {
+            ci-group $"Building feature binary \(($feature)\)" {
             if $effective_no_cache {
                 build-in-worktree --no-cache --extra-rustflags $effective_extra_rustflags --bench-features $features $feature_wt $feature $profile $effective_features $feature_sha
             } else {
                 build-in-worktree $feature_wt $feature $profile $effective_features $feature_sha
+            }
             }
         }
 
@@ -1710,6 +1731,7 @@ def "main bench" [
                 print $"Using cached dual-hardfork snapshot \(initialized ($marker.initialized_at)\)"
             } else {
                 # Generate two genesis files with different hardfork schedules
+                ci-group $"Generating dual-hardfork genesis files" {
                 print $"Generating baseline genesis \(latest fork: ($baseline_hardfork)\)..."
                 let baseline_genesis_dir = $"($abs_localnet)/genesis-baseline-dir"
                 if ($baseline_genesis_dir | path exists) { rm -rf $baseline_genesis_dir }
@@ -1741,9 +1763,11 @@ def "main bench" [
                 }
                 cp $"($feature_genesis_dir)/genesis.json" $feature_genesis_path
                 rm -rf $feature_genesis_dir
+                }
 
                 # Generate bloat file (shared, fork-agnostic)
                 if $bloat > 0 and not ($bloat_file | path exists) {
+                    ci-group $"Generating state bloat file \(($bloat) MiB\)" {
                     print $"Generating state bloat \(($bloat) MiB\)..."
                     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                     if $baseline == "local" {
@@ -1754,6 +1778,7 @@ def "main bench" [
                             cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
                         }
                     }
+                    }
                 }
 
                 # Initialize both datadirs
@@ -1761,6 +1786,7 @@ def "main bench" [
                     { name: "baseline", genesis: $baseline_genesis_path, dd: $baseline_datadir, tempo: $baseline_tempo }
                     { name: "feature", genesis: $feature_genesis_path, dd: $feature_datadir, tempo: $feature_tempo }
                 ] {
+                    ci-group $"Initializing ($side.name) database + loading bloat" {
                     # Clean existing data
                     for subdir in [db static_files rocksdb consensus invalid_block_hooks] {
                         let path = $"($side.dd)/($subdir)"
@@ -1779,8 +1805,10 @@ def "main bench" [
                         print $"Loading state bloat into ($side.name)..."
                         run-external $side.tempo "init-from-binary-dump" "--chain" $side.genesis "--datadir" $side.dd $bloat_file | complete
                     }
+                    }
                 }
 
+                ci-group "Promoting dual-hardfork snapshot" {
                 # Save genesis files to meta dir
                 mkdir $meta_dir
                 cp $baseline_genesis_path $"($meta_dir)/genesis-baseline.json"
@@ -1807,6 +1835,7 @@ def "main bench" [
                 print $"Bench marker written to ($marker_path)"
 
                 print "Dual-hardfork databases initialized and promoted."
+                }
             }
         } else {
             # ============================================================
@@ -1831,6 +1860,7 @@ def "main bench" [
             } else {
                 # Full init: generate genesis + bloat, init db, promote
                 if not ($genesis_path_std | path exists) {
+                    ci-group $"Generating genesis \(($genesis_accounts) accounts\)" {
                     if not ($abs_localnet | path exists) { mkdir $abs_localnet }
                     print $"Generating genesis with ($genesis_accounts) accounts from baseline..."
                     if $baseline == "local" {
@@ -1841,9 +1871,11 @@ def "main bench" [
                             cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis
                         }
                     }
+                    }
                 }
 
                 if $bloat > 0 and not ($bloat_file | path exists) {
+                    ci-group $"Generating state bloat file \(($bloat) MiB\)" {
                     print $"Generating state bloat \(($bloat) MiB\) from baseline..."
                     let token_args = ($TIP20_TOKEN_IDS | each { |id| ["--token" $"($id)"] } | flatten)
                     if $baseline == "local" {
@@ -1854,8 +1886,10 @@ def "main bench" [
                             cargo run -p tempo-xtask --profile $profile -- generate-state-bloat --size $bloat --out $bloat_file ...$token_args
                         }
                     }
+                    }
                 }
 
+                ci-group $"Initializing database + loading state bloat \(($bloat) MiB\)" {
                 for subdir in [db static_files rocksdb consensus invalid_block_hooks] {
                     let path = $"($datadir)/($subdir)"
                     if ($path | path exists) { rm -rf $path }
@@ -1872,7 +1906,9 @@ def "main bench" [
                     print $"Loading state bloat into ($datadir)..."
                     run-external $feature_tempo "init-from-binary-dump" "--chain" $genesis_path_std "--datadir" $datadir $bloat_file | complete
                 }
+                }
 
+                ci-group "Promoting snapshot" {
                 mkdir $meta_dir
                 cp $genesis_path_std $"($meta_dir)/genesis.json"
                 if $bloat > 0 and ($bloat_file | path exists) {
@@ -1885,6 +1921,7 @@ def "main bench" [
                 write-bench-marker $bloat $genesis_accounts $datadir
 
                 print "Database initialized and promoted to virgin baseline."
+                }
             }
         }
 
@@ -1929,17 +1966,21 @@ def "main bench" [
         }
 
         for run in $runs {
+            ci-group $"Run: ($run.label)" {
             # bench-recover restores the entire schelk volume to the promoted
             # virgin state. In dual-hardfork mode this resets both baseline-db
             # and feature-db subdirs at once.
             bench-recover $datadir
             run-bench-single $run.tempo $baseline_bench_bin $run.genesis $run.datadir $run.label $results_dir $tps $duration $accounts $max_concurrent_requests $weights $preset $bench_args $loud $node_args $bloat $run.git_ref $benchmark_id $reference_epoch $samply $samply_args_list $tracy $tracy_filter $tracy_seconds $tracy_offset $tracing_otlp
+            }
         }
 
         # Generate summary report
+        ci-group "Generating summary report" {
         let baseline_label = if $dual_hardfork { $"($baseline) \(($baseline_hardfork | str upcase)\)" } else { $baseline }
         let feature_label = if $dual_hardfork { $"($feature) \(($feature_hardfork | str upcase)\)" } else { $feature }
         generate-summary $results_dir $baseline_label $feature_label $bloat $preset $tps $duration --benchmark-id $benchmark_id --reference-epoch $reference_epoch
+        }
 
         # Cleanup worktrees (only those we created)
         if $baseline != "local" or $feature != "local" {

--- a/tempo.nu
+++ b/tempo.nu
@@ -1894,7 +1894,6 @@ def "main bench" [
 
         if $init_only {
             print "State initialization complete (--init-only). Skipping benchmark runs."
-            restore-system-tuning $tuning_state
             return
         }
 


### PR DESCRIPTION
**DO NOT MERGE — diagnostics only**

Bumps bench timeout from 300 (5h) to 1200 (20h) and fixes bloat loading to use the feature binary instead of baseline.

The 100GB bloat bench OOM'd on ghr-euw-06 because `init-from-binary-dump` was running with the baseline (`main`) binary, which lacks the streaming fix from `yk/fix-state-bloat-oom`. The feature binary keeps heap at ~3 GB; the baseline binary peaked at 113 GB → OOM.

Fix: `tempo.nu` now uses `$feature_tempo` for `init` and `init-from-binary-dump` in standard comparison mode.

Prompted by: YK