### PR TITLE
fix(transaction-pool): use resolved fee token in maintenance

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -18,7 +18,9 @@ use reth_chainspec::ChainSpecProvider;
 use reth_primitives_traits::AlloyBlockHeader;
 use reth_provider::{CanonStateNotification, CanonStateSubscriptions, Chain};
 use reth_storage_api::StateProviderFactory;
-use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
+use reth_transaction_pool::{
+    PoolTransaction, TransactionOrigin, TransactionPool, ValidPoolTransaction,
+};
 use std::{
     collections::{BTreeMap, btree_map::Entry},
     sync::Arc,
@@ -663,12 +665,9 @@ where
 
                     // Group transactions by fee token for efficient batch processing.
                     // This single pass over all transactions handles all pause events.
-                    let mut by_token: AddressMap<Vec<TxHash>> = AddressMap::default();
-                    for tx in all_txs.pending.iter().chain(all_txs.queued.iter()) {
-                        if let Some(fee_token) = tx.transaction.inner().fee_token() {
-                            by_token.entry(fee_token).or_default().push(*tx.hash());
-                        }
-                    }
+                    let mut by_token = group_transaction_hashes_by_fee_token(
+                        all_txs.pending.iter().chain(all_txs.queued.iter()),
+                    );
 
                     // Process each pause token
                     for token in pause_tokens {
@@ -892,6 +891,18 @@ where
     count
 }
 
+fn group_transaction_hashes_by_fee_token<'a>(
+    txs: impl Iterator<Item = &'a Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+) -> AddressMap<Vec<TxHash>> {
+    let mut by_token: AddressMap<Vec<TxHash>> = AddressMap::default();
+    for tx in txs {
+        if let Some(fee_token) = tx.transaction.effective_fee_token() {
+            by_token.entry(fee_token).or_default().push(*tx.hash());
+        }
+    }
+    by_token
+}
+
 /// Handles a reorg event by identifying orphaned AA 2D transactions from the old chain
 /// that are not in the new chain.
 ///
@@ -952,10 +963,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TxBuilder;
+    use crate::test_utils::{TxBuilder, wrap_valid_tx};
     use alloy_primitives::{Address, TxHash, U256};
     use reth_primitives_traits::RecoveredBlock;
-    use reth_transaction_pool::PoolTransaction;
+    use reth_transaction_pool::{PoolTransaction, TransactionOrigin};
     use std::collections::HashSet;
     use tempo_primitives::{Block, BlockBody, TempoHeader, TempoTxEnvelope};
 
@@ -1257,6 +1268,24 @@ mod tests {
     /// Helper to extract a TempoTxEnvelope from a TempoPooledTransaction.
     fn extract_envelope(tx: &crate::transaction::TempoPooledTransaction) -> TempoTxEnvelope {
         tx.inner().clone().into_inner()
+    }
+
+    #[test]
+    fn group_transaction_hashes_by_fee_token_uses_resolved_fee_token() {
+        let paused_token = Address::random();
+        let aa_tx = TxBuilder::aa(Address::random()).build();
+        aa_tx.set_resolved_fee_token(paused_token);
+        let aa_tx = Arc::new(wrap_valid_tx(aa_tx, TransactionOrigin::External));
+
+        let non_aa_tx = Arc::new(wrap_valid_tx(
+            TxBuilder::eip1559(Address::random()).build_eip1559(),
+            TransactionOrigin::External,
+        ));
+
+        let grouped = group_transaction_hashes_by_fee_token([&aa_tx, &non_aa_tx].into_iter());
+
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped.get(&paused_token), Some(&vec![*aa_tx.hash()]));
     }
 
     /// Tests all reorg handling scenarios:

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -287,15 +287,13 @@ where
             // Prevents mass eviction because it only:
             // - evicts when NO validator token has enough liquidity
             // - considers active validators (protects from permissionless `setValidatorToken`)
-            if has_active_validator_token_changes && let Some(ref provider) = state_provider {
-                let user_token = tx
-                    .transaction
-                    .inner()
-                    .fee_token()
-                    .unwrap_or(tempo_precompiles::DEFAULT_FEE_TOKEN);
+            if has_active_validator_token_changes
+                && let Some(ref provider) = state_provider
+                && let Some(fee_context) = aa_fee_context(tx)
+            {
                 let cost = tx.transaction.fee_token_cost();
 
-                match amm_cache.has_enough_liquidity(user_token, cost, &**provider) {
+                match amm_cache.has_enough_liquidity(fee_context.fee_token, cost, &**provider) {
                     Ok(true) => {}
                     Ok(false) => {
                         to_remove.push(*tx.hash());
@@ -307,27 +305,24 @@ where
             }
 
             // Check 4: Blacklisted fee payers
-            // Only check AA transactions with a fee token (non-AA transactions don't have
-            // a fee payer that can be blacklisted via TIP403)
+            // Only check AA transactions. Non-AA transactions do not use fee-token fee payment.
             if !updates.blacklist_additions.is_empty()
                 && let Some(ref mut provider) = state_provider
-                && let Some(fee_token) = tx.transaction.inner().fee_token()
+                && let Some(fee_context) = aa_fee_context(tx)
             {
-                let fee_payer = tx
-                    .transaction
-                    .inner()
-                    .fee_payer(tx.transaction.sender())
-                    .unwrap_or(tx.transaction.sender());
-
                 // Check if any blacklist addition applies to this transaction's fee payer
                 let mut sender_evicted = false;
                 for &(blacklist_policy_id, blacklisted_account) in &updates.blacklist_additions {
-                    if fee_payer != blacklisted_account {
+                    if fee_context.fee_payer != blacklisted_account {
                         continue;
                     }
 
-                    let token_policies =
-                        get_sender_policy_ids(provider, fee_token, spec, &mut policy_cache);
+                    let token_policies = get_sender_policy_ids(
+                        provider,
+                        fee_context.fee_token,
+                        spec,
+                        &mut policy_cache,
+                    );
 
                     if token_policies
                         .as_ref()
@@ -343,7 +338,7 @@ where
                 // transfer to TIP_FEE_MANAGER_ADDRESS would be rejected.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_blacklisted.is_empty()
-                    && get_recipient_policy_ids(provider, fee_token, spec)
+                    && get_recipient_policy_ids(provider, fee_context.fee_token, spec)
                         .is_some_and(|ids| fee_manager_blacklisted.iter().any(|p| ids.contains(p)));
 
                 if sender_evicted || recipient_evicted {
@@ -357,22 +352,20 @@ where
             // will fail validation at execution time.
             if !updates.whitelist_removals.is_empty()
                 && let Some(ref mut provider) = state_provider
-                && let Some(fee_token) = tx.transaction.inner().fee_token()
+                && let Some(fee_context) = aa_fee_context(tx)
             {
-                let fee_payer = tx
-                    .transaction
-                    .inner()
-                    .fee_payer(tx.transaction.sender())
-                    .unwrap_or(tx.transaction.sender());
-
                 let mut sender_evicted = false;
                 for &(whitelist_policy_id, unwhitelisted_account) in &updates.whitelist_removals {
-                    if fee_payer != unwhitelisted_account {
+                    if fee_context.fee_payer != unwhitelisted_account {
                         continue;
                     }
 
-                    let token_policies =
-                        get_sender_policy_ids(provider, fee_token, spec, &mut policy_cache);
+                    let token_policies = get_sender_policy_ids(
+                        provider,
+                        fee_context.fee_token,
+                        spec,
+                        &mut policy_cache,
+                    );
 
                     if token_policies
                         .as_ref()
@@ -387,9 +380,9 @@ where
                 // token's recipient policy.
                 let recipient_evicted = !sender_evicted
                     && !fee_manager_unwhitelisted.is_empty()
-                    && get_recipient_policy_ids(provider, fee_token, spec).is_some_and(|ids| {
-                        fee_manager_unwhitelisted.iter().any(|p| ids.contains(p))
-                    });
+                    && get_recipient_policy_ids(provider, fee_context.fee_token, spec).is_some_and(
+                        |ids| fee_manager_unwhitelisted.iter().any(|p| ids.contains(p)),
+                    );
 
                 if sender_evicted || recipient_evicted {
                     to_remove.push(*tx.hash());
@@ -1177,6 +1170,25 @@ pub(crate) fn exceeds_spending_limit(
         .unwrap_or_default()
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AaFeeContext {
+    fee_payer: Address,
+    fee_token: Address,
+}
+
+fn aa_fee_context(tx: &ValidPoolTransaction<TempoPooledTransaction>) -> Option<AaFeeContext> {
+    let fee_token = tx.transaction.effective_fee_token()?;
+    let fee_payer = tx
+        .transaction
+        .inner()
+        .fee_payer(tx.transaction.sender())
+        .unwrap_or(tx.transaction.sender());
+    Some(AaFeeContext {
+        fee_payer,
+        fee_token,
+    })
+}
+
 /// Returns the set of policy IDs that can affect fee_payer authorization for a token.
 ///
 /// For simple policies the set contains just the policy ID. For compound policies
@@ -1257,7 +1269,10 @@ fn get_recipient_policy_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transaction::KeychainSubject;
+    use crate::{
+        test_utils::{TxBuilder, wrap_valid_tx},
+        transaction::KeychainSubject,
+    };
     use alloy_primitives::{U256, address};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_storage_api::StateProviderFactory;
@@ -1303,6 +1318,29 @@ mod tests {
         );
 
         provider.latest().unwrap()
+    }
+
+    #[test]
+    fn aa_fee_context_uses_resolved_fee_token() {
+        let sender = Address::random();
+        let explicit_fee_token = Address::random();
+        let resolved_fee_token = Address::random();
+        let tx = TxBuilder::aa(sender).fee_token(explicit_fee_token).build();
+        tx.set_resolved_fee_token(resolved_fee_token);
+        let valid_tx = wrap_valid_tx(tx, TransactionOrigin::External);
+
+        let context = aa_fee_context(&valid_tx).expect("AA transactions should have fee context");
+
+        assert_eq!(context.fee_payer, sender);
+        assert_eq!(context.fee_token, resolved_fee_token);
+    }
+
+    #[test]
+    fn aa_fee_context_skips_non_aa_transactions() {
+        let tx = TxBuilder::eip1559(Address::random()).build_eip1559();
+        let valid_tx = wrap_valid_tx(tx, TransactionOrigin::External);
+
+        assert!(aa_fee_context(&valid_tx).is_none());
     }
 
     /// Eviction must match sub-policy IDs against compound policies.

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -131,6 +131,19 @@ impl TempoPooledTransaction {
         self.is_expiring_nonce
     }
 
+    /// Returns the effective fee token for AA transactions.
+    ///
+    /// Prefers the token resolved during validation so maintenance uses the same fee token
+    /// admission checked, even when the transaction relied on storage or validator selection.
+    pub fn effective_fee_token(&self) -> Option<Address> {
+        self.is_aa().then(|| {
+            self.resolved_fee_token
+                .get()
+                .copied()
+                .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN))
+        })
+    }
+
     /// Extracts the keychain subject (account, key_id, fee_token) from this transaction.
     ///
     /// Returns `None` if:
@@ -143,11 +156,7 @@ impl TempoPooledTransaction {
         let aa_tx = self.inner().as_aa()?;
         let keychain_sig = aa_tx.signature().as_keychain()?;
         let key_id = keychain_sig.key_id(&aa_tx.signature_hash()).ok()?;
-        let fee_token = self
-            .resolved_fee_token
-            .get()
-            .copied()
-            .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
+        let fee_token = self.effective_fee_token()?;
         Some(KeychainSubject {
             account: keychain_sig.user_address,
             key_id,
@@ -828,6 +837,25 @@ mod tests {
         let slot2 = tx.nonce_key_slot();
         assert_eq!(slot2, Some(expected_slot));
         assert_eq!(slot1, slot2);
+    }
+
+    #[test]
+    fn test_effective_fee_token_prefers_resolved_value_for_aa_transaction() {
+        let sender = Address::random();
+        let explicit_fee_token = Address::random();
+        let resolved_fee_token = Address::random();
+        let tx = TxBuilder::aa(sender).fee_token(explicit_fee_token).build();
+
+        tx.set_resolved_fee_token(resolved_fee_token);
+
+        assert_eq!(tx.effective_fee_token(), Some(resolved_fee_token));
+    }
+
+    #[test]
+    fn test_effective_fee_token_is_none_for_non_aa_transaction() {
+        let tx = TxBuilder::eip1559(Address::random()).build_eip1559();
+
+        assert_eq!(tx.effective_fee_token(), None);
     }
 
     #[test]


### PR DESCRIPTION
Uses the fee token resolved during validation for AA maintenance paths instead of re-reading the raw `fee_token` field.

makes pause handling, liquidity rechecks, and blacklist/whitelist evictions aligned with admission, so transactions are maintained against the same fee token they were validated with.