### PR TITLE
fix(faucet): use standard nonces instead of expiring nonces

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -266,10 +266,31 @@ impl MaxTpsArgs {
             // Default: Use expiring nonces (TIP-1009)
             // Use the default 25-second expiry window (protocol max is 30s).
             let expiry_secs = ExpiringNonceFiller::DEFAULT_EXPIRY_SECS;
+
+            // Compute clock offset between wall clock and node block timestamps.
+            // Local bench nodes can lag behind wall clock after startup, causing
+            // valid_before to be rejected as "too far in the future".
+            let probe: DynProvider<TempoNetwork> = ProviderBuilder::default()
+                .connect_http(self.target_urls[0].clone())
+                .erased();
+            let block_timestamp = probe
+                .get_block_by_number(alloy::eips::BlockNumberOrTag::Latest)
+                .await?
+                .ok_or_else(|| eyre::eyre!("failed to fetch latest block for clock calibration"))?
+                .header
+                .timestamp();
+            let wall_clock = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before UNIX_EPOCH")
+                .as_secs();
+            let clock_offset_secs = block_timestamp as i64 - wall_clock as i64;
             info!(
                 accounts = self.accounts,
-                expiry_secs, "Creating signers (with expiring nonces - TIP-1009)"
+                expiry_secs,
+                clock_offset_secs,
+                "Creating signers (with expiring nonces - TIP-1009)"
             );
+
             let signer_provider_manager = SignerProviderManager::new(
                 self.mnemonic.resolve(),
                 self.from_mnemonic_index,
@@ -277,7 +298,10 @@ impl MaxTpsArgs {
                 self.target_urls.clone(),
                 Box::new(move |target_url, _cached_nonce_manager| {
                     ProviderBuilder::default()
-                        .filler(ExpiringNonceFiller::with_expiry_secs(expiry_secs))
+                        .filler(
+                            ExpiringNonceFiller::with_expiry_secs(expiry_secs)
+                                .with_clock_offset_secs(clock_offset_secs),
+                        )
                         .with_gas_estimation()
                         .fetch_chain_id()
                         .connect_http(target_url)

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -85,12 +85,16 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for R
 pub struct ExpiringNonceFiller {
     /// Expiry window in seconds from current time.
     expiry_secs: u64,
+    /// Fixed offset (in seconds) to adjust wall-clock time toward the node's block timestamp.
+    /// Computed as `block_timestamp - wall_clock_timestamp`. Negative when the node lags behind.
+    clock_offset_secs: i64,
 }
 
 impl Default for ExpiringNonceFiller {
     fn default() -> Self {
         Self {
             expiry_secs: Self::DEFAULT_EXPIRY_SECS,
+            clock_offset_secs: 0,
         }
     }
 }
@@ -106,7 +110,18 @@ impl ExpiringNonceFiller {
     /// For benchmarking purposes, use a large value (e.g., 3600 for 1 hour) to avoid
     /// transactions expiring before they're sent.
     pub fn with_expiry_secs(expiry_secs: u64) -> Self {
-        Self { expiry_secs }
+        Self {
+            expiry_secs,
+            clock_offset_secs: 0,
+        }
+    }
+
+    /// Sets a fixed clock offset to correct for drift between wall-clock time and the node's
+    /// block timestamps. The offset is `block_timestamp - wall_clock_timestamp` and is applied
+    /// when computing `valid_before`.
+    pub fn with_clock_offset_secs(mut self, offset_secs: i64) -> Self {
+        self.clock_offset_secs = offset_secs;
+        self
     }
 
     /// Returns `true` if all expiring nonce fields are properly set:
@@ -119,16 +134,17 @@ impl ExpiringNonceFiller {
             && tx.valid_before.is_some()
     }
 
-    /// Returns the current unix timestamp, saturating to 0 if system time is before UNIX_EPOCH
-    /// (which can occur due to NTP adjustments or VM clock drift).
-    fn current_timestamp() -> u64 {
-        SystemTime::now()
+    /// Returns the current unix timestamp adjusted by the clock offset, saturating to 0 if
+    /// system time is before UNIX_EPOCH (which can occur due to NTP adjustments or VM clock drift).
+    fn current_timestamp(&self) -> u64 {
+        let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or_else(|_| {
                 tracing::warn!("system clock before UNIX_EPOCH, using 0");
                 0
-            })
+            });
+        now.saturating_add_signed(self.clock_offset_secs)
     }
 }
 
@@ -151,7 +167,7 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for E
             // Nonce must be 0 for expiring nonce transactions
             builder.set_nonce(0);
             // Set valid_before to current time + expiry window
-            builder.set_valid_before(Self::current_timestamp() + self.expiry_secs);
+            builder.set_valid_before(self.current_timestamp() + self.expiry_secs);
         }
     }
 

--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -5,7 +5,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use clap::Args;
-use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
+use tempo_alloy::TempoNetwork;
 
 /// Faucet-specific CLI arguments
 #[derive(Debug, Clone, Default, Args, PartialEq, Eq)]
@@ -68,8 +68,10 @@ impl FaucetArgs {
     }
 
     pub fn provider(&self) -> DynProvider<TempoNetwork> {
-        ProviderBuilder::new_with_network::<TempoNetwork>()
-            .with_expiring_nonces()
+        // Use standard sequential nonces for the faucet — it's a privileged internal tool
+        // and doesn't need expiring nonces (TIP-1009), which can fail when the node's block
+        // timestamps lag behind wall-clock time at startup.
+        ProviderBuilder::default()
             .wallet(self.wallet())
             .connect_http(
                 self.node_address


### PR DESCRIPTION
The node's built-in faucet was using expiring nonces (TIP-1009) which set `valid_before` from wall-clock time. When the node's block timestamps lag behind wall clock at startup (~2 min in bench CI), the 30s TIP-1009 limit rejects the faucet transactions.

The faucet is a privileged internal tool — standard sequential nonces work fine.

Prompted by: YK