### PR TITLE
refactor: request proposals through FCU requests

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -28,11 +28,7 @@ use prometheus_client::metrics::counter::Counter;
 
 use commonware_utils::{SystemTimeExt, channel::oneshot};
 use eyre::{OptionExt as _, WrapErr as _, bail, ensure, eyre};
-use futures::{
-    StreamExt as _, TryFutureExt as _,
-    channel::mpsc,
-    future::{ready, try_join},
-};
+use futures::{StreamExt as _, TryFutureExt as _, channel::mpsc, future::try_join};
 use rand_08::{CryptoRng, Rng};
 use reth_ethereum::chainspec::EthChainSpec as _;
 use reth_node_builder::{Block as _, BuiltPayload, ConsensusEngineHandle};
@@ -419,10 +415,10 @@ impl Inner<Init> {
             // Only make the verified block canonical when not doing a
             // re-propose at the end of an epoch.
             if parent.1 != payload
-                && let Err(error) =
-                    self.state
-                        .executor
-                        .canonicalize_head(block.height(), block.digest(), None)
+                && let Err(error) = self
+                    .state
+                    .executor
+                    .canonicalize_head(block.height(), block.digest())
             {
                 tracing::warn!(
                     %error,
@@ -560,15 +556,12 @@ impl Inner<Init> {
 
         let interrupt_handle = attrs.interrupt_handle().clone();
 
-        let payload_id = ready(self.state.executor.canonicalize_head(
-            parent.height(),
-            parent.digest(),
-            Some(attrs),
-        ))
-        .and_then(|ack| ack.map_err(eyre::Report::new))
-        .await
-        .wrap_err("failed updating canonical head to parent")?
-        .ok_or_eyre("no payload id received from an FCU request with attributes")?;
+        let payload_id = self
+            .state
+            .executor
+            .canonicalize_and_build(parent.height(), parent.digest(), attrs)
+            .await
+            .wrap_err("failed requesting a new payload build")?;
 
         debug!(
             resolve_time_ms = self.payload_resolve_time.as_millis(),
@@ -672,10 +665,10 @@ impl Inner<Init> {
             return Ok((block, false));
         }
 
-        if let Err(error) =
-            self.state
-                .executor
-                .canonicalize_head(parent.height(), parent.digest(), None)
+        if let Err(error) = self
+            .state
+            .executor
+            .canonicalize_head(parent.height(), parent.digest())
         {
             tracing::warn!(
                 %error,

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -33,7 +33,10 @@ use super::{
     Config,
     ingress::{CanonicalizeHead, Command, Message, SubscribeFinalized},
 };
-use crate::consensus::{Digest, block::Block};
+use crate::{
+    consensus::{Digest, block::Block},
+    executor::ingress::CanonicalizeAndBuild,
+};
 
 /// Tracks the last forkchoice state that the executor sent to the execution layer.
 ///
@@ -303,12 +306,7 @@ where
     async fn handle_message(&mut self, message: Message) -> eyre::Result<()> {
         let cause = message.cause;
         match message.command {
-            Command::CanonicalizeHead(CanonicalizeHead {
-                height,
-                digest,
-                attributes,
-                ack,
-            }) => {
+            Command::CanonicalizeHead(CanonicalizeHead { height, digest }) => {
                 // Errors are logged inside canonicalize; head canonicalization failures
                 // are non-fatal and will be retried on the next block.
                 let _ = self
@@ -317,10 +315,27 @@ where
                         HeadOrFinalized::Head,
                         height,
                         digest,
-                        attributes.map(|a| *a),
-                        ack,
+                        None,
+                        oneshot::channel().0,
                     )
                     .await;
+            }
+            Command::CanonicalizeAndBuild(CanonicalizeAndBuild {
+                height,
+                digest,
+                attributes,
+                id_tx: ack,
+            }) => {
+                self.canonicalize(
+                    cause,
+                    HeadOrFinalized::Head,
+                    height,
+                    digest,
+                    Some(*attributes),
+                    ack,
+                )
+                .await
+                .wrap_err("failed canonicalizing and building payload")?;
             }
             Command::Finalize(finalized) => {
                 self.finalize(cause, *finalized)
@@ -359,7 +374,7 @@ where
         height: Height,
         digest: Digest,
         attributes: Option<TempoPayloadAttributes>,
-        ack: oneshot::Sender<Option<PayloadId>>,
+        payload_id_tx: oneshot::Sender<PayloadId>,
     ) -> eyre::Result<()> {
         let new_canonicalized = match head_or_finalized {
             HeadOrFinalized::Head => self.last_canonicalized.update_head(height, digest),
@@ -368,7 +383,6 @@ where
 
         if new_canonicalized == self.last_canonicalized && attributes.is_none() {
             info!("would not change forkchoice state; not sending it to the execution layer");
-            let _ = ack.send(None);
             return Ok(());
         }
 
@@ -398,7 +412,9 @@ where
                 .wrap_err("execution layer responded with error for forkchoice-update"));
         }
 
-        let _ = ack.send(fcu_response.payload_id);
+        if let Some(payload_id) = fcu_response.payload_id {
+            let _ = payload_id_tx.send(payload_id);
+        }
         self.last_canonicalized = new_canonicalized;
         self.reset_fcu_heartbeat_timer();
 

--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -17,23 +17,34 @@ pub(crate) struct Mailbox {
 
 impl Mailbox {
     /// Requests the agent to update the head of the canonical chain to `digest`.
-    pub(crate) fn canonicalize_head(
-        &self,
-        height: Height,
-        digest: Digest,
-        attributes: Option<TempoPayloadAttributes>,
-    ) -> eyre::Result<oneshot::Receiver<Option<PayloadId>>> {
-        let (tx, rx) = oneshot::channel();
+    pub(crate) fn canonicalize_head(&self, height: Height, digest: Digest) -> eyre::Result<()> {
         self.inner
             .unbounded_send(Message::in_current_span(CanonicalizeHead {
                 height,
                 digest,
-                attributes: attributes.map(Box::new),
-                ack: tx,
             }))
-            .wrap_err("failed sending canonicalize request to agent, this means it exited")?;
+            .wrap_err("failed sending canonicalize request to agent, this means it exited")
+    }
 
-        Ok(rx)
+    /// Canonicalizes the given head and requests a new payload to be built.
+    pub(crate) async fn canonicalize_and_build(
+        &self,
+        height: Height,
+        digest: Digest,
+        attributes: TempoPayloadAttributes,
+    ) -> eyre::Result<PayloadId> {
+        let (id_tx, id_rx) = oneshot::channel();
+        self.inner
+            .unbounded_send(Message::in_current_span(CanonicalizeAndBuild {
+                height,
+                digest,
+                attributes: Box::new(attributes),
+                id_tx,
+            }))
+            .wrap_err(
+                "failed sending canonicalize and build request to agent, this means it exited",
+            )?;
+        id_rx.await.map_err(|_| eyre!("no payload id received"))
     }
 
     pub(crate) async fn subscribe_finalized(&self, height: Height) -> eyre::Result<()> {
@@ -69,6 +80,8 @@ impl Message {
 pub(super) enum Command {
     /// Requests the agent to set the head of the canonical chain to `digest`.
     CanonicalizeHead(CanonicalizeHead),
+    /// Requests the agent to canonicalize the head and build a new payload.
+    CanonicalizeAndBuild(CanonicalizeAndBuild),
     /// Requests the agent to forward a finalization event to the execution layer.
     Finalize(Box<Update<Block>>),
     /// Returns once the executor actor has finalized the block at `height`.
@@ -79,8 +92,14 @@ pub(super) enum Command {
 pub(super) struct CanonicalizeHead {
     pub(super) height: Height,
     pub(super) digest: Digest,
-    pub(super) attributes: Option<Box<TempoPayloadAttributes>>,
-    pub(super) ack: oneshot::Sender<Option<PayloadId>>,
+}
+
+#[derive(Debug)]
+pub(super) struct CanonicalizeAndBuild {
+    pub(super) height: Height,
+    pub(super) digest: Digest,
+    pub(super) attributes: Box<TempoPayloadAttributes>,
+    pub(super) id_tx: oneshot::Sender<PayloadId>,
 }
 
 #[derive(Debug)]
@@ -92,6 +111,12 @@ pub(super) struct SubscribeFinalized {
 impl From<CanonicalizeHead> for Command {
     fn from(value: CanonicalizeHead) -> Self {
         Self::CanonicalizeHead(value)
+    }
+}
+
+impl From<CanonicalizeAndBuild> for Command {
+    fn from(value: CanonicalizeAndBuild) -> Self {
+        Self::CanonicalizeAndBuild(value)
     }
 }
 


### PR DESCRIPTION
Changes CL logic to request proposals through FCU requests with payload attributes, like it's done by other chains.

This would allow to inherit reth optimizations we're working on that are sharing caches and other perf infrastructure from engine with payload builder directly