### PR TITLE
Update "Configuration" in scripts/consensus/README

### DIFF
--- a/scripts/consensus/README.md
+++ b/scripts/consensus/README.md
@@ -29,6 +29,10 @@ Shared utilities for monitoring block production, starting/stopping validators, 
 
 To regenerate the validator configs, run the following command:
 ```bash
-cargo x generate-config --output scripts/consensus/configs --peers 4 --bootstrappers 1 --message-backlog 16384 --mailbox-size 16384 --deque-size 10 --from-port 8000 --fee-recipient 0x0000000000000000000000000000000000000000 --seed 0
+cargo x generate-localnet \
+  --output scripts/consensus/configs \
+  --force \
+  --validators 127.0.0.1:8000,127.0.0.1:8001,127.0.0.1:8002,127.0.0.1:8003 \
+  --seed 0
 ```
 


### PR DESCRIPTION
`scripts/consensus/README.md` referenced `cargo x generate-config` …, but `cargo x` is an alias for running `tempo-xtask` (`.cargo/config.toml`), and `tempo-xtask` does not define a `generate-config` subcommand (`xtask/src/main.rs`). Updated the docs to use` cargo x generate-localnet` with the current CLI flags so the command is copy-paste runnable.