### PR TITLE
fix(ci): install amp via curl instead of npm in changelog job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.head_ref }}
           persist-credentials: true
 
-      - run: npm install -g @sourcegraph/amp
+      - run: curl -fsSL https://ampcode.com/install.sh | bash
 
       - uses: wevm/changelogs/check@master
         with:


### PR DESCRIPTION
Uses `curl -fsSL https://ampcode.com/install.sh | bash` instead of `npm install -g @sourcegraph/amp` to install amp in the changelog CI job. The npm package was causing failures.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey