### PR TITLE
test(node): remove post-T1C tempo transaction skips

### DIFF
--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -51,35 +51,19 @@ mod rpc;
 
 /// Run all matrix tests and scenario runners against a single environment.
 async fn run_all_matrices(env: &mut impl TestEnv) -> eyre::Result<()> {
-    // TODO(rusowsky): remove `skip_pre_t1c` and `check` after T1C activation on all networks
-    let skip_pre_t1c = !env.hardfork().is_t1c();
-
-    let check = |r: eyre::Result<()>| match r {
-        Err(e)
-            if skip_pre_t1c
-                && (e.to_string().contains("not valid before T1C activation")
-                    || e.to_string()
-                        .contains("failed to decode signed transaction")) =>
-        {
-            eprintln!("SKIPPED: network is pre-T1C");
-            Ok(())
-        }
-        other => other,
-    };
-
-    check(env.run_send_matrix().await)?;
-    check(env.run_raw_send_matrix().await)?;
-    check(env.run_fill_transaction_matrix().await)?;
-    check(env.run_fill_sign_send_matrix().await)?;
-    check(env.run_fee_payer_cosign_scenario().await)?;
-    check(env.run_authorization_list_scenario().await)?;
-    check(env.run_keychain_auth_list_skipped_scenario().await)?;
-    check(env.run_keychain_expiry_scenario().await)?;
-    check(env.run_create_contract_address_scenario().await)?;
-    check(env.run_send_negative_scenario().await)?;
-    check(env.run_nonce_rejection_scenario().await)?;
-    check(env.run_fee_payer_negative_scenario().await)?;
-    check(env.run_gas_fee_boundary_scenario().await)?;
+    env.run_send_matrix().await?;
+    env.run_raw_send_matrix().await?;
+    env.run_fill_transaction_matrix().await?;
+    env.run_fill_sign_send_matrix().await?;
+    env.run_fee_payer_cosign_scenario().await?;
+    env.run_authorization_list_scenario().await?;
+    env.run_keychain_auth_list_skipped_scenario().await?;
+    env.run_keychain_expiry_scenario().await?;
+    env.run_create_contract_address_scenario().await?;
+    env.run_send_negative_scenario().await?;
+    env.run_nonce_rejection_scenario().await?;
+    env.run_fee_payer_negative_scenario().await?;
+    env.run_gas_fee_boundary_scenario().await?;
     Ok(())
 }
 

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -2182,13 +2182,6 @@ pub(super) async fn run_send_negative_scenario<E: TestEnv>(env: &mut E) -> eyre:
 pub(super) async fn run_fee_payer_negative_scenario<E: TestEnv>(env: &mut E) -> eyre::Result<()> {
     println!("\n=== Fee payer negative scenario ===\n");
 
-    // Fee-payer negative checks rely on T1C+ validation behavior. Shared RPCs
-    // can be behind rollout, so skip this scenario on pre-T1C networks.
-    if !env.hardfork().is_t1c() {
-        eprintln!("SKIPPED: fee_payer_negative_scenario requires T1C+");
-        return Ok(());
-    }
-
     let chain_id = env.chain_id();
     let user_signer = PrivateKeySigner::random();
     let user_addr = user_signer.address();


### PR DESCRIPTION
Removes the temporary pre-T1C skip handling from the tempo transaction matrix tests and fee payer negative scenario. T1C is now active on the network schedules covered by these tests, so the rollout-era skip paths only hide real failures.

This makes the matrix suite fail normally on post-T1C regressions instead of downgrading them to skipped cases.
