### PR TITLE
refactor(account-keychain): prototype vec-backed scope indexes

### DIFF
--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -45,6 +45,7 @@ pub const MAX_RECIPIENTS_PER_SELECTOR: u8 = 16;
 const TIP20_TRANSFER_SELECTOR: [u8; 4] = ITIP20::transferCall::SELECTOR;
 const TIP20_APPROVE_SELECTOR: [u8; 4] = ITIP20::approveCall::SELECTOR;
 const TIP20_TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = ITIP20::transferWithMemoCall::SELECTOR;
+type SelectorKey = FixedBytes<4>;
 
 #[inline]
 pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
@@ -85,12 +86,12 @@ pub struct SelectorScope {
 /// mode:
 /// - 0 => unset/disabled
 /// - 1 => all selectors allowed
-/// - 2 => only selectors in the set are allowed
+/// - 2 => only selectors in the configured list are allowed
 #[derive(Debug, Clone, Storable, Default)]
 pub struct TargetScope {
     pub mode: u8,
-    pub selectors: Set<FixedBytes<4>>,
-    pub selector_scopes: Mapping<FixedBytes<4>, SelectorScope>,
+    pub selectors: Vec<SelectorKey>,
+    pub selector_scopes: Mapping<SelectorKey, SelectorScope>,
 }
 
 /// Key-level call scope.
@@ -102,7 +103,7 @@ pub struct TargetScope {
 #[derive(Debug, Clone, Storable, Default)]
 pub struct KeyScope {
     pub mode: u8,
-    pub targets: Set<Address>,
+    pub targets: Vec<Address>,
     pub target_scopes: Mapping<Address, TargetScope>,
 }
 
@@ -800,10 +801,11 @@ impl AccountKeychain {
             return Err(AccountKeychainError::call_not_allowed().into());
         }
 
-        let selector = FixedBytes::<4>::from([input[0], input[1], input[2], input[3]]);
+        let selector: SelectorKey = [input[0], input[1], input[2], input[3]].into();
         if !self.key_scopes[key_hash].target_scopes[target]
             .selectors
-            .contains(&selector)?
+            .read()?
+            .contains(&selector)
         {
             return Err(AccountKeychainError::call_not_allowed().into());
         }
@@ -897,9 +899,17 @@ impl AccountKeychain {
     }
 
     fn remove_target_scope(&mut self, account_key: B256, target: Address) -> Result<()> {
-        if !self.key_scopes[account_key].targets.remove(&target)? {
+        if self.key_scopes[account_key].target_scopes[target]
+            .mode
+            .read()?
+            == 0
+        {
             return Ok(());
         }
+
+        let mut targets = self.key_scopes[account_key].targets.read()?;
+        targets.retain(|configured_target| configured_target != &target);
+        self.key_scopes[account_key].targets.write(targets)?;
 
         self.clear_target_selectors(account_key, target)?;
         self.key_scopes[account_key].target_scopes[target]
@@ -938,13 +948,21 @@ impl AccountKeychain {
             self.validate_selector_rules(target, rules)?;
         }
 
-        if !self.key_scopes[account_key].targets.contains(&target)? {
-            let count = self.key_scopes[account_key].targets.len()?;
+        if self.key_scopes[account_key].target_scopes[target]
+            .mode
+            .read()?
+            == 0
+        {
+            let mut targets = self.key_scopes[account_key].targets.read()?;
+            let count = targets.len();
             if count >= MAX_CALL_SCOPES as usize {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            self.key_scopes[account_key].targets.insert(target)?;
+            if !targets.contains(&target) {
+                targets.push(target);
+                self.key_scopes[account_key].targets.write(targets)?;
+            }
         }
 
         self.clear_target_selectors(account_key, target)?;
@@ -961,10 +979,10 @@ impl AccountKeychain {
                     .write(2)?;
 
                 for rule in rules {
-                    let selector = FixedBytes::<4>::from(rule.selector);
+                    let selector: SelectorKey = rule.selector.into();
                     self.key_scopes[account_key].target_scopes[target]
                         .selectors
-                        .insert(selector)?;
+                        .push(selector)?;
 
                     match rule.recipients {
                         None => {

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -953,15 +953,17 @@ impl AccountKeychain {
             .read()?
             == 0
         {
-            let mut targets = self.key_scopes[account_key].targets.read()?;
-            let count = targets.len();
+            let count = self.key_scopes[account_key].targets.len()?;
             if count >= MAX_CALL_SCOPES as usize {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            if !targets.contains(&target) {
-                targets.push(target);
-                self.key_scopes[account_key].targets.write(targets)?;
+            if !self.key_scopes[account_key]
+                .targets
+                .read()?
+                .contains(&target)
+            {
+                self.key_scopes[account_key].targets.push(target)?;
             }
         }
 
@@ -3705,6 +3707,73 @@ mod tests {
                 )
                 .expect_err("unexpected success for wrong selector");
             assert_call_not_allowed(wrong_selector);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_validate_call_scope_rejects_selector_not_listed_in_vec() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let key_id = Address::random();
+        let target = DEFAULT_FEE_TOKEN;
+        let selector = FixedBytes::<4>::from(TIP20_TRANSFER_SELECTOR);
+        let allowed_recipient = Address::repeat_byte(0x44);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let key_hash = AccountKeychain::spending_limit_key(account, key_id);
+            keychain.key_scopes[key_hash].mode.write(1)?;
+            keychain.key_scopes[key_hash].targets.write(vec![target])?;
+            keychain.key_scopes[key_hash].target_scopes[target]
+                .mode
+                .write(2)?;
+            keychain.key_scopes[key_hash].target_scopes[target]
+                .selectors
+                .write(vec![])?;
+            keychain.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
+                .mode
+                .write(2)?;
+            keychain.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
+                .recipients
+                .write(Set::from(vec![allowed_recipient]))?;
+
+            let mut calldata = TIP20_TRANSFER_SELECTOR.to_vec();
+            let mut recipient_word = [0u8; 32];
+            recipient_word[12..].copy_from_slice(allowed_recipient.as_slice());
+            calldata.extend_from_slice(&recipient_word);
+            calldata.extend_from_slice(&[0u8; 32]);
+
+            let err = keychain
+                .validate_call_scope_for_transaction(
+                    account,
+                    key_id,
+                    &TxKind::Call(target),
+                    &calldata,
+                )
+                .expect_err("unexpected success for selector missing from vec index");
+            assert_call_not_allowed(err);
 
             Ok(())
         })

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -45,7 +45,6 @@ pub const MAX_RECIPIENTS_PER_SELECTOR: u8 = 16;
 const TIP20_TRANSFER_SELECTOR: [u8; 4] = ITIP20::transferCall::SELECTOR;
 const TIP20_APPROVE_SELECTOR: [u8; 4] = ITIP20::approveCall::SELECTOR;
 const TIP20_TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = ITIP20::transferWithMemoCall::SELECTOR;
-type SelectorKey = FixedBytes<4>;
 
 #[inline]
 pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
@@ -90,8 +89,8 @@ pub struct SelectorScope {
 #[derive(Debug, Clone, Storable, Default)]
 pub struct TargetScope {
     pub mode: u8,
-    pub selectors: Vec<SelectorKey>,
-    pub selector_scopes: Mapping<SelectorKey, SelectorScope>,
+    pub selectors: Vec<FixedBytes<4>>,
+    pub selector_scopes: Mapping<FixedBytes<4>, SelectorScope>,
 }
 
 /// Key-level call scope.
@@ -271,7 +270,7 @@ impl AccountKeychain {
         &self,
         account_key: B256,
         target: Address,
-        selector: SelectorKey,
+        selector: FixedBytes<4>,
     ) -> Result<u8> {
         if !self.key_scopes[account_key].target_scopes[target]
             .selectors
@@ -304,7 +303,7 @@ impl AccountKeychain {
         &mut self,
         account_key: B256,
         target: Address,
-        selector: SelectorKey,
+        selector: FixedBytes<4>,
     ) -> Result<()> {
         if !self.key_scopes[account_key].target_scopes[target]
             .selectors
@@ -867,7 +866,7 @@ impl AccountKeychain {
             return Err(AccountKeychainError::call_not_allowed().into());
         }
 
-        let selector: SelectorKey = [input[0], input[1], input[2], input[3]].into();
+        let selector: FixedBytes<4> = [input[0], input[1], input[2], input[3]].into();
         let selector_mode = self.indexed_selector_mode(key_hash, target, selector)?;
         if selector_mode == 1 {
             return Ok(());
@@ -1030,7 +1029,7 @@ impl AccountKeychain {
                     .write(2)?;
 
                 for rule in rules {
-                    let selector: SelectorKey = rule.selector.into();
+                    let selector: FixedBytes<4> = rule.selector.into();
                     self.push_unique_selector(account_key, target, selector)?;
 
                     match rule.recipients {

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -28,7 +28,7 @@ pub use tempo_contracts::precompiles::{
 use crate::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     error::Result,
-    storage::{Handler, Mapping, Set, packing::insert_into_word},
+    storage::{EnumerableMap, Handler, Mapping, Set, packing::insert_into_word},
     tip20_factory::TIP20Factory,
 };
 use alloy::primitives::{Address, B256, FixedBytes, TxKind, U256, keccak256};
@@ -89,8 +89,7 @@ pub struct SelectorScope {
 #[derive(Debug, Clone, Storable, Default)]
 pub struct TargetScope {
     pub mode: u8,
-    pub selectors: Vec<FixedBytes<4>>,
-    pub selector_scopes: Mapping<FixedBytes<4>, SelectorScope>,
+    pub selectors: EnumerableMap<FixedBytes<4>, SelectorScope>,
 }
 
 /// Key-level call scope.
@@ -102,8 +101,7 @@ pub struct TargetScope {
 #[derive(Debug, Clone, Storable, Default)]
 pub struct KeyScope {
     pub mode: u8,
-    pub targets: Vec<Address>,
-    pub target_scopes: Mapping<Address, TargetScope>,
+    pub targets: EnumerableMap<Address, TargetScope>,
 }
 
 /// Key information stored in the precompile
@@ -248,42 +246,6 @@ impl AccountKeychain {
         }
 
         Ok(limit.to::<u128>())
-    }
-
-    #[inline]
-    fn ensure_target_indexed(&mut self, account_key: B256, target: Address) -> Result<()> {
-        if !self.key_scopes[account_key].targets.read()?.contains(&target) {
-            self.key_scopes[account_key].targets.push(target)?;
-        }
-
-        Ok(())
-    }
-
-    #[inline]
-    fn remove_target_index(&mut self, account_key: B256, target: Address) -> Result<()> {
-        let mut targets = self.key_scopes[account_key].targets.read()?;
-        targets.retain(|configured_target| configured_target != &target);
-        self.key_scopes[account_key].targets.write(targets)
-    }
-
-    #[inline]
-    fn ensure_selector_indexed(
-        &mut self,
-        account_key: B256,
-        target: Address,
-        selector: FixedBytes<4>,
-    ) -> Result<()> {
-        if !self.key_scopes[account_key].target_scopes[target]
-            .selectors
-            .read()?
-            .contains(&selector)
-        {
-            self.key_scopes[account_key].target_scopes[target]
-                .selectors
-                .push(selector)?;
-        }
-
-        Ok(())
     }
 
     /// Initializes the account keychain precompile.
@@ -653,7 +615,7 @@ impl AccountKeychain {
             }]);
         }
 
-        let targets = self.key_scopes[key_hash].targets.read()?;
+        let targets = self.key_scopes[key_hash].targets.keys()?;
         if targets.is_empty() {
             return Ok(vec![CallScope {
                 target: Address::ZERO,
@@ -664,9 +626,7 @@ impl AccountKeychain {
 
         let mut scopes = Vec::new();
         for target in targets {
-            let target_mode = self.key_scopes[key_hash].target_scopes[target]
-                .mode
-                .read()?;
+            let target_mode = self.key_scopes[key_hash].targets[target].mode.read()?;
 
             let scope = match target_mode {
                 1 => CallScope {
@@ -676,22 +636,19 @@ impl AccountKeychain {
                 },
                 2 => {
                     let mut rules = Vec::new();
-                    let selectors = self.key_scopes[key_hash].target_scopes[target]
-                        .selectors
-                        .read()?;
+                    let selectors = self.key_scopes[key_hash].targets[target].selectors.keys()?;
                     for selector in selectors {
-                        let selector_mode = self.key_scopes[key_hash].target_scopes[target]
-                            .selector_scopes[selector]
+                        let selector_mode = self.key_scopes[key_hash].targets[target].selectors
+                            [selector]
                             .mode
                             .read()?;
 
                         let recipients = if selector_mode == 2 {
-                            let recipients: Vec<Address> = self.key_scopes[key_hash].target_scopes
-                                [target]
-                                .selector_scopes[selector]
-                                .recipients
-                                .read()?
-                                .into();
+                            let recipients: Vec<Address> =
+                                self.key_scopes[key_hash].targets[target].selectors[selector]
+                                    .recipients
+                                    .read()?
+                                    .into();
                             recipients
                         } else if selector_mode == 1 {
                             Vec::new()
@@ -821,7 +778,7 @@ impl AccountKeychain {
             TxKind::Create => return Err(AccountKeychainError::call_not_allowed().into()),
         };
 
-        let target_mode = self.key_scopes[key_hash].target_scopes[target].mode.read()?;
+        let target_mode = self.key_scopes[key_hash].targets[target].mode.read()?;
         if target_mode == 1 {
             return Ok(());
         }
@@ -835,8 +792,7 @@ impl AccountKeychain {
         }
 
         let selector: FixedBytes<4> = [input[0], input[1], input[2], input[3]].into();
-        let selector_mode = self.key_scopes[key_hash].target_scopes[target].selector_scopes
-            [selector]
+        let selector_mode = self.key_scopes[key_hash].targets[target].selectors[selector]
             .mode
             .read()?;
         if selector_mode == 1 {
@@ -856,7 +812,7 @@ impl AccountKeychain {
         }
 
         let recipient = Address::from_slice(&recipient_word[12..]);
-        if self.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
+        if self.key_scopes[key_hash].targets[target].selectors[selector]
             .recipients
             .contains(&recipient)?
         {
@@ -916,7 +872,7 @@ impl AccountKeychain {
     }
 
     fn clear_all_target_scopes(&mut self, account_key: B256) -> Result<()> {
-        let targets = self.key_scopes[account_key].targets.read()?;
+        let targets = self.key_scopes[account_key].targets.keys()?;
         for target in targets {
             self.remove_target_scope(account_key, target)?;
         }
@@ -925,38 +881,32 @@ impl AccountKeychain {
     }
 
     fn remove_target_scope(&mut self, account_key: B256, target: Address) -> Result<()> {
-        if self.key_scopes[account_key].target_scopes[target]
-            .mode
-            .read()?
-            == 0
-        {
+        if self.key_scopes[account_key].targets[target].mode.read()? == 0 {
             return Ok(());
         }
 
-        self.remove_target_index(account_key, target)?;
-
         self.clear_target_selectors(account_key, target)?;
-        self.key_scopes[account_key].target_scopes[target]
-            .mode
-            .write(0)
+        self.key_scopes[account_key].targets[target].mode.write(0)?;
+        self.key_scopes[account_key].targets.remove_key(&target)?;
+        Ok(())
     }
 
     fn clear_target_selectors(&mut self, account_key: B256, target: Address) -> Result<()> {
-        let selectors = self.key_scopes[account_key].target_scopes[target]
+        let selectors = self.key_scopes[account_key].targets[target]
             .selectors
-            .read()?;
+            .keys()?;
         for selector in selectors {
-            self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
+            self.key_scopes[account_key].targets[target].selectors[selector]
                 .recipients
                 .delete()?;
-            self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
+            self.key_scopes[account_key].targets[target].selectors[selector]
                 .mode
                 .write(0)?;
         }
 
-        self.key_scopes[account_key].target_scopes[target]
+        self.key_scopes[account_key].targets[target]
             .selectors
-            .delete()
+            .clear_keys()
     }
 
     fn upsert_target_scope(
@@ -972,54 +922,49 @@ impl AccountKeychain {
             self.validate_selector_rules(target, rules)?;
         }
 
-        if self.key_scopes[account_key].target_scopes[target]
-            .mode
-            .read()?
-            == 0
+        if !self.key_scopes[account_key]
+            .targets
+            .contains_mapped(&target, |scope| scope.mode.read().map(|mode| mode != 0))?
         {
             let count = self.key_scopes[account_key].targets.len()?;
             if count >= MAX_CALL_SCOPES as usize {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            self.ensure_target_indexed(account_key, target)?;
+            self.key_scopes[account_key]
+                .targets
+                .insert_key_unchecked(target)?;
         }
 
         self.clear_target_selectors(account_key, target)?;
 
         match selector_rules {
             None => {
-                self.key_scopes[account_key].target_scopes[target]
-                    .mode
-                    .write(1)?;
+                self.key_scopes[account_key].targets[target].mode.write(1)?;
             }
             Some(rules) => {
-                self.key_scopes[account_key].target_scopes[target]
-                    .mode
-                    .write(2)?;
+                self.key_scopes[account_key].targets[target].mode.write(2)?;
 
                 for rule in rules {
                     let selector: FixedBytes<4> = rule.selector.into();
-                    self.ensure_selector_indexed(account_key, target, selector)?;
+                    self.key_scopes[account_key].targets[target]
+                        .selectors
+                        .insert_key_unchecked(selector)?;
 
                     match rule.recipients {
                         None => {
-                            self.key_scopes[account_key].target_scopes[target].selector_scopes
-                                [selector]
+                            self.key_scopes[account_key].targets[target].selectors[selector]
                                 .mode
                                 .write(1)?;
-                            self.key_scopes[account_key].target_scopes[target].selector_scopes
-                                [selector]
+                            self.key_scopes[account_key].targets[target].selectors[selector]
                                 .recipients
                                 .delete()?;
                         }
                         Some(recipients) => {
-                            self.key_scopes[account_key].target_scopes[target].selector_scopes
-                                [selector]
+                            self.key_scopes[account_key].targets[target].selectors[selector]
                                 .mode
                                 .write(2)?;
-                            self.key_scopes[account_key].target_scopes[target].selector_scopes
-                                [selector]
+                            self.key_scopes[account_key].targets[target].selectors[selector]
                                 .recipients
                                 .write(Set::from(recipients))?;
                         }

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -251,6 +251,74 @@ impl AccountKeychain {
         Ok(limit.to::<u128>())
     }
 
+    #[inline]
+    fn indexed_target_mode(&self, account_key: B256, target: Address) -> Result<u8> {
+        if !self.key_scopes[account_key]
+            .targets
+            .read()?
+            .contains(&target)
+        {
+            return Ok(0);
+        }
+
+        self.key_scopes[account_key].target_scopes[target]
+            .mode
+            .read()
+    }
+
+    #[inline]
+    fn indexed_selector_mode(
+        &self,
+        account_key: B256,
+        target: Address,
+        selector: SelectorKey,
+    ) -> Result<u8> {
+        if !self.key_scopes[account_key].target_scopes[target]
+            .selectors
+            .read()?
+            .contains(&selector)
+        {
+            return Ok(0);
+        }
+
+        self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
+            .mode
+            .read()
+    }
+
+    #[inline]
+    fn push_unique_target(&mut self, account_key: B256, target: Address) -> Result<()> {
+        if !self.key_scopes[account_key]
+            .targets
+            .read()?
+            .contains(&target)
+        {
+            self.key_scopes[account_key].targets.push(target)?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn push_unique_selector(
+        &mut self,
+        account_key: B256,
+        target: Address,
+        selector: SelectorKey,
+    ) -> Result<()> {
+        if !self.key_scopes[account_key].target_scopes[target]
+            .selectors
+            .read()?
+            .contains(&selector)
+        {
+            self.key_scopes[account_key].target_scopes[target]
+                .selectors
+                .push(selector)?;
+        }
+
+        Ok(())
+    }
+
     /// Initializes the account keychain precompile.
     pub fn initialize(&mut self) -> Result<()> {
         self.__initialize()
@@ -786,9 +854,7 @@ impl AccountKeychain {
             TxKind::Create => return Err(AccountKeychainError::call_not_allowed().into()),
         };
 
-        let target_mode = self.key_scopes[key_hash].target_scopes[target]
-            .mode
-            .read()?;
+        let target_mode = self.indexed_target_mode(key_hash, target)?;
         if target_mode == 1 {
             return Ok(());
         }
@@ -802,18 +868,7 @@ impl AccountKeychain {
         }
 
         let selector: SelectorKey = [input[0], input[1], input[2], input[3]].into();
-        if !self.key_scopes[key_hash].target_scopes[target]
-            .selectors
-            .read()?
-            .contains(&selector)
-        {
-            return Err(AccountKeychainError::call_not_allowed().into());
-        }
-
-        let selector_mode = self.key_scopes[key_hash].target_scopes[target].selector_scopes
-            [selector]
-            .mode
-            .read()?;
+        let selector_mode = self.indexed_selector_mode(key_hash, target, selector)?;
         if selector_mode == 1 {
             return Ok(());
         }
@@ -848,8 +903,8 @@ impl AccountKeychain {
     ) -> Result<()> {
         // Fresh authorizations should not have any pre-existing call-scope rows because
         // `authorize_key` rejects both existing and previously revoked keys before reaching this
-        // path. We still clear the scope tree first as a defense-in-depth measure against stale or
-        // out-of-band state, and keep it because the valid-path cost is low (empty target set).
+        // path. We still clear the indexed scope tree first as a defense-in-depth measure against
+        // stale state. Off-index rows are inert because validation fails closed on vec membership.
         self.clear_all_target_scopes(account_key)?;
 
         match allowed_calls {
@@ -958,13 +1013,7 @@ impl AccountKeychain {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            if !self.key_scopes[account_key]
-                .targets
-                .read()?
-                .contains(&target)
-            {
-                self.key_scopes[account_key].targets.push(target)?;
-            }
+            self.push_unique_target(account_key, target)?;
         }
 
         self.clear_target_selectors(account_key, target)?;
@@ -982,9 +1031,7 @@ impl AccountKeychain {
 
                 for rule in rules {
                     let selector: SelectorKey = rule.selector.into();
-                    self.key_scopes[account_key].target_scopes[target]
-                        .selectors
-                        .push(selector)?;
+                    self.push_unique_selector(account_key, target, selector)?;
 
                     match rule.recipients {
                         None => {
@@ -3773,6 +3820,51 @@ mod tests {
                     &calldata,
                 )
                 .expect_err("unexpected success for selector missing from vec index");
+            assert_call_not_allowed(err);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_validate_call_scope_rejects_target_not_listed_in_vec() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let key_id = Address::random();
+        let target = DEFAULT_FEE_TOKEN;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let key_hash = AccountKeychain::spending_limit_key(account, key_id);
+            keychain.key_scopes[key_hash].mode.write(1)?;
+            keychain.key_scopes[key_hash].targets.write(vec![])?;
+            keychain.key_scopes[key_hash].target_scopes[target]
+                .mode
+                .write(1)?;
+
+            let err = keychain
+                .validate_call_scope_for_transaction(account, key_id, &TxKind::Call(target), &[])
+                .expect_err("unexpected success for target missing from vec index");
             assert_call_not_allowed(err);
 
             Ok(())

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -250,6 +250,42 @@ impl AccountKeychain {
         Ok(limit.to::<u128>())
     }
 
+    #[inline]
+    fn ensure_target_indexed(&mut self, account_key: B256, target: Address) -> Result<()> {
+        if !self.key_scopes[account_key].targets.read()?.contains(&target) {
+            self.key_scopes[account_key].targets.push(target)?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn remove_target_index(&mut self, account_key: B256, target: Address) -> Result<()> {
+        let mut targets = self.key_scopes[account_key].targets.read()?;
+        targets.retain(|configured_target| configured_target != &target);
+        self.key_scopes[account_key].targets.write(targets)
+    }
+
+    #[inline]
+    fn ensure_selector_indexed(
+        &mut self,
+        account_key: B256,
+        target: Address,
+        selector: FixedBytes<4>,
+    ) -> Result<()> {
+        if !self.key_scopes[account_key].target_scopes[target]
+            .selectors
+            .read()?
+            .contains(&selector)
+        {
+            self.key_scopes[account_key].target_scopes[target]
+                .selectors
+                .push(selector)?;
+        }
+
+        Ok(())
+    }
+
     /// Initializes the account keychain precompile.
     pub fn initialize(&mut self) -> Result<()> {
         self.__initialize()
@@ -785,11 +821,7 @@ impl AccountKeychain {
             TxKind::Create => return Err(AccountKeychainError::call_not_allowed().into()),
         };
 
-        let target_mode = if !self.key_scopes[key_hash].targets.read()?.contains(&target) {
-            0
-        } else {
-            self.key_scopes[key_hash].target_scopes[target].mode.read()?
-        };
+        let target_mode = self.key_scopes[key_hash].target_scopes[target].mode.read()?;
         if target_mode == 1 {
             return Ok(());
         }
@@ -803,17 +835,10 @@ impl AccountKeychain {
         }
 
         let selector: FixedBytes<4> = [input[0], input[1], input[2], input[3]].into();
-        let selector_mode = if !self.key_scopes[key_hash].target_scopes[target]
-            .selectors
-            .read()?
-            .contains(&selector)
-        {
-            0
-        } else {
-            self.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
-                .mode
-                .read()?
-        };
+        let selector_mode = self.key_scopes[key_hash].target_scopes[target].selector_scopes
+            [selector]
+            .mode
+            .read()?;
         if selector_mode == 1 {
             return Ok(());
         }
@@ -849,7 +874,8 @@ impl AccountKeychain {
         // Fresh authorizations should not have any pre-existing call-scope rows because
         // `authorize_key` rejects both existing and previously revoked keys before reaching this
         // path. We still clear the indexed scope tree first as a defense-in-depth measure against
-        // stale state. Off-index rows are inert because validation fails closed on vec membership.
+        // stale state. Mapping rows are the internal source of truth; vec indexes are maintained
+        // by mutator paths so externally enumerated scopes remain correct.
         self.clear_all_target_scopes(account_key)?;
 
         match allowed_calls {
@@ -907,9 +933,7 @@ impl AccountKeychain {
             return Ok(());
         }
 
-        let mut targets = self.key_scopes[account_key].targets.read()?;
-        targets.retain(|configured_target| configured_target != &target);
-        self.key_scopes[account_key].targets.write(targets)?;
+        self.remove_target_index(account_key, target)?;
 
         self.clear_target_selectors(account_key, target)?;
         self.key_scopes[account_key].target_scopes[target]
@@ -958,9 +982,7 @@ impl AccountKeychain {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            if !self.key_scopes[account_key].targets.read()?.contains(&target) {
-                self.key_scopes[account_key].targets.push(target)?;
-            }
+            self.ensure_target_indexed(account_key, target)?;
         }
 
         self.clear_target_selectors(account_key, target)?;
@@ -978,15 +1000,7 @@ impl AccountKeychain {
 
                 for rule in rules {
                     let selector: FixedBytes<4> = rule.selector.into();
-                    if !self.key_scopes[account_key].target_scopes[target]
-                        .selectors
-                        .read()?
-                        .contains(&selector)
-                    {
-                        self.key_scopes[account_key].target_scopes[target]
-                            .selectors
-                            .push(selector)?;
-                    }
+                    self.ensure_selector_indexed(account_key, target, selector)?;
 
                     match rule.recipients {
                         None => {
@@ -3574,6 +3588,69 @@ mod tests {
     }
 
     #[test]
+    fn test_t3_set_allowed_calls_replaces_selector_index_without_duplicates() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let key_id = Address::random();
+        let target = DEFAULT_FEE_TOKEN;
+        let first_selector = TIP20_TRANSFER_SELECTOR;
+        let second_selector = TIP20_APPROVE_SELECTOR;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let set_scope = |keychain: &mut AccountKeychain, selector: [u8; 4]| {
+                keychain.set_allowed_calls(
+                    account,
+                    setAllowedCallsCall {
+                        keyId: key_id,
+                        scope: CallScope {
+                            target,
+                            allowAllSelectors: false,
+                            selectorRules: vec![SelectorRule {
+                                selector: selector.into(),
+                                recipients: vec![],
+                            }],
+                        },
+                    },
+                )
+            };
+
+            set_scope(&mut keychain, first_selector)?;
+            set_scope(&mut keychain, second_selector)?;
+
+            let scopes = keychain.get_allowed_calls(getAllowedCallsCall {
+                account,
+                keyId: key_id,
+            })?;
+            assert_eq!(scopes.len(), 1);
+            assert_eq!(scopes[0].target, target);
+            assert_eq!(scopes[0].selectorRules.len(), 1);
+            assert_eq!(*scopes[0].selectorRules[0].selector, second_selector);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_t3_set_allowed_calls_allow_all_selectors_ignores_selector_rules() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         let account = Address::random();
@@ -3709,118 +3786,6 @@ mod tests {
                 )
                 .expect_err("unexpected success for wrong selector");
             assert_call_not_allowed(wrong_selector);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_t3_validate_call_scope_rejects_selector_not_listed_in_vec() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        let account = Address::random();
-        let key_id = Address::random();
-        let target = DEFAULT_FEE_TOKEN;
-        let selector = FixedBytes::<4>::from(TIP20_TRANSFER_SELECTOR);
-        let allowed_recipient = Address::repeat_byte(0x44);
-
-        StorageCtx::enter(&mut storage, || {
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_transaction_key(Address::ZERO)?;
-            keychain.set_tx_origin(account)?;
-            TIP20Setup::path_usd(account).apply()?;
-
-            keychain.authorize_key(
-                account,
-                authorizeKeyCall {
-                    keyId: key_id,
-                    signatureType: SignatureType::Secp256k1,
-                    config: KeyRestrictions {
-                        expiry: u64::MAX,
-                        enforceLimits: false,
-                        limits: vec![],
-                        enforceAllowedCalls: false,
-                        allowedCalls: vec![],
-                    },
-                },
-            )?;
-
-            let key_hash = AccountKeychain::spending_limit_key(account, key_id);
-            keychain.key_scopes[key_hash].mode.write(1)?;
-            keychain.key_scopes[key_hash].targets.write(vec![target])?;
-            keychain.key_scopes[key_hash].target_scopes[target]
-                .mode
-                .write(2)?;
-            keychain.key_scopes[key_hash].target_scopes[target]
-                .selectors
-                .write(vec![])?;
-            keychain.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
-                .mode
-                .write(2)?;
-            keychain.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
-                .recipients
-                .write(Set::from(vec![allowed_recipient]))?;
-
-            let mut calldata = TIP20_TRANSFER_SELECTOR.to_vec();
-            let mut recipient_word = [0u8; 32];
-            recipient_word[12..].copy_from_slice(allowed_recipient.as_slice());
-            calldata.extend_from_slice(&recipient_word);
-            calldata.extend_from_slice(&[0u8; 32]);
-
-            let err = keychain
-                .validate_call_scope_for_transaction(
-                    account,
-                    key_id,
-                    &TxKind::Call(target),
-                    &calldata,
-                )
-                .expect_err("unexpected success for selector missing from vec index");
-            assert_call_not_allowed(err);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_t3_validate_call_scope_rejects_target_not_listed_in_vec() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        let account = Address::random();
-        let key_id = Address::random();
-        let target = DEFAULT_FEE_TOKEN;
-
-        StorageCtx::enter(&mut storage, || {
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_transaction_key(Address::ZERO)?;
-            keychain.set_tx_origin(account)?;
-            TIP20Setup::path_usd(account).apply()?;
-
-            keychain.authorize_key(
-                account,
-                authorizeKeyCall {
-                    keyId: key_id,
-                    signatureType: SignatureType::Secp256k1,
-                    config: KeyRestrictions {
-                        expiry: u64::MAX,
-                        enforceLimits: false,
-                        limits: vec![],
-                        enforceAllowedCalls: false,
-                        allowedCalls: vec![],
-                    },
-                },
-            )?;
-
-            let key_hash = AccountKeychain::spending_limit_key(account, key_id);
-            keychain.key_scopes[key_hash].mode.write(1)?;
-            keychain.key_scopes[key_hash].targets.write(vec![])?;
-            keychain.key_scopes[key_hash].target_scopes[target]
-                .mode
-                .write(1)?;
-
-            let err = keychain
-                .validate_call_scope_for_transaction(account, key_id, &TxKind::Call(target), &[])
-                .expect_err("unexpected success for target missing from vec index");
-            assert_call_not_allowed(err);
 
             Ok(())
         })

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -250,74 +250,6 @@ impl AccountKeychain {
         Ok(limit.to::<u128>())
     }
 
-    #[inline]
-    fn indexed_target_mode(&self, account_key: B256, target: Address) -> Result<u8> {
-        if !self.key_scopes[account_key]
-            .targets
-            .read()?
-            .contains(&target)
-        {
-            return Ok(0);
-        }
-
-        self.key_scopes[account_key].target_scopes[target]
-            .mode
-            .read()
-    }
-
-    #[inline]
-    fn indexed_selector_mode(
-        &self,
-        account_key: B256,
-        target: Address,
-        selector: FixedBytes<4>,
-    ) -> Result<u8> {
-        if !self.key_scopes[account_key].target_scopes[target]
-            .selectors
-            .read()?
-            .contains(&selector)
-        {
-            return Ok(0);
-        }
-
-        self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
-            .mode
-            .read()
-    }
-
-    #[inline]
-    fn push_unique_target(&mut self, account_key: B256, target: Address) -> Result<()> {
-        if !self.key_scopes[account_key]
-            .targets
-            .read()?
-            .contains(&target)
-        {
-            self.key_scopes[account_key].targets.push(target)?;
-        }
-
-        Ok(())
-    }
-
-    #[inline]
-    fn push_unique_selector(
-        &mut self,
-        account_key: B256,
-        target: Address,
-        selector: FixedBytes<4>,
-    ) -> Result<()> {
-        if !self.key_scopes[account_key].target_scopes[target]
-            .selectors
-            .read()?
-            .contains(&selector)
-        {
-            self.key_scopes[account_key].target_scopes[target]
-                .selectors
-                .push(selector)?;
-        }
-
-        Ok(())
-    }
-
     /// Initializes the account keychain precompile.
     pub fn initialize(&mut self) -> Result<()> {
         self.__initialize()
@@ -853,7 +785,11 @@ impl AccountKeychain {
             TxKind::Create => return Err(AccountKeychainError::call_not_allowed().into()),
         };
 
-        let target_mode = self.indexed_target_mode(key_hash, target)?;
+        let target_mode = if !self.key_scopes[key_hash].targets.read()?.contains(&target) {
+            0
+        } else {
+            self.key_scopes[key_hash].target_scopes[target].mode.read()?
+        };
         if target_mode == 1 {
             return Ok(());
         }
@@ -867,7 +803,17 @@ impl AccountKeychain {
         }
 
         let selector: FixedBytes<4> = [input[0], input[1], input[2], input[3]].into();
-        let selector_mode = self.indexed_selector_mode(key_hash, target, selector)?;
+        let selector_mode = if !self.key_scopes[key_hash].target_scopes[target]
+            .selectors
+            .read()?
+            .contains(&selector)
+        {
+            0
+        } else {
+            self.key_scopes[key_hash].target_scopes[target].selector_scopes[selector]
+                .mode
+                .read()?
+        };
         if selector_mode == 1 {
             return Ok(());
         }
@@ -1012,7 +958,9 @@ impl AccountKeychain {
                 return Err(AccountKeychainError::scope_limit_exceeded().into());
             }
 
-            self.push_unique_target(account_key, target)?;
+            if !self.key_scopes[account_key].targets.read()?.contains(&target) {
+                self.key_scopes[account_key].targets.push(target)?;
+            }
         }
 
         self.clear_target_selectors(account_key, target)?;
@@ -1030,7 +978,15 @@ impl AccountKeychain {
 
                 for rule in rules {
                     let selector: FixedBytes<4> = rule.selector.into();
-                    self.push_unique_selector(account_key, target, selector)?;
+                    if !self.key_scopes[account_key].target_scopes[target]
+                        .selectors
+                        .read()?
+                        .contains(&selector)
+                    {
+                        self.key_scopes[account_key].target_scopes[target]
+                            .selectors
+                            .push(selector)?;
+                    }
 
                     match rule.recipients {
                         None => {

--- a/crates/precompiles/src/storage/types/enumerable_map.rs
+++ b/crates/precompiles/src/storage/types/enumerable_map.rs
@@ -277,9 +277,23 @@ where
 mod tests {
     use super::*;
     use crate::{
-        storage::{Handler, StorageCtx},
+        storage::{Handler, LayoutCtx, StorableType, StorageCtx},
         test_util::setup_storage,
     };
+    use tempo_precompiles_macros::Storable;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Storable)]
+    struct TestScope {
+        mode: u8,
+        payload: u64,
+    }
+
+    #[derive(Debug, Clone, Storable, Default)]
+    struct TestContainer {
+        marker: u8,
+        entries: EnumerableMap<Address, TestScope>,
+        tail: u8,
+    }
 
     #[test]
     fn test_enumerable_map_key_index_preserves_order_and_uniqueness() {
@@ -336,6 +350,56 @@ mod tests {
 
             map[key].write(0)?;
             assert!(!map.contains_mapped(&key, |value| value.read().map(|mode| mode != 0))?);
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_enumerable_map_embedded_layout_and_persistence() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, || -> Result<()> {
+            let first = Address::repeat_byte(0x55);
+            let second = Address::repeat_byte(0x66);
+
+            let mut container = TestContainer::handle(U256::ZERO, LayoutCtx::FULL, address);
+
+            assert_eq!(container.marker.slot(), U256::ZERO);
+            assert_eq!(container.entries.base_slot(), U256::ONE);
+            assert_eq!(container.tail.slot(), U256::from(3));
+
+            container.marker.write(9)?;
+            container.tail.write(7)?;
+
+            container.entries.insert_key_unchecked(first)?;
+            container.entries[first].mode.write(2)?;
+            container.entries[first].payload.write(11)?;
+
+            container.entries.insert_key_unchecked(second)?;
+            container.entries[second].mode.write(1)?;
+            container.entries[second].payload.write(22)?;
+
+            let container = TestContainer::handle(U256::ZERO, LayoutCtx::FULL, address);
+            assert_eq!(container.marker.read()?, 9);
+            assert_eq!(container.tail.read()?, 7);
+            assert_eq!(container.entries.keys()?, vec![first, second]);
+            assert!(
+                container
+                    .entries
+                    .contains_mapped(&first, |scope| { scope.mode.read().map(|mode| mode != 0) })?
+            );
+            assert_eq!(container.entries[first].payload.read()?, 11);
+            assert_eq!(container.entries[second].payload.read()?, 22);
+
+            let mut container = TestContainer::handle(U256::ZERO, LayoutCtx::FULL, address);
+            assert!(container.entries.remove_key(&first)?);
+
+            let container = TestContainer::handle(U256::ZERO, LayoutCtx::FULL, address);
+            assert_eq!(container.entries.keys()?, vec![second]);
+            assert_eq!(container.entries[first].payload.read()?, 11);
+            assert_eq!(container.marker.read()?, 9);
+            assert_eq!(container.tail.read()?, 7);
 
             Ok(())
         })

--- a/crates/precompiles/src/storage/types/enumerable_map.rs
+++ b/crates/precompiles/src/storage/types/enumerable_map.rs
@@ -1,0 +1,344 @@
+//! Minimal enumerable map for EVM storage.
+//!
+//! This stores an authoritative `Mapping<K, V>` alongside a `Vec<K>` index used only for
+//! enumeration and bounded cleanup. It deliberately does not maintain an auxiliary positions
+//! mapping, so insert/remove on the key index are O(n) scans over the key list.
+//!
+//! # Storage Layout
+//!
+//! EnumerableMap uses two storage structures:
+//! - **Keys Vec**: a `Vec<K>` storing the enumerated keys at `base_slot`
+//! - **Values Mapping**: a `Mapping<K, V>` at `base_slot + 1`
+//!
+//! # Design
+//!
+//! - Reads on hot paths should go through the mapping, e.g. `map[key].field.read()?`
+//! - The key vector is only for cold-path enumeration and cleanup
+//! - Mutations to mapped values and the key index are intentionally separate so callers can
+//!   decide how liveness is represented in `V`
+
+use alloy::primitives::{Address, U256};
+use std::{
+    fmt,
+    hash::Hash,
+    ops::{Index, IndexMut},
+};
+
+use crate::{
+    error::{Result, TempoPrecompileError},
+    storage::{
+        Handler, Layout, LayoutCtx, Mapping, Storable, StorableType, StorageKey, vec::VecHandler,
+    },
+};
+
+/// Enumerable map storage primitive backed by `Vec<K> + Mapping<K, V>`.
+pub struct EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    keys: VecHandler<K>,
+    values: Mapping<K, V>,
+    base_slot: U256,
+    address: Address,
+}
+
+impl<K, V> EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    /// Creates a new enumerable map handler for the given base slot.
+    #[inline]
+    pub fn new(base_slot: U256, address: Address) -> Self {
+        Self {
+            keys: VecHandler::new(base_slot, address),
+            values: Mapping::new(base_slot + U256::ONE, address),
+            base_slot,
+            address,
+        }
+    }
+
+    /// Returns the base storage slot for this map.
+    #[inline]
+    pub fn base_slot(&self) -> U256 {
+        self.base_slot
+    }
+
+    /// Returns the number of enumerated keys.
+    #[inline]
+    pub fn len(&self) -> Result<usize> {
+        self.keys.len()
+    }
+
+    /// Returns whether the enumerated key index is empty.
+    #[inline]
+    pub fn is_empty(&self) -> Result<bool> {
+        self.keys.is_empty()
+    }
+
+    /// Returns the enumerated keys in insertion order.
+    #[inline]
+    pub fn keys(&self) -> Result<Vec<K>> {
+        self.keys.read()
+    }
+
+    /// Returns true if the key exists in the enumerable index.
+    #[inline]
+    pub fn contains_key(&self, key: &K) -> Result<bool> {
+        Ok(self.keys()?.contains(key))
+    }
+
+    /// Returns whether the mapped value for `key` should be considered present.
+    ///
+    /// This is for value types that encode liveness in the mapped payload itself,
+    /// e.g. a `mode` field where `0` means absent and non-zero means present.
+    /// The enumerable key index is not consulted.
+    #[inline]
+    pub fn contains_mapped<F>(&self, key: &K, is_present: F) -> Result<bool>
+    where
+        F: FnOnce(&V::Handler) -> Result<bool>,
+    {
+        is_present(self.at(key))
+    }
+
+    /// Adds a key to the enumerable index if it is not already present.
+    ///
+    /// Returns `true` when the key was inserted into the index.
+    #[inline]
+    pub fn insert_key(&mut self, key: K) -> Result<bool>
+    where
+        K::Handler: Handler<K>,
+    {
+        if self.contains_key(&key)? {
+            return Ok(false);
+        }
+
+        self.keys.push(key)?;
+        Ok(true)
+    }
+
+    /// Appends a key to the enumerable index without checking for duplicates.
+    ///
+    /// Callers must only use this after proving absence from the authoritative
+    /// mapping or otherwise guaranteeing uniqueness.
+    #[inline]
+    pub fn insert_key_unchecked(&self, key: K) -> Result<()>
+    where
+        K::Handler: Handler<K>,
+    {
+        self.keys.push(key)
+    }
+
+    /// Removes a key from the enumerable index.
+    ///
+    /// This only updates the key index. Callers remain responsible for clearing any mapped value.
+    #[inline]
+    pub fn remove_key(&mut self, key: &K) -> Result<bool> {
+        let mut keys = self.keys()?;
+        let original_len = keys.len();
+        keys.retain(|existing| existing != key);
+
+        if keys.len() == original_len {
+            return Ok(false);
+        }
+
+        self.keys.write(keys)?;
+        Ok(true)
+    }
+
+    /// Clears the enumerable key index without touching mapped values.
+    #[inline]
+    pub fn clear_keys(&mut self) -> Result<()> {
+        self.keys.delete()
+    }
+
+    /// Returns the value handler for the given key.
+    #[inline]
+    pub fn at(&self, key: &K) -> &V::Handler {
+        self.values.at(key)
+    }
+
+    /// Returns the mutable value handler for the given key.
+    #[inline]
+    pub fn at_mut(&mut self, key: &K) -> &mut V::Handler {
+        self.values.at_mut(key)
+    }
+}
+
+impl<K, V> Default for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    fn default() -> Self {
+        Self::new(U256::ZERO, Address::ZERO)
+    }
+}
+
+impl<K, V> Storable for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    fn load<S: crate::storage::StorageOps>(
+        _storage: &S,
+        _slot: U256,
+        _ctx: LayoutCtx,
+    ) -> Result<Self> {
+        Err(TempoPrecompileError::Fatal(
+            "EnumerableMap must be accessed through its generated handler".into(),
+        ))
+    }
+
+    fn store<S: crate::storage::StorageOps>(
+        &self,
+        _storage: &mut S,
+        _slot: U256,
+        _ctx: LayoutCtx,
+    ) -> Result<()> {
+        Err(TempoPrecompileError::Fatal(
+            "EnumerableMap must be accessed through its generated handler".into(),
+        ))
+    }
+
+    fn delete<S: crate::storage::StorageOps>(
+        _storage: &mut S,
+        _slot: U256,
+        _ctx: LayoutCtx,
+    ) -> Result<()> {
+        Err(TempoPrecompileError::Fatal(
+            "EnumerableMap must be accessed through its generated handler".into(),
+        ))
+    }
+}
+
+impl<K, V> Index<K> for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    type Output = V::Handler;
+
+    #[inline]
+    fn index(&self, key: K) -> &Self::Output {
+        &self.values[key]
+    }
+}
+
+impl<K, V> IndexMut<K> for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    #[inline]
+    fn index_mut(&mut self, key: K) -> &mut Self::Output {
+        &mut self.values[key]
+    }
+}
+
+impl<K, V> StorableType for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    const LAYOUT: Layout = Layout::Slots(2);
+    type Handler = Self;
+
+    fn handle(slot: U256, _ctx: LayoutCtx, address: Address) -> Self::Handler {
+        Self::new(slot, address)
+    }
+}
+
+impl<K, V> fmt::Debug for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EnumerableMap")
+            .field("base_slot", &self.base_slot)
+            .field("address", &self.address)
+            .finish()
+    }
+}
+
+impl<K, V> Clone for EnumerableMap<K, V>
+where
+    K: Storable + StorageKey + Hash + Eq + Clone,
+    V: StorableType,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.base_slot, self.address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        storage::{Handler, StorageCtx},
+        test_util::setup_storage,
+    };
+
+    #[test]
+    fn test_enumerable_map_key_index_preserves_order_and_uniqueness() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, || -> Result<()> {
+            let mut map = EnumerableMap::<Address, u8>::new(U256::ZERO, address);
+            let first = Address::repeat_byte(0x11);
+            let second = Address::repeat_byte(0x22);
+
+            assert!(map.insert_key(first)?);
+            assert!(map.insert_key(second)?);
+            assert!(!map.insert_key(first)?);
+
+            assert_eq!(map.keys()?, vec![first, second]);
+            assert!(map.contains_key(&first)?);
+            assert_eq!(map.len()?, 2);
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_enumerable_map_remove_key_only_updates_index() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, || -> Result<()> {
+            let mut map = EnumerableMap::<Address, u8>::new(U256::ZERO, address);
+            let key = Address::repeat_byte(0x33);
+
+            assert!(map.insert_key(key)?);
+            map[key].write(7)?;
+
+            assert!(map.remove_key(&key)?);
+            assert!(!map.contains_key(&key)?);
+            assert!(map.keys()?.is_empty());
+            assert_eq!(map[key].read()?, 7);
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_enumerable_map_contains_mapped_uses_value_liveness() {
+        let (mut storage, address) = setup_storage();
+        StorageCtx::enter(&mut storage, || -> Result<()> {
+            let key = Address::repeat_byte(0x44);
+            let mut map = EnumerableMap::<Address, u8>::new(U256::ZERO, address);
+
+            assert!(!map.contains_mapped(&key, |value| value.read().map(|mode| mode != 0))?);
+
+            map[key].write(2)?;
+            assert!(map.contains_mapped(&key, |value| value.read().map(|mode| mode != 0))?);
+
+            map[key].write(0)?;
+            assert!(!map.contains_mapped(&key, |value| value.read().map(|mode| mode != 0))?);
+
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/crates/precompiles/src/storage/types/mod.rs
+++ b/crates/precompiles/src/storage/types/mod.rs
@@ -11,8 +11,10 @@ pub mod mapping;
 pub use mapping::*;
 
 pub mod array;
+pub mod enumerable_map;
 pub mod set;
 pub mod vec;
+pub use enumerable_map::EnumerableMap;
 pub use set::{Set, SetHandler};
 
 pub mod bytes_like;

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -117,6 +117,9 @@ impl Encodable for TokenLimit {
 /// - `None` => allow any selector for this target
 /// - `Some([])` => deny all selectors for this target
 /// - `Some([..])` => allow exactly the listed selector rules
+///
+/// On the raw protocol model, `Some([])` is a no-match scope. The Solidity
+/// keychain mutator normalizes that form as delete-equivalent for the target.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
 #[rlp(trailing)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -344,11 +344,11 @@ impl KeyAuthorization {
 
                 // Storage write accounting:
                 // - account mode write: 1
-                // - each target insertion + target mode write: 3 + 1
-                // - each selector insertion + selector mode write: 3 + 1
+                // - each target vec push + target mode write: 2 + 1
+                // - each selector vec push + selector mode write: 2 + 1
                 // - recipient-constrained selectors also write recipient set length: +1 per selector
                 // - recipient set values+positions: +2 per recipient
-                1 + scopes.len() as u64 * 4 + selectors * 4 + constrained_selectors + recipients * 2
+                1 + scopes.len() as u64 * 3 + selectors * 3 + constrained_selectors + recipients * 2
             }
         }
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2667,10 +2667,10 @@ mod tests {
         };
 
         let gas = calculate_key_authorization_gas(&scoped, &t1b_gas_params, TempoHardfork::T3);
-        // 1 key write + 14 scope slots:
-        // account mode(1) + target insert+mode(4) + selector insert+mode(4)
+        // 1 key write + 12 scope slots:
+        // account mode(1) + target vec push+mode(3) + selector vec push+mode(3)
         // + constrained selector recipient-length(1) + recipients values+positions(2*2).
-        let expected = ECRECOVER_GAS + sload + sstore * (1 + 14) + BUFFER;
+        let expected = ECRECOVER_GAS + sload + sstore * (1 + 12) + BUFFER;
         assert_eq!(gas, expected, "T3 scope writes should be fully charged");
     }
 

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -402,8 +402,8 @@ Definitions:
 Scoped-call storage writes counted for intrinsic gas:
 
 1. Restricted-mode marker: `1` slot when `allowed_calls` is `Some(...)`.
-2. Each target scope writes `4` slots: target-set length, target-set value, target-set position, and target mode.
-3. Each selector rule writes `4` slots: selector-set length, selector-set value, selector-set position, and selector mode.
+2. Each target scope writes `3` slots: target-vec length, target-vec value, and target mode.
+3. Each selector rule writes `3` slots: selector-vec length, selector-vec value, and selector mode.
 4. Each recipient-constrained selector writes `1` additional slot for recipient-set length.
 5. Each recipient entry writes `2` slots: recipient-set value and recipient-set position.
 
@@ -413,10 +413,10 @@ gas_key_authorization_new = gas_key_authorization_existing
 
 scope_slots = 0                    if allowed_calls is None
             = 1                    if allowed_calls is Some([])   // explicit restricted-mode marker
-            = 1 + 4*S + 4*K + C + 2*W    if allowed_calls is Some(scopes)
+            = 1 + 3*S + 3*K + C + 2*W    if allowed_calls is Some(scopes)
 ```
 
-Justification for `1 + 4*S + 4*K + C + 2*W`: `1` stores restricted mode, each target scope materializes as four set/mode writes, each selector rule materializes as four set/mode writes, each constrained selector writes one recipient-set length slot, and each recipient writes two set-membership slots.
+Justification for `1 + 3*S + 3*K + C + 2*W`: `1` stores restricted mode, each target scope materializes as one vec length write, one vec element write, and one mode write, each selector rule materializes as one vec length write, one vec element write, and one mode write, each constrained selector writes one recipient-set length slot, and each recipient writes two set-membership slots.
 
 Bounds:
 
@@ -525,18 +525,38 @@ Additive periodic-limit layout:
 | `spending_limits[account_key][token]` | `U256` | Remaining amount / `remainingInPeriod` |
 | `spending_limit_period_state[account_key][token]` | struct `{ max, period, period_end }` | Periodic limit metadata |
 
-Call-scope storage is account-scoped and represented as nested sets/maps:
+Call-scope storage is account-scoped and represented as nested vecs/maps/sets:
 
 | Path | Type | Description |
 |------|------|-------------|
 | `key_scopes[account_key].mode` | `u8` | `0 = unrestricted`, `1 = scoped`, `2 = deny-all` |
-| `key_scopes[account_key].targets` | `Set<address>` | Scoped target membership |
+| `key_scopes[account_key].targets` | `Vec<address>` | Ordered list of scoped targets |
 | `key_scopes[account_key].target_scopes[target].mode` | `u8` | `0 = none`, `1 = any-selector`, `2 = explicit-selector-rules` |
-| `key_scopes[account_key].target_scopes[target].selectors` | `Set<u32>` | Explicit selector membership |
+| `key_scopes[account_key].target_scopes[target].selectors` | `Vec<bytes4>` | Ordered list of explicit selectors |
 | `key_scopes[account_key].target_scopes[target].selector_scopes[selector].mode` | `u8` | `1 = any-recipient`, `2 = constrained-recipient-set` |
 | `key_scopes[account_key].target_scopes[target].selector_scopes[selector].recipients` | `Set<address>` | Selector-level recipient membership |
 
 `account_key = keccak256(account || key_id)` to avoid cross-account collisions for shared key IDs.
+
+Within a `KeyScope` row rooted at `key_scopes[account_key]`, slot offsets are:
+
+1. `+0`: `mode`
+2. `+1`: `targets` vec length; target data begins at `keccak256(base + 1)`
+3. `+2`: `target_scopes` mapping base
+
+Within a `TargetScope` row rooted at `key_scopes[account_key].target_scopes[target]`, slot offsets are:
+
+1. `+0`: `mode`
+2. `+1`: `selectors` vec length; selector data begins at `keccak256(base + 1)`
+3. `+2`: `selector_scopes` mapping base
+
+Within a `SelectorScope` row rooted at `key_scopes[account_key].target_scopes[target].selector_scopes[selector]`, slot offsets are:
+
+1. `+0`: `mode`
+2. `+1`: recipient-set base slot (`Set<address>`)
+3. `+2`: recipient-set positions mapping base
+
+Selector keys are stored and mapped as `bytes4` values directly. The `selectors` vec preserves deterministic enumeration order, while `selector_scopes[selector]` remains the hot-path lookup table for validation.
 
 Implementations MAY maintain additional internal indexes or equivalent layouts so long as semantics remain unchanged.
 

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -538,26 +538,6 @@ Call-scope storage is account-scoped and represented as nested vecs/maps/sets:
 
 `account_key = keccak256(account || key_id)` to avoid cross-account collisions for shared key IDs.
 
-Within a `KeyScope` row rooted at `key_scopes[account_key]`, slot offsets are:
-
-1. `+0`: `mode`
-2. `+1`: `targets` vec length; target data begins at `keccak256(base + 1)`
-3. `+2`: `target_scopes` mapping base
-
-Within a `TargetScope` row rooted at `key_scopes[account_key].target_scopes[target]`, slot offsets are:
-
-1. `+0`: `mode`
-2. `+1`: `selectors` vec length; selector data begins at `keccak256(base + 1)`
-3. `+2`: `selector_scopes` mapping base
-
-Within a `SelectorScope` row rooted at `key_scopes[account_key].target_scopes[target].selector_scopes[selector]`, slot offsets are:
-
-1. `+0`: `mode`
-2. `+1`: recipient-set base slot (`Set<address>`)
-3. `+2`: recipient-set positions mapping base
-
-Selector keys are stored and mapped as `bytes4` values directly. The `selectors` vec preserves deterministic enumeration order, while `selector_scopes[selector]` remains the hot-path lookup table for validation.
-
 Implementations MAY maintain additional internal indexes or equivalent layouts so long as semantics remain unchanged.
 
 ## Hardfork-Gated Features


### PR DESCRIPTION
Stacks on #3323.

Prototypes the alternative storage shape discussed in review: vec-backed target and selector indexes for external enumeration, with mapping-backed payload rows preserved as the internal source of truth for validation.

What changed:
- replace `Set<address>` targets with `Vec<address>`
- replace `Set<u32>` selectors with `Vec<bytes4>`
- store selector keys directly as `bytes4` / `FixedBytes<4>` instead of round-tripping through `u32`
- update scoped-call intrinsic gas accounting and TIP text to match the vec-backed write pattern
- keep the TIP diff limited to scope-specific changes only

Write-path synchronization:
- validation no longer scans vec indexes in the hot path
- `target_scopes` and `selector_scopes` are the internal source of truth
- small mutator helpers now keep the vec indexes synchronized on add/remove so `getAllowedCalls()` and other external enumeration remain correct
- added a regression covering selector-index replacement without duplicate externally returned rules

Audit outcome:
- I ran an oracle review on the rebased diff to look for stale-state hazards, gas-accounting drift, and abstraction needs
- the conclusion was that a small local sync layer on the mutator path is the right tradeoff here, and that a larger generic storage abstraction is not needed for this PR

Validation:
- `cargo test -p tempo-precompiles account_keychain --lib`
- `cargo test -p tempo-transaction-pool keychain --lib`
