### PR TITLE
ci: add zepter auto-fix step to reth bump workflow

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -303,6 +303,23 @@ jobs:
             echo "No source changes to commit."
           fi
 
+      # ── zepter feature lint ─────────────────────────────────────
+      - uses: taiki-e/cache-cargo-install-action@34ce5120836e5f9f1508d8713d7fdea0e8facd6f # v3.0.1
+        with:
+          tool: zepter
+      - name: Fix zepter lint
+        run: |
+          if ! zepter run check; then
+            echo "Zepter check failed — running auto-fix..."
+            zepter
+            if [ -n "$(git status --porcelain)" ]; then
+              git add -A
+              git commit -m "fix: resolve zepter feature propagation from reth update ($(date -u +%Y-%m-%d))"
+            fi
+          else
+            echo "Zepter check passed."
+          fi
+
       # ── push ───────────────────────────────────────────────────
       - name: Push working branch
         run: |


### PR DESCRIPTION
Zepter checks Cargo.toml feature propagation consistency. When reth deps change, features can get out of sync and `zepter run check` fails in CI.

The existing post-CI fix loop couldn't handle this because `gh run view --log-failed | tail -200` only captured sccache stats and git cleanup — the actual zepter error output was truncated. Amp never saw what failed and fixed an unrelated e2e stack overflow instead.

This adds a deterministic `zepter run check` + `zepter` (auto-fix) step before push, right after the clippy/test fix loops. Since zepter is fully auto-fixable, this avoids relying on the post-CI loop entirely.

Prompted by: Arsenii