### PR TITLE
docs(tip-1040): epoch-scoped temporary storage precompile

### DIFF
--- a/tips/tip-1037.md
+++ b/tips/tip-1037.md
@@ -1,0 +1,157 @@
+---
+id: TIP-1037
+title: Epoch-Scoped Temporary Storage Precompile
+description: A precompile providing cheap temporary key-value storage that automatically expires after one to two epochs.
+authors: Dankrad
+status: Draft
+related: N/A
+protocolVersion: TBD
+---
+
+# TIP-1037: Epoch-Scoped Temporary Storage Precompile
+
+## Abstract
+
+This TIP introduces a precompile that provides temporary key-value storage scoped to epochs. An epoch is 2^16 (65,536) blocks. Data written in a given epoch is readable during that epoch and the next, then automatically becomes inaccessible. This gives stored values a lifetime of between 2^16 and 2^17 blocks depending on when within the epoch the write occurs. Nodes may prune storage from epochs older than the previous one.
+
+## Motivation
+
+Certain use cases need on-chain data availability for a bounded time window rather than permanent storage — for example time-limited approvals, ephemeral session state, or temporary commitments. Today these patterns require permanent `SSTORE` writes and separate cleanup transactions, wasting gas and bloating state.
+
+Epoch-scoped temporary storage solves this by:
+
+1. **Eliminating cleanup cost** — stale data becomes inaccessible automatically, no explicit deletion needed.
+2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
+3. **Cheaper writes** — a flat 40,000 gas per store with no state gas overhead (no refund accounting, no cold/warm store distinction on writes).
+
+Alternatives considered:
+
+- **EIP-1153 transient storage (`TSTORE`/`TLOAD`)**: Too short-lived — data is discarded at the end of a single transaction. Does not cover multi-block use cases.
+- **Application-level expiry with `SSTORE`**: Requires explicit cleanup transactions, is more expensive, and leaves dead state in the trie permanently.
+- **Off-chain data with on-chain commitments**: Adds complexity and trust assumptions around data availability.
+
+## Assumptions
+
+- The block number is always available to the precompile at execution time.
+- Nodes maintain at least two complete epoch storage trees (current and previous) at all times. A node that has pruned the previous epoch's tree is non-conforming.
+- The precompile address is reserved and not used by any existing contract.
+- Epoch boundaries are deterministic: `epoch = block_number >> 16`.
+- Storage keys are collision-resistant due to the `keccak256(sender, key)` derivation; two different senders cannot write to the same slot.
+
+If the assumption that nodes keep two epochs is violated (e.g., a node prunes the previous epoch early), `temporaryLoad` may incorrectly return zero for data that should still be accessible.
+
+---
+
+# Specification
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `EPOCH_LENGTH` | 2^16 (65,536 blocks) | Number of blocks per epoch |
+| `PRECOMPILE_ADDRESS` | TBD | Reserved address for the temporary storage precompile |
+| `TEMPORARY_STORE_GAS` | 40,000 | Flat gas cost for `temporaryStore` |
+| `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
+| `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
+
+## Epoch Derivation
+
+```
+epoch(block_number) = block_number >> 16
+```
+
+The current epoch is `epoch(block.number)`. The previous epoch is `epoch(block.number) - 1`. At genesis (epoch 0), there is no previous epoch to fall back to.
+
+## Storage Layout
+
+The precompile maintains a separate storage tree per epoch. Only two trees exist at any time: the current epoch tree and the previous epoch tree. Each storage slot within a tree is addressed by:
+
+```
+slot = keccak256(sender || key)
+```
+
+where `sender` is the `msg.sender` (the immediate caller of the precompile) and `key` is the caller-provided 32-byte key. The `||` operator denotes concatenation.
+
+The epoch tree is indexed by `uint16(epoch)`, which wraps around every 2^16 epochs. Since only two adjacent epoch trees are ever live, there is no ambiguity from the wrap-around.
+
+## Precompile Interface
+
+### `temporaryStore(bytes32 key, bytes32 value)`
+
+Stores `value` at the derived slot in the current epoch's storage tree.
+
+**Selector**: `0x` + first 4 bytes of `keccak256("temporaryStore(bytes32,bytes32)")`
+
+**Input**: ABI-encoded `(bytes32 key, bytes32 value)` — 64 bytes after the 4-byte selector.
+
+**Behavior**:
+
+1. Compute `slot = keccak256(msg.sender || key)`.
+2. Compute `epoch_index = uint16(epoch(block.number))`.
+3. Write `value` to the current epoch tree at `(epoch_index, slot)`.
+4. Charge `TEMPORARY_STORE_GAS` (40,000 gas). No additional cold/warm state gas is applied.
+
+**Output**: Empty (0 bytes). Execution succeeds silently.
+
+**Error**: Reverts only if insufficient gas is provided.
+
+### `temporaryLoad(bytes32 key) returns (bytes32)`
+
+Loads the value for the derived slot, checking the current epoch first and falling back to the previous epoch.
+
+**Selector**: `0x` + first 4 bytes of `keccak256("temporaryLoad(bytes32)")`
+
+**Input**: ABI-encoded `(bytes32 key)` — 32 bytes after the 4-byte selector.
+
+**Behavior**:
+
+1. Compute `slot = keccak256(msg.sender || key)`.
+2. Compute `current_epoch_index = uint16(epoch(block.number))`.
+3. Look up `slot` in the current epoch tree. If a non-zero value exists, return it.
+4. Compute `previous_epoch_index = uint16(epoch(block.number) - 1)`.
+5. Look up `slot` in the previous epoch tree. If a non-zero value exists, return it.
+6. Return `bytes32(0)`.
+
+**Gas**: Follows the EIP-2929 access-list model. Each `(epoch_index, slot)` pair is tracked independently for hot/cold purposes:
+- First access to a given `(epoch_index, slot)` within the transaction: `TEMPORARY_LOAD_GAS_COLD` (2,100 gas).
+- Subsequent accesses to the same `(epoch_index, slot)`: `TEMPORARY_LOAD_GAS_WARM` (100 gas).
+- If the fallback to the previous epoch is triggered, its slot access is charged independently (cold or warm based on whether that specific `(previous_epoch_index, slot)` was previously accessed).
+
+**Output**: ABI-encoded `bytes32` (32 bytes).
+
+## Interaction with `temporaryStore` warm/cold tracking
+
+A `temporaryStore` to a slot marks that `(current_epoch_index, slot)` as warm for subsequent `temporaryLoad` calls within the same transaction. The store itself always costs a flat 40,000 gas regardless of cold/warm status.
+
+## Epoch Transition
+
+When `block.number` crosses an epoch boundary (i.e., `epoch(block.number) != epoch(block.number - 1)`):
+
+1. The tree for `epoch(block.number) - 2` (two epochs ago) becomes unreachable and may be pruned by the node.
+2. A new empty tree is created for the current epoch.
+3. The previous epoch's tree (now `epoch(block.number) - 1`) remains accessible for reads.
+
+Nodes MUST keep the current and previous epoch trees. Nodes MAY discard all older epoch trees.
+
+## Node Storage Requirements
+
+Nodes are required to maintain exactly two epoch storage trees. At steady state, this bounds the temporary storage to at most `2 × (number of unique slots written per epoch)` entries. This is a significant improvement over permanent storage, where state only grows.
+
+## Calldata Encoding
+
+Both functions use standard Solidity ABI encoding:
+
+```
+temporaryStore: 0x<selector> <key:bytes32> <value:bytes32>   (4 + 32 + 32 = 68 bytes)
+temporaryLoad:  0x<selector> <key:bytes32>                   (4 + 32 = 36 bytes)
+```
+
+# Invariants
+
+1. **Bounded lifetime**: A value written in epoch `E` MUST be readable in epochs `E` and `E+1`, and MUST NOT be readable from epoch `E+2` onward.
+2. **Sender isolation**: `keccak256(sender_a || key) != keccak256(sender_b || key)` for `sender_a != sender_b` — different senders cannot read or overwrite each other's storage for the same key.
+3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
+4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
+5. **Epoch tree pruning safety**: Pruning any epoch tree older than `epoch(block.number) - 1` MUST NOT affect the result of any `temporaryLoad` call.
+6. **Deterministic gas**: `temporaryStore` always costs exactly 40,000 gas. `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
+7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -22,7 +22,7 @@ Epoch-scoped temporary storage solves this by:
 
 1. **Eliminating cleanup cost** — stale data becomes inaccessible automatically, no explicit deletion needed.
 2. **Reducing long-term state growth** — nodes can prune expired storage, keeping the state trie bounded.
-3. **Cheaper writes** — a flat 40,000 gas per store with no state gas overhead (no refund accounting, no cold/warm store distinction on writes).
+3. **Cheaper writes** — 40,000 gas for new slots; overwrites within the same epoch follow standard SSTORE hot/cold pricing, much cheaper than a fresh write.
 
 Alternatives considered:
 
@@ -50,7 +50,10 @@ If the assumption that nodes keep two epochs is violated (e.g., a node prunes th
 |------|-------|-------------|
 | `EPOCH_LENGTH` | 2^16 (65,536 blocks) | Number of blocks per epoch |
 | `PRECOMPILE_ADDRESS` | TBD | Reserved address for the temporary storage precompile |
-| `TEMPORARY_STORE_GAS` | 40,000 | Flat gas cost for `temporaryStore` |
+| `TEMPORARY_STORE_GAS_NEW` | 40,000 | Gas cost for `temporaryStore` when the slot is zero in the current epoch |
+| `TEMPORARY_STORE_GAS_EXISTING_COLD` | 5,000 | Gas cost for `temporaryStore` when the slot is already nonzero in the current epoch and cold (same as `SSTORE_RESET_GAS`) |
+| `TEMPORARY_STORE_GAS_EXISTING_WARM` | 200 | Gas cost for `temporaryStore` when the slot is already nonzero in the current epoch and warm (same as `WARM_STORAGE_READ_COST + SSTORE_WRITE_GAS_DELTA`) |
+| `COLD_SLOAD_COST` | 2,100 | Additional cold access surcharge applied once per slot per transaction |
 | `TEMPORARY_LOAD_GAS_COLD` | 2,100 | Gas cost for `temporaryLoad` on a cold slot (same as `COLD_SLOAD_COST`) |
 | `TEMPORARY_LOAD_GAS_WARM` | 100 | Gas cost for `temporaryLoad` on a warm slot (same as `WARM_STORAGE_READ_COST`) |
 
@@ -88,8 +91,19 @@ Stores `value` at the derived slot in the current epoch's storage tree.
 
 1. Compute `slot = keccak256(msg.sender || key)`.
 2. Compute `epoch_index = uint16(epoch(block.number))`.
-3. Write `value` to the current epoch tree at `(epoch_index, slot)`.
-4. Charge `TEMPORARY_STORE_GAS` (40,000 gas). No additional cold/warm state gas is applied.
+3. Read the existing value at `(epoch_index, slot)` in the current epoch tree.
+4. Write `value` to the current epoch tree at `(epoch_index, slot)`.
+
+**Gas**:
+
+The gas cost depends on whether the slot already holds a nonzero value **in the current epoch's tree**. A nonzero value in the previous epoch's tree does not count — only the current epoch matters.
+
+- **New slot** (current epoch value is zero): `TEMPORARY_STORE_GAS_NEW` (40,000 gas). No cold/warm surcharge.
+- **Existing slot** (current epoch value is nonzero):
+  - Cold (first access to this slot in the transaction): `COLD_SLOAD_COST` (2,100) + `TEMPORARY_STORE_GAS_EXISTING_COLD` (5,000) = 7,100 gas.
+  - Warm (slot already accessed in this transaction): `TEMPORARY_STORE_GAS_EXISTING_WARM` (200 gas).
+
+A `temporaryStore` to a new slot also marks it as warm for subsequent accesses.
 
 **Output**: Empty (0 bytes). Execution succeeds silently.
 
@@ -119,9 +133,9 @@ Loads the value for the derived slot, checking the current epoch first and falli
 
 **Output**: ABI-encoded `bytes32` (32 bytes).
 
-## Interaction with `temporaryStore` warm/cold tracking
+## Warm/Cold Tracking
 
-A `temporaryStore` to a slot marks that `(current_epoch_index, slot)` as warm for subsequent `temporaryLoad` calls within the same transaction. The store itself always costs a flat 40,000 gas regardless of cold/warm status.
+Both `temporaryStore` and `temporaryLoad` participate in a shared per-transaction access set keyed by `(epoch_index, slot)`. Any access (store or load) to a slot marks it warm. The warm/cold distinction affects gas costs for both functions as described above. A new-slot store (40,000 gas) also marks the slot warm.
 
 ## Epoch Transition
 
@@ -153,5 +167,5 @@ temporaryLoad:  0x<selector> <key:bytes32>                   (4 + 32 = 36 bytes)
 3. **Write-read consistency**: A `temporaryStore(key, value)` followed by `temporaryLoad(key)` in the same transaction MUST return `value`.
 4. **Zero default**: `temporaryLoad` for a key that has never been written (in the current or previous epoch) MUST return `bytes32(0)`.
 5. **Epoch tree pruning safety**: Pruning any epoch tree older than `epoch(block.number) - 1` MUST NOT affect the result of any `temporaryLoad` call.
-6. **Deterministic gas**: `temporaryStore` always costs exactly 40,000 gas. `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
+6. **Deterministic gas**: `temporaryStore` costs 40,000 gas for new slots (zero in current epoch) and follows SSTORE-equivalent hot/cold pricing for existing slots (nonzero in current epoch). A nonzero value in the previous epoch alone does not make the slot "existing". `temporaryLoad` cost depends only on the cold/warm state of the accessed slots within the transaction.
 7. **Overwrite semantics**: A second `temporaryStore(key, value2)` in the same epoch overwrites the previous value. `temporaryLoad(key)` MUST return `value2`.

--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1037
+id: TIP-1040
 title: Epoch-Scoped Temporary Storage Precompile
 description: A precompile providing cheap temporary key-value storage that automatically expires after one to two epochs.
 authors: Dankrad
@@ -8,7 +8,7 @@ related: N/A
 protocolVersion: TBD
 ---
 
-# TIP-1037: Epoch-Scoped Temporary Storage Precompile
+# TIP-1040: Epoch-Scoped Temporary Storage Precompile
 
 ## Abstract
 


### PR DESCRIPTION
Adds TIP-1040: a precompile for epoch-scoped temporary key-value storage. Values are available for 2^16 to 2^17 blocks then automatically expire. Nodes can prune anything older than the previous epoch.

Key design points:
- Epochs are 2^16 blocks. Current + previous epoch storage are live; older epochs are forgotten.
- Storage slot = `keccak256(sender || key)` scoped per `uint16(epoch)` — sender-isolated, no cross-contract collisions.
- New slot store costs 40k gas. Overwriting an existing nonzero slot in the current epoch uses SSTORE-equivalent hot/cold pricing. A value only in the previous epoch still incurs the 40k new-slot cost.
- Load follows EIP-2929 cold/warm model (2,100 / 100 gas), checks current epoch first, falls back to previous.

Prompted by: dankrad