### PR TITLE
ci: use curl installer for Amp CLI in update-reth workflow

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -104,7 +104,7 @@ jobs:
 
       # ── amp CLI ────────────────────────────────────────────────
       - name: Install Amp CLI
-        run: npm install -g @sourcegraph/amp
+        run: curl -fsSL https://ampcode.com/install.sh | bash
 
       # ── amp helper ────────────────────────────────────────────
       - name: Create amp wrapper


### PR DESCRIPTION
Replaces `npm install -g @sourcegraph/amp` with `curl -fsSL https://ampcode.com/install.sh | bash` for installing the Amp CLI.

Prompted by: alexey