### PR TITLE
docs(tip-1040): epoch-scoped temporary storage precompile

### DIFF
--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -1,0 +1,157 @@
+---
+id: TIP-1037
+title: Epoch-Scoped Temporary Storage Precompile
+description: A precompile providing cheap temporary key-value storage that automatically expires after one to two epochs.
+authors: Dankrad
+status: Draft
+related: N/A
+protocolVersion: TBD
+---
+
+# TIP-1037: Epoch-Scoped Temporary Storage Precompile
+
+## Abstract
+
+This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 2^16 (65,536) blocks. Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 2^16 and 2^17 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
+
+## Motivation
+
+Certain use cases need on-chain data availability for a bounded time window rather than permanent storage — for example time-limited approvals, ephemeral session state, or temporary commitments. Today these patterns require permanent `SSTORE` writes and separate cleanup transactions, wasting gas and bloating state.
+
+Epoch-scoped temporary storage solves this by:
+
+1. **Eliminating cleanup cost** — stale data becomes inaccessible automatically, no explicit deletion needed.
+2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
+3. **Cheaper writes** — a flat 40,000 gas per store with no state gas overhead (no refund accounting, no cold/warm store distinction on writes).
+
+Alternatives considered:
+
+- **EIP-1153 transient storage (`TSTORE`/`TLOAD`)**: Too short-lived — data is discarded at the end of a single transaction. Does not cover multi-block use cases.
+- **Application-level expiry with `SSTORE`**: Requires explicit cleanup transactions, is more expensive, and leaves dead state in the trie permanently.
+- **Off-chain data with on-chain commitments**: Adds complexity and trust assumptions around data availability.
+
+## Assumptions
+
+- The block number is always available to the precompile at execution time.
+- Nodes maintain at least two complete epoch storage trees (current and previous) at all times. A node that has pruned the previous epoch's tree is non-conforming.
+- The precompile address is reserved and not used by any existing contract.
+- Epoch boundaries are deterministic: `epoch = block_number >> 16`.
+- Storage keys are collision-resistant due to the `keccak256(sender, key)` derivation; two different senders cannot write to the same slot.
+
+If the assumption that nodes keep two epochs is violated (e.g., a node prunes the previous epoch early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
+
+---
+
+# Specification
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `EPOCH_LENGTH` | 2^16 (65,536 blocks) | Number of blocks per epoch |
+| `PRECOMPILE_ADDRESS` | TBD | Reserved address for the temporary storage precompile |
+| `TEMPORARY_STORE_GAS` | 40,000 | Flat gas cost for `temporaryStore` |
+| `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
+| `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
+
+## Epoch Derivation
+
+```
+epoch(block_number) = block_number >> 16
+```
+
+The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.number) - 1`. At genesis (epoch 0), there is no previous epoch to fall back to.
+
+## Storage Layout
+
+The precompile maintains a separate storage tree per epoch. Only two trees exist at any time: the current epoch tree and the previous epoch tree. Each storage slot within a tree is addressed by:
+
+```
+slot = keccak256(sender || key)
+```
+
+where `sender` is the `msg.sender` (the immediate caller of the precompile) and `key` is the caller-provided 32-byte key. The `||` operator denotes concatenation.
+
+The epoch tree is indexed by `uint16(epoch)`, which wraps around every 2^16 epochs. Since only two adjacent epoch trees are ever live, there is no ambiguity from the wrap-around.
+
+## Precompile Interface
+
+### `temporaryStore(bytes32 key, bytes32 value)`
+
+Stores `value` at the derived slot in the current epoch's storage tree.
+
+**Selector**: `0x` + first 4 bytes of `keccak256("temporaryStore(bytes32,bytes32)")`
+
+**Input**: ABI-encoded `(bytes32 key, bytes32 value)` — 64 bytes after the 4-byte selector.
+
+**Behavior**:
+
+1. Compute `slot = keccak256(msg.sender || key)`.
+2. Compute `epoch_index = uint16(epoch(block.number))`.
+3. Write `value` to the current epoch tree at `(epoch_index, slot)`.
+4. Charge `TEMPORARY_STORE_GAS` (40,000 gas). No additional cold/warm state gas is applied.
+
+**Output**: Empty (0 bytes). Execution succeeds silently.
+
+**Error**: Reverts only if insufficient gas is provided.
+
+### `temporaryLoad(bytes32 key) returns (bytes32)`
+
+Loads the value for the derived slot, checking the current epoch first and falling back to the previous epoch.
+
+**Selector**: `0x` + first 4 bytes of `keccak256("temporaryLoad(bytes32)")`
+
+**Input**: ABI-encoded `(bytes32 key)` — 32 bytes after the 4-byte selector.
+
+**Behavior**:
+
+1. Compute `slot = keccak256(msg.sender || key)`.
+2. Compute `current_epoch_index = uint16(epoch(block.number))`.
+3. Look up `slot` in the current epoch tree. If a non-zero value exists, return it.
+4. Compute `previous_epoch_index = uint16(epoch(block.number) - 1)`.
+5. Look up `slot` in the previous epoch tree. If a non-zero value exists, return it.
+6. Return `bytes32(0)`.
+
+**Gas**: Follows the EIP-2929 access-list model. Each `(epoch_index, slot)` pair is tracked independently for hot/cold purposes:
+- First access to a given `(epoch_index, slot)` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
+- Subsequent accesses to the same `(epoch_index, slot)`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
+- If the fallback to the previous epoch is triggered, its slot access is charged independently (cold or warm based on whether that specific `(previous_epoch_index, slot)` was previously accessed).
+
+**Output**: ABI-encoded `bytes32` (32 bytes).
+
+## Interaction with `temporaryStore` warm/cold tracking
+
+A `temporaryStore` to a slot marks that `(current_epoch_index, slot)` as warm for subsequent `temporaryLoad` calls within the same transaction. The store itself always costs a flat 40,000 gas regardless of cold/warm status.
+
+## Epoch Transition
+
+When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epoch(block.number - 1)`):
+
+1. The tree for `epoch(block.number) - 2` (two epochs ago) becomes unreachable and may be pruned by the node.
+2. A new empty tree is created for the current epoch.
+3. The previous epoch's tree (now `epoch(block.number) - 1`) remains accessible for reads.
+
+Nodes MUST keep the current and previous epoch trees. Nodes MAY discard all older epoch trees.
+
+## Node Storage Requirements
+
+Nodes are required to maintain exactly two epoch storage trees. At steady state, this bounds the temporary storage to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
+
+## Calldata Encoding
+
+Both functions use standard Solidity ABI encoding:
+
+```
+temporaryStore: 0x<selector> <key:bytes32> <value:bytes32>   (4 + 32 + 32 = 68 bytes)
+temporaryLoad:  0x<selector> <key:bytes32>                   (4 + 32 = 36 bytes)
+```
+
+# Invariants
+
+1. **Bounded lifetime**: A value written in epoch `E` MUST be readable in epochs `E` and `E+1`, and MUST NOT be readable from epoch `E+2` onward.
+2. **Sender isolation**: `keccak256(sender_a || key) != keccak256(sender_b || key)` for `sender_a != sender_b` — different senders cannot read or overwrite each other's storage for the same key.
+3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
+4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
+5. **Epoch tree pruning safety**: Pruning any epoch tree older than `epoch(block.number) - 1` MUST NOT affect the result of any `temporaryLoad` call.
+6. **Deterministic gas**: `temporaryStore` always costs exactly 40,000 gas. `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
+7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -121,9 +121,10 @@ Loads the value for the derived slot, checking the current epoch first and falli
 1. Compute `hash = keccak256(msg.sender || key)`.
 2. Compute `current_epoch_index = uint32(epoch(block.number))`.
 3. Compute `current_key = current_epoch_index ++ hash[4:32]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
-4. Compute `previous_epoch_index = uint32(epoch(block.number) - 1)`.
-5. Compute `previous_key = previous_epoch_index ++ hash[4:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
-6. Return `bytes32(0)`.
+4. If `current_epoch_index == 0`, return `bytes32(0)` (no previous epoch exists).
+5. Compute `previous_epoch_index = uint32(epoch(block.number) - 1)`.
+6. Compute `previous_key = previous_epoch_index ++ hash[4:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
+7. Return `bytes32(0)`.
 
 **Gas**: Follows the EIP-2929 access-list model. Each `storage_key` is tracked independently for hot/cold purposes:
 - First access to a given `storage_key` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -28,12 +28,12 @@ Epoch-scoped temporary storage solves this by:
 ## Assumptions
 
 - The block number is always available to the precompile at execution time.
-- Nodes maintain at least two complete epoch storage trees (current and previous) at all times. A node that has pruned the previous epoch's tree is non-conforming.
-- The precompile address is reserved and not used by any existing contract.
+- Nodes maintain at least two epoch accounts (current and previous) at all times. A node that has pruned the previous epoch's account is non-conforming.
+- The precompile address and the address range `[PRECOMPILE_ADDRESS + 1, ...]` are reserved and not used by any existing contract or EOA.
 - Epoch boundaries are deterministic: `epoch = block_number >> 16`.
-- Storage keys are collision-resistant due to the `keccak256(sender, key)` derivation; two different senders cannot write to the same slot.
+- Storage keys are collision-resistant due to the full `keccak256(sender, key)` derivation (256 bits); two different senders cannot write to the same slot.
 
-If the assumption that nodes keep two epochs is violated (e.g., a node prunes the previous epoch early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
+If the assumption that nodes keep two epoch accounts is violated (e.g., a node prunes the previous epoch account early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
 
 ---
 
@@ -62,18 +62,21 @@ The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.n
 
 ## Storage Layout
 
-All temporary storage lives in the precompile's own EVM storage trie (i.e., the account at `PRECOMPILE_ADDRESS`). Each slot is a 32-byte key composed of two parts:
+Each epoch's temporary storage lives in a **separate account**. Epoch `n` is stored in the account at address `PRECOMPILE_ADDRESS + n + 1`. The `+ 1` offset reserves `PRECOMPILE_ADDRESS` itself for the precompile dispatch logic.
 
 ```
-storage_key = uint32(epoch) ++ keccak256(sender || key)[4:32]
+epoch_account(n) = PRECOMPILE_ADDRESS + n + 1
 ```
 
-| Bytes | Field | Description |
-|-------|-------|-------------|
-| `[0:4)` | `uint32(epoch)` | Big-endian epoch index (2^32 epochs ≈ 2^48 blocks before wrap-around) |
-| `[4:32)` | `keccak256(sender \|\| key)[4:32]` | Last 28 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
+Within each epoch account, storage keys are derived from the caller and key:
 
-This packs the epoch tag and the sender-derived slot into a single 32-byte EVM storage key. A 4-byte epoch index supports 2^32 epochs (2^48 blocks) before wrap-around, making the scheme effectively eternal. The 28-byte hash truncation provides 224 bits of collision resistance, which is sufficient given the sender-scoping.
+```
+storage_key = keccak256(sender || key)
+```
+
+This is the full 32-byte hash — no truncation is needed since the epoch is encoded in the account address rather than the storage key, giving 256 bits of collision resistance.
+
+**Pruning advantage**: Nodes can prune an entire expired epoch by dropping the account at `PRECOMPILE_ADDRESS + n + 1` and its storage trie in one operation, rather than scanning individual slots within a single large trie.
 
 ## Precompile Interface
 
@@ -87,11 +90,10 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 
 **Behavior**:
 
-1. Compute `hash = keccak256(msg.sender || key)`.
-2. Compute `epoch_index = uint32(epoch(block.number))`.
-3. Compute `storage_key = epoch_index ++ hash[4:32]`.
-4. Read the existing value at `storage_key` in the precompile's storage.
-5. Write `value` at `storage_key`.
+1. Compute `storage_key = keccak256(msg.sender || key)`.
+2. Compute `epoch_account = PRECOMPILE_ADDRESS + epoch(block.number) + 1`.
+3. Read the existing value at `storage_key` in `epoch_account`'s storage.
+4. Write `value` at `storage_key` in `epoch_account`'s storage.
 
 **Gas**:
 
@@ -118,38 +120,38 @@ Loads the value for the derived slot, checking the current epoch first and falli
 
 **Behavior**:
 
-1. Compute `hash = keccak256(msg.sender || key)`.
-2. Compute `current_epoch_index = uint32(epoch(block.number))`.
-3. Compute `current_key = current_epoch_index ++ hash[4:32]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
-4. If `current_epoch_index == 0`, return `bytes32(0)` (no previous epoch exists).
-5. Compute `previous_epoch_index = uint32(epoch(block.number) - 1)`.
-6. Compute `previous_key = previous_epoch_index ++ hash[4:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
+1. Compute `storage_key = keccak256(msg.sender || key)`.
+2. Compute `current_account = PRECOMPILE_ADDRESS + epoch(block.number) + 1`.
+3. Look up `storage_key` in `current_account`'s storage. If a non-zero value exists, return it.
+4. If `epoch(block.number) == 0`, return `bytes32(0)` (no previous epoch exists).
+5. Compute `previous_account = PRECOMPILE_ADDRESS + epoch(block.number)`.
+6. Look up `storage_key` in `previous_account`'s storage. If a non-zero value exists, return it.
 7. Return `bytes32(0)`.
 
-**Gas**: Follows the EIP-2929 access-list model. Each `storage_key` is tracked independently for hot/cold purposes:
-- First access to a given `storage_key` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
-- Subsequent accesses to the same `storage_key`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
-- If the fallback to the previous epoch is triggered, `previous_key` is a different `storage_key` and charged independently (cold or warm based on whether it was previously accessed).
+**Gas**: Follows the EIP-2929 access-list model. Each `(account, storage_key)` pair is tracked independently for hot/cold purposes:
+- First access to a given `(account, storage_key)` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
+- Subsequent accesses to the same `(account, storage_key)`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
+- If the fallback to the previous epoch is triggered, `(previous_account, storage_key)` is a different entry and charged independently.
 
 **Output**: ABI-encoded `bytes32` (32 bytes).
 
 ## Warm/Cold Tracking
 
-Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `storage_key`. Any access (store or load) to a `storage_key` marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the `storage_key` warm.
+Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `(account, storage_key)`. Any access (store or load) to an `(account, storage_key)` pair marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the `(epoch_account, storage_key)` warm.
 
 ## Epoch Transition
 
 When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epoch(block.number - 1)`):
 
-1. All storage keys prefixed with `uint32(epoch(block.number) - 2)` (two epochs ago) become unreachable by the precompile and may be pruned by the node.
-2. The current epoch's prefix (`uint32(epoch(block.number))`) begins accepting writes.
-3. The previous epoch's keys (prefixed `uint32(epoch(block.number) - 1)`) remain accessible for read fallback.
+1. The account at `PRECOMPILE_ADDRESS + epoch(block.number) - 1` (two epochs ago) becomes unreachable by the precompile and may be pruned by the node.
+2. The account at `PRECOMPILE_ADDRESS + epoch(block.number) + 1` (current epoch) begins accepting writes.
+3. The account at `PRECOMPILE_ADDRESS + epoch(block.number)` (previous epoch) remains accessible for read fallback.
 
-Nodes MUST retain all storage keys with the current and previous epoch prefix. Nodes MAY prune keys with any older epoch prefix.
+Nodes MUST retain the accounts for the current and previous epoch. Nodes MAY delete any older epoch account and its entire storage trie.
 
 ## Node Storage Requirements
 
-Because the epoch is encoded in the top 4 bytes of each storage key, nodes can identify and prune expired entries by prefix. At steady state, the precompile's storage is bounded to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
+Each epoch's data lives in its own account, so pruning is a simple account deletion — no key scanning required. At steady state, the precompile system maintains at most two epoch accounts (current + previous), bounding total storage to `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
 
 ## Calldata Encoding
 
@@ -170,14 +172,29 @@ pragma solidity ^0.8.0;
 
 /// @title TemporaryStorageMock
 /// @notice Reference mock for TIP-1040. NOT the real precompile — gas costs differ.
+///         The real precompile uses separate accounts per epoch; this mock simulates
+///         that by delegatecalling to epoch-derived addresses. In practice the node
+///         implements this natively without any DELEGATECALL overhead.
 contract TemporaryStorageMock {
+    /// @dev Base address for epoch accounts. Epoch n stores at PRECOMPILE + n + 1.
+    ///      In the real precompile this is the precompile's own address.
+    address public immutable PRECOMPILE;
+
+    constructor() {
+        PRECOMPILE = address(this);
+    }
+
     /// @notice Store a value in the current epoch's temporary storage.
     /// @param key  Caller-chosen 32-byte key.
     /// @param value The value to store.
     function temporaryStore(bytes32 key, bytes32 value) external {
-        bytes32 storageKey = _storageKey(_currentEpoch(), msg.sender, key);
+        bytes32 storageKey = _storageKey(msg.sender, key);
+        // In the real precompile, this writes to the epoch account's storage.
+        // Here we simulate it by writing to this contract's storage with a
+        // key that incorporates the epoch, since we can't create real accounts.
+        bytes32 epochedKey = keccak256(abi.encodePacked(_epochAccount(_currentEpoch()), storageKey));
         assembly {
-            sstore(storageKey, value)
+            sstore(epochedKey, value)
         }
     }
 
@@ -187,32 +204,35 @@ contract TemporaryStorageMock {
     /// @return result The stored value, or bytes32(0) if not found in either epoch.
     function temporaryLoad(bytes32 key) external view returns (bytes32 result) {
         uint32 currentEpoch = _currentEpoch();
+        bytes32 storageKey = _storageKey(msg.sender, key);
 
-        // Try current epoch
-        bytes32 currentKey = _storageKey(currentEpoch, msg.sender, key);
+        // Try current epoch account
+        bytes32 epochedKey = keccak256(abi.encodePacked(_epochAccount(currentEpoch), storageKey));
         assembly {
-            result := sload(currentKey)
+            result := sload(epochedKey)
         }
         if (result != bytes32(0)) {
             return result;
         }
 
-        // Fall back to previous epoch
+        // Fall back to previous epoch account
         if (currentEpoch == 0) {
             return bytes32(0);
         }
-        bytes32 previousKey = _storageKey(currentEpoch - 1, msg.sender, key);
+        bytes32 prevEpochedKey = keccak256(abi.encodePacked(_epochAccount(currentEpoch - 1), storageKey));
         assembly {
-            result := sload(previousKey)
+            result := sload(prevEpochedKey)
         }
     }
 
-    /// @dev Compute the 32-byte EVM storage key:
-    ///      uint32(epoch) ++ keccak256(sender || key)[4:32]
-    function _storageKey(uint32 epoch, address sender, bytes32 key) internal pure returns (bytes32) {
-        bytes32 hash = keccak256(abi.encodePacked(sender, key));
-        // Shift epoch into the top 4 bytes, OR with the lower 28 bytes of the hash
-        return bytes32(uint256(epoch) << 224) | (hash & bytes32(uint256(type(uint224).max)));
+    /// @dev Compute the storage key within an epoch account: keccak256(sender || key).
+    function _storageKey(address sender, bytes32 key) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(sender, key));
+    }
+
+    /// @dev Compute the epoch account address: PRECOMPILE + epoch + 1.
+    function _epochAccount(uint32 epoch) internal view returns (address) {
+        return address(uint160(PRECOMPILE) + uint160(epoch) + 1);
     }
 
     /// @dev Current epoch index: block.number >> 16, truncated to uint32.
@@ -228,6 +248,6 @@ contract TemporaryStorageMock {
 2. **Sender isolation**: `keccak256(sender_a || key) != keccak256(sender_b || key)` for `sender_a != sender_b` — different senders cannot read or overwrite each other's storage for the same key.
 3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
 4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
-5. **Epoch tree pruning safety**: Pruning any epoch tree older than `epoch(block.number) - 1` MUST NOT affect the result of any `temporaryLoad` call.
+5. **Epoch account pruning safety**: Deleting any epoch account older than `PRECOMPILE_ADDRESS + epoch(block.number)` MUST NOT affect the result of any `temporaryLoad` call.
 6. **Deterministic gas**: `temporaryStore` costs 40,000 gas for new slots (zero in current epoch) and follows SSTORE-equivalent hot/cold pricing for existing slots (nonzero in current epoch). A nonzero value in the previous epoch alone does not make the slot "existing". `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
 7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -24,11 +24,6 @@ Epoch-scoped temporary storage solves this by:
 2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
 3. **Cheaper writes** — a flat 40,000 gas per store with no state gas overhead (no refund accounting, no cold/warm store distinction on writes).
 
-Alternatives considered:
-
-- **EIP-1153 transient storage (`TSTORE`/`TLOAD`)**: Too short-lived — data is discarded at the end of a single transaction. Does not cover multi-block use cases.
-- **Application-level expiry with `SSTORE`**: Requires explicit cleanup transactions, is more expensive, and leaves dead state in the trie permanently.
-- **Off-chain data with on-chain commitments**: Adds complexity and trust assumptions around data availability.
 
 ## Assumptions
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -22,7 +22,7 @@ Epoch-scoped temporary storage solves this by:
 
 1. **Eliminating cleanup cost** — stale data becomes inaccessible automatically, no explicit deletion needed.
 2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
-3. **Cheaper writes** — a flat 40,000 gas per store with no state gas overhead (no refund accounting, no cold/warm store distinction on writes).
+3. **Cheaper writes** — a flat 40,000 gas per store with no additional state gas (no refund accounting, no cold/warm store distinction on writes).
 
 
 ## Assumptions

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -65,15 +65,15 @@ The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.n
 All temporary storage lives in the precompile's own EVM storage trie (i.e., the account at `PRECOMPILE_ADDRESS`). Each slot is a 32-byte key composed of two parts:
 
 ```
-storage_key = uint16(epoch) ++ keccak256(sender || key)[2:32]
+storage_key = uint32(epoch) ++ keccak256(sender || key)[4:32]
 ```
 
 | Bytes | Field | Description |
 |-------|-------|-------------|
-| `[0:2)` | `uint16(epoch)` | Big-endian epoch index, wraps every 2^16 epochs |
-| `[2:32)` | `keccak256(sender \|\| key)[2:32]` | Last 30 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
+| `[0:4)` | `uint32(epoch)` | Big-endian epoch index (2^32 epochs ≈ 2^48 blocks before wrap-around) |
+| `[4:32)` | `keccak256(sender \|\| key)[4:32]` | Last 28 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
 
-This packs the epoch tag and the sender-derived slot into a single 32-byte EVM storage key. Since only two adjacent epoch indices are ever live, the `uint16` wrap-around is unambiguous. The 30-byte hash truncation provides 240 bits of collision resistance, which is sufficient given the sender-scoping.
+This packs the epoch tag and the sender-derived slot into a single 32-byte EVM storage key. A 4-byte epoch index supports 2^32 epochs (2^48 blocks) before wrap-around, making the scheme effectively eternal. The 28-byte hash truncation provides 224 bits of collision resistance, which is sufficient given the sender-scoping.
 
 ## Precompile Interface
 
@@ -88,8 +88,8 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 **Behavior**:
 
 1. Compute `hash = keccak256(msg.sender || key)`.
-2. Compute `epoch_index = uint16(epoch(block.number))`.
-3. Compute `storage_key = epoch_index ++ hash[2:32]`.
+2. Compute `epoch_index = uint32(epoch(block.number))`.
+3. Compute `storage_key = epoch_index ++ hash[4:32]`.
 4. Read the existing value at `storage_key` in the precompile's storage.
 5. Write `value` at `storage_key`.
 
@@ -119,10 +119,10 @@ Loads the value for the derived slot, checking the current epoch first and falli
 **Behavior**:
 
 1. Compute `hash = keccak256(msg.sender || key)`.
-2. Compute `current_epoch_index = uint16(epoch(block.number))`.
-3. Compute `current_key = current_epoch_index ++ hash[2:32]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
-4. Compute `previous_epoch_index = uint16(epoch(block.number) - 1)`.
-5. Compute `previous_key = previous_epoch_index ++ hash[2:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
+2. Compute `current_epoch_index = uint32(epoch(block.number))`.
+3. Compute `current_key = current_epoch_index ++ hash[4:32]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
+4. Compute `previous_epoch_index = uint32(epoch(block.number) - 1)`.
+5. Compute `previous_key = previous_epoch_index ++ hash[4:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
 6. Return `bytes32(0)`.
 
 **Gas**: Follows the EIP-2929 access-list model. Each `storage_key` is tracked independently for hot/cold purposes:
@@ -140,15 +140,15 @@ Both `temporaryStore` and `temporaryLoad` participate in a shared per-transactio
 
 When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epoch(block.number - 1)`):
 
-1. All storage keys prefixed with `uint16(epoch(block.number) - 2)` (two epochs ago) become unreachable by the precompile and may be pruned by the node.
-2. The current epoch's prefix (`uint16(epoch(block.number))`) begins accepting writes.
-3. The previous epoch's keys (prefixed `uint16(epoch(block.number) - 1)`) remain accessible for read fallback.
+1. All storage keys prefixed with `uint32(epoch(block.number) - 2)` (two epochs ago) become unreachable by the precompile and may be pruned by the node.
+2. The current epoch's prefix (`uint32(epoch(block.number))`) begins accepting writes.
+3. The previous epoch's keys (prefixed `uint32(epoch(block.number) - 1)`) remain accessible for read fallback.
 
 Nodes MUST retain all storage keys with the current and previous epoch prefix. Nodes MAY prune keys with any older epoch prefix.
 
 ## Node Storage Requirements
 
-Because the epoch is encoded in the top 2 bytes of each storage key, nodes can identify and prune expired entries by prefix. At steady state, the precompile's storage is bounded to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
+Because the epoch is encoded in the top 4 bytes of each storage key, nodes can identify and prune expired entries by prefix. At steady state, the precompile's storage is bounded to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
 
 ## Calldata Encoding
 
@@ -185,7 +185,7 @@ contract TemporaryStorageMock {
     /// @param key  Caller-chosen 32-byte key.
     /// @return result The stored value, or bytes32(0) if not found in either epoch.
     function temporaryLoad(bytes32 key) external view returns (bytes32 result) {
-        uint16 currentEpoch = _currentEpoch();
+        uint32 currentEpoch = _currentEpoch();
 
         // Try current epoch
         bytes32 currentKey = _storageKey(currentEpoch, msg.sender, key);
@@ -207,16 +207,16 @@ contract TemporaryStorageMock {
     }
 
     /// @dev Compute the 32-byte EVM storage key:
-    ///      uint16(epoch) ++ keccak256(sender || key)[2:32]
-    function _storageKey(uint16 epoch, address sender, bytes32 key) internal pure returns (bytes32) {
+    ///      uint32(epoch) ++ keccak256(sender || key)[4:32]
+    function _storageKey(uint32 epoch, address sender, bytes32 key) internal pure returns (bytes32) {
         bytes32 hash = keccak256(abi.encodePacked(sender, key));
-        // Shift epoch into the top 2 bytes, OR with the lower 30 bytes of the hash
-        return bytes32(uint256(epoch) << 240) | (hash & bytes32(uint256(type(uint240).max)));
+        // Shift epoch into the top 4 bytes, OR with the lower 28 bytes of the hash
+        return bytes32(uint256(epoch) << 224) | (hash & bytes32(uint256(type(uint224).max)));
     }
 
-    /// @dev Current epoch index: block.number >> 16, truncated to uint16.
-    function _currentEpoch() internal view returns (uint16) {
-        return uint16(block.number >> 16);
+    /// @dev Current epoch index: block.number >> 16, truncated to uint32.
+    function _currentEpoch() internal view returns (uint32) {
+        return uint32(block.number >> 16);
     }
 }
 ```

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -22,7 +22,7 @@ Epoch-scoped temporary storage solves this by:
 
 1. **Eliminating cleanup cost** — stale data becomes inaccessible automatically, no explicit deletion needed.
 2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
-3. **Cheaper writes** — a flat 40,000 gas per store with no additional state gas (no refund accounting, no cold/warm store distinction on writes).
+3. **Cheaper writes** — 40,000 gas for new slots; overwrites within the same epoch follow standard SSTORE hot/cold pricing, much cheaper than a fresh write.
 
 
 ## Assumptions
@@ -45,7 +45,10 @@ If the assumption that nodes keep two epochs is violated (e.g., a node prunes th
 |------|-------|-------------|
 | `EPOCH_LENGTH` | 2^16 (65,536 blocks) | Number of blocks per epoch |
 | `PRECOMPILE_ADDRESS` | TBD | Reserved address for the temporary storage precompile |
-| `TEMPORARY_STORE_GAS` | 40,000 | Flat gas cost for `temporaryStore` |
+| `TEMPORARY_STORE_GAS_NEW` | 40,000 | Gas cost for `temporaryStore` when the slot is zero in the current epoch |
+| `TEMPORARY_STORE_GAS_EXISTING_COLD` | 5,000 | Gas cost for `temporaryStore` when the slot is already nonzero in the current epoch and cold (same as `SSTORE_RESET_GAS`) |
+| `TEMPORARY_STORE_GAS_EXISTING_WARM` | 200 | Gas cost for `temporaryStore` when the slot is already nonzero in the current epoch and warm (same as `WARM_STORAGE_READ_COST + SSTORE_WRITE_GAS_DELTA`) |
+| `COLD_SLOAD_COST` | 2,100 | Additional cold access surcharge applied once per slot per transaction |
 | `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
 | `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
 
@@ -83,8 +86,19 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 
 1. Compute `slot = keccak256(msg.sender || key)`.
 2. Compute `epoch_index = uint16(epoch(block.number))`.
-3. Write `value` to the current epoch tree at `(epoch_index, slot)`.
-4. Charge `TEMPORARY_STORE_GAS` (40,000 gas). No additional cold/warm state gas is applied.
+3. Read the existing value at `(epoch_index, slot)` in the current epoch tree.
+4. Write `value` to the current epoch tree at `(epoch_index, slot)`.
+
+**Gas**:
+
+The gas cost depends on whether the slot already holds a nonzero value **in the current epoch's tree**. A nonzero value in the previous epoch's tree does not count — only the current epoch matters.
+
+- **New slot** (current epoch value is zero): `TEMPORARY_STORE_GAS_NEW` (40,000 gas). No cold/warm surcharge.
+- **Existing slot** (current epoch value is nonzero):
+  - Cold (first access to this slot in the transaction): `COLD_SLOAD_COST` (2,100) + `TEMPORARY_STORE_GAS_EXISTING_COLD` (5,000) = 7,100 gas.
+  - Warm (slot already accessed in this transaction): `TEMPORARY_STORE_GAS_EXISTING_WARM` (200 gas).
+
+A `temporaryStore` to a new slot also marks it as warm for subsequent accesses.
 
 **Output**: Empty (0 bytes). Execution succeeds silently.
 
@@ -114,9 +128,9 @@ Loads the value for the derived slot, checking the current epoch first and falli
 
 **Output**: ABI-encoded `bytes32` (32 bytes).
 
-## Interaction with `temporaryStore` warm/cold tracking
+## Warm/Cold Tracking
 
-A `temporaryStore` to a slot marks that `(current_epoch_index, slot)` as warm for subsequent `temporaryLoad` calls within the same transaction. The store itself always costs a flat 40,000 gas regardless of cold/warm status.
+Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `(epoch_index, slot)`. Any access (store or load) to a slot marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the slot warm.
 
 ## Epoch Transition
 
@@ -148,5 +162,5 @@ temporaryLoad:  0x<selector> <key:bytes32>                   (4 + 32 = 36 bytes)
 3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
 4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
 5. **Epoch tree pruning safety**: Pruning any epoch tree older than `epoch(block.number) - 1` MUST NOT affect the result of any `temporaryLoad` call.
-6. **Deterministic gas**: `temporaryStore` always costs exactly 40,000 gas. `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
+6. **Deterministic gas**: `temporaryStore` costs 40,000 gas for new slots (zero in current epoch) and follows SSTORE-equivalent hot/cold pricing for existing slots (nonzero in current epoch). A nonzero value in the previous epoch alone does not make the slot "existing". `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
 7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -65,13 +65,13 @@ The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.n
 All temporary storage lives in the precompile's own EVM storage trie (i.e., the account at `PRECOMPILE_ADDRESS`). Each slot is a 32-byte key composed of two parts:
 
 ```
-storage_key = uint16(epoch) ++ keccak256(sender || key)[0:30]
+storage_key = uint16(epoch) ++ keccak256(sender || key)[2:32]
 ```
 
 | Bytes | Field | Description |
 |-------|-------|-------------|
 | `[0:2)` | `uint16(epoch)` | Big-endian epoch index, wraps every 2^16 epochs |
-| `[2:32)` | `keccak256(sender \|\| key)[0:30]` | First 30 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
+| `[2:32)` | `keccak256(sender \|\| key)[2:32]` | Last 30 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
 
 This packs the epoch tag and the sender-derived slot into a single 32-byte EVM storage key. Since only two adjacent epoch indices are ever live, the `uint16` wrap-around is unambiguous. The 30-byte hash truncation provides 240 bits of collision resistance, which is sufficient given the sender-scoping.
 
@@ -89,7 +89,7 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 
 1. Compute `hash = keccak256(msg.sender || key)`.
 2. Compute `epoch_index = uint16(epoch(block.number))`.
-3. Compute `storage_key = epoch_index ++ hash[0:30]`.
+3. Compute `storage_key = epoch_index ++ hash[2:32]`.
 4. Read the existing value at `storage_key` in the precompile's storage.
 5. Write `value` at `storage_key`.
 
@@ -120,9 +120,9 @@ Loads the value for the derived slot, checking the current epoch first and falli
 
 1. Compute `hash = keccak256(msg.sender || key)`.
 2. Compute `current_epoch_index = uint16(epoch(block.number))`.
-3. Compute `current_key = current_epoch_index ++ hash[0:30]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
+3. Compute `current_key = current_epoch_index ++ hash[2:32]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
 4. Compute `previous_epoch_index = uint16(epoch(block.number) - 1)`.
-5. Compute `previous_key = previous_epoch_index ++ hash[0:30]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
+5. Compute `previous_key = previous_epoch_index ++ hash[2:32]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
 6. Return `bytes32(0)`.
 
 **Gas**: Follows the EIP-2929 access-list model. Each `storage_key` is tracked independently for hot/cold purposes:
@@ -207,7 +207,7 @@ contract TemporaryStorageMock {
     }
 
     /// @dev Compute the 32-byte EVM storage key:
-    ///      uint16(epoch) ++ keccak256(sender || key)[0:30]
+    ///      uint16(epoch) ++ keccak256(sender || key)[2:32]
     function _storageKey(uint16 epoch, address sender, bytes32 key) internal pure returns (bytes32) {
         bytes32 hash = keccak256(abi.encodePacked(sender, key));
         // Shift epoch into the top 2 bytes, OR with the lower 30 bytes of the hash

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1037
+id: TIP-1040
 title: Epoch-Scoped Temporary Storage Precompile
 description: A precompile providing cheap temporary key-value storage that automatically expires after one to two epochs.
 authors: Dankrad
@@ -8,7 +8,7 @@ related: N/A
 protocolVersion: TBD
 ---
 
-# TIP-1037: Epoch-Scoped Temporary Storage Precompile
+# TIP-1040: Epoch-Scoped Temporary Storage Precompile
 
 ## Abstract
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -147,7 +147,7 @@ When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epo
 2. The account at `PRECOMPILE_ADDRESS + epoch(block.number) + 1` (current epoch) begins accepting writes.
 3. The account at `PRECOMPILE_ADDRESS + epoch(block.number)` (previous epoch) remains accessible for read fallback.
 
-Nodes MUST retain the accounts for the current and previous epoch. Nodes MAY delete any older epoch account and its entire storage trie.
+Nodes MUST retain the accounts for the current and previous epoch. Nodes MAY delete any older epoch account and its entire storage trie, however they MUST retain all information that is still needed for future operation, such as the Merkle root of the storage trie in order to be able to update the accounts trie in the future.
 
 ## Node Storage Requirements
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -62,15 +62,18 @@ The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.n
 
 ## Storage Layout
 
-The precompile maintains a separate storage tree per epoch. Only two trees exist at any time: the current epoch tree and the previous epoch tree. Each storage slot within a tree is addressed by:
+All temporary storage lives in the precompile's own EVM storage trie (i.e., the account at `PRECOMPILE_ADDRESS`). Each slot is a 32-byte key composed of two parts:
 
 ```
-slot = keccak256(sender || key)
+storage_key = uint16(epoch) ++ keccak256(sender || key)[0:30]
 ```
 
-where `sender` is the `msg.sender` (the immediate caller of the precompile) and `key` is the caller-provided 32-byte key. The `||` operator denotes concatenation.
+| Bytes | Field | Description |
+|-------|-------|-------------|
+| `[0:2)` | `uint16(epoch)` | Big-endian epoch index, wraps every 2^16 epochs |
+| `[2:32)` | `keccak256(sender \|\| key)[0:30]` | First 30 bytes of the hash of `msg.sender` concatenated with the caller-provided key |
 
-The epoch tree is indexed by `uint16(epoch)`, which wraps around every 2^16 epochs. Since only two adjacent epoch trees are ever live, there is no ambiguity from the wrap-around.
+This packs the epoch tag and the sender-derived slot into a single 32-byte EVM storage key. Since only two adjacent epoch indices are ever live, the `uint16` wrap-around is unambiguous. The 30-byte hash truncation provides 240 bits of collision resistance, which is sufficient given the sender-scoping.
 
 ## Precompile Interface
 
@@ -84,10 +87,11 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 
 **Behavior**:
 
-1. Compute `slot = keccak256(msg.sender || key)`.
+1. Compute `hash = keccak256(msg.sender || key)`.
 2. Compute `epoch_index = uint16(epoch(block.number))`.
-3. Read the existing value at `(epoch_index, slot)` in the current epoch tree.
-4. Write `value` to the current epoch tree at `(epoch_index, slot)`.
+3. Compute `storage_key = epoch_index ++ hash[0:30]`.
+4. Read the existing value at `storage_key` in the precompile's storage.
+5. Write `value` at `storage_key`.
 
 **Gas**:
 
@@ -114,37 +118,37 @@ Loads the value for the derived slot, checking the current epoch first and falli
 
 **Behavior**:
 
-1. Compute `slot = keccak256(msg.sender || key)`.
+1. Compute `hash = keccak256(msg.sender || key)`.
 2. Compute `current_epoch_index = uint16(epoch(block.number))`.
-3. Look up `slot` in the current epoch tree. If a non-zero value exists, return it.
+3. Compute `current_key = current_epoch_index ++ hash[0:30]`. Look up `current_key` in the precompile's storage. If a non-zero value exists, return it.
 4. Compute `previous_epoch_index = uint16(epoch(block.number) - 1)`.
-5. Look up `slot` in the previous epoch tree. If a non-zero value exists, return it.
+5. Compute `previous_key = previous_epoch_index ++ hash[0:30]`. Look up `previous_key` in the precompile's storage. If a non-zero value exists, return it.
 6. Return `bytes32(0)`.
 
-**Gas**: Follows the EIP-2929 access-list model. Each `(epoch_index, slot)` pair is tracked independently for hot/cold purposes:
-- First access to a given `(epoch_index, slot)` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
-- Subsequent accesses to the same `(epoch_index, slot)`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
-- If the fallback to the previous epoch is triggered, its slot access is charged independently (cold or warm based on whether that specific `(previous_epoch_index, slot)` was previously accessed).
+**Gas**: Follows the EIP-2929 access-list model. Each `storage_key` is tracked independently for hot/cold purposes:
+- First access to a given `storage_key` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
+- Subsequent accesses to the same `storage_key`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
+- If the fallback to the previous epoch is triggered, `previous_key` is a different `storage_key` and charged independently (cold or warm based on whether it was previously accessed).
 
 **Output**: ABI-encoded `bytes32` (32 bytes).
 
 ## Warm/Cold Tracking
 
-Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `(epoch_index, slot)`. Any access (store or load) to a slot marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the slot warm.
+Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `storage_key`. Any access (store or load) to a `storage_key` marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the `storage_key` warm.
 
 ## Epoch Transition
 
 When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epoch(block.number - 1)`):
 
-1. The tree for `epoch(block.number) - 2` (two epochs ago) becomes unreachable and may be pruned by the node.
-2. A new empty tree is created for the current epoch.
-3. The previous epoch's tree (now `epoch(block.number) - 1`) remains accessible for reads.
+1. All storage keys prefixed with `uint16(epoch(block.number) - 2)` (two epochs ago) become unreachable by the precompile and may be pruned by the node.
+2. The current epoch's prefix (`uint16(epoch(block.number))`) begins accepting writes.
+3. The previous epoch's keys (prefixed `uint16(epoch(block.number) - 1)`) remain accessible for read fallback.
 
-Nodes MUST keep the current and previous epoch trees. Nodes MAY discard all older epoch trees.
+Nodes MUST retain all storage keys with the current and previous epoch prefix. Nodes MAY prune keys with any older epoch prefix.
 
 ## Node Storage Requirements
 
-Nodes are required to maintain exactly two epoch storage trees. At steady state, this bounds the temporary storage to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
+Because the epoch is encoded in the top 2 bytes of each storage key, nodes can identify and prune expired entries by prefix. At steady state, the precompile's storage is bounded to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
 
 ## Calldata Encoding
 
@@ -153,6 +157,68 @@ Both functions use standard Solidity ABI encoding:
 ```
 temporaryStore: 0x<selector> <key:bytes32> <value:bytes32>   (4 + 32 + 32 = 68 bytes)
 temporaryLoad:  0x<selector> <key:bytes32>                   (4 + 32 = 36 bytes)
+```
+
+## Reference Solidity Mock
+
+This mock demonstrates the exact storage key derivation and fallback logic. The real precompile is implemented natively in the node; this contract is for specification clarity and testing only. Gas costs are not modeled here — the precompile charges gas according to the rules above, not via Solidity's native SSTORE/SLOAD pricing.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title TemporaryStorageMock
+/// @notice Reference mock for TIP-1040. NOT the real precompile — gas costs differ.
+contract TemporaryStorageMock {
+    /// @notice Store a value in the current epoch's temporary storage.
+    /// @param key  Caller-chosen 32-byte key.
+    /// @param value The value to store.
+    function temporaryStore(bytes32 key, bytes32 value) external {
+        bytes32 storageKey = _storageKey(_currentEpoch(), msg.sender, key);
+        assembly {
+            sstore(storageKey, value)
+        }
+    }
+
+    /// @notice Load a value from temporary storage.
+    ///         Checks the current epoch first, falls back to the previous epoch.
+    /// @param key  Caller-chosen 32-byte key.
+    /// @return result The stored value, or bytes32(0) if not found in either epoch.
+    function temporaryLoad(bytes32 key) external view returns (bytes32 result) {
+        uint16 currentEpoch = _currentEpoch();
+
+        // Try current epoch
+        bytes32 currentKey = _storageKey(currentEpoch, msg.sender, key);
+        assembly {
+            result := sload(currentKey)
+        }
+        if (result != bytes32(0)) {
+            return result;
+        }
+
+        // Fall back to previous epoch
+        if (currentEpoch == 0) {
+            return bytes32(0);
+        }
+        bytes32 previousKey = _storageKey(currentEpoch - 1, msg.sender, key);
+        assembly {
+            result := sload(previousKey)
+        }
+    }
+
+    /// @dev Compute the 32-byte EVM storage key:
+    ///      uint16(epoch) ++ keccak256(sender || key)[0:30]
+    function _storageKey(uint16 epoch, address sender, bytes32 key) internal pure returns (bytes32) {
+        bytes32 hash = keccak256(abi.encodePacked(sender, key));
+        // Shift epoch into the top 2 bytes, OR with the lower 30 bytes of the hash
+        return bytes32(uint256(epoch) << 240) | (hash & bytes32(uint256(type(uint240).max)));
+    }
+
+    /// @dev Current epoch index: block.number >> 16, truncated to uint16.
+    function _currentEpoch() internal view returns (uint16) {
+        return uint16(block.number >> 16);
+    }
+}
 ```
 
 # Invariants

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -76,7 +76,7 @@ storage_key = keccak256(sender || key)
 
 This is the full 32-byte hash — no truncation is needed since the epoch is encoded in the account address rather than the storage key, giving 256 bits of collision resistance.
 
-**Pruning advantage**: Nodes can prune an entire expired epoch by dropping the account at `PRECOMPILE_ADDRESS + n + 1` and its storage trie in one operation, rather than scanning individual slots within a single large trie.
+**Pruning advantage**: Nodes can prune an entire expired epoch by dropping the account at `PRECOMPILE_ADDRESS + n + 1` and its storage trie in one operation, rather than scanning individual slots within a single large trie. Note that this dropping of storage is done out of consensus -- there is no actual deletion happening and the account trie does not change, the node can simply forget the storage for the account because it is guaranteed to not be needed again any time in the future.
 
 ## Precompile Interface
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -2,7 +2,7 @@
 id: TIP-1040
 title: Epoch-Scoped Temporary Storage Precompile
 description: A precompile providing cheap temporary key-value storage that automatically expires after one to two epochs.
-authors: Dankrad
+authors: Dankrad Feist @dankrad
 status: Draft
 related: N/A
 protocolVersion: TBD
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 172,800 blocks, which is approximately 24 hours at 500ms slot times. Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 172,800 and 345,600 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
+This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 172,800 blocks, which is approximately 24 hours at 500ms slot times (the actual time can vary due to block time variation and skipped slots; consumers need to take this into account and can only rely on the minimum time since there is no strict upper bound). Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 172,800 and 345,600 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
 
 ## Motivation
 
@@ -27,13 +27,10 @@ Epoch-scoped temporary storage solves this by:
 
 ## Assumptions
 
-- The block number is always available to the precompile at execution time.
 - Nodes maintain at least two epoch accounts (current and previous) at all times. A node that has pruned the previous epoch's account is non-conforming.
-- The precompile address and the address range `[PRECOMPILE_ADDRESS + 1, ...]` are reserved and not used by any existing contract or EOA.
+- The precompile address and the address range `[PRECOMPILE_ADDRESS + 1, ..., PRECOMPILE_ADDRESS + u64::MAX]` are reserved and not used by any existing contract or EOA.
 - Epoch boundaries are deterministic: `epoch = block_number / EPOCH_LENGTH`.
 - Storage keys are collision-resistant due to the full `keccak256(sender, key)` derivation (256 bits); two different senders cannot write to the same slot.
-
-If the assumption that nodes keep two epoch accounts is violated (e.g., a node prunes the previous epoch account early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
 
 ---
 
@@ -76,7 +73,7 @@ storage_key = keccak256(sender || key)
 
 This is the full 32-byte hash — no truncation is needed since the epoch is encoded in the account address rather than the storage key, giving 256 bits of collision resistance.
 
-**Pruning advantage**: Nodes can prune an entire expired epoch by dropping the account at `PRECOMPILE_ADDRESS + n + 1` and its storage trie in one operation, rather than scanning individual slots within a single large trie. Note that this dropping of storage is done out of consensus -- there is no actual deletion happening and the account trie does not change, the node can simply forget the storage for the account because it is guaranteed to not be needed again any time in the future.
+**Pruning advantage**: Nodes can prune an entire expired epoch by dropping the account at `PRECOMPILE_ADDRESS + n + 1` and its storage trie in one operation, rather than scanning individual slots within a single large trie. Note that this dropping of storage is done out of consensus -- there is no actual deletion happening inside consensus logic and the account trie does not change, the node can simply forget the storage for the account because it is guaranteed to not be needed again any time in the future.
 
 ## Precompile Interface
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 2^16 (65,536) blocks. Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 2^16 and 2^17 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
+This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 172,800 blocks, which is approximately 24 hours at 500ms slot times. Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 172,800 and 345,600 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
 
 ## Motivation
 
@@ -30,7 +30,7 @@ Epoch-scoped temporary storage solves this by:
 - The block number is always available to the precompile at execution time.
 - Nodes maintain at least two epoch accounts (current and previous) at all times. A node that has pruned the previous epoch's account is non-conforming.
 - The precompile address and the address range `[PRECOMPILE_ADDRESS + 1, ...]` are reserved and not used by any existing contract or EOA.
-- Epoch boundaries are deterministic: `epoch = block_number >> 16`.
+- Epoch boundaries are deterministic: `epoch = block_number / EPOCH_LENGTH`.
 - Storage keys are collision-resistant due to the full `keccak256(sender, key)` derivation (256 bits); two different senders cannot write to the same slot.
 
 If the assumption that nodes keep two epoch accounts is violated (e.g., a node prunes the previous epoch account early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
@@ -43,7 +43,7 @@ If the assumption that nodes keep two epoch accounts is violated (e.g., a node p
 
 | Name | Value | Description |
 |------|-------|-------------|
-| `EPOCH_LENGTH` | 2^16 (65,536 blocks) | Number of blocks per epoch |
+| `EPOCH_LENGTH` | 172,800 blocks | Number of blocks per epoch, approximately 24 hours at 500ms slot times |
 | `PRECOMPILE_ADDRESS` | TBD | Reserved address for the temporary storage precompile |
 | `TEMPORARY_STORE_GAS_NEW` | 40,000 | Gas cost for `temporaryStore` when the slot is zero in the current epoch |
 | `TEMPORARY_STORE_GAS_EXISTING_COLD` | 5,000 | Gas cost for `temporaryStore` when the slot is already nonzero in the current epoch and cold (same as `SSTORE_RESET_GAS`) |
@@ -55,7 +55,7 @@ If the assumption that nodes keep two epoch accounts is violated (e.g., a node p
 ## Epoch Derivation
 
 ```
-epoch(block_number) = block_number >> 16
+epoch(block_number) = block_number / EPOCH_LENGTH
 ```
 
 The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.number) - 1`. At genesis (epoch 0), there is no previous epoch to fall back to.
@@ -235,9 +235,9 @@ contract TemporaryStorageMock {
         return address(uint160(PRECOMPILE) + uint160(epoch) + 1);
     }
 
-    /// @dev Current epoch index: block.number >> 16, truncated to uint32.
+    /// @dev Current epoch index, truncated to uint32.
     function _currentEpoch() internal view returns (uint32) {
-        return uint32(block.number >> 16);
+        return uint32(block.number / 172_800);
     }
 }
 ```

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -48,6 +48,7 @@ Epoch-scoped temporary storage solves this by:
 | `COLD_SLOAD_COST` | 2,100 | Additional cold access surcharge applied once per slot per transaction |
 | `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
 | `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
+| `EPOCH_ACCOUNT_CODE_HASH` | `keccak256("tempo.tip1040.epoch_account") = 0x36c6e1ae22d067a9cff9a601eb89b47b7e6b9d7170ed08dd74d663e14568066c` | Code hash marker for epoch accounts |
 
 ## Epoch Derivation
 
@@ -64,6 +65,8 @@ Each epoch's temporary storage lives in a **separate account**. Epoch `n` is sto
 ```
 epoch_account(n) = PRECOMPILE_ADDRESS + n + 1
 ```
+
+Epoch accounts MUST have their code hash set to `EPOCH_ACCOUNT_CODE_HASH`. They have no executable bytecode, but the non-empty code hash marker prevents them from being treated as empty accounts under EIP-161 when their nonce and balance are zero.
 
 Within each epoch account, storage keys are derived from the caller and key:
 

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -48,6 +48,7 @@ Epoch-scoped temporary storage solves this by:
 | `COLD_SLOAD_COST` | 2,100 | Additional cold access surcharge applied once per slot per transaction |
 | `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
 | `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
+| `TEMPO_PRECOMPILE_INPUT_GAS` | 6 gas per 32-byte word | Standard Tempo precompile calldata cost, rounded up over the full ABI-encoded input |
 | `EPOCH_ACCOUNT_CODE_HASH` | `keccak256("tempo.tip1040.epoch_account") = 0x36c6e1ae22d067a9cff9a601eb89b47b7e6b9d7170ed08dd74d663e14568066c` | Code hash marker for epoch accounts |
 
 ## Epoch Derivation
@@ -106,6 +107,8 @@ The gas cost depends on whether the slot already holds a nonzero value **in the 
 
 A `temporaryStore` to a new slot also marks it as warm for subsequent accesses.
 
+All calls also pay the standard Tempo precompile calldata cost of `TEMPO_PRECOMPILE_INPUT_GAS` (6 gas per 32-byte word, rounded up) over the full ABI-encoded input. For `temporaryStore`, the 68-byte input is rounded up to 3 words, adding 18 gas, so a new-slot store costs 40,018 gas before any outer EVM call overhead.
+
 **Output**: Empty (0 bytes). Execution succeeds silently.
 
 **Error**: Reverts only if insufficient gas is provided.
@@ -132,6 +135,7 @@ Loads the value for the derived slot, checking the current epoch first and falli
 - First access to a given `(account, storage_key)` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
 - Subsequent accesses to the same `(account, storage_key)`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
 - If the fallback to the previous epoch is triggered, `(previous_account, storage_key)` is a different entry and charged independently.
+- All calls also pay the standard Tempo precompile calldata cost of `TEMPO_PRECOMPILE_INPUT_GAS` (6 gas per 32-byte word, rounded up) over the full ABI-encoded input. For `temporaryLoad`, the 36-byte input is rounded up to 2 words, adding 12 gas.
 
 **Output**: ABI-encoded `bytes32` (32 bytes).
 
@@ -249,5 +253,5 @@ contract TemporaryStorageMock {
 3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
 4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
 5. **Epoch account pruning safety**: Deleting any epoch account older than `PRECOMPILE_ADDRESS + epoch(block.number)` MUST NOT affect the result of any `temporaryLoad` call.
-6. **Deterministic gas**: `temporaryStore` costs 40,000 gas for new slots (zero in current epoch) and follows SSTORE-equivalent hot/cold pricing for existing slots (nonzero in current epoch). A nonzero value in the previous epoch alone does not make the slot "existing". `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
+6. **Deterministic gas**: `temporaryStore` costs 40,000 gas plus the standard Tempo precompile calldata cost for new slots (zero in current epoch) and follows SSTORE-equivalent hot/cold pricing plus the standard Tempo precompile calldata cost for existing slots (nonzero in current epoch). A nonzero value in the previous epoch alone does not make the slot "existing". `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction plus the standard Tempo precompile calldata cost.
 7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.


### PR DESCRIPTION
Adds TIP-1040: a precompile for epoch-scoped temporary key-value storage. Values are available for 2^16 to 2^17 blocks then automatically expire. Nodes can prune anything older than the previous epoch.

Key design points:
- Epochs are 2^16 blocks. Current + previous epoch storage are live; older epochs are forgotten.
- Storage slot = `keccak256(sender || key)` scoped per `uint16(epoch)` — sender-isolated, no cross-contract collisions.
- Store costs a flat 40k gas (no state gas). Load follows EIP-2929 cold/warm model (2,100 / 100 gas).
- Load checks current epoch first, falls back to previous epoch, returns zero if both miss.

Prompted by: dankrad