### PR TITLE
docs(tip-1020): clarify v-value normalization and ecrecover compatibility

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -112,7 +112,7 @@ Solidity developers commonly use `ecrecover(hash, v, r, s)` to recover an addres
 
 #### `v` Value Normalization
 
-For secp256k1 signatures, the precompile normalizes the recovery identifier `v`: both Ethereum-style values (`27`, `28`) and raw values (`0`, `1`) are accepted. This matches `ecrecover` behavior and differs from TIP-1004 (`permit()`), which requires `v ∈ {27, 28}` and reverts on `0` or `1`.
+For secp256k1 signatures, the precompile normalizes the recovery identifier `v`: both Ethereum-style values (`27`, `28`) and raw values (`0`, `1`) are accepted. This is intentional — `recover()` is designed to be as close to a drop-in replacement for `ecrecover` as possible, so it accepts the same `v` values. This differs from TIP-1004 (`permit()`), which requires `v ∈ {27, 28}` and reverts on `0` or `1`.
 
 #### Existing secp256k1 Signature Payloads
 


### PR DESCRIPTION
Adds a note clarifying that TIP-1020 normalizes `v` values (`0`/`1` and `27`/`28` both accepted), matching `ecrecover` behavior. This differs from TIP-1004's `permit()`, which requires `v ∈ {27, 28}` and reverts on raw values.

Prompted by: rusowsky