### PR TITLE
docs(tip-1037): extended memo support

### DIFF
--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -1,0 +1,165 @@
+---
+id: TIP-1037
+title: Extended Memo Support
+description: Adds variable-length memo support to TIP-20 transfers, mints, and burns via new functions that accept dynamic bytes alongside a bytes32 memo hash for efficient log indexing.
+authors: Daniel Robinson (@danrobinson)
+status: Draft
+related: TIP-20
+protocolVersion: TBD
+---
+
+# TIP-1037: Extended Memo Support
+
+## Abstract
+
+TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 1024 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The existing 32-byte `WithMemo` functions remain unchanged.
+
+## Motivation
+
+The current `bytes32` memo is sufficient for compact identifiers (invoice IDs, reference codes), but payment integrators and on-chain applications increasingly need to attach richer metadata to transfers — for example, structured payment references, multi-field routing data, or human-readable notes. A 32-byte ceiling forces integrators to store metadata off-chain and correlate it after the fact, adding latency and fragility.
+
+### Alternatives Considered
+
+1. **`transferWithMemos(bytes32[])`**: Structured multi-slot approach. Rejected because it optimises for a use case (independently indexable fields) that callers can achieve by ABI-encoding into a single `bytes` blob, while adding unbounded calldata risk and awkward padding for free-text memos.
+
+2. **`transferWithLongMemo(bytes128)`**: Fixed-size extension. Rejected because any fixed size is either too large (wasted calldata for short memos) or too small (not future-proof). A dynamic `bytes` with an enforced cap is strictly more flexible at similar gas cost for typical payloads.
+
+## Assumptions
+
+- The existing `bytes32` memo functions (`transferWithMemo`, etc.) remain the recommended path for short, fixed-size identifiers. This TIP does not deprecate them.
+- Callers are responsible for choosing the encoding of the memo blob (UTF-8 text, ABI-encoded struct, etc.). The protocol treats it as opaque bytes.
+- The 1024-byte cap is chosen to keep calldata costs reasonable (~16k gas for a full memo) while covering foreseeable use cases. It can be adjusted via a future TIP if needed.
+
+---
+
+# Specification
+
+## New Functions
+
+The following functions are added to the `ITIP20` interface:
+
+```solidity
+/// @notice Transfers tokens with a variable-length memo.
+/// @param to The recipient address.
+/// @param amount The amount of tokens to transfer.
+/// @param memo The memo to attach (max 1024 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
+
+/// @notice Transfers tokens from one address to another with a variable-length memo, using allowance.
+/// @param from The address to transfer from.
+/// @param to The recipient address.
+/// @param amount The amount of tokens to transfer.
+/// @param memo The memo to attach (max 1024 bytes).
+/// @return success True if the transfer was successful.
+/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+function transferFromWithLongMemo(
+    address from,
+    address to,
+    uint256 amount,
+    bytes calldata memo
+) external returns (bool);
+
+/// @notice Mints tokens with a variable-length memo.
+/// @param to The address to mint tokens to.
+/// @param amount The amount of tokens to mint.
+/// @param memo The memo to attach (max 1024 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
+
+/// @notice Burns tokens with a variable-length memo.
+/// @param amount The amount of tokens to burn.
+/// @param memo The memo to attach (max 1024 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
+```
+
+## New Error
+
+```solidity
+/// @notice Reverts when a memo exceeds the maximum allowed length.
+error MemoTooLong();
+```
+
+## New Event
+
+```solidity
+/// @notice Emitted when tokens are transferred with a variable-length memo.
+/// @param from The sender address.
+/// @param to The recipient address.
+/// @param amount The amount of tokens transferred.
+/// @param memoHash The keccak256 hash of the memo, for topic-based log filtering.
+/// @param memo The full memo bytes, stored in log data.
+event TransferWithLongMemo(
+    address indexed from,
+    address indexed to,
+    uint256 amount,
+    bytes32 indexed memoHash,
+    bytes memo
+);
+```
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `MAX_MEMO_LENGTH` | 1024 | Maximum memo length in bytes |
+
+## Behavior
+
+### Memo Validation
+
+All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > MAX_MEMO_LENGTH`. Empty memos (`memo.length == 0`) are permitted.
+
+### Transfer Logic
+
+The transfer, allowance, policy, and pause logic is identical to the existing `WithMemo` variants. The only difference is the memo parameter type and the event emitted.
+
+### Event Emission
+
+Each `WithLongMemo` function emits a `TransferWithLongMemo` event with:
+- `memoHash` set to `keccak256(memo)`, computed by the contract (never caller-supplied)
+- `memo` set to the raw bytes passed by the caller
+
+This gives off-chain consumers two capabilities:
+1. **Filtering**: query logs by `memoHash` topic to find transfers with a specific known memo
+2. **Reading**: decode the full memo from the log's `data` field without prior knowledge of the memo contents
+
+### Gas Cost
+
+The gas overhead relative to a standard transfer is:
+- ABI decoding of dynamic `bytes`: ~200 gas base + 3 gas per byte (calldata cost)
+- `keccak256` hash: 30 gas + 6 gas per 32-byte word
+- Log emission: 375 gas base + 8 gas per byte of log data + 375 gas per indexed topic
+
+For a 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
+
+### Interaction with Existing Functions
+
+The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged. Callers that only need short memos should continue using them for lower gas cost.
+
+---
+
+# Invariants
+
+1. **Memo Length Invariant**: Any call with `memo.length > 1024` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
+
+2. **Hash Integrity Invariant**: The `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)` where `memo` is the raw bytes in the same event's data field.
+
+3. **Transfer Equivalence Invariant**: For any valid call, the transfer behavior (balance changes, allowance deduction, policy checks, pause checks) MUST be identical to the corresponding existing `WithMemo` function. Only the event signature differs.
+
+4. **Backward Compatibility Invariant**: The existing `transferWithMemo(address, uint256, bytes32)`, `transferFromWithMemo`, `mintWithMemo`, and `burnWithMemo` functions and their `TransferWithMemo` event MUST remain unchanged.
+
+## Critical Test Cases
+
+1. **Basic long memo transfer**: `transferWithLongMemo` with a 256-byte memo succeeds and emits `TransferWithLongMemo` with correct `memoHash` and `memo`
+2. **Empty memo**: `transferWithLongMemo` with zero-length memo succeeds
+3. **Max length**: `transferWithLongMemo` with exactly 1024 bytes succeeds
+4. **Exceeds max**: `transferWithLongMemo` with 1025 bytes reverts with `MemoTooLong()`
+5. **Hash correctness**: `memoHash` in emitted event equals `keccak256(memo)` for various memo lengths
+6. **Allowance enforcement**: `transferFromWithLongMemo` correctly checks and deducts allowance
+7. **Policy enforcement**: `transferWithLongMemo` respects transfer policies (blocked by policy → revert)
+8. **Pause enforcement**: `transferWithLongMemo` reverts with `ContractPaused` when paused
+9. **Mint/burn access control**: `mintWithLongMemo` and `burnWithLongMemo` enforce role requirements
+10. **Backward compatibility**: Existing `transferWithMemo(address, uint256, bytes32)` continues to work and emits the original `TransferWithMemo` event
+11. **Function selector uniqueness**: New function selectors do not collide with existing ITIP20 selectors

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-Overloads the existing `transferWithMemo`, `transferFromWithMemo`, `mintWithMemo`, and `burnWithMemo` functions with `bytes` variants that accept a dynamic memo (up to 256 bytes). The overloaded event `TransferWithMemo` emits both a `bytes32 indexed memoHash` for topic filtering and the raw `bytes memo` in log data. Existing `bytes32` memo functions and events are unchanged.
+Overloads the existing `transferWithMemo`, `transferFromWithMemo`, `mintWithMemo`, and `burnWithMemo` functions with `bytes` variants that accept a dynamic memo (up to 256 bytes). A new `TransferWithBytesMemo` event emits both a `bytes32 indexed memoHash` for topic filtering and the raw `bytes memo` in log data. Existing `bytes32` memo functions and events are unchanged.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ The current `bytes32` memo covers compact identifiers but not structured payment
 ```solidity
 error MemoTooLong();
 
-event TransferWithMemo(
+event TransferWithBytesMemo(
     address indexed from,
     address indexed to,
     uint256 amount,
@@ -62,7 +62,7 @@ These overload the existing `bytes32` variants — Solidity resolves them by par
 # Invariants
 
 1. Any call with `memo.length > 256` MUST revert with `MemoTooLong()`.
-2. `memoHash` in every `TransferWithMemo(address,address,uint256,bytes32,bytes)` event MUST equal `keccak256(memo)`.
+2. `memoHash` in every `TransferWithBytesMemo` event MUST equal `keccak256(memo)`.
 3. Transfer behavior (balances, allowances, policies, pause) MUST be identical to the corresponding `bytes32` variant.
 4. Existing `bytes32` memo functions and `TransferWithMemo(address,address,uint256,bytes32)` event MUST remain unchanged.
 

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 1024 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The existing 32-byte `WithMemo` functions remain unchanged.
+TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 256 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The memo cap is set to 256 bytes — large enough for structured payment references and human-readable notes, but too small for image or media inscriptions that could attract ordinals-style abuse. The existing 32-byte `WithMemo` functions remain unchanged.
 
 ## Motivation
 
@@ -24,11 +24,13 @@ The current `bytes32` memo is sufficient for compact identifiers (invoice IDs, r
 
 2. **`transferWithLongMemo(bytes128)`**: Fixed-size extension. Rejected because any fixed size is either too large (wasted calldata for short memos) or too small (not future-proof). A dynamic `bytes` with an enforced cap is strictly more flexible at similar gas cost for typical payloads.
 
+3. **Larger caps (1024+ bytes)**: Rejected because memos large enough to hold images, SVGs, or base64-encoded media would make the chain an attractive target for ordinals-style inscription protocols. A 256-byte cap is sufficient for all legitimate payment metadata while being too small for meaningful media inscriptions.
+
 ## Assumptions
 
 - The existing `bytes32` memo functions (`transferWithMemo`, etc.) remain the recommended path for short, fixed-size identifiers. This TIP does not deprecate them.
 - Callers are responsible for choosing the encoding of the memo blob (UTF-8 text, ABI-encoded struct, etc.). The protocol treats it as opaque bytes.
-- The 1024-byte cap is chosen to keep calldata costs reasonable (~16k gas for a full memo) while covering foreseeable use cases. It can be adjusted via a future TIP if needed.
+- The 256-byte cap is chosen to cover legitimate payment metadata while discouraging ordinals-style inscription abuse. It can be adjusted via a future TIP if needed.
 
 ---
 
@@ -42,17 +44,17 @@ The following functions are added to the `ITIP20` interface:
 /// @notice Transfers tokens with a variable-length memo.
 /// @param to The recipient address.
 /// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
 
 /// @notice Transfers tokens from one address to another with a variable-length memo, using allowance.
 /// @param from The address to transfer from.
 /// @param to The recipient address.
 /// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 1024 bytes).
+/// @param memo The memo to attach (max 256 bytes).
 /// @return success True if the transfer was successful.
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function transferFromWithLongMemo(
     address from,
     address to,
@@ -63,14 +65,14 @@ function transferFromWithLongMemo(
 /// @notice Mints tokens with a variable-length memo.
 /// @param to The address to mint tokens to.
 /// @param amount The amount of tokens to mint.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
 
 /// @notice Burns tokens with a variable-length memo.
 /// @param amount The amount of tokens to burn.
-/// @param memo The memo to attach (max 1024 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 1024 bytes.
+/// @param memo The memo to attach (max 256 bytes).
+/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
 function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
 ```
 
@@ -103,13 +105,13 @@ event TransferWithLongMemo(
 
 | Name | Value | Description |
 |------|-------|-------------|
-| `MAX_MEMO_LENGTH` | 1024 | Maximum memo length in bytes |
+| `MAX_MEMO_LENGTH` | 256 | Maximum memo length in bytes |
 
 ## Behavior
 
 ### Memo Validation
 
-All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > MAX_MEMO_LENGTH`. Empty memos (`memo.length == 0`) are permitted.
+All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > 256`. Empty memos (`memo.length == 0`) are permitted.
 
 ### Transfer Logic
 
@@ -132,7 +134,7 @@ The gas overhead relative to a standard transfer is:
 - `keccak256` hash: 30 gas + 6 gas per 32-byte word
 - Log emission: 375 gas base + 8 gas per byte of log data + 375 gas per indexed topic
 
-For a 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
+For a max-length 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
 
 ### Interaction with Existing Functions
 
@@ -142,7 +144,7 @@ The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged
 
 # Invariants
 
-1. **Memo Length Invariant**: Any call with `memo.length > 1024` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
+1. **Memo Length Invariant**: Any call with `memo.length > 256` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
 
 2. **Hash Integrity Invariant**: The `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)` where `memo` is the raw bytes in the same event's data field.
 
@@ -154,8 +156,8 @@ The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged
 
 1. **Basic long memo transfer**: `transferWithLongMemo` with a 256-byte memo succeeds and emits `TransferWithLongMemo` with correct `memoHash` and `memo`
 2. **Empty memo**: `transferWithLongMemo` with zero-length memo succeeds
-3. **Max length**: `transferWithLongMemo` with exactly 1024 bytes succeeds
-4. **Exceeds max**: `transferWithLongMemo` with 1025 bytes reverts with `MemoTooLong()`
+3. **Max length**: `transferWithLongMemo` with exactly 256 bytes succeeds
+4. **Exceeds max**: `transferWithLongMemo` with 257 bytes reverts with `MemoTooLong()`
 5. **Hash correctness**: `memoHash` in emitted event equals `keccak256(memo)` for various memo lengths
 6. **Allowance enforcement**: `transferFromWithLongMemo` correctly checks and deducts allowance
 7. **Policy enforcement**: `transferWithLongMemo` respects transfer policies (blocked by policy → revert)

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -55,7 +55,7 @@ These overload the existing `bytes32` variants — Solidity resolves them by par
 - Transfer, allowance, policy, and pause logic is identical to the existing `bytes32` variants.
 - Events set `memoHash = keccak256(memo)`, computed by the contract (never caller-supplied).
 - For a max-length 256-byte memo, the additional gas cost beyond a standard transfer is approximately 3,500 gas.
-- TIP-1035 (Payment Transaction Classification) must be updated to add the four new selectors to the payment lane allowlist. Unlike existing memo selectors which have fixed calldata lengths, these use dynamic `bytes` and require a length range check: calldata must be at least the ABI-encoded minimum (selector + fixed params + offset + length = 132/164 bytes depending on function) and at most that minimum plus 256 bytes of memo data, padded to 32-byte alignment.
+- TIP-1035 (Payment Transaction Classification) must be updated to add the four new selectors to the payment lane allowlist. Unlike existing memo selectors which have fixed calldata lengths, these use dynamic `bytes` and require a length range check per function: `transferWithMemo` and `mintWithMemo` (min 132, max 388 bytes), `transferFromWithMemo` (min 164, max 420 bytes), `burnWithMemo` (min 100, max 356 bytes).
 
 ---
 

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -4,7 +4,7 @@ title: Extended Memo Support
 description: Variable-length memo support for TIP-20 transfers, mints, and burns.
 authors: Daniel Robinson (@danrobinson)
 status: Draft
-related: TIP-20
+related: TIP-20, TIP-1035
 protocolVersion: TBD
 ---
 
@@ -53,6 +53,7 @@ function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
 - Transfer, allowance, policy, and pause logic is identical to the existing `WithMemo` variants.
 - Events set `memoHash = keccak256(memo)`, computed by the contract (never caller-supplied).
 - For a max-length 256-byte memo, the additional gas cost beyond a standard transfer is approximately 3,500 gas.
+- TIP-1035 (Payment Transaction Classification) must be updated to add the four new selectors to the payment lane allowlist. Unlike existing memo selectors which have fixed calldata lengths, these use dynamic `bytes` and require a length range check: calldata must be at least the ABI-encoded minimum (selector + fixed params + offset + length = 132/164 bytes depending on function) and at most that minimum plus 256 bytes of memo data, padded to 32-byte alignment.
 
 ---
 

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 256 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The memo cap is set to 256 bytes — large enough for structured payment references and human-readable notes, but too small for image or media inscriptions that could attract ordinals-style abuse. The existing 32-byte `WithMemo` functions remain unchanged.
+TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 256 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The memo cap is set to 256 bytes — large enough for structured payment references and human-readable notes, but small enough to discourage abuse via large calldata blobs. The existing 32-byte `WithMemo` functions remain unchanged.
 
 ## Motivation
 
@@ -24,13 +24,13 @@ The current `bytes32` memo is sufficient for compact identifiers (invoice IDs, r
 
 2. **`transferWithLongMemo(bytes128)`**: Fixed-size extension. Rejected because any fixed size is either too large (wasted calldata for short memos) or too small (not future-proof). A dynamic `bytes` with an enforced cap is strictly more flexible at similar gas cost for typical payloads.
 
-3. **Larger caps (1024+ bytes)**: Rejected because memos large enough to hold images, SVGs, or base64-encoded media would make the chain an attractive target for ordinals-style inscription protocols. A 256-byte cap is sufficient for all legitimate payment metadata while being too small for meaningful media inscriptions.
+3. **Larger caps (1024+ bytes)**: Rejected because larger memos increase log bloat, calldata costs, and the surface area for non-payment use cases. A 256-byte cap covers all legitimate payment metadata while keeping per-transaction overhead low.
 
 ## Assumptions
 
 - The existing `bytes32` memo functions (`transferWithMemo`, etc.) remain the recommended path for short, fixed-size identifiers. This TIP does not deprecate them.
 - Callers are responsible for choosing the encoding of the memo blob (UTF-8 text, ABI-encoded struct, etc.). The protocol treats it as opaque bytes.
-- The 256-byte cap is chosen to cover legitimate payment metadata while discouraging ordinals-style inscription abuse. It can be adjusted via a future TIP if needed.
+- The 256-byte cap is chosen to cover legitimate payment metadata while keeping per-transaction overhead minimal. It can be adjusted via a future TIP if needed.
 
 ---
 

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-Adds `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` that accept a dynamic `bytes memo` (up to 256 bytes). Events emit both a `bytes32 indexed memoHash` for topic filtering and the raw `bytes memo` in log data. Existing `bytes32` memo functions are unchanged.
+Overloads the existing `transferWithMemo`, `transferFromWithMemo`, `mintWithMemo`, and `burnWithMemo` functions with `bytes` variants that accept a dynamic memo (up to 256 bytes). The overloaded event `TransferWithMemo` emits both a `bytes32 indexed memoHash` for topic filtering and the raw `bytes memo` in log data. Existing `bytes32` memo functions and events are unchanged.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ The current `bytes32` memo covers compact identifiers but not structured payment
 ```solidity
 error MemoTooLong();
 
-event TransferWithLongMemo(
+event TransferWithMemo(
     address indexed from,
     address indexed to,
     uint256 amount,
@@ -41,16 +41,18 @@ event TransferWithLongMemo(
     bytes memo
 );
 
-function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
-function transferFromWithLongMemo(address from, address to, uint256 amount, bytes calldata memo) external returns (bool);
-function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
-function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
+function transferWithMemo(address to, uint256 amount, bytes calldata memo) external;
+function transferFromWithMemo(address from, address to, uint256 amount, bytes calldata memo) external returns (bool);
+function mintWithMemo(address to, uint256 amount, bytes calldata memo) external;
+function burnWithMemo(uint256 amount, bytes calldata memo) external;
 ```
+
+These overload the existing `bytes32` variants — Solidity resolves them by parameter type, and they produce distinct function selectors.
 
 ## Behavior
 
 - Reverts with `MemoTooLong()` if `memo.length > 256`. Empty memos are permitted.
-- Transfer, allowance, policy, and pause logic is identical to the existing `WithMemo` variants.
+- Transfer, allowance, policy, and pause logic is identical to the existing `bytes32` variants.
 - Events set `memoHash = keccak256(memo)`, computed by the contract (never caller-supplied).
 - For a max-length 256-byte memo, the additional gas cost beyond a standard transfer is approximately 3,500 gas.
 - TIP-1035 (Payment Transaction Classification) must be updated to add the four new selectors to the payment lane allowlist. Unlike existing memo selectors which have fixed calldata lengths, these use dynamic `bytes` and require a length range check: calldata must be at least the ABI-encoded minimum (selector + fixed params + offset + length = 132/164 bytes depending on function) and at most that minimum plus 256 bytes of memo data, padded to 32-byte alignment.
@@ -60,15 +62,15 @@ function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
 # Invariants
 
 1. Any call with `memo.length > 256` MUST revert with `MemoTooLong()`.
-2. `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)`.
-3. Transfer behavior (balances, allowances, policies, pause) MUST be identical to the corresponding `WithMemo` function.
-4. Existing `bytes32` memo functions and `TransferWithMemo` event MUST remain unchanged.
+2. `memoHash` in every `TransferWithMemo(address,address,uint256,bytes32,bytes)` event MUST equal `keccak256(memo)`.
+3. Transfer behavior (balances, allowances, policies, pause) MUST be identical to the corresponding `bytes32` variant.
+4. Existing `bytes32` memo functions and `TransferWithMemo(address,address,uint256,bytes32)` event MUST remain unchanged.
 
 ## Critical Test Cases
 
 1. 256-byte memo succeeds and emits correct `memoHash`
 2. Empty memo succeeds
 3. 257-byte memo reverts with `MemoTooLong()`
-4. `transferFromWithLongMemo` enforces allowance
+4. `transferFromWithMemo(address,address,uint256,bytes)` enforces allowance
 5. Transfer policies and pause state are respected
-6. Existing `transferWithMemo(address, uint256, bytes32)` still works
+6. Existing `transferWithMemo(address,uint256,bytes32)` still works

--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1037
 title: Extended Memo Support
-description: Adds variable-length memo support to TIP-20 transfers, mints, and burns via new functions that accept dynamic bytes alongside a bytes32 memo hash for efficient log indexing.
+description: Variable-length memo support for TIP-20 transfers, mints, and burns.
 authors: Daniel Robinson (@danrobinson)
 status: Draft
 related: TIP-20
@@ -12,86 +12,27 @@ protocolVersion: TBD
 
 ## Abstract
 
-TIP-1037 extends the TIP-20 memo system beyond the current 32-byte limit. New `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` accept a dynamic `bytes memo` of up to 256 bytes. Events emit both a `bytes32 indexed memoHash` (the keccak256 of the memo) for efficient topic-based filtering and the raw `bytes memo` in log data for full readability. The memo cap is set to 256 bytes — large enough for structured payment references and human-readable notes, but small enough to discourage abuse via large calldata blobs. The existing 32-byte `WithMemo` functions remain unchanged.
+Adds `WithLongMemo` variants of `transfer`, `transferFrom`, `mint`, and `burn` that accept a dynamic `bytes memo` (up to 256 bytes). Events emit both a `bytes32 indexed memoHash` for topic filtering and the raw `bytes memo` in log data. Existing `bytes32` memo functions are unchanged.
 
 ## Motivation
 
-The current `bytes32` memo is sufficient for compact identifiers (invoice IDs, reference codes), but payment integrators and on-chain applications increasingly need to attach richer metadata to transfers — for example, structured payment references, multi-field routing data, or human-readable notes. A 32-byte ceiling forces integrators to store metadata off-chain and correlate it after the fact, adding latency and fragility.
+The current `bytes32` memo covers compact identifiers but not structured payment references, multi-field routing data, or human-readable notes. A 256-byte dynamic `bytes` with an enforced cap is flexible enough for these use cases while keeping per-transaction overhead low.
 
 ### Alternatives Considered
 
-1. **`transferWithMemos(bytes32[])`**: Structured multi-slot approach. Rejected because it optimises for a use case (independently indexable fields) that callers can achieve by ABI-encoding into a single `bytes` blob, while adding unbounded calldata risk and awkward padding for free-text memos.
-
-2. **`transferWithLongMemo(bytes128)`**: Fixed-size extension. Rejected because any fixed size is either too large (wasted calldata for short memos) or too small (not future-proof). A dynamic `bytes` with an enforced cap is strictly more flexible at similar gas cost for typical payloads.
-
-3. **Larger caps (1024+ bytes)**: Rejected because larger memos increase log bloat, calldata costs, and the surface area for non-payment use cases. A 256-byte cap covers all legitimate payment metadata while keeping per-transaction overhead low.
-
-## Assumptions
-
-- The existing `bytes32` memo functions (`transferWithMemo`, etc.) remain the recommended path for short, fixed-size identifiers. This TIP does not deprecate them.
-- Callers are responsible for choosing the encoding of the memo blob (UTF-8 text, ABI-encoded struct, etc.). The protocol treats it as opaque bytes.
-- The 256-byte cap is chosen to cover legitimate payment metadata while keeping per-transaction overhead minimal. It can be adjusted via a future TIP if needed.
+1. **`bytes32[]`**: Adds unbounded calldata risk and awkward padding. Callers can ABI-encode structured fields into a single `bytes` blob instead.
+2. **`bytes128`**: Any fixed size is either wasteful or insufficient. Dynamic `bytes` with a cap is strictly better.
+3. **Larger caps (1024+)**: Increases log bloat and surface area for non-payment use cases.
 
 ---
 
 # Specification
 
-## New Functions
-
-The following functions are added to the `ITIP20` interface:
+## Interface Additions
 
 ```solidity
-/// @notice Transfers tokens with a variable-length memo.
-/// @param to The recipient address.
-/// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 256 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
-function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
-
-/// @notice Transfers tokens from one address to another with a variable-length memo, using allowance.
-/// @param from The address to transfer from.
-/// @param to The recipient address.
-/// @param amount The amount of tokens to transfer.
-/// @param memo The memo to attach (max 256 bytes).
-/// @return success True if the transfer was successful.
-/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
-function transferFromWithLongMemo(
-    address from,
-    address to,
-    uint256 amount,
-    bytes calldata memo
-) external returns (bool);
-
-/// @notice Mints tokens with a variable-length memo.
-/// @param to The address to mint tokens to.
-/// @param amount The amount of tokens to mint.
-/// @param memo The memo to attach (max 256 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
-function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
-
-/// @notice Burns tokens with a variable-length memo.
-/// @param amount The amount of tokens to burn.
-/// @param memo The memo to attach (max 256 bytes).
-/// @dev Reverts with MemoTooLong if memo exceeds 256 bytes.
-function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
-```
-
-## New Error
-
-```solidity
-/// @notice Reverts when a memo exceeds the maximum allowed length.
 error MemoTooLong();
-```
 
-## New Event
-
-```solidity
-/// @notice Emitted when tokens are transferred with a variable-length memo.
-/// @param from The sender address.
-/// @param to The recipient address.
-/// @param amount The amount of tokens transferred.
-/// @param memoHash The keccak256 hash of the memo, for topic-based log filtering.
-/// @param memo The full memo bytes, stored in log data.
 event TransferWithLongMemo(
     address indexed from,
     address indexed to,
@@ -99,69 +40,34 @@ event TransferWithLongMemo(
     bytes32 indexed memoHash,
     bytes memo
 );
+
+function transferWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
+function transferFromWithLongMemo(address from, address to, uint256 amount, bytes calldata memo) external returns (bool);
+function mintWithLongMemo(address to, uint256 amount, bytes calldata memo) external;
+function burnWithLongMemo(uint256 amount, bytes calldata memo) external;
 ```
-
-## Constants
-
-| Name | Value | Description |
-|------|-------|-------------|
-| `MAX_MEMO_LENGTH` | 256 | Maximum memo length in bytes |
 
 ## Behavior
 
-### Memo Validation
-
-All `WithLongMemo` functions MUST revert with `MemoTooLong()` if `memo.length > 256`. Empty memos (`memo.length == 0`) are permitted.
-
-### Transfer Logic
-
-The transfer, allowance, policy, and pause logic is identical to the existing `WithMemo` variants. The only difference is the memo parameter type and the event emitted.
-
-### Event Emission
-
-Each `WithLongMemo` function emits a `TransferWithLongMemo` event with:
-- `memoHash` set to `keccak256(memo)`, computed by the contract (never caller-supplied)
-- `memo` set to the raw bytes passed by the caller
-
-This gives off-chain consumers two capabilities:
-1. **Filtering**: query logs by `memoHash` topic to find transfers with a specific known memo
-2. **Reading**: decode the full memo from the log's `data` field without prior knowledge of the memo contents
-
-### Gas Cost
-
-The gas overhead relative to a standard transfer is:
-- ABI decoding of dynamic `bytes`: ~200 gas base + 3 gas per byte (calldata cost)
-- `keccak256` hash: 30 gas + 6 gas per 32-byte word
-- Log emission: 375 gas base + 8 gas per byte of log data + 375 gas per indexed topic
-
-For a max-length 256-byte memo, the additional cost beyond a standard transfer is approximately 3,500 gas.
-
-### Interaction with Existing Functions
-
-The existing `bytes32` memo functions and `TransferWithMemo` event are unchanged. Callers that only need short memos should continue using them for lower gas cost.
+- Reverts with `MemoTooLong()` if `memo.length > 256`. Empty memos are permitted.
+- Transfer, allowance, policy, and pause logic is identical to the existing `WithMemo` variants.
+- Events set `memoHash = keccak256(memo)`, computed by the contract (never caller-supplied).
+- For a max-length 256-byte memo, the additional gas cost beyond a standard transfer is approximately 3,500 gas.
 
 ---
 
 # Invariants
 
-1. **Memo Length Invariant**: Any call with `memo.length > 256` MUST revert with `MemoTooLong()`. No memo data may be stored or emitted if validation fails.
-
-2. **Hash Integrity Invariant**: The `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)` where `memo` is the raw bytes in the same event's data field.
-
-3. **Transfer Equivalence Invariant**: For any valid call, the transfer behavior (balance changes, allowance deduction, policy checks, pause checks) MUST be identical to the corresponding existing `WithMemo` function. Only the event signature differs.
-
-4. **Backward Compatibility Invariant**: The existing `transferWithMemo(address, uint256, bytes32)`, `transferFromWithMemo`, `mintWithMemo`, and `burnWithMemo` functions and their `TransferWithMemo` event MUST remain unchanged.
+1. Any call with `memo.length > 256` MUST revert with `MemoTooLong()`.
+2. `memoHash` in every `TransferWithLongMemo` event MUST equal `keccak256(memo)`.
+3. Transfer behavior (balances, allowances, policies, pause) MUST be identical to the corresponding `WithMemo` function.
+4. Existing `bytes32` memo functions and `TransferWithMemo` event MUST remain unchanged.
 
 ## Critical Test Cases
 
-1. **Basic long memo transfer**: `transferWithLongMemo` with a 256-byte memo succeeds and emits `TransferWithLongMemo` with correct `memoHash` and `memo`
-2. **Empty memo**: `transferWithLongMemo` with zero-length memo succeeds
-3. **Max length**: `transferWithLongMemo` with exactly 256 bytes succeeds
-4. **Exceeds max**: `transferWithLongMemo` with 257 bytes reverts with `MemoTooLong()`
-5. **Hash correctness**: `memoHash` in emitted event equals `keccak256(memo)` for various memo lengths
-6. **Allowance enforcement**: `transferFromWithLongMemo` correctly checks and deducts allowance
-7. **Policy enforcement**: `transferWithLongMemo` respects transfer policies (blocked by policy → revert)
-8. **Pause enforcement**: `transferWithLongMemo` reverts with `ContractPaused` when paused
-9. **Mint/burn access control**: `mintWithLongMemo` and `burnWithLongMemo` enforce role requirements
-10. **Backward compatibility**: Existing `transferWithMemo(address, uint256, bytes32)` continues to work and emits the original `TransferWithMemo` event
-11. **Function selector uniqueness**: New function selectors do not collide with existing ITIP20 selectors
+1. 256-byte memo succeeds and emits correct `memoHash`
+2. Empty memo succeeds
+3. 257-byte memo reverts with `MemoTooLong()`
+4. `transferFromWithLongMemo` enforces allowance
+5. Transfer policies and pause state are respected
+6. Existing `transferWithMemo(address, uint256, bytes32)` still works


### PR DESCRIPTION
Adds TIP-1037: Extended Memo Support. Introduces `WithLongMemo` variants of transfer, transferFrom, mint, and burn that accept dynamic `bytes memo` (up to 256 bytes). Events emit both `bytes32 indexed memoHash` for topic filtering and raw `bytes memo` for readability. Cap set to 256 bytes to discourage ordinals-style inscription abuse.

Co-Authored-By: Daniel Robinson <1187252+danrobinson@users.noreply.github.com>

Prompted by: dan