### PR TITLE
docs(tip-1039): remove refund cap and add code deposit refund

### DIFF
--- a/tips/tip-1039.md
+++ b/tips/tip-1039.md
@@ -1,0 +1,220 @@
+---
+id: TIP-1039
+title: Remove Refund Cap and Add Code Deposit Refund
+description: Removes the 20% gas refund cap and adds a code deposit refund for contracts created and destroyed in the same transaction.
+authors: Dankrad Feist @dankrad
+status: Draft
+related: TIP-1000, TIP-1016, EIP-3529, EIP-6780
+protocolVersion: T3
+---
+
+# TIP-1039: Remove Refund Cap and Add Code Deposit Refund
+
+## Abstract
+
+This TIP makes two changes to Tempo's gas refund mechanics:
+
+1. **Remove the 20% refund cap**: Gas refunds are no longer capped at 20% of total gas used. The full refund amount from SSTORE slot restoration (0→X→0) is returned.
+
+2. **Add code deposit refund for same-transaction SELFDESTRUCT**: When a contract is created and destroyed via SELFDESTRUCT in the same transaction (EIP-6780), the code deposit gas (both regular and state components) and contract metadata gas are refunded via `refund_counter`.
+
+## Motivation
+
+### The 20% refund cap is unnecessary on Tempo
+
+The refund cap was introduced on Ethereum via EIP-3529 (reducing from 50% to 20%) to kill gas token exploits (GST2, CHI). Gas tokens worked by stockpiling state during low gas prices and clearing it during high gas prices for refunds.
+
+On Tempo, gas tokens are already impossible for two independent reasons:
+
+1. **EIP-6780**: SELFDESTRUCT can only clear code and storage when called in the same transaction as contract creation. Cross-transaction state stockpiling and clearing is not possible.
+
+2. **Stable fee token**: Gas is priced in USDC (mainnet) / PathUSD (testnet), eliminating the gas price volatility that gas token arbitrage requires.
+
+The only remaining refund path is same-transaction SSTORE 0→X→0, which is a legitimate pattern (temporary storage during computation). The 20% cap actively penalizes this real use case without preventing any exploit.
+
+Additionally, the concern about blocks having negative effective gas usage is not relevant on Tempo because TIP-1016 already exempts state gas from block gas limits.
+
+### Code deposit should be refundable for same-tx destruction
+
+When a contract is created and destroyed in the same transaction (the only case where SELFDESTRUCT fully works under EIP-6780), no permanent state growth occurs for the contract code — the code is never persisted. The code deposit cost (2,500 gas/byte under TIP-1016) and contract metadata cost (500,000 gas) are charges for permanent storage burden that does not materialize.
+
+This is analogous to the SSTORE 0→X→0 refund: temporary state that is cleaned up in the same transaction should not be charged the full state growth penalty. Without this refund, counterfactual address patterns (CREATE2 → use → SELFDESTRUCT → redeploy) pay the full code deposit every cycle despite creating no net state growth.
+
+---
+
+# Specification
+
+## 1. Remove Refund Cap
+
+### Current Behavior (TIP-1016)
+
+Gas refunds via `refund_counter` are capped at 20% of `tx_gas_used_before_refund`:
+
+```python
+tx_gas_refund = min(tx_gas_used_before_refund // 5, tx_output.refund_counter)
+```
+
+### Proposed Behavior
+
+The refund cap is removed. The full `refund_counter` value is applied:
+
+```python
+tx_gas_refund = tx_output.refund_counter
+```
+
+The post-refund gas used calculation remains unchanged:
+
+```python
+tx_gas_used_after_refund = max(
+    tx_gas_used_before_refund - tx_gas_refund,
+    calldata_floor_gas_cost
+)
+```
+
+The EIP-7623 calldata floor still applies as a lower bound, ensuring calldata-heavy transactions always pay at least the floor cost.
+
+## 2. Code Deposit Refund for Same-Transaction SELFDESTRUCT
+
+### Current Behavior
+
+When a contract is created and then destroyed via SELFDESTRUCT in the same transaction (EIP-6780 same-tx destruction), the code deposit cost and contract metadata cost are fully consumed with no refund.
+
+### Proposed Behavior
+
+When SELFDESTRUCT executes and EIP-6780 determines that the contract was created in the current transaction (full destruction path), the following are added to `refund_counter`:
+
+| Component | Regular Gas Refund | State Gas Refund | Total Refund |
+|-----------|-------------------|-----------------|-------------|
+| Code deposit (per byte) | 200 | 2,300 | 2,500 per byte |
+| Contract metadata (keccak + nonce) | 32,000 | 468,000 | 500,000 |
+
+The account creation cost (250,000 gas) is **not** refunded, consistent with TIP-1016 invariant 14 which states that account creation gas is consumed even on revert.
+
+### Refund Calculation
+
+When SELFDESTRUCT triggers full destruction (same-tx created contract):
+
+```python
+code_length = len(contract.code)
+code_deposit_refund = code_length * 2_500  # 200 regular + 2,300 state per byte
+metadata_refund = 500_000                  # 32,000 regular + 468,000 state
+refund_counter += code_deposit_refund + metadata_refund
+```
+
+### Interaction with Reservoir Model
+
+The code deposit refund contains both regular and state gas components. The refund is applied via `refund_counter` at the transaction level (post-execution), consistent with TIP-1016 invariant 13 which requires all refunds to use `refund_counter` rather than direct gas decrements.
+
+### Conditions
+
+The code deposit refund applies only when ALL of the following are true:
+
+1. SELFDESTRUCT is executed
+2. The contract was created in the current transaction (EIP-6780 same-tx condition)
+3. The contract has non-empty code (code length > 0)
+
+The refund does NOT apply when:
+
+- SELFDESTRUCT is called on a contract created in a prior transaction (EIP-6780 no-op path — code and storage are preserved, only balance is sent)
+- The contract has zero-length code
+
+---
+
+# Examples
+
+## Counterfactual Address Pattern (1KB contract)
+
+A factory deploys a 1,024-byte contract via CREATE2, uses it, then calls SELFDESTRUCT — all in one transaction.
+
+### Before TIP-1039
+
+| Cost | Gas |
+|------|-----|
+| Contract metadata | 500,000 |
+| Account creation | 250,000 |
+| Code deposit (1,024 × 2,500) | 2,560,000 |
+| SELFDESTRUCT base | 5,000 |
+| **Total** | **3,315,000** |
+| Refund (storage slots only) | capped at 20% |
+
+### After TIP-1039
+
+| Cost | Gas |
+|------|-----|
+| Contract metadata | 500,000 |
+| Account creation | 250,000 |
+| Code deposit (1,024 × 2,500) | 2,560,000 |
+| SELFDESTRUCT base | 5,000 |
+| **Subtotal** | **3,315,000** |
+| Code deposit refund | −2,560,000 |
+| Metadata refund | −500,000 |
+| **Net cost** | **255,000** |
+
+The net cost is the account creation (250,000) + SELFDESTRUCT base (5,000), which correctly reflects that no permanent code state was created.
+
+## SSTORE 0→X→0 Pattern
+
+A transaction writes a storage slot temporarily and clears it.
+
+### Before TIP-1039
+
+| | Gas |
+|---|---|
+| SSTORE (0→X) | 250,000 |
+| SSTORE (X→0) | 2,900 |
+| Refund (via counter) | −247,800 |
+| 20% cap (on 252,900 total) | limits refund to −50,580 |
+| **Net cost** | **202,320** |
+
+### After TIP-1039
+
+| | Gas |
+|---|---|
+| SSTORE (0→X) | 250,000 |
+| SSTORE (X→0) | 2,900 |
+| Refund (via counter, uncapped) | −247,800 |
+| **Net cost** | **5,100** |
+
+---
+
+# Invariants
+
+1. **No Refund Cap**: `tx_gas_refund` MUST equal `tx_output.refund_counter` (no percentage cap applied). The EIP-7623 calldata floor still applies as a lower bound on `tx_gas_used_after_refund`.
+
+2. **Code Deposit Refund**: When SELFDESTRUCT triggers full destruction (EIP-6780 same-tx path), `refund_counter` MUST be incremented by `code_length × 2,500 + 500,000`.
+
+3. **Account Creation Not Refunded**: The account creation cost (250,000 gas) MUST NOT be refunded by SELFDESTRUCT, consistent with TIP-1016 invariant 14.
+
+4. **Same-TX Only**: The code deposit refund MUST only apply when the contract was created in the current transaction (EIP-6780 same-tx condition).
+
+5. **Refund Counter Mechanism**: All refunds MUST use `refund_counter`, consistent with TIP-1016 invariant 13. No direct gas accounting decrements.
+
+6. **Calldata Floor Preserved**: `tx_gas_used_after_refund` MUST be at least `calldata_floor_gas_cost` (EIP-7623), even after uncapped refunds.
+
+7. **Storage Slot Refunds Unchanged**: The SSTORE 0→X→0 refund amounts (230,000 state + 17,800 regular per slot) are unchanged. Only the cap is removed.
+
+---
+
+# Security Considerations
+
+## Gas Token Attacks
+
+Gas tokens are not viable on Tempo because:
+- EIP-6780 prevents cross-transaction state stockpiling via SELFDESTRUCT
+- Stable fee token (USDC/PathUSD) eliminates gas price volatility arbitrage
+- SSTORE 0→X→0 refunds only apply within a single transaction
+
+## Block Gas Accounting
+
+Removing the refund cap does not affect block gas limits because:
+- State gas is already exempt from block limits (TIP-1016)
+- Regular gas refunds reduce `tx_gas_used_after_refund` but cannot go below `calldata_floor_gas_cost`
+- Block `gas_used` is based on regular gas only
+
+## Denial of Service
+
+Without the cap, a transaction could theoretically receive large refunds. However:
+- The user must first pay for all gas upfront (no free execution)
+- Refunds only return gas that was charged — net gas used is always ≥ 0 (before floor)
+- The calldata floor (EIP-7623) provides an additional lower bound
+- Large refunds require large transactions, which are naturally limited by block gas limits


### PR DESCRIPTION
Two changes to Tempo gas refund mechanics:

1. **Remove 20% refund cap** — gas tokens are already dead on Tempo (EIP-6780 + stable fee token), so the cap only penalizes legitimate same-tx SSTORE 0→X→0 patterns.

2. **Add code deposit refund for same-tx SELFDESTRUCT** — when a contract is created and destroyed in the same transaction, no permanent state growth occurs for code, so the code deposit (2,500 gas/byte) and metadata (500,000 gas) should be refunded. Enables efficient counterfactual address patterns.

Related: TIP-1000, TIP-1016, EIP-3529, EIP-6780

Prompted by: Dankrad