### PR TITLE
fix(transaction-pool): reject queued txs discarded on insert

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -26,6 +26,7 @@ use reth_transaction_pool::{
     blobstore::InMemoryBlobStore,
     error::{PoolError, PoolErrorKind},
     identifier::TransactionId,
+    pool::AddedTransaction,
 };
 use revm::database::BundleAccount;
 use std::{sync::Arc, time::Instant};
@@ -44,6 +45,17 @@ use tempo_precompiles::{
 };
 use tempo_primitives::Block;
 use tempo_revm::TempoStateAccess;
+
+fn aa_2d_tx_was_discarded_on_insert(
+    added: &AddedTransaction<TempoPooledTransaction>,
+    aa_2d_pool: &AA2dPool,
+) -> bool {
+    let hash = *added.hash();
+    match added.as_pending() {
+        Some(pending) => pending.discarded.iter().any(|tx| *tx.hash() == hash),
+        None => !aa_2d_pool.contains(&hash),
+    }
+}
 
 /// Tempo transaction pool that routes based on nonce_key
 pub struct TempoTransactionPool<Client> {
@@ -472,16 +484,19 @@ where
                         .tip_timestamp();
                     let hardfork = self.client().chain_spec().tempo_hardfork_at(tip_timestamp);
 
-                    let added = self.aa_2d_pool.write().add_transaction(
-                        Arc::new(tx),
-                        state_nonce,
-                        hardfork,
-                    )?;
+                    let (added, discarded_on_insert) = {
+                        let mut aa_2d_pool = self.aa_2d_pool.write();
+                        let added =
+                            aa_2d_pool.add_transaction(Arc::new(tx), state_nonce, hardfork)?;
+                        let discarded_on_insert =
+                            aa_2d_tx_was_discarded_on_insert(&added, &aa_2d_pool);
+                        (added, discarded_on_insert)
+                    };
                     let hash = *added.hash();
+                    if discarded_on_insert {
+                        return Err(PoolError::new(hash, PoolErrorKind::DiscardedOnInsert));
+                    }
                     if let Some(pending) = added.as_pending() {
-                        if pending.discarded.iter().any(|tx| *tx.hash() == hash) {
-                            return Err(PoolError::new(hash, PoolErrorKind::DiscardedOnInsert));
-                        }
                         self.protocol_pool
                             .inner()
                             .on_new_pending_transaction(pending);
@@ -1257,10 +1272,18 @@ fn get_recipient_policy_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transaction::KeychainSubject;
+    use crate::{
+        test_utils::{TxBuilder, wrap_valid_tx},
+        transaction::KeychainSubject,
+        tt_2d_pool::AA2dPoolConfig,
+    };
     use alloy_primitives::{U256, address};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_storage_api::StateProviderFactory;
+    use reth_transaction_pool::{
+        SubPool,
+        pool::{AddedTransaction, QueuedReason},
+    };
     use tempo_contracts::precompiles::ITIP403Registry;
     use tempo_precompiles::{
         ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS,
@@ -1303,6 +1326,23 @@ mod tests {
         );
 
         provider.latest().unwrap()
+    }
+
+    #[test]
+    fn parked_aa2d_tx_removed_from_pool_is_discarded_on_insert() {
+        let tx = Arc::new(wrap_valid_tx(
+            TxBuilder::aa(Address::random()).nonce_key(U256::from(1)).nonce(1000).build(),
+            TransactionOrigin::Local,
+        ));
+        let added = AddedTransaction::Parked {
+            transaction: Arc::clone(&tx),
+            replaced: None,
+            subpool: SubPool::Queued,
+            queued_reason: Some(QueuedReason::NonceGap),
+        };
+        let pool = AA2dPool::new(AA2dPoolConfig::default());
+
+        assert!(aa_2d_tx_was_discarded_on_insert(&added, &pool));
     }
 
     /// Eviction must match sub-policy IDs against compound policies.

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -305,16 +305,7 @@ impl AA2dPool {
         }
 
         // Call discard for queued transactions too
-        let discarded = self.discard();
-        if discarded
-            .iter()
-            .any(|discarded_tx| *discarded_tx.hash() == *transaction.hash())
-        {
-            return Err(PoolError::new(
-                *transaction.hash(),
-                PoolErrorKind::DiscardedOnInsert,
-            ));
-        }
+        let _ = self.discard();
 
         Ok(AddedTransaction::Parked {
             transaction,
@@ -4050,12 +4041,7 @@ mod tests {
                 0,
                 TempoHardfork::T1,
             );
-            if i < 2 {
-                assert!(result.is_ok(), "Transaction {i} should be added");
-            } else {
-                let err = result.expect_err("Transaction {i} should be discarded on insert");
-                assert!(matches!(err.kind, PoolErrorKind::DiscardedOnInsert));
-            }
+            assert!(result.is_ok(), "Transaction {i} should be added");
         }
 
         let (pending, queued) = pool.pending_and_queued_txn_count();

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -142,9 +142,11 @@ impl AA2dPool {
             transaction.transaction.is_aa(),
             "only AA transactions are supported"
         );
-        let tx_hash = *transaction.hash();
-        if self.contains(&tx_hash) {
-            return Err(PoolError::new(tx_hash, PoolErrorKind::AlreadyImported));
+        if self.contains(transaction.hash()) {
+            return Err(PoolError::new(
+                *transaction.hash(),
+                PoolErrorKind::AlreadyImported,
+            ));
         }
 
         // Handle expiring nonce transactions separately - they use expiring nonce hash as unique ID
@@ -161,7 +163,7 @@ impl AA2dPool {
         if transaction.nonce() < on_chain_nonce {
             // outdated transaction
             return Err(PoolError::new(
-                tx_hash,
+                *transaction.hash(),
                 PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
                     InvalidTransactionError::NonceNotConsistent {
                         tx: transaction.nonce(),
@@ -195,7 +197,7 @@ impl AA2dPool {
                     .is_underpriced(&tx.inner.transaction, &self.config.price_bump_config)
                 {
                     return Err(PoolError::new(
-                        tx_hash,
+                        *transaction.hash(),
                         PoolErrorKind::ReplacementUnderpriced,
                     ));
                 }
@@ -207,7 +209,7 @@ impl AA2dPool {
                 let sender_count = self.txs_by_sender.get(&sender).copied().unwrap_or(0);
                 if sender_count >= self.config.max_txs_per_sender {
                     return Err(PoolError::new(
-                        tx_hash,
+                        *transaction.hash(),
                         PoolErrorKind::SpammerExceededCapacity(sender),
                     ));
                 }
@@ -306,9 +308,12 @@ impl AA2dPool {
         let discarded = self.discard();
         if discarded
             .iter()
-            .any(|discarded_tx| *discarded_tx.hash() == tx_hash)
+            .any(|discarded_tx| *discarded_tx.hash() == *transaction.hash())
         {
-            return Err(PoolError::new(tx_hash, PoolErrorKind::DiscardedOnInsert));
+            return Err(PoolError::new(
+                *transaction.hash(),
+                PoolErrorKind::DiscardedOnInsert,
+            ));
         }
 
         Ok(AddedTransaction::Parked {
@@ -4033,8 +4038,7 @@ mod tests {
         };
         let mut pool = AA2dPool::new(config);
 
-        // Add 5 transactions each with a LARGE nonce gap so they are all queued.
-        // Only the first 2 should survive; later inserts are immediately discarded.
+        // Add 5 transactions each with a LARGE nonce gap so they are all queued
         for i in 0..5usize {
             let sender = Address::from_word(B256::from(U256::from(i)));
             let tx = TxBuilder::aa(sender)

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -142,11 +142,9 @@ impl AA2dPool {
             transaction.transaction.is_aa(),
             "only AA transactions are supported"
         );
-        if self.contains(transaction.hash()) {
-            return Err(PoolError::new(
-                *transaction.hash(),
-                PoolErrorKind::AlreadyImported,
-            ));
+        let tx_hash = *transaction.hash();
+        if self.contains(&tx_hash) {
+            return Err(PoolError::new(tx_hash, PoolErrorKind::AlreadyImported));
         }
 
         // Handle expiring nonce transactions separately - they use expiring nonce hash as unique ID
@@ -163,7 +161,7 @@ impl AA2dPool {
         if transaction.nonce() < on_chain_nonce {
             // outdated transaction
             return Err(PoolError::new(
-                *transaction.hash(),
+                tx_hash,
                 PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
                     InvalidTransactionError::NonceNotConsistent {
                         tx: transaction.nonce(),
@@ -197,7 +195,7 @@ impl AA2dPool {
                     .is_underpriced(&tx.inner.transaction, &self.config.price_bump_config)
                 {
                     return Err(PoolError::new(
-                        *transaction.hash(),
+                        tx_hash,
                         PoolErrorKind::ReplacementUnderpriced,
                     ));
                 }
@@ -209,7 +207,7 @@ impl AA2dPool {
                 let sender_count = self.txs_by_sender.get(&sender).copied().unwrap_or(0);
                 if sender_count >= self.config.max_txs_per_sender {
                     return Err(PoolError::new(
-                        *transaction.hash(),
+                        tx_hash,
                         PoolErrorKind::SpammerExceededCapacity(sender),
                     ));
                 }
@@ -305,7 +303,13 @@ impl AA2dPool {
         }
 
         // Call discard for queued transactions too
-        let _ = self.discard();
+        let discarded = self.discard();
+        if discarded
+            .iter()
+            .any(|discarded_tx| *discarded_tx.hash() == tx_hash)
+        {
+            return Err(PoolError::new(tx_hash, PoolErrorKind::DiscardedOnInsert));
+        }
 
         Ok(AddedTransaction::Parked {
             transaction,
@@ -4029,7 +4033,8 @@ mod tests {
         };
         let mut pool = AA2dPool::new(config);
 
-        // Add 5 transactions each with a LARGE nonce gap so they are all queued
+        // Add 5 transactions each with a LARGE nonce gap so they are all queued.
+        // Only the first 2 should survive; later inserts are immediately discarded.
         for i in 0..5usize {
             let sender = Address::from_word(B256::from(U256::from(i)));
             let tx = TxBuilder::aa(sender)
@@ -4041,7 +4046,12 @@ mod tests {
                 0,
                 TempoHardfork::T1,
             );
-            assert!(result.is_ok(), "Transaction {i} should be added");
+            if i < 2 {
+                assert!(result.is_ok(), "Transaction {i} should be added");
+            } else {
+                let err = result.expect_err("Transaction {i} should be discarded on insert");
+                assert!(matches!(err.kind, PoolErrorKind::DiscardedOnInsert));
+            }
         }
 
         let (pending, queued) = pool.pending_and_queued_txn_count();


### PR DESCRIPTION
Returns `DiscardedOnInsert` when an AA2d queued transaction is immediately evicted by `discard()` during insertion instead of reporting it as parked.

keeps AA2d pool insert semantics aligned with the standard pool and avoids reporting success for transactions that are no longer in the pool.