### PR TITLE
docs: add TIP branch naming convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,14 @@ Tempo is a blockchain node built on [Reth SDK](https://github.com/paradigmxyz/re
 
 ## Pull Requests
 
-### Branches
+## TIPs (Tempo Improvement Proposals)
+
+When creating a new TIP:
+
+- Branch: `tip/XXXX` where `XXXX` is the next available TIP number (check `tips/` directory).
+- File: `tips/tip-XXXX.md` matching the branch number.
+- Follow the template in `tips/tip_template.md`.
+- Follow the process and quality gates in `tips/tip-0000.md`.
 
 When adding a new TIP, use the branch format `tip/XXXX` where `XXXX` is the next available TIP number.
 


### PR DESCRIPTION
Codifies the existing `tip/XXXX` branch naming convention for new TIPs.

Prompted by: Dan