### PR TITLE
feat(account-keychain): add periodic spending limits

### DIFF
--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -4,7 +4,7 @@ use crate::rpc::{TempoHeaderResponse, TempoTransactionReceipt, TempoTransactionR
 use alloy_consensus::{ReceiptWithBloom, TxType, error::UnsupportedTransactionType};
 
 use alloy_network::{
-    BuildResult, Ethereum, EthereumWallet, IntoWallet, Network, NetworkWallet, TransactionBuilder,
+    BuildResult, EthereumWallet, IntoWallet, Network, NetworkWallet, TransactionBuilder,
     TransactionBuilderError, UnbuiltTransactionError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
@@ -292,33 +292,6 @@ impl RecommendedFillers for TempoNetwork {
     }
 }
 
-impl NetworkWallet<TempoNetwork> for EthereumWallet {
-    fn default_signer_address(&self) -> Address {
-        NetworkWallet::<Ethereum>::default_signer_address(self)
-    }
-
-    fn has_signer_for(&self, address: &Address) -> bool {
-        NetworkWallet::<Ethereum>::has_signer_for(self, address)
-    }
-
-    fn signer_addresses(&self) -> impl Iterator<Item = Address> {
-        NetworkWallet::<Ethereum>::signer_addresses(self)
-    }
-
-    #[doc(alias = "sign_tx_from")]
-    async fn sign_transaction_from(
-        &self,
-        sender: Address,
-        mut tx: TempoTypedTransaction,
-    ) -> alloy_signer::Result<TempoTxEnvelope> {
-        let signer = self.signer_by_address(sender).ok_or_else(|| {
-            alloy_signer::Error::other(format!("Missing signing credential for {sender}"))
-        })?;
-        let sig = signer.sign_transaction(tx.as_dyn_signable_mut()).await?;
-        Ok(tx.into_envelope(sig))
-    }
-}
-
 impl IntoWallet<TempoNetwork> for PrivateKeySigner {
     type NetworkWallet = EthereumWallet;
 
@@ -526,6 +499,7 @@ mod tests {
                     key_id: Address::ZERO,
                     expiry: None,
                     limits: None,
+                    allowed_calls: None,
                 },
                 signature: PrimitiveSignature::Secp256k1(Signature::new(
                     U256::ZERO,

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -7,6 +7,7 @@ use alloy_provider::{
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     IAccountKeychain::{IAccountKeychainInstance, KeyInfo},
+    getRemainingLimitReturn,
 };
 
 use crate::{
@@ -40,14 +41,20 @@ pub trait TempoProviderExt: Provider<TempoNetwork> {
         account: Address,
         key_id: Address,
         token: Address,
-    ) -> ContractResult<U256>
+    ) -> ContractResult<(U256, u64)>
     where
         Self: Sized,
     {
-        self.account_keychain()
-            .getRemainingLimit(account, key_id, token)
+        let getRemainingLimitReturn {
+            remaining,
+            periodEnd,
+        } = self
+            .account_keychain()
+            .getRemainingLimitWithPeriod(account, key_id, token)
             .call()
-            .await
+            .await?;
+
+        Ok((remaining, periodEnd))
     }
 
     /// Returns the key ID used in the current transaction context.
@@ -140,8 +147,12 @@ mod tests {
     use alloy::sol_types::SolCall;
     use alloy_primitives::{Address, Bytes, U256};
     use alloy_provider::{Identity, ProviderBuilder, fillers::JoinFill, mock::Asserter};
-    use tempo_contracts::precompiles::IAccountKeychain::{
-        KeyInfo, SignatureType, getKeyCall, getRemainingLimitCall, getTransactionKeyCall,
+    use tempo_contracts::precompiles::{
+        IAccountKeychain::{
+            KeyInfo, SignatureType, getKeyCall, getRemainingLimitWithPeriodCall,
+            getTransactionKeyCall,
+        },
+        getRemainingLimitReturn,
     };
 
     use crate::{
@@ -203,11 +214,14 @@ mod tests {
         let account = Address::repeat_byte(0x11);
         let key_id = Address::repeat_byte(0x22);
         let token = Address::repeat_byte(0x33);
-        let expected = U256::from(42_u64);
+        let expected = (U256::from(42_u64), 1337_u64);
 
-        asserter.push_success(&Bytes::from(getRemainingLimitCall::abi_encode_returns(
-            &expected,
-        )));
+        asserter.push_success(&Bytes::from(
+            getRemainingLimitWithPeriodCall::abi_encode_returns(&getRemainingLimitReturn {
+                remaining: expected.0,
+                periodEnd: expected.1,
+            }),
+        ));
 
         let actual = provider
             .get_keychain_remaining_limit(account, key_id, token)

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -586,6 +586,7 @@ mod tests {
                 key_id: address!("0x1111111111111111111111111111111111111111"),
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             },
             signature: PrimitiveSignature::default(),
         };
@@ -659,47 +660,6 @@ mod tests {
         assert_eq!(
             roundtrip.calls, batch,
             "multi-call AA must not gain phantom calls on round-trip"
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "tempo-compat")]
-    fn test_aa_roundtrip_via_tx_env() {
-        use reth_evm::EvmEnv;
-        use reth_rpc_convert::TryIntoTxEnv;
-
-        let calls = vec![
-            Call {
-                to: address!("0x1111111111111111111111111111111111111111").into(),
-                value: U256::ZERO,
-                input: Bytes::from(vec![0xaa]),
-            },
-            Call {
-                to: address!("0x2222222222222222222222222222222222222222").into(),
-                value: U256::ZERO,
-                input: Bytes::from(vec![0xbb]),
-            },
-        ];
-
-        let tx = TempoTransaction {
-            chain_id: 4217,
-            nonce: 1,
-            gas_limit: 100_000,
-            max_fee_per_gas: 1_000_000_000,
-            max_priority_fee_per_gas: 1_000_000,
-            calls: calls.clone(),
-            ..Default::default()
-        };
-
-        let req = TempoTransactionRequest::from(tx);
-
-        let evm_env = EvmEnv::default();
-        let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let aa_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
-
-        assert_eq!(
-            aa_calls, calls,
-            "roundtrip via try_into_tx_env must preserve exact call list"
         );
     }
 }

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -1,5 +1,9 @@
+#![allow(clippy::too_many_arguments)]
+
 pub use IAccountKeychain::{
     IAccountKeychainErrors as AccountKeychainError, IAccountKeychainEvents as AccountKeychainEvent,
+    authorizeKey_0Call as legacyAuthorizeKeyCall, authorizeKey_1Call as authorizeKeyCall,
+    getRemainingLimitWithPeriodCall, getRemainingLimitWithPeriodReturn as getRemainingLimitReturn,
 };
 
 crate::sol! {
@@ -21,10 +25,43 @@ crate::sol! {
             WebAuthn,
         }
 
+        /// Legacy token spending limit structure used before T3.
+        struct LegacyTokenLimit {
+            address token;
+            uint256 amount;
+        }
+
         /// Token spending limit structure
         struct TokenLimit {
             address token;
             uint256 amount;
+            uint64 period;
+        }
+
+        /// Selector-level recipient rule.
+        struct SelectorRule {
+            bytes4 selector;
+            /// Empty means no recipient restriction for this selector.
+            /// To block the selector entirely, remove the selector rule instead of passing `[]`.
+            address[] recipients;
+        }
+
+        /// Per-target call scope.
+        struct CallScope {
+            address target;
+            /// Empty means no selector restriction for this target.
+            /// To block the target entirely, omit this scope from `allowedCalls` or call
+            /// `removeAllowedCalls` for incremental updates.
+            SelectorRule[] selectorRules;
+        }
+
+        /// Optional access-key restrictions configured at authorization time.
+        struct KeyRestrictions {
+            uint64 expiry;
+            bool enforceLimits;
+            TokenLimit[] limits;
+            bool enforceAllowedCalls;
+            CallScope[] allowedCalls;
         }
 
         /// Key information structure
@@ -44,18 +81,32 @@ crate::sol! {
         /// Emitted when a spending limit is updated
         event SpendingLimitUpdated(address indexed account, address indexed publicKey, address indexed token, uint256 newLimit);
 
-        /// Authorize a new key for the caller's account
-        /// @param keyId The key identifier (address derived from public key)
-        /// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
-        /// @param expiry Block timestamp when the key expires (u64::MAX for never expires)
-        /// @param enforceLimits Whether to enforce spending limits for this key
-        /// @param limits Initial spending limits for tokens (only used if enforceLimits is true)
+        /// Emitted when an access key spends against a token limit.
+        event AccessKeySpend(
+            address indexed account,
+            address indexed publicKey,
+            address indexed token,
+            uint256 amount,
+            uint256 remainingLimit
+        );
+
+        /// Legacy authorize-key entrypoint used before T3.
         function authorizeKey(
             address keyId,
             SignatureType signatureType,
             uint64 expiry,
             bool enforceLimits,
-            TokenLimit[] calldata limits
+            LegacyTokenLimit[] calldata limits
+        ) external;
+
+        /// Authorize a new key for the caller's account with T3 extensions.
+        /// @param keyId The key identifier (address derived from public key)
+        /// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
+        /// @param config Access-key expiry and optional limits / call restrictions
+        function authorizeKey(
+            address keyId,
+            SignatureType signatureType,
+            KeyRestrictions calldata config
         ) external;
 
         /// Revoke an authorized key
@@ -72,22 +123,48 @@ crate::sol! {
             uint256 newLimit
         ) external;
 
+        /// Set or replace allowed calls for a key+target pair.
+        /// @dev `scope.selectorRules = []` does NOT block the target; it allows any selector on that target.
+        /// @dev To block the target entirely, call `removeAllowedCalls`. To block one selector,
+        ///      omit that selector rule from `scope.selectorRules`.
+        function setAllowedCalls(
+            address keyId,
+            CallScope calldata scope
+        ) external;
+
+        /// Remove any configured call scope for a key+target pair.
+        function removeAllowedCalls(address keyId, address target) external;
+
         /// Get key information
         /// @param account The account address
         /// @param publicKey The public key
         /// @return Key information
         function getKey(address account, address keyId) external view returns (KeyInfo memory);
 
-        /// Get remaining spending limit
+        /// Get remaining spending limit using the legacy pre-T3 return shape.
         /// @param account The account address
         /// @param publicKey The public key
         /// @param token The token address
-        /// @return Remaining spending amount
         function getRemainingLimit(
             address account,
             address keyId,
             address token
-        ) external view returns (uint256);
+        ) external view returns (uint256 remaining);
+
+        /// Get remaining spending limit together with the active period end.
+        /// @param account The account address
+        /// @param publicKey The public key
+        /// @param token The token address
+        /// @return remaining Remaining spending amount
+        /// @return periodEnd Period end timestamp for periodic limits (0 for one-time)
+        function getRemainingLimitWithPeriod(
+            address account,
+            address keyId,
+            address token
+        ) external view returns (uint256 remaining, uint64 periodEnd);
+
+        /// Returns configured call scopes for an account key.
+        function getAllowedCalls(address account, address keyId) external view returns (CallScope[] memory);
 
         /// Get the key used in the current transaction
         /// @return The keyId used in the current transaction
@@ -99,11 +176,17 @@ crate::sol! {
         error KeyNotFound();
         error KeyExpired();
         error SpendingLimitExceeded();
+        error InvalidSpendingLimit();
         error InvalidSignatureType();
         error ZeroPublicKey();
         error ExpiryInPast();
         error KeyAlreadyRevoked();
         error SignatureTypeMismatch(uint8 expected, uint8 actual);
+        error CallNotAllowed();
+        error InvalidCallScope();
+        error ScopeLimitExceeded();
+        error SelectorLimitExceeded();
+        error RecipientLimitExceeded();
     }
 }
 
@@ -138,6 +221,11 @@ impl AccountKeychainError {
         Self::SpendingLimitExceeded(IAccountKeychain::SpendingLimitExceeded {})
     }
 
+    /// Creates an error for spending limits that exceed the TIP-20 u128 supply cap.
+    pub const fn invalid_spending_limit() -> Self {
+        Self::InvalidSpendingLimit(IAccountKeychain::InvalidSpendingLimit {})
+    }
+
     /// Creates an error for invalid signature type.
     pub const fn invalid_signature_type() -> Self {
         Self::InvalidSignatureType(IAccountKeychain::InvalidSignatureType {})
@@ -158,5 +246,30 @@ impl AccountKeychainError {
     /// This prevents replay attacks where a revoked key's authorization is reused.
     pub const fn key_already_revoked() -> Self {
         Self::KeyAlreadyRevoked(IAccountKeychain::KeyAlreadyRevoked {})
+    }
+
+    /// Creates an error for disallowed call attempts by scoped access keys.
+    pub const fn call_not_allowed() -> Self {
+        Self::CallNotAllowed(IAccountKeychain::CallNotAllowed {})
+    }
+
+    /// Creates an error for invalid scope configuration.
+    pub const fn invalid_call_scope() -> Self {
+        Self::InvalidCallScope(IAccountKeychain::InvalidCallScope {})
+    }
+
+    /// Creates an error for scope count limit violations.
+    pub const fn scope_limit_exceeded() -> Self {
+        Self::ScopeLimitExceeded(IAccountKeychain::ScopeLimitExceeded {})
+    }
+
+    /// Creates an error for selector count limit violations.
+    pub const fn selector_limit_exceeded() -> Self {
+        Self::SelectorLimitExceeded(IAccountKeychain::SelectorLimitExceeded {})
+    }
+
+    /// Creates an error for recipient count limit violations.
+    pub const fn recipient_limit_exceeded() -> Self {
+        Self::RecipientLimitExceeded(IAccountKeychain::RecipientLimitExceeded {})
     }
 }

--- a/crates/node/tests/it/key_authorization.rs
+++ b/crates/node/tests/it/key_authorization.rs
@@ -34,6 +34,7 @@ fn build_create_key_auth_tx(
         key_id: Address::random(),
         expiry: None,
         limits: None,
+        allowed_calls: None,
     };
     let sig = signer.sign_hash_sync(&key_auth.signature_hash())?;
     let signed_key_auth = key_auth.into_signed(PrimitiveSignature::Secp256k1(sig));

--- a/crates/node/tests/it/tempo_transaction/helpers.rs
+++ b/crates/node/tests/it/tempo_transaction/helpers.rs
@@ -192,6 +192,7 @@ pub(crate) fn create_signed_key_authorization(
                 .map(|_| TokenLimit {
                     token: Address::ZERO,
                     limit: U256::ZERO,
+                    period: 0,
                 })
                 .collect(),
         )
@@ -203,6 +204,7 @@ pub(crate) fn create_signed_key_authorization(
         key_id: Address::random(), // Random key being authorized
         expiry: None,              // Never expires
         limits,
+        allowed_calls: None,
     };
 
     // Sign the key authorization
@@ -311,6 +313,7 @@ pub(crate) fn create_key_authorization(
         key_id: access_key_addr,
         expiry,
         limits: spending_limits,
+        allowed_calls: None,
     };
 
     // Root key signs the authorization
@@ -585,6 +588,7 @@ pub(crate) fn create_default_token_limit(
     vec![TokenLimit {
         token: DEFAULT_FEE_TOKEN,
         limit: funded / U256::from(2),
+        period: 0,
     }]
 }
 

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -1681,6 +1681,7 @@ async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
         Some(vec![tempo_primitives::transaction::TokenLimit {
             token: DEFAULT_FEE_TOKEN,
             limit: initial_spending_limit,
+            period: 0,
         }]),
     )?;
 

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -699,15 +699,21 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
         KeySetup::ZeroPubKey => {
             use tempo_precompiles::{
                 ACCOUNT_KEYCHAIN_ADDRESS,
-                account_keychain::{SignatureType as KCSignatureType, authorizeKeyCall},
+                account_keychain::{
+                    KeyRestrictions, SignatureType as KCSignatureType, authorizeKeyCall,
+                },
             };
 
             let authorize_call = authorizeKeyCall {
                 keyId: Address::ZERO,
                 signatureType: KCSignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             tx.calls = vec![Call {
                 to: ACCOUNT_KEYCHAIN_ADDRESS.into(),
@@ -735,6 +741,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                 SpendingLimits::Custom(amount) => Some(vec![TokenLimit {
                     token: DEFAULT_FEE_TOKEN,
                     limit: *amount,
+                    period: 0,
                 }]),
             };
 
@@ -867,6 +874,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: access_addr,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     };
                     let wrong_sig = wrong_root.sign_hash_sync(&key_auth.signature_hash())?;
                     let invalid_key_auth =
@@ -895,6 +903,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: addr_3,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     }
                     .signature_hash();
 
@@ -912,6 +921,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: addr_3,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     }
                     .into_signed(PrimitiveSignature::P256(P256SignatureWithPreHash {
                         r: B256::from_slice(&wrong_sig_bytes[0..32]),

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,10 +1,16 @@
 //! ABI dispatch for the [`AccountKeychain`] precompile.
 
-use super::AccountKeychain;
-use crate::{Precompile, dispatch_call, input_cost, mutate_void, view};
-use alloy::{primitives::Address, sol_types::SolInterface};
+use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
+use crate::{Precompile, dispatch_call, input_cost, mutate_void, unknown_selector, view};
+use alloy::{
+    primitives::Address,
+    sol_types::{SolCall, SolInterface},
+};
 use revm::precompile::{PrecompileError, PrecompileResult};
-use tempo_contracts::precompiles::IAccountKeychain::IAccountKeychainCalls;
+use tempo_contracts::precompiles::{
+    IAccountKeychain::{IAccountKeychainCalls, removeAllowedCallsCall, setAllowedCallsCall},
+    legacyAuthorizeKeyCall,
+};
 
 impl Precompile for AccountKeychain {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -16,7 +22,43 @@ impl Precompile for AccountKeychain {
             calldata,
             IAccountKeychainCalls::abi_decode,
             |call| match call {
-                IAccountKeychainCalls::authorizeKey(call) => {
+                IAccountKeychainCalls::authorizeKey_0(call) => {
+                    if self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            legacyAuthorizeKeyCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
+
+                    let call = authorizeKeyCall {
+                        keyId: call.keyId,
+                        signatureType: call.signatureType,
+                        config: KeyRestrictions {
+                            expiry: call.expiry,
+                            enforceLimits: call.enforceLimits,
+                            limits: call
+                                .limits
+                                .into_iter()
+                                .map(|limit| TokenLimit {
+                                    token: limit.token,
+                                    amount: limit.amount,
+                                    period: 0,
+                                })
+                                .collect(),
+                            enforceAllowedCalls: false,
+                            allowedCalls: vec![],
+                        },
+                    };
+
+                    mutate_void(call, msg_sender, |sender, c| self.authorize_key(sender, c))
+                }
+                IAccountKeychainCalls::authorizeKey_1(call) => {
+                    if !self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            authorizeKeyCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
                     mutate_void(call, msg_sender, |sender, c| self.authorize_key(sender, c))
                 }
                 IAccountKeychainCalls::revokeKey(call) => {
@@ -27,9 +69,55 @@ impl Precompile for AccountKeychain {
                         self.update_spending_limit(sender, c)
                     })
                 }
+                IAccountKeychainCalls::setAllowedCalls(call) => {
+                    if !self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            setAllowedCallsCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
+                    mutate_void(call, msg_sender, |sender, c| {
+                        self.set_allowed_calls(sender, c)
+                    })
+                }
+                IAccountKeychainCalls::removeAllowedCalls(call) => {
+                    if !self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            removeAllowedCallsCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
+                    mutate_void(call, msg_sender, |sender, c| {
+                        self.remove_allowed_calls(sender, c)
+                    })
+                }
                 IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
                 IAccountKeychainCalls::getRemainingLimit(call) => {
+                    if self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            tempo_contracts::precompiles::IAccountKeychain::getRemainingLimitCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
                     view(call, |c| self.get_remaining_limit(c))
+                }
+                IAccountKeychainCalls::getRemainingLimitWithPeriod(call) => {
+                    if !self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            tempo_contracts::precompiles::getRemainingLimitWithPeriodCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
+                    view(call, |c| self.get_remaining_limit_with_period(c))
+                }
+                IAccountKeychainCalls::getAllowedCalls(call) => {
+                    if !self.storage.spec().is_t3() {
+                        return unknown_selector(
+                            tempo_contracts::precompiles::IAccountKeychain::getAllowedCallsCall::SELECTOR,
+                            self.storage.gas_used(),
+                        );
+                    }
+                    view(call, |c| self.get_allowed_calls(c))
                 }
                 IAccountKeychainCalls::getTransactionKey(call) => {
                     view(call, |c| self.get_transaction_key(c, msg_sender))
@@ -43,13 +131,17 @@ impl Precompile for AccountKeychain {
 mod tests {
     use super::*;
     use crate::{
-        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        Precompile,
+        account_keychain::{getRemainingLimitCall, getRemainingLimitWithPeriodCall},
+        storage::{Handler, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{assert_full_coverage, check_selector_coverage},
     };
+    use alloy::{primitives::U256, sol_types::SolCall};
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
     fn test_account_keychain_selector_coverage() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         StorageCtx::enter(&mut storage, || {
             let mut fee_manager = AccountKeychain::new();
 
@@ -61,6 +153,177 @@ mod tests {
             );
 
             assert_full_coverage([unsupported]);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_legacy_authorize_key_selector_supported_pre_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let calldata = legacyAuthorizeKeyCall {
+                keyId: key_id,
+                signatureType:
+                    tempo_contracts::precompiles::IAccountKeychain::SignatureType::Secp256k1,
+                expiry: u64::MAX,
+                enforceLimits: true,
+                limits: vec![
+                    tempo_contracts::precompiles::IAccountKeychain::LegacyTokenLimit {
+                        token,
+                        amount: U256::from(100),
+                    },
+                ],
+            }
+            .abi_encode();
+
+            let _ = keychain.call(&calldata, account)?;
+
+            let key = keychain.keys[account][key_id].read()?;
+            assert_eq!(key.expiry, u64::MAX);
+
+            let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+            let remaining = keychain.spending_limits[limit_key][token].read()?.remaining;
+            assert_eq!(remaining, U256::from(100));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_new_authorize_key_selector_rejected_pre_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        let account = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let calldata = authorizeKeyCall {
+                keyId: Address::random(),
+                signatureType:
+                    tempo_contracts::precompiles::IAccountKeychain::SignatureType::Secp256k1,
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token: Address::random(),
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
+            }
+            .abi_encode();
+
+            let result = keychain.call(&calldata, account)?;
+            assert!(result.reverted);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_legacy_authorize_key_selector_rejected_post_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let calldata = legacyAuthorizeKeyCall {
+                keyId: Address::random(),
+                signatureType:
+                    tempo_contracts::precompiles::IAccountKeychain::SignatureType::Secp256k1,
+                expiry: u64::MAX,
+                enforceLimits: false,
+                limits: vec![],
+            }
+            .abi_encode();
+
+            let result = keychain.call(&calldata, account)?;
+            assert!(result.reverted);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_get_remaining_limit_uses_legacy_return_shape_pre_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let authorize_calldata = legacyAuthorizeKeyCall {
+                keyId: key_id,
+                signatureType:
+                    tempo_contracts::precompiles::IAccountKeychain::SignatureType::Secp256k1,
+                expiry: u64::MAX,
+                enforceLimits: true,
+                limits: vec![
+                    tempo_contracts::precompiles::IAccountKeychain::LegacyTokenLimit {
+                        token,
+                        amount: U256::from(123),
+                    },
+                ],
+            }
+            .abi_encode();
+            let _ = keychain.call(&authorize_calldata, account)?;
+
+            let get_limit_calldata = getRemainingLimitCall {
+                account,
+                keyId: key_id,
+                token,
+            }
+            .abi_encode();
+
+            let output = keychain.call(&get_limit_calldata, account)?;
+            assert!(!output.reverted);
+            assert_eq!(
+                output.bytes.len(),
+                32,
+                "pre-T3 should return legacy uint256"
+            );
+
+            let remaining = getRemainingLimitCall::abi_decode_returns(&output.bytes)?;
+            assert_eq!(remaining, U256::from(123));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_get_remaining_limit_with_period_rejected_pre_t3() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        let account = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let calldata = getRemainingLimitWithPeriodCall {
+                account,
+                keyId: Address::random(),
+                token: Address::random(),
+            }
+            .abi_encode();
+
+            let result = keychain.call(&calldata, account)?;
+            assert!(result.reverted);
 
             Ok(())
         })

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -15,9 +15,12 @@ use tempo_contracts::precompiles::{AccountKeychainError, AccountKeychainEvent};
 pub use tempo_contracts::precompiles::{
     IAccountKeychain,
     IAccountKeychain::{
-        KeyInfo, SignatureType, TokenLimit, authorizeKeyCall, getKeyCall, getRemainingLimitCall,
-        getTransactionKeyCall, revokeKeyCall, updateSpendingLimitCall,
+        CallScope, KeyInfo, KeyRestrictions, SignatureType, TokenLimit,
+        getAllowedCallsCall, getKeyCall, getRemainingLimitCall, getRemainingLimitWithPeriodCall,
+        getTransactionKeyCall, removeAllowedCallsCall, revokeKeyCall, setAllowedCallsCall,
+        updateSpendingLimitCall,
     },
+    authorizeKeyCall, getRemainingLimitReturn,
 };
 
 use crate::{
@@ -25,7 +28,7 @@ use crate::{
     error::Result,
     storage::{Handler, Mapping, packing::insert_into_word},
 };
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{Address, B256, TxKind, U256, keccak256};
 use tempo_precompiles_macros::{Storable, contract};
 
 /// Key information stored in the precompile
@@ -46,6 +49,33 @@ pub struct AuthorizedKey {
     /// Whether this key has been revoked. Once revoked, a key cannot be re-authorized
     /// with the same key_id. This prevents replay attacks.
     pub is_revoked: bool,
+}
+
+/// Per-token spending limit state.
+///
+/// `remaining` stays in the first slot so the legacy `spending_limits` layout remains intact.
+/// T3+ extends the same row with period metadata in later slots.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Storable)]
+pub struct SpendingLimitState {
+    /// Remaining amount currently available to spend.
+    pub remaining: U256,
+    /// Maximum amount allowed per period, capped to TIP-20's `u128` supply range.
+    pub max: u128,
+    /// Duration of each period in seconds. `0` means non-periodic.
+    pub period: u64,
+    /// End timestamp of the current period window.
+    pub period_end: u64,
+}
+
+impl SpendingLimitState {
+    /// Computes the period end for the current rollover window, saturating on
+    /// all intermediate operations to avoid overflow in extreme timestamps.
+    fn compute_next_period_end(&self, current_timestamp: u64) -> u64 {
+        let elapsed = current_timestamp.saturating_sub(self.period_end);
+        let periods_elapsed = (elapsed / self.period).saturating_add(1);
+        let advance = self.period.saturating_mul(periods_elapsed);
+        self.period_end.saturating_add(advance)
+    }
 }
 
 // TODO(rusowsky): remove this and create a read-only wrapper that is callable from read-only ctx with db access
@@ -108,9 +138,9 @@ impl AuthorizedKey {
 pub struct AccountKeychain {
     // keys[account][keyId] -> AuthorizedKey
     keys: Mapping<Address, Mapping<Address, AuthorizedKey>>,
-    // spendingLimits[(account, keyId)][token] -> amount
+    // spendingLimits[(account, keyId)][token] -> { remaining, max, period, period_end }
     // Using a hash of account and keyId as the key to avoid triple nesting
-    spending_limits: Mapping<B256, Mapping<Address, U256>>,
+    spending_limits: Mapping<B256, Mapping<Address, SpendingLimitState>>,
 
     // WARNING(rusowsky): transient storage slots must always be placed at the very end until the `contract`
     // macro is refactored and has 2 independent layouts (persistent and transient).
@@ -122,16 +152,24 @@ pub struct AccountKeychain {
 }
 
 impl AccountKeychain {
-    /// Create a hash key for spending limits mapping from account and keyId.
+    /// Create a hash key for account+key scoped storage rows.
     ///
-    /// This is used to access `spending_limits[key][token]` where `key` is the result
-    /// of this function. The hash combines account and key_id to avoid triple nesting.
+    /// This is used to access account-key rows like `spending_limits[key][token]` and
+    /// `key_scopes[key]`. The hash combines account and key_id to avoid triple nesting.
     pub fn spending_limit_key(account: Address, key_id: Address) -> B256 {
-        use alloy::primitives::keccak256;
         let mut data = [0u8; 40];
         data[..20].copy_from_slice(account.as_slice());
         data[20..].copy_from_slice(key_id.as_slice());
         keccak256(data)
+    }
+
+    #[inline]
+    fn t3_spending_limit_cap(limit: U256) -> Result<u128> {
+        if limit > U256::from(u128::MAX) {
+            return Err(AccountKeychainError::invalid_spending_limit().into());
+        }
+
+        Ok(limit.to::<u128>())
     }
 
     /// Initializes the account keychain precompile.
@@ -151,7 +189,10 @@ impl AccountKeychain {
     /// - `KeyAlreadyRevoked` — revoked keys cannot be re-authorized
     /// - `InvalidSignatureType` — must be Secp256k1, P256, or WebAuthn
     pub fn authorize_key(&mut self, msg_sender: Address, call: authorizeKeyCall) -> Result<()> {
+        let config = &call.config;
+
         self.ensure_admin_caller(msg_sender)?;
+        let is_t3 = self.storage.spec().is_t3();
 
         // Validate inputs
         if call.keyId == Address::ZERO {
@@ -161,7 +202,7 @@ impl AccountKeychain {
         // T0+: Expiry must be in the future (also catches expiry == 0 which means "key doesn't exist")
         if self.storage.spec().is_t0() {
             let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
-            if call.expiry <= current_timestamp {
+            if config.expiry <= current_timestamp {
                 return Err(AccountKeychainError::expiry_in_past().into());
             }
         }
@@ -185,23 +226,35 @@ impl AccountKeychain {
             _ => return Err(AccountKeychainError::invalid_signature_type().into()),
         };
 
+        // TIP-1011 fields are hardfork-gated at T3. This branch only implements periodic limits;
+        // scoped calls are added in the follow-up PR, so reject them here before mutating state.
+        if !is_t3 {
+            if config.limits.iter().any(|limit| limit.period != 0) {
+                return Err(AccountKeychainError::invalid_call_scope().into());
+            }
+        }
+
+        if config.enforceAllowedCalls || !config.allowedCalls.is_empty() {
+            return Err(AccountKeychainError::invalid_call_scope().into());
+        }
+
         // Create and store the new key
         let new_key = AuthorizedKey {
             signature_type,
-            expiry: call.expiry,
-            enforce_limits: call.enforceLimits,
+            expiry: config.expiry,
+            enforce_limits: config.enforceLimits,
             is_revoked: false,
         };
 
         self.keys[msg_sender][call.keyId].write(new_key)?;
 
-        // Set initial spending limits (only if enforce_limits is true)
-        if call.enforceLimits {
-            let limit_key = Self::spending_limit_key(msg_sender, call.keyId);
-            for limit in call.limits {
-                self.spending_limits[limit_key][limit.token].write(limit.amount)?;
-            }
-        }
+        let limits = config
+            .enforceLimits
+            .then_some(config.limits.iter())
+            .into_iter()
+            .flatten();
+
+        self.apply_key_authorization_restrictions(msg_sender, call.keyId, limits)?;
 
         // Emit event
         self.emit_event(AccountKeychainEvent::KeyAuthorized(
@@ -209,7 +262,7 @@ impl AccountKeychain {
                 account: msg_sender,
                 publicKey: call.keyId,
                 signatureType: signature_type,
-                expiry: call.expiry,
+                expiry: config.expiry,
             },
         ))
     }
@@ -283,7 +336,14 @@ impl AccountKeychain {
 
         // Update the spending limit
         let limit_key = Self::spending_limit_key(msg_sender, call.keyId);
-        self.spending_limits[limit_key][call.token].write(call.newLimit)?;
+        let mut limit_state = self.spending_limits[limit_key][call.token].read()?;
+        limit_state.remaining = call.newLimit;
+        if self.storage.spec().is_t3() {
+            // T3: newLimit updates both the configured cap and current remaining amount,
+            // while preserving period + period_end.
+            limit_state.max = Self::t3_spending_limit_cap(call.newLimit)?;
+        }
+        self.spending_limits[limit_key][call.token].write(limit_state)?;
 
         // Emit event
         self.emit_event(AccountKeychainEvent::SpendingLimitUpdated(
@@ -331,16 +391,75 @@ impl AccountKeychain {
     /// Returns the remaining spending limit for a key-token pair, or a blank entry if inexistent
     /// or revoked (T2+).
     pub fn get_remaining_limit(&self, call: getRemainingLimitCall) -> Result<U256> {
+        self.get_remaining_limit_with_period(getRemainingLimitWithPeriodCall {
+            account: call.account,
+            keyId: call.keyId,
+            token: call.token,
+        })
+        .map(|ret| ret.remaining)
+    }
+
+    /// Returns the remaining spending limit together with the active period end timestamp.
+    pub fn get_remaining_limit_with_period(
+        &self,
+        call: getRemainingLimitWithPeriodCall,
+    ) -> Result<getRemainingLimitReturn> {
         // T2+: return zero if key doesn't exist or has been revoked
         if self.storage.spec().is_t2() {
             let key = self.keys[call.account][call.keyId].read()?;
             if key.expiry == 0 || key.is_revoked {
-                return Ok(U256::ZERO);
+                return Ok(getRemainingLimitReturn {
+                    remaining: U256::ZERO,
+                    periodEnd: 0,
+                });
             }
         }
 
+        if self.storage.spec().is_t3() {
+            let (remaining, period_end) = self.effective_limit_state(
+                call.account,
+                call.keyId,
+                call.token,
+                self.storage.timestamp().saturating_to::<u64>(),
+            )?;
+
+            return Ok(getRemainingLimitReturn {
+                remaining,
+                periodEnd: period_end,
+            });
+        }
+
         let limit_key = Self::spending_limit_key(call.account, call.keyId);
-        self.spending_limits[limit_key][call.token].read()
+        let remaining = self.spending_limits[limit_key][call.token]
+            .read()?
+            .remaining;
+        Ok(getRemainingLimitReturn {
+            remaining,
+            periodEnd: 0,
+        })
+    }
+
+    /// Scoped-call mutations land in the follow-up stacked PR.
+    pub fn set_allowed_calls(
+        &mut self,
+        _msg_sender: Address,
+        _call: setAllowedCallsCall,
+    ) -> Result<()> {
+        Err(AccountKeychainError::invalid_call_scope().into())
+    }
+
+    /// Scoped-call mutations land in the follow-up stacked PR.
+    pub fn remove_allowed_calls(
+        &mut self,
+        _msg_sender: Address,
+        _call: removeAllowedCallsCall,
+    ) -> Result<()> {
+        Err(AccountKeychainError::invalid_call_scope().into())
+    }
+
+    /// Scoped-call reads land in the follow-up stacked PR.
+    pub fn get_allowed_calls(&self, _call: getAllowedCallsCall) -> Result<Vec<CallScope>> {
+        Ok(Vec::new())
     }
 
     /// Returns the access key used to authorize the current transaction (`Address::ZERO` = root key).
@@ -372,6 +491,55 @@ impl AccountKeychain {
     /// Uses transient storage, so it's automatically cleared after the transaction.
     pub fn set_tx_origin(&mut self, origin: Address) -> Result<()> {
         self.tx_origin.t_write(origin)
+    }
+
+    fn apply_key_authorization_restrictions<'a>(
+        &mut self,
+        account: Address,
+        key_id: Address,
+        limits: impl IntoIterator<Item = &'a TokenLimit>,
+    ) -> Result<()> {
+        let limit_key = Self::spending_limit_key(account, key_id);
+
+        if !self.storage.spec().is_t3() {
+            for limit in limits {
+                self.spending_limits[limit_key][limit.token].write(SpendingLimitState {
+                    remaining: limit.amount,
+                    ..Default::default()
+                })?;
+            }
+
+            return Ok(());
+        }
+
+        let now = self.storage.timestamp().saturating_to::<u64>();
+        for limit in limits {
+            let period_end = if limit.period == 0 {
+                0
+            } else {
+                now.saturating_add(limit.period)
+            };
+
+            self.spending_limits[limit_key][limit.token].write(SpendingLimitState {
+                remaining: limit.amount,
+                max: Self::t3_spending_limit_cap(limit.amount)?,
+                period: limit.period,
+                period_end,
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Scoped-call enforcement lands in the follow-up stacked PR.
+    pub fn validate_call_scope_for_transaction(
+        &self,
+        _account: Address,
+        _key_id: Address,
+        _to: &TxKind,
+        _input: &[u8],
+    ) -> Result<()> {
+        Ok(())
     }
 
     /// Ensures admin operations are authorized for this caller.
@@ -469,6 +637,48 @@ impl AccountKeychain {
         Ok(())
     }
 
+    /// Computes the effective remaining limit at `current_timestamp` without mutating storage.
+    pub fn effective_remaining_limit(
+        &self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+        current_timestamp: u64,
+    ) -> Result<U256> {
+        self.effective_limit_state(account, key_id, token, current_timestamp)
+            .map(|(remaining, _)| remaining)
+    }
+
+    /// Computes the effective remaining limit and period end at `current_timestamp`
+    /// without mutating storage.
+    fn effective_limit_state(
+        &self,
+        account: Address,
+        key_id: Address,
+        token: Address,
+        current_timestamp: u64,
+    ) -> Result<(U256, u64)> {
+        let limit_key = Self::spending_limit_key(account, key_id);
+        let limit_state = self.spending_limits[limit_key][token].read()?;
+        let remaining = limit_state.remaining;
+
+        if !self.storage.spec().is_t3() {
+            return Ok((remaining, 0));
+        }
+
+        if limit_state.period == 0 {
+            return Ok((remaining, 0));
+        }
+
+        if current_timestamp < limit_state.period_end {
+            return Ok((remaining, limit_state.period_end));
+        }
+
+        let next_end = limit_state.compute_next_period_end(current_timestamp);
+
+        Ok((U256::from(limit_state.max), next_end))
+    }
+
     /// Deducts `amount` from the key's remaining spending limit for `token`, failing if exceeded.
     ///
     /// # Errors
@@ -497,14 +707,44 @@ impl AccountKeychain {
 
         // Check and update spending limit
         let limit_key = Self::spending_limit_key(account, key_id);
-        let remaining = self.spending_limits[limit_key][token].read()?;
+        let mut limit_state = self.spending_limits[limit_key][token].read()?;
+        let mut remaining = limit_state.remaining;
+
+        if self.storage.spec().is_t3() {
+            if limit_state.period > 0 {
+                let now = self.storage.timestamp().saturating_to::<u64>();
+                if now >= limit_state.period_end {
+                    let next_end = limit_state.compute_next_period_end(now);
+
+                    remaining = U256::from(limit_state.max);
+                    limit_state.remaining = remaining;
+                    limit_state.period_end = next_end;
+                }
+            }
+        }
 
         if amount > remaining {
             return Err(AccountKeychainError::spending_limit_exceeded().into());
         }
 
         // Update remaining limit
-        self.spending_limits[limit_key][token].write(remaining - amount)
+        let new_remaining = remaining - amount;
+        limit_state.remaining = new_remaining;
+        self.spending_limits[limit_key][token].write(limit_state)?;
+
+        if self.storage.spec().is_t3() {
+            self.emit_event(AccountKeychainEvent::AccessKeySpend(
+                IAccountKeychain::AccessKeySpend {
+                    account,
+                    publicKey: key_id,
+                    token,
+                    amount,
+                    remainingLimit: new_remaining,
+                },
+            ))?;
+        }
+
+        Ok(())
     }
 
     /// Refund spending limit after a fee refund.
@@ -541,11 +781,10 @@ impl AccountKeychain {
         }
 
         let limit_key = Self::spending_limit_key(account, transaction_key);
-        let remaining = self.spending_limits[limit_key][token].read()?;
+        let mut limit_state = self.spending_limits[limit_key][token].read()?;
+        limit_state.remaining = limit_state.remaining.saturating_add(amount);
 
-        let new_remaining = remaining.saturating_add(amount);
-
-        self.spending_limits[limit_key][token].write(new_remaining)
+        self.spending_limits[limit_key][token].write(limit_state)
     }
 
     /// Authorize a token transfer with access key spending limits.
@@ -634,6 +873,7 @@ mod tests {
     use crate::{
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::TIP20Setup,
     };
     use alloy::primitives::{Address, U256};
     use revm::state::Bytecode;
@@ -714,9 +954,13 @@ mod tests {
             let setup_call = authorizeKeyCall {
                 keyId: existing_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(msg_sender, setup_call)?;
 
@@ -727,9 +971,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: other,
                 signatureType: SignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             let auth_result = keychain.authorize_key(msg_sender, auth_call);
             assert!(
@@ -792,9 +1040,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: existing_key,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -806,9 +1058,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: other,
                     signatureType: SignatureType::P256,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             );
             assert!(auth_result.is_err());
@@ -863,12 +1119,17 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_id,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token,
-                        amount: U256::from(100),
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -923,12 +1184,17 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_id,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token,
-                        amount: U256::from(100),
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -973,12 +1239,17 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_id,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token,
-                        amount: U256::from(100),
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1022,12 +1293,17 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_id,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token,
-                        amount: U256::from(100),
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1041,9 +1317,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: other_key,
                     signatureType: SignatureType::P256,
-                    expiry: u64::MAX,
-                    enforceLimits: false,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             );
             assert!(
@@ -1097,12 +1377,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call.clone())?;
 
@@ -1181,9 +1466,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: 0, // Zero expiry is in the past - should fail
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: 0, // Zero expiry is in the past - should fail
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             let result = keychain.authorize_key(account, auth_call);
             assert!(
@@ -1206,9 +1495,13 @@ mod tests {
             let auth_call_past = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: 1, // Very old timestamp - should fail
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: 1, // Very old timestamp - should fail
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             let result_past = keychain.authorize_key(account, auth_call_past);
             assert!(
@@ -1219,6 +1512,64 @@ mod tests {
                     ))
                 ),
                 "Expected ExpiryInPast error for past expiry, got: {result_past:?}"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_pre_t3_authorize_key_rejects_tip_1011_fields_without_writing_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1C);
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+
+            let result = keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100u64),
+                            period: 60,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            );
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPrecompileError::AccountKeychainError(
+                        AccountKeychainError::InvalidCallScope(_)
+                    ))
+                ),
+                "expected InvalidCallScope, got {result:?}"
+            );
+
+            assert_eq!(
+                keychain.keys[account][key_id].read()?,
+                AuthorizedKey::default(),
+                "pre-T3 invalid TIP-1011 fields must not leave behind a key"
+            );
+
+            let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+            assert_eq!(
+                keychain.spending_limits[limit_key][token].read()?,
+                SpendingLimitState::default(),
+                "pre-T3 invalid TIP-1011 fields must not initialize limits"
             );
 
             Ok(())
@@ -1242,9 +1593,13 @@ mod tests {
             let auth_call_1 = authorizeKeyCall {
                 keyId: key_id_1,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call_1)?;
 
@@ -1255,9 +1610,13 @@ mod tests {
             let auth_call_2 = authorizeKeyCall {
                 keyId: key_id_2,
                 signatureType: SignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call_2)?;
 
@@ -1293,12 +1652,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: access_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(eoa, auth_call)?;
 
@@ -1405,12 +1769,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: access_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(eoa_alice, auth_call)?;
 
@@ -1537,9 +1906,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: 1, // Minimal positive expiry
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: 1, // Minimal positive expiry
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call.clone())?;
 
@@ -1622,11 +1995,14 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
-
             // This would fail if initialize didn't set up storage properly
             keychain.authorize_key(account, auth_call)?;
 
@@ -1655,9 +2031,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::WebAuthn,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call)?;
 
@@ -1702,12 +2082,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call)?;
 
@@ -1750,9 +2135,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: false, // Initially no limits
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false, // Initially no limits
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call)?;
 
@@ -1812,9 +2201,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id_revoked,
                 signatureType: SignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call)?;
             keychain.revoke_key(
@@ -1828,9 +2221,13 @@ mod tests {
             let auth_valid = authorizeKeyCall {
                 keyId: key_id_valid,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_valid)?;
 
@@ -1902,9 +2299,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_secp,
                     signatureType: SignatureType::Secp256k1, // type 0
-                    expiry: u64::MAX,
-                    enforceLimits: false,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1913,9 +2314,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_p256,
                     signatureType: SignatureType::P256, // type 1
-                    expiry: u64::MAX,
-                    enforceLimits: false,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1924,9 +2329,13 @@ mod tests {
                 authorizeKeyCall {
                     keyId: key_webauthn,
                     signatureType: SignatureType::WebAuthn, // type 2
-                    expiry: u64::MAX,
-                    enforceLimits: false,
-                    limits: vec![],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1986,9 +2395,13 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: key_id,
                 signatureType: SignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: false,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(account, auth_call)?;
 
@@ -2051,12 +2464,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: access_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(eoa, auth_call)?;
 
@@ -2121,12 +2539,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: access_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: U256::from(100),
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(eoa, auth_call)?;
 
@@ -2182,12 +2605,17 @@ mod tests {
             let auth_call = authorizeKeyCall {
                 keyId: access_key,
                 signatureType: SignatureType::Secp256k1,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![TokenLimit {
-                    token,
-                    amount: original_limit,
-                }],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: original_limit,
+                        period: 0,
+                    }],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             keychain.authorize_key(eoa, auth_call)?;
 
@@ -2216,6 +2644,249 @@ mod tests {
                 "saturating_add should allow refund beyond original limit without overflow"
             );
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_authorize_key_ignores_limits_when_enforce_limits_false() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: false,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 60,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+            assert_eq!(
+                keychain.spending_limits[limit_key][token].read()?,
+                SpendingLimitState::default()
+            );
+
+            let remaining =
+                keychain.get_remaining_limit_with_period(getRemainingLimitWithPeriodCall {
+                    account,
+                    keyId: key_id,
+                    token,
+                })?;
+            assert_eq!(remaining.remaining, U256::ZERO);
+            assert_eq!(remaining.periodEnd, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_rejects_spending_limits_above_u128() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let invalid_key_id = Address::random();
+        let valid_key_id = Address::random();
+        let token = Address::random();
+        let oversized_limit = U256::from(u128::MAX) + U256::from(1u8);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            let authorize_result = keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: invalid_key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: oversized_limit,
+                            period: 60,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            );
+
+            assert!(
+                matches!(
+                    authorize_result,
+                    Err(TempoPrecompileError::AccountKeychainError(
+                        AccountKeychainError::InvalidSpendingLimit(_)
+                    ))
+                ),
+                "expected InvalidSpendingLimit, got {authorize_result:?}"
+            );
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: valid_key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100u64),
+                            period: 60,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let update_result = keychain.update_spending_limit(
+                account,
+                updateSpendingLimitCall {
+                    keyId: valid_key_id,
+                    token,
+                    newLimit: oversized_limit,
+                },
+            );
+
+            assert!(
+                matches!(
+                    update_result,
+                    Err(TempoPrecompileError::AccountKeychainError(
+                        AccountKeychainError::InvalidSpendingLimit(_)
+                    ))
+                ),
+                "expected InvalidSpendingLimit, got {update_result:?}"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_spending_limit_state_preserves_legacy_remaining_slot() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+            let handler = &mut keychain.spending_limits[limit_key][token];
+            let remaining = U256::from(123u64);
+            handler.write(SpendingLimitState {
+                remaining,
+                max: 456,
+                period: 60,
+                period_end: 120,
+            })?;
+
+            assert_eq!(
+                StorageCtx.sload(ACCOUNT_KEYCHAIN_ADDRESS, handler.as_slot().slot())?,
+                remaining
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_periodic_limit_rollover() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            keychain.apply_key_authorization_restrictions(
+                account,
+                key_id,
+                &[TokenLimit {
+                    token,
+                    amount: U256::from(100),
+                    period: 60,
+                }],
+            )?;
+
+            keychain.set_transaction_key(key_id)?;
+            keychain.authorize_transfer(account, token, U256::from(80))?;
+
+            let remaining = keychain.get_remaining_limit(getRemainingLimitCall {
+                account,
+                keyId: key_id,
+                token,
+            })?;
+            assert_eq!(remaining, U256::from(20));
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(1_070u64));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.set_transaction_key(key_id)?;
+            keychain.set_tx_origin(account)?;
+
+            keychain.authorize_transfer(account, token, U256::from(10))?;
+
+            let remaining = keychain.get_remaining_limit(getRemainingLimitCall {
+                account,
+                keyId: key_id,
+                token,
+            })?;
+            assert_eq!(remaining, U256::from(90));
             Ok(())
         })
     }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -40,7 +40,8 @@ use tracing::trace;
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
-use tempo_contracts::precompiles::DECIMALS as TIP20_DECIMALS;
+/// Decimal precision for TIP-20 tokens.
+const TIP20_DECIMALS: u8 = 6;
 
 /// TIP20 token address prefix (12 bytes)
 /// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -40,8 +40,7 @@ use tracing::trace;
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
-/// Decimal precision for TIP-20 tokens
-const TIP20_DECIMALS: u8 = 6;
+use tempo_contracts::precompiles::DECIMALS as TIP20_DECIMALS;
 
 /// TIP20 token address prefix (12 bytes)
 /// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)
@@ -130,7 +129,7 @@ pub static PAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"PAUSE_ROLE"
 pub static UNPAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"UNPAUSE_ROLE"));
 /// Role hash for minting new tokens.
 pub static ISSUER_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"ISSUER_ROLE"));
-/// Role hash that prevents an account from burning tokens.
+/// Role hash that authorizes burning tokens from blocked accounts.
 pub static BURN_BLOCKED_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"BURN_BLOCKED_ROLE"));
 
 impl TIP20Token {
@@ -856,7 +855,7 @@ impl TIP20Token {
         self.next_quote_token.write(quote_token)?;
 
         // Set default values
-        self.supply_cap.write(U256::from(u128::MAX))?;
+        self.supply_cap.write(U128_MAX)?;
         self.transfer_policy_id.write(1)?;
 
         // Initialize roles system and grant admin role
@@ -893,7 +892,7 @@ impl TIP20Token {
 
     /// Validates that the recipient is not:
     /// - the zero address (preventing accidental burns)
-    /// - another TIP20 token
+    /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
     fn check_recipient(&self, to: Address) -> Result<()> {
         if to.is_zero() || is_tip20_prefix(to) {
             return Err(TIP20Error::invalid_recipient().into());
@@ -1091,7 +1090,8 @@ pub(crate) mod tests {
     use crate::{
         PATH_USD_ADDRESS,
         account_keychain::{
-            AccountKeychain, SignatureType, TokenLimit, authorizeKeyCall, getRemainingLimitCall,
+            AccountKeychain, KeyRestrictions, SignatureType, TokenLimit, authorizeKeyCall,
+            getRemainingLimitCall,
         },
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
@@ -1440,12 +1440,17 @@ pub(crate) mod tests {
                 authorizeKeyCall {
                     keyId: access_key,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token: token_address,
-                        amount: spending_limit,
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token: token_address,
+                            amount: spending_limit,
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 
@@ -1508,12 +1513,17 @@ pub(crate) mod tests {
                 authorizeKeyCall {
                     keyId: access_key,
                     signatureType: SignatureType::Secp256k1,
-                    expiry: u64::MAX,
-                    enforceLimits: true,
-                    limits: vec![TokenLimit {
-                        token: token_address,
-                        amount: spending_limit,
-                    }],
+                    config: KeyRestrictions {
+                        expiry: u64::MAX,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token: token_address,
+                            amount: spending_limit,
+                            period: 0,
+                        }],
+                        enforceAllowedCalls: false,
+                        allowedCalls: vec![],
+                    },
                 },
             )?;
 

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -3,13 +3,13 @@ use crate::transaction::PrimitiveSignature;
 use alloc::vec::Vec;
 use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::{Address, B256, U256, keccak256};
-use alloy_rlp::Encodable;
+use alloy_rlp::{Buf, Decodable, EMPTY_STRING_CODE, Encodable};
 
 /// Token spending limit for access keys
 ///
 /// Defines a per-token spending limit for an access key provisioned via key_authorization.
 /// This limit is enforced by the AccountKeychain precompile when the key is used.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -21,6 +21,129 @@ pub struct TokenLimit {
 
     /// Maximum spending amount for this token (enforced over the key's lifetime)
     pub limit: U256,
+
+    /// Period duration in seconds.
+    ///
+    /// `0` means one-time limit. `>0` means the limit resets periodically.
+    pub period: u64,
+}
+
+impl Decodable for TokenLimit {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        let remaining = buf.len();
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let mut fields = &buf[..header.payload_length];
+
+        let token = Decodable::decode(&mut fields)?;
+        let limit = Decodable::decode(&mut fields)?;
+        // Backward-compatible decode: legacy payloads omit period and map to one-time limits.
+        let period = if fields.is_empty() {
+            0
+        } else {
+            let period: u64 = Decodable::decode(&mut fields)?;
+            if period == 0 {
+                return Err(alloy_rlp::Error::Custom(
+                    "token limit period=0 must be encoded in legacy two-field form",
+                ));
+            }
+            period
+        };
+
+        if !fields.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(Self {
+            token,
+            limit,
+            period,
+        })
+    }
+}
+
+impl Encodable for TokenLimit {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let payload_length = self.token.length()
+            + self.limit.length()
+            + if self.period == 0 {
+                0
+            } else {
+                self.period.length()
+            };
+
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(out);
+
+        self.token.encode(out);
+        self.limit.encode(out);
+        if self.period != 0 {
+            self.period.encode(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.token.length()
+            + self.limit.length()
+            + if self.period == 0 {
+                0
+            } else {
+                self.period.length()
+            };
+
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .length_with_payload()
+    }
+}
+
+/// Per-target call scope for an access key.
+///
+/// `selector_rules` uses tri-state semantics:
+/// - `None` => allow any selector for this target
+/// - `Some([])` => deny all selectors for this target
+/// - `Some([..])` => allow exactly the listed selector rules
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[rlp(trailing)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct CallScope {
+    /// Target contract address.
+    pub target: Address,
+    /// Optional selector rules for this target.
+    pub selector_rules: Option<Vec<SelectorRule>>,
+}
+
+/// Selector-level rule within a [`CallScope`].
+///
+/// `recipients` semantics:
+/// - `None` => no recipient constraint
+/// - `Some([..])` => first ABI address argument must be in this list
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[rlp(trailing)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct SelectorRule {
+    /// 4-byte function selector.
+    pub selector: [u8; 4],
+    /// Optional recipient allowlist.
+    pub recipients: Option<Vec<Address>>,
 }
 
 /// Key authorization for provisioning access keys
@@ -28,11 +151,12 @@ pub struct TokenLimit {
 /// Used in TempoTransaction to add a new key to the AccountKeychain precompile.
 /// The transaction must be signed by the root key to authorize adding this access key.
 ///
-/// RLP encoding: `[key_type, key_id, expiry?, limits?]`
+/// RLP encoding: `[chain_id, key_type, key_id, expiry?, limits?, allowed_calls?]`
 /// - Non-optional fields come first, followed by optional (trailing) fields
 /// - `expiry`: `None` (omitted or 0x80) = key never expires, `Some(timestamp)` = expires at timestamp
 /// - `limits`: `None` (omitted or 0x80) = unlimited spending, `Some([])` = no spending, `Some([...])` = specific limits
-#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+/// - `allowed_calls`: `None` = unrestricted, `Some([])` = deny-all, `Some([...])` = scoped calls
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable)]
 #[rlp(trailing)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -60,6 +184,74 @@ pub struct KeyAuthorization {
     /// - `Some([])` = no spending allowed (enforce_limits=true but no tokens allowed)
     /// - `Some([TokenLimit{...}])` = specific limits enforced
     pub limits: Option<Vec<TokenLimit>>,
+
+    /// Optional call scopes for this key.
+    /// - `None` (RLP 0x80) = unrestricted calls
+    /// - `Some([])` = scoped mode with no allowed calls (deny-all)
+    /// - `Some([CallScope{...}])` = explicit target/selector scope list
+    pub allowed_calls: Option<Vec<CallScope>>,
+}
+
+impl Decodable for KeyAuthorization {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        fn decode_optional_field<T: Decodable>(fields: &mut &[u8]) -> alloy_rlp::Result<Option<T>> {
+            if fields.is_empty() {
+                return Ok(None);
+            }
+            if fields.first() == Some(&EMPTY_STRING_CODE) {
+                fields.advance(1);
+                return Ok(None);
+            }
+
+            Ok(Some(Decodable::decode(fields)?))
+        }
+
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        let remaining = buf.len();
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let mut fields = &buf[..header.payload_length];
+
+        let chain_id = Decodable::decode(&mut fields)?;
+        let key_type = Decodable::decode(&mut fields)?;
+        let key_id = Decodable::decode(&mut fields)?;
+
+        let expiry: Option<u64> = decode_optional_field(&mut fields)?;
+        let limits: Option<Vec<TokenLimit>> = decode_optional_field(&mut fields)?;
+
+        let allowed_calls = if fields.is_empty() {
+            None
+        } else {
+            if fields.first() == Some(&EMPTY_STRING_CODE) {
+                return Err(alloy_rlp::Error::Custom(
+                    "key authorization allowed_calls=None must be omitted on wire",
+                ));
+            }
+
+            Some(Decodable::decode(&mut fields)?)
+        };
+
+        if !fields.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(Self {
+            chain_id,
+            key_type,
+            key_id,
+            expiry,
+            limits,
+            allowed_calls,
+        })
+    }
 }
 
 impl KeyAuthorization {
@@ -68,6 +260,18 @@ impl KeyAuthorization {
         let mut buf = Vec::new();
         self.encode(&mut buf);
         keccak256(&buf)
+    }
+
+    /// Returns whether any token limit uses periodic reset semantics.
+    pub fn has_periodic_limits(&self) -> bool {
+        self.limits
+            .as_ref()
+            .is_some_and(|limits| limits.iter().any(|limit| limit.period != 0))
+    }
+
+    /// Returns whether this authorization carries explicit call-scope restrictions.
+    pub fn has_call_scopes(&self) -> bool {
+        self.allowed_calls.is_some()
     }
 
     /// Returns whether this key has unlimited spending (limits is None)
@@ -113,6 +317,42 @@ impl KeyAuthorization {
         Ok(())
     }
 
+    /// Returns the number of storage rows written for scoped-call state.
+    ///
+    /// This mirrors the writes performed by `authorize_key -> replace_allowed_calls ->
+    /// upsert_target_scope` in the account keychain precompile.
+    pub fn call_scope_storage_slots(&self) -> u64 {
+        match self.allowed_calls.as_ref() {
+            None => 0,
+            Some(scopes) if scopes.is_empty() => 1,
+            Some(scopes) => {
+                let mut selectors = 0u64;
+                let mut constrained_selectors = 0u64;
+                let mut recipients = 0u64;
+
+                for scope in scopes {
+                    if let Some(rules) = scope.selector_rules.as_ref() {
+                        selectors += rules.len() as u64;
+                        for rule in rules {
+                            if let Some(rule_recipients) = rule.recipients.as_ref() {
+                                constrained_selectors += 1;
+                                recipients += rule_recipients.len() as u64;
+                            }
+                        }
+                    }
+                }
+
+                // Storage write accounting:
+                // - account mode write: 1
+                // - each target insertion + target mode write: 3 + 1
+                // - each selector insertion + selector mode write: 3 + 1
+                // - recipient-constrained selectors also write recipient set length: +1 per selector
+                // - recipient set values+positions: +2 per recipient
+                1 + scopes.len() as u64 * 4 + selectors * 4 + constrained_selectors + recipients * 2
+            }
+        }
+    }
+
     /// Calculates a heuristic for the in-memory size of the key authorization
     pub fn size(&self) -> usize {
         size_of::<Self>()
@@ -120,6 +360,25 @@ impl KeyAuthorization {
                 .limits
                 .as_ref()
                 .map_or(0, |limits| limits.capacity() * size_of::<TokenLimit>())
+            + self.allowed_calls.as_ref().map_or(0, |scopes| {
+                scopes.capacity() * size_of::<CallScope>()
+                    + scopes
+                        .iter()
+                        .map(|scope| {
+                            scope.selector_rules.as_ref().map_or(0, |rules| {
+                                rules.capacity() * size_of::<SelectorRule>()
+                                    + rules
+                                        .iter()
+                                        .map(|rule| {
+                                            rule.recipients.as_ref().map_or(0, |recipients| {
+                                                recipients.capacity() * size_of::<Address>()
+                                            })
+                                        })
+                                        .sum::<usize>()
+                            })
+                        })
+                        .sum::<usize>()
+            })
     }
 }
 
@@ -171,24 +430,6 @@ impl SignedKeyAuthorization {
     }
 }
 
-#[cfg(feature = "reth-codec")]
-impl reth_codecs::Compact for SignedKeyAuthorization {
-    fn to_compact<B>(&self, buf: &mut B) -> usize
-    where
-        B: alloy_rlp::BufMut + AsMut<[u8]>,
-    {
-        // Use RLP encoding for compact representation
-        self.encode(buf);
-        self.length()
-    }
-
-    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
-        let item = alloy_rlp::Decodable::decode(&mut buf)
-            .expect("Failed to decode KeyAuthorization from compact");
-        (item, buf)
-    }
-}
-
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -199,6 +440,7 @@ impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
             // Ensure that Some(0) is not generated as it's becoming `None` after RLP roundtrip.
             expiry: u.arbitrary::<Option<u64>>()?.filter(|v| *v != 0),
             limits: u.arbitrary()?,
+            allowed_calls: u.arbitrary()?,
         })
     }
 }
@@ -218,6 +460,7 @@ mod tests {
             key_id: Address::random(),
             expiry,
             limits,
+            allowed_calls: None,
         }
     }
 
@@ -273,6 +516,7 @@ mod tests {
                 Some(vec![TokenLimit {
                     token: Address::ZERO,
                     limit: U256::from(100),
+                    period: 0,
                 }])
             )
             .has_unlimited_spending()
@@ -284,6 +528,42 @@ mod tests {
         assert!(!make_auth(Some(0), None).never_expires()); // 0 is still Some
     }
 
+    #[test]
+    fn test_size_does_not_double_count_call_scope_structs() {
+        let recipients = vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)];
+        let mut rules = Vec::with_capacity(3);
+        rules.push(SelectorRule {
+            selector: [1, 2, 3, 4],
+            recipients: Some(recipients),
+        });
+
+        let mut scopes = Vec::with_capacity(2);
+        scopes.push(CallScope {
+            target: Address::repeat_byte(0x33),
+            selector_rules: Some(rules),
+        });
+
+        let auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::repeat_byte(0x44),
+            expiry: None,
+            limits: None,
+            allowed_calls: Some(scopes),
+        };
+
+        let scope_rules = auth.allowed_calls.as_ref().unwrap();
+        let selector_rules = scope_rules[0].selector_rules.as_ref().unwrap();
+        let recipients = selector_rules[0].recipients.as_ref().unwrap();
+
+        let expected = size_of::<KeyAuthorization>()
+            + scope_rules.capacity() * size_of::<CallScope>()
+            + selector_rules.capacity() * size_of::<SelectorRule>()
+            + recipients.capacity() * size_of::<Address>();
+
+        assert_eq!(auth.size(), expected);
+    }
+
     fn make_auth_with_chain_id(chain_id: u64) -> KeyAuthorization {
         KeyAuthorization {
             chain_id,
@@ -291,7 +571,96 @@ mod tests {
             key_id: Address::random(),
             expiry: None,
             limits: None,
+            allowed_calls: None,
         }
+    }
+
+    #[test]
+    fn test_token_limit_legacy_decode_defaults_period_to_zero() {
+        let token = Address::random();
+        let limit = U256::from(42);
+
+        // Legacy pre-T3 payloads encode TokenLimit as [token, limit].
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: token.length() + limit.length(),
+        }
+        .encode(&mut encoded);
+        token.encode(&mut encoded);
+        limit.encode(&mut encoded);
+
+        let decoded: TokenLimit =
+            Decodable::decode(&mut encoded.as_slice()).expect("decode legacy token limit");
+        assert_eq!(decoded.token, token);
+        assert_eq!(decoded.limit, limit);
+        assert_eq!(decoded.period, 0);
+    }
+
+    #[test]
+    fn test_token_limit_encoding_omits_zero_period() {
+        let token_limit = TokenLimit {
+            token: Address::random(),
+            limit: U256::from(1234),
+            period: 0,
+        };
+
+        let mut encoded = Vec::new();
+        token_limit.encode(&mut encoded);
+
+        let mut payload = &encoded[..];
+        let header = alloy_rlp::Header::decode(&mut payload).expect("decode list header");
+        assert!(header.list);
+        assert_eq!(
+            header.payload_length,
+            token_limit.token.length() + token_limit.limit.length()
+        );
+    }
+
+    #[test]
+    fn test_token_limit_decode_rejects_explicit_zero_period_field() {
+        let token = Address::random();
+        let limit = U256::from(42);
+        let period = 0u64;
+
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: token.length() + limit.length() + period.length(),
+        }
+        .encode(&mut encoded);
+        token.encode(&mut encoded);
+        limit.encode(&mut encoded);
+        period.encode(&mut encoded);
+
+        let err: alloy_rlp::Error =
+            <TokenLimit as Decodable>::decode(&mut encoded.as_slice()).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)));
+    }
+
+    #[test]
+    fn test_key_authorization_decode_rejects_explicit_unrestricted_allowed_calls_field() {
+        let chain_id = 1u64;
+        let key_type = SignatureType::Secp256k1;
+        let key_id = Address::random();
+
+        let mut payload = Vec::new();
+        chain_id.encode(&mut payload);
+        key_type.encode(&mut payload);
+        key_id.encode(&mut payload);
+        payload.extend_from_slice(&[EMPTY_STRING_CODE, EMPTY_STRING_CODE, EMPTY_STRING_CODE]);
+
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: payload.len(),
+        }
+        .encode(&mut encoded);
+        encoded.extend_from_slice(&payload);
+
+        let err: alloy_rlp::Error =
+            <KeyAuthorization as Decodable>::decode(&mut encoded.as_slice()).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -15,7 +15,8 @@ pub use tt_signature::{
 pub use alloy_eips::eip7702::Authorization;
 pub use envelope::{TIP20_PAYMENT_PREFIX, TempoTxEnvelope, TempoTxType, TempoTypedTransaction};
 pub use key_authorization::{
-    KeyAuthorization, KeyAuthorizationChainIdError, SignedKeyAuthorization, TokenLimit,
+    CallScope, KeyAuthorization, KeyAuthorizationChainIdError, SelectorRule,
+    SignedKeyAuthorization, TokenLimit,
 };
 pub use tempo_transaction::{
     Call, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -794,13 +794,6 @@ impl Decodable for TempoTransaction {
     }
 }
 
-#[cfg(feature = "reth")]
-impl reth_primitives_traits::InMemorySize for TempoTransaction {
-    fn size(&self) -> usize {
-        Self::size(self)
-    }
-}
-
 // Custom Arbitrary implementation to ensure calls is never empty and CREATE validation passes
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for TempoTransaction {
@@ -1615,7 +1608,9 @@ mod tests {
             limits: Some(vec![crate::transaction::TokenLimit {
                 token: address!("0000000000000000000000000000000000000003"),
                 limit: U256::from(10000),
+                period: 0,
             }]),
+            allowed_calls: None,
             key_id: address!("0000000000000000000000000000000000000004"),
         }
         .into_signed(PrimitiveSignature::Secp256k1(Signature::test_signature()));

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -35,7 +35,7 @@ use tempo_chainspec::{
 };
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
-    account_keychain::AccountKeychain,
+    account_keychain::{AccountKeychain, SpendingLimitState},
     error::Result as TempoPrecompileResult,
     nonce::NonceManager,
     storage::Handler,
@@ -287,7 +287,7 @@ where
             // Prevents mass eviction because it only:
             // - evicts when NO validator token has enough liquidity
             // - considers active validators (protects from permissionless `setValidatorToken`)
-            if has_active_validator_token_changes && let Some(ref provider) = state_provider {
+            if has_active_validator_token_changes && let Some(ref mut provider) = state_provider {
                 let user_token = tx
                     .transaction
                     .inner()
@@ -295,7 +295,7 @@ where
                     .unwrap_or(tempo_precompiles::DEFAULT_FEE_TOKEN);
                 let cost = tx.transaction.fee_token_cost();
 
-                match amm_cache.has_enough_liquidity(user_token, cost, &**provider) {
+                match amm_cache.has_enough_liquidity(user_token, cost, provider) {
                     Ok(true) => {}
                     Ok(false) => {
                         to_remove.push(*tx.hash());
@@ -1171,7 +1171,9 @@ pub(crate) fn exceeds_spending_limit(
                 return Ok(false);
             }
 
-            let remaining = keychain.spending_limits[limit_key][subject.fee_token].read()?;
+            let remaining = keychain.spending_limits[limit_key][subject.fee_token]
+                .read()?
+                .remaining;
             Ok(fee_token_cost > remaining)
         })
         .unwrap_or_default()
@@ -1257,16 +1259,16 @@ fn get_recipient_policy_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transaction::KeychainSubject;
+    use crate::{test_utils::MockProviderStorageExt, transaction::KeychainSubject};
     use alloy_primitives::{U256, address};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_storage_api::StateProviderFactory;
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::ITIP403Registry;
     use tempo_precompiles::{
-        ACCOUNT_KEYCHAIN_ADDRESS, TIP403_REGISTRY_ADDRESS,
         account_keychain::{AccountKeychain, AuthorizedKey},
         tip20::slots as tip20_slots,
-        tip403_registry::PolicyData,
+        tip403_registry::{CompoundPolicyData, PolicyData, TIP403Registry},
     };
 
     fn provider_with_spending_limit(
@@ -1279,28 +1281,24 @@ mod tests {
             tempo_chainspec::spec::MODERATO.clone(),
         ));
 
-        let keychain = AccountKeychain::new();
-
         // Write AuthorizedKey with enforce_limits=true
-        let key_slot = keychain.keys[account][key_id].base_slot();
-        let authorized_key = AuthorizedKey {
-            signature_type: 0,
-            expiry: u64::MAX,
-            enforce_limits: true,
-            is_revoked: false,
-        }
-        .encode_to_slot();
-
-        let limit_key = AccountKeychain::spending_limit_key(account, key_id);
-        let limit_slot = keychain.spending_limits[limit_key][fee_token].slot();
-
-        provider.add_account(
-            ACCOUNT_KEYCHAIN_ADDRESS,
-            ExtendedAccount::new(0, alloy_primitives::U256::ZERO).extend_storage([
-                (key_slot.into(), authorized_key),
-                (limit_slot.into(), remaining_limit),
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut keychain = AccountKeychain::new();
+                keychain.keys[account][key_id].write(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: true,
+                    is_revoked: false,
+                })?;
+                let limit_key = AccountKeychain::spending_limit_key(account, key_id);
+                keychain.spending_limits[limit_key][fee_token].write(SpendingLimitState {
+                    remaining: remaining_limit,
+                    ..Default::default()
+                })?;
+                Ok::<(), tempo_precompiles::error::TempoPrecompileError>(())
+            })
+            .unwrap();
 
         provider.latest().unwrap()
     }
@@ -1331,26 +1329,24 @@ mod tests {
         );
 
         // Set up TIP403 registry with compound policy pointing to sub-policies
-        let registry = TIP403Registry::new();
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-            admin: Address::ZERO,
-        };
-        let base_slot = registry.policy_records[compound_policy_id].base.base_slot();
-        let compound_slot = registry.policy_records[compound_policy_id]
-            .compound
-            .base_slot();
-        // CompoundPolicyData: 3 u64s packed into one slot
-        let compound_encoded =
-            U256::from(sender_sub_policy) | (U256::from(recipient_sub_policy) << 64);
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([
-                (base_slot.into(), policy_data.encode_to_slot()),
-                (compound_slot.into(), compound_encoded),
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[compound_policy_id]
+                    .base
+                    .write(PolicyData {
+                        policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+                        admin: Address::ZERO,
+                    })?;
+                registry.policy_records[compound_policy_id]
+                    .compound
+                    .write(CompoundPolicyData {
+                        sender_policy_id: sender_sub_policy,
+                        recipient_policy_id: recipient_sub_policy,
+                        mint_recipient_policy_id: 0,
+                    })
+            })
+            .unwrap();
 
         let mut state = provider.latest().unwrap();
         let mut cache: AddressMap<Vec<u64>> = AddressMap::default();
@@ -1392,25 +1388,24 @@ mod tests {
             )]),
         );
 
-        let registry = TIP403Registry::new();
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-            admin: Address::ZERO,
-        };
-        let base_slot = registry.policy_records[compound_policy_id].base.base_slot();
-        let compound_slot = registry.policy_records[compound_policy_id]
-            .compound
-            .base_slot();
-        let compound_encoded =
-            U256::from(sender_sub_policy) | (U256::from(recipient_sub_policy) << 64);
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([
-                (base_slot.into(), policy_data.encode_to_slot()),
-                (compound_slot.into(), compound_encoded),
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[compound_policy_id]
+                    .base
+                    .write(PolicyData {
+                        policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+                        admin: Address::ZERO,
+                    })?;
+                registry.policy_records[compound_policy_id]
+                    .compound
+                    .write(CompoundPolicyData {
+                        sender_policy_id: sender_sub_policy,
+                        recipient_policy_id: recipient_sub_policy,
+                        mint_recipient_policy_id: 0,
+                    })
+            })
+            .unwrap();
 
         let mut state = provider.latest().unwrap();
         let mut cache: AddressMap<Vec<u64>> = AddressMap::default();
@@ -1451,26 +1446,24 @@ mod tests {
             )]),
         );
 
-        let registry = TIP403Registry::new();
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-            admin: Address::ZERO,
-        };
-        let base_slot = registry.policy_records[compound_policy_id].base.base_slot();
-        let compound_slot = registry.policy_records[compound_policy_id]
-            .compound
-            .base_slot();
-        let compound_encoded = U256::from(sender_sub)
-            | (U256::from(recipient_sub) << 64)
-            | (U256::from(mint_recipient_sub) << 128);
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([
-                (base_slot.into(), policy_data.encode_to_slot()),
-                (compound_slot.into(), compound_encoded),
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[compound_policy_id]
+                    .base
+                    .write(PolicyData {
+                        policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+                        admin: Address::ZERO,
+                    })?;
+                registry.policy_records[compound_policy_id]
+                    .compound
+                    .write(CompoundPolicyData {
+                        sender_policy_id: sender_sub,
+                        recipient_policy_id: recipient_sub,
+                        mint_recipient_policy_id: mint_recipient_sub,
+                    })
+            })
+            .unwrap();
 
         let mut state = provider.latest().unwrap();
         let mut cache: AddressMap<Vec<u64>> = AddressMap::default();
@@ -1507,24 +1500,24 @@ mod tests {
             )]),
         );
 
-        let registry = TIP403Registry::new();
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
-            admin: Address::ZERO,
-        };
-        let base_slot = registry.policy_records[compound_policy_id].base.base_slot();
-        let compound_slot = registry.policy_records[compound_policy_id]
-            .compound
-            .base_slot();
-        let compound_encoded = U256::from(sender_sub) | (U256::from(recipient_sub) << 64);
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([
-                (base_slot.into(), policy_data.encode_to_slot()),
-                (compound_slot.into(), compound_encoded),
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[compound_policy_id]
+                    .base
+                    .write(PolicyData {
+                        policy_type: ITIP403Registry::PolicyType::COMPOUND as u8,
+                        admin: Address::ZERO,
+                    })?;
+                registry.policy_records[compound_policy_id]
+                    .compound
+                    .write(CompoundPolicyData {
+                        sender_policy_id: sender_sub,
+                        recipient_policy_id: recipient_sub,
+                        mint_recipient_policy_id: 0,
+                    })
+            })
+            .unwrap();
 
         let mut state = provider.latest().unwrap();
         let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::default())
@@ -1564,18 +1557,17 @@ mod tests {
             )]),
         );
 
-        let registry = TIP403Registry::new();
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
-            admin: Address::ZERO,
-        };
-        let base_slot = registry.policy_records[simple_policy_id].base.base_slot();
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO)
-                .extend_storage([(base_slot.into(), policy_data.encode_to_slot())]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[simple_policy_id]
+                    .base
+                    .write(PolicyData {
+                        policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
+                        admin: Address::ZERO,
+                    })
+            })
+            .unwrap();
 
         let mut state = provider.latest().unwrap();
         let ids = get_recipient_policy_ids(&mut state, fee_token, TempoHardfork::default())
@@ -1649,23 +1641,19 @@ mod tests {
         let provider = MockEthProvider::default().with_chain_spec(std::sync::Arc::unwrap_or_clone(
             tempo_chainspec::spec::MODERATO.clone(),
         ));
-        let key_slot = AccountKeychain::new().keys[account][key_id].base_slot();
-        let authorized_key = AuthorizedKey {
-            signature_type: 0,
-            expiry: u64::MAX,
-            enforce_limits: true,
-            is_revoked: false,
-        }
-        .encode_to_slot();
-        provider.add_account(
-            ACCOUNT_KEYCHAIN_ADDRESS,
-            ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
-                .extend_storage([(key_slot.into(), authorized_key)]),
-        );
-        let mut state = provider.latest().unwrap();
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                AccountKeychain::new().keys[account][key_id].write(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: true,
+                    is_revoked: false,
+                })
+            })
+            .unwrap();
 
         assert!(exceeds_spending_limit(
-            &mut state,
+            &mut provider.latest().unwrap(),
             &subject,
             alloy_primitives::U256::from(1)
         ));
@@ -1686,23 +1674,19 @@ mod tests {
         let provider = MockEthProvider::default().with_chain_spec(std::sync::Arc::unwrap_or_clone(
             tempo_chainspec::spec::MODERATO.clone(),
         ));
-        let key_slot = AccountKeychain::new().keys[account][key_id].base_slot();
-        let authorized_key = AuthorizedKey {
-            signature_type: 0,
-            expiry: u64::MAX,
-            enforce_limits: false,
-            is_revoked: false,
-        }
-        .encode_to_slot();
-        provider.add_account(
-            ACCOUNT_KEYCHAIN_ADDRESS,
-            ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
-                .extend_storage([(key_slot.into(), authorized_key)]),
-        );
-        let mut state = provider.latest().unwrap();
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                AccountKeychain::new().keys[account][key_id].write(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: false,
+                    is_revoked: false,
+                })
+            })
+            .unwrap();
 
         assert!(!exceeds_spending_limit(
-            &mut state,
+            &mut provider.latest().unwrap(),
             &subject,
             alloy_primitives::U256::from(1)
         ));

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -1,47 +1,56 @@
 ---
 id: TIP-1011
 title: Enhanced Access Key Permissions
-description: Extends Access Keys with periodic spending limits and destination address scoping for subscription-based and restricted access patterns.
-authors: Tanishk Goyal 
+description: Extends Access Keys with periodic spending limits, destination/function scoping, and limited calldata recipient scoping.
+authors: Tanishk Goyal
 status: Draft
-related: TIP-1000, AccountKeychain, IAccountKeychain.sol
-protocolVersion: TBD (requires hardfork)
+related: Tempo Transaction Spec
+protocolVersion: T3
 ---
 
 # TIP-1011: Enhanced Access Key Permissions
 
 ## Abstract
 
-This TIP extends Access Keys with two new permission features: (1) **periodic spending limits** that automatically reset after a configurable time period, enabling subscription-based access patterns, and (2) **destination address scoping** that restricts keys to only interact with specific contract addresses.
+This TIP extends Access Keys with three permission features:
+
+1. **Periodic spending limits** that reset on fixed intervals.
+2. **Call scoping** that limits what addresses a key can call and which selectors it can use.
+3. **Limited calldata recipient scoping** for token transfer/approval selectors.
+
 
 ## Motivation
 
-Currently, Access Keys support spending limits (per-TIP-20 token caps) and expiry timestamps. However, these primitives are insufficient for common real-world patterns:
+Currently Access Keys support per-token limits and expiry, but miss two practical controls.
 
 ### Periodic Spending Limits
 
-The existing `TokenLimit` specifies a one-time spending cap that depletes permanently. This model doesn't support subscription-based patterns where:
-
-- A service needs recurring access to a fixed amount per billing cycle
-- Users want to authorize "up to X tokens per month" without re-authorizing
-- dApps implement subscription models (e.g., streaming services, SaaS payments)
+One-time limits cannot express recurring allowances.
 
 **Use cases:**
-1. **Subscription services**: Authorize a streaming service to charge 10 USDC/month
-2. **Recurring donations**: Allow an NPO to withdraw up to 5 USDC weekly
-3. **Payroll systems**: Enable payroll contracts to transfer salaries monthly
-4. **Rate-limited APIs**: Authorize API access keys with per-period token budgets
 
-### Destination Address Scoping
+1. Subscription billing (`10 USDC / month`).
+2. Payroll schedules (monthly budgeted payouts).
+3. Rate-limited agent/API budgets.
 
-Users have requested the ability to bind Access Keys to specific destinations (e.g., "only allow transactions to Uniswap"). This provides more granular permission scoping similar to Solana's delegate primitive.
+### Call Scoping (Target + Selector Set)
 
-**Use cases:**
-1. **DeFi integrations**: Allow a trading bot key to only interact with specific DEX contracts
-2. **Gaming**: Scope a session key to only interact with a game contract
-3. **Subscription services**: Allow a key to only call a specific payment contract
+Users need finer controls than "any call". They want keys like:
 
-**Current workaround**: Deploy a proxy contract that enforces destination restrictions, adding gas overhead and complexity.
+1. "Only call `swap()` and `exactInput()` on DEX X."
+2. "Only call gameplay methods on contract Y."
+3. "Only perform plain transfers, not token extension methods."
+4. "Only vote() on governance contracts."
+
+**Current workaround**: Deploy a proxy contract that enforces destination/function restrictions, adding gas overhead and complexity.
+
+### Recipient-Bound Token Calls
+
+Target + selector scoping still allows an access key to move funds to arbitrary recipients for token methods like `transfer` and `approve`.
+
+Users need a narrower policy: the key may call transfer/approve selectors, but only when the recipient/spender matches a configured address.
+
+This TIP intentionally adds a narrow calldata rule (first ABI `address` argument equality) instead of a generic calldata policy language.
 
 ---
 
@@ -49,265 +58,563 @@ Users have requested the ability to bind Access Keys to specific destinations (e
 
 ## Extended Data Structures
 
+Conventions used in this section:
+
+1. Protocol/RLP structs are written with Rust-like `Option<...>` notation.
+2. Solidity ABI structs are listed separately where ABI cannot directly represent protocol `Option` semantics.
+
 ### TokenLimit
 
 **Current:**
+
 ```solidity
 struct TokenLimit {
     address token;
-    uint256 limit;
+    uint256 amount;
 }
 ```
 
 **Proposed:**
+
 ```solidity
 struct TokenLimit {
     address token;
-    uint256 limit;      // Per-period limit when period > 0, one-time limit otherwise
-    uint256 remainingInPeriod;  // Remaining allowance in current period
-    uint64 period;      // Period duration in seconds (0 = one-time limit)
-    uint64 periodEnd;   // Timestamp when current period expires
+    uint256 amount;  // One-time cap when period == 0, per-period cap when period > 0
+    uint64 period;  // Period duration in seconds (0 = one-time limit)
 }
 ```
 
+Design note: `period` is specified as an explicit field (instead of packed into `token`) to keep encoding/auditing straightforward and avoid migration risk for existing limit semantics.
+
+Runtime state is derived and stored by the precompile (not signed):
+
+```text
+TokenLimitState {
+    remainingInPeriod: uint256,
+    periodEnd: uint64,
+}
+```
+
+Initialization and persistence:
+
+1. `TokenLimitState` is initialized when the key is authorized (or a limit is created via root mutation), not lazily at first spend.
+2. `period == 0` initializes `remainingInPeriod = limit` and `periodEnd = 0`.
+3. `period > 0` initializes `remainingInPeriod = limit` and `periodEnd = authorize_time + period`.
+4. For a given `(account,key,token)`, there is exactly one active `TokenLimit`; duplicate token entries in a single authorization MUST be rejected.
+
+### CallScope
+
+Call scoping is defined with optional fields (protocol-level / RLP model):
+
+```text
+CallScope {
+    target: address,
+    selector_rules: Option<Vec<SelectorRule>>,   // None => any selector on this target
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct CallScope {
+    address target;
+    SelectorRule[] selectorRules;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `selectorRules = []` maps to `selector_rules = None` (allow any selector on `target`, not "block all").
+2. `selectorRules = [r1, ...]` maps to `selector_rules = Some([r1, ...])`.
+3. To remove a target scope in the Solidity precompile API, callers MUST use `removeAllowedCalls(keyId, target)`.
+
+`selector_rules` behavior intentionally mirrors `limits` tri-state semantics:
+
+1. `None`: allow any selector.
+2. `Some([])`: allow no selectors (matches nothing for that scope).
+3. `Some([r1, r2, ...])`: allow exactly the listed selector rules.
+
+In the Solidity precompile API, omitting a target scope blocks that target; `selectorRules = []` does not.
+
+### SelectorRule
+
+```text
+SelectorRule {
+    selector: bytes4,
+    recipients: Option<Vec<address>>, // None => any recipient, Some([a1, ...]) => only listed recipients
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct SelectorRule {
+    bytes4 selector;
+    address[] recipients;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `recipients = []` maps to `recipients = None`. Note: empty array maps to allowing all recipients in solidity. To block all recipients, omit/remove that selector rule.
+2. `recipients = [a1, ...]` maps to `recipients = Some([a1, ...])`.
+
+`SelectorRule.recipients` behavior:
+
+1. `None` => no calldata recipient checks for this selector.
+2. `Some([a1, a2, ...])` => enforce `arg0` recipient membership for this selector.
+3. Selector rules MUST be unique per target (`selector` appears at most once).
+
+Supported constrained selectors in this TIP:
+
+1. `0xa9059cbb` => `transfer(address,uint256)`
+2. `0x095ea7b3` => `approve(address,uint256)`
+3. `0x95777d59` => `transferWithMemo(address,uint256,bytes32)`
+
+If a selector rule uses `recipients = Some([..])`, then:
+
+1. `target` MUST be a TIP-20 token address.
+2. `selector` MUST be one of the constrained selectors above.
+3. Otherwise, key authorization MUST be rejected.
+
+For these selectors, the constrained field is ABI argument `0` (the first `address` argument).
+
+Selector width is fixed at 4 bytes.
+
+1. Each `SelectorRule.selector` MUST be exactly 4 bytes.
+2. Implementations MUST revert when decoding or accepting any selector whose length is not exactly 4 bytes.
+3. Selectorless calls (`calldata.length < 4`) and fallback/receive routing are scope-matchable only for address-only scopes (`selector_rules = None`). They MUST be rejected when explicit selector matching is required.
+4. Contracts with non-standard selector parsing are NOT supported.
+
+Examples:
+
+1. `{ target: 0x123, selector_rules: Some([{selector: 0xaabbccdd, recipients: None}, {selector: 0xeeff0011, recipients: None}]) }`: allow two selectors on one target.
+2. `{ target: 0x123, selector_rules: None }`: address-only scoping (any calldata shape on `0x123`, including selectorless/fallback-style calls).
+3. `{ target: 0x123, selector_rules: Some([]) }`: matches no selector on `0x123`.
+4. `allowedCalls = None`: unrestricted key.
+5. `allowedCalls = Some([])`: key is authorized but cannot make scoped calls.
+6. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xReceiver])}]) }`: allow `transfer` only when `to == 0xReceiver`.
+7. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xA, 0xB])}]) }`: allow `transfer` only when `to` is in `{0xA, 0xB}`.
+8. Distinct target scopes are independent: allowing selector `s` on target `A` never allows selector `s` on target `B`.
+
 ### KeyAuthorization
 
-**Current fields retained:**
-- `spendingLimits`: `TokenLimit[]`
-- `expiry`: `uint64`
+Existing fields remain, with a trailing optional call-scope field:
 
-**New field:**
-```solidity
-struct KeyAuthorization {
-    TokenLimit[] spendingLimits;
-    uint64 expiry;
-    address[] allowedDestinations; // Empty array = unrestricted
+```text
+KeyAuthorization {
+    chain_id: u64,
+    key_type: SignatureType,
+    key_id: address,
+    expiry: Option<u64>,
+    limits: Option<Vec<TokenLimit>>,
+    allowed_calls: Option<Vec<CallScope>>,  // New trailing field
 }
 ```
 
 ## Interface Changes
 
+### Events
+
+```solidity
+/// @notice Emitted when an access key spends tokens against a spending limit
+/// @param account The account whose key was used
+/// @param publicKey The public key (address) that initiated the spend
+/// @param token The token address being spent
+/// @param amount The amount spent in this transaction
+/// @param remainingLimit The remaining spending limit after this spend
+event AccessKeySpend(
+    address indexed account,
+    address indexed publicKey,
+    address indexed token,
+    uint256 amount,
+    uint256 remainingLimit
+);
+```
+
+This event MUST be emitted whenever an access-key transaction deducts from a spending limit (one-time or periodic).
+
 ### IAccountKeychain.sol
 
 ```solidity
 /// @notice Authorizes a key with enhanced permissions
-/// @param key The public key to authorize
+/// @param keyId The key identifier (address derived from public key)
+/// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
 /// @param expiry Block timestamp when key expires
+/// @param enforceLimits Whether spending limits are enforced for this key
 /// @param spendingLimits Token spending limits (may include periodic limits)
-/// @param allowedDestinations Addresses the key may call (empty = unrestricted)
+/// @param enforceAllowedCalls Whether call-scope restrictions are enabled for this key
+/// @param allowedCalls Per-target call scopes for this key.
 function authorizeKey(
-    bytes calldata key,
+    address keyId,
+    SignatureType signatureType,
     uint64 expiry,
+    bool enforceLimits,
     TokenLimit[] calldata spendingLimits,
-    address[] calldata allowedDestinations
+    bool enforceAllowedCalls,
+    CallScope[] calldata allowedCalls
 ) external;
 
-/// @notice Returns the allowed destinations for a key
-/// @param key The public key to query
-/// @return destinations Array of allowed destination addresses (empty = unrestricted)
-function getAllowedDestinations(bytes calldata key) external view returns (address[] memory destinations);
+/// @notice Creates or replaces one target scope for a key
+/// @dev Root key only. If `target` does not exist, creates a new scope; otherwise replaces it atomically.
+/// @dev `scope.selectorRules = []` allows any selector on `scope.target`; it does not block the target.
+/// @dev If a selector rule has `recipients`, `target` MUST be TIP-20 and `selector` MUST be transfer/approve (+memo).
+/// @dev For each selector rule, `recipients = []` means no recipient restriction.
+function setAllowedCalls(
+    address keyId,
+    CallScope calldata scope
+) external;
 
-/// @notice Returns the remaining limit for a token, accounting for period resets
-/// @param key The public key to query
-/// @param token The token address
-/// @return remaining The remaining spending limit for the current period
-/// @return periodEnd The timestamp when the current period ends (0 if one-time limit)
-function getRemainingLimit(bytes calldata key, address token) external view returns (uint256 remaining, uint64 periodEnd);
+/// @notice Removes one target scope for a key
+function removeAllowedCalls(address keyId, address target) external;
+
+/// @notice Returns allowed call scopes for an account+key
+/// @dev Explicit deny-all (`allowed_calls = Some([])`) is returned as the sentinel
+///      `{ target: address(0), selectorRules: [] }`
+///      so callers can distinguish it from unrestricted mode (`[]`).
+function getAllowedCalls(
+    address account,
+    address keyId
+) external view returns (CallScope[] memory calls);
+
+/// @notice Returns remaining limit for a token, accounting for period resets
+function getRemainingLimit(
+    address account,
+    address keyId,
+    address token
+) external view returns (uint256 remaining, uint64 periodEnd);
 ```
 
 ## Semantic Behavior
 
 ### Periodic Limit Reset Logic
 
-When a spending attempt occurs:
+On each spend attempt for `(account, key, token)`:
 
-```
-function verifyAndUpdateSpending(key, token, amount):
-    limit = getTokenLimit(key, token)
-    
-    if limit.period > 0:  // Periodic limit
-        if block.timestamp >= limit.periodEnd:
-            // Reset period
-            limit.periodEnd = block.timestamp + limit.period
-            limit.remainingInPeriod = limit.limit  // Reset to per-period allowance
-    
-    if amount > limit.remainingInPeriod:
-        revert SpendingLimitExceeded()
-    
-    limit.remainingInPeriod -= amount
-```
+1. Implementations MUST load the configured `TokenLimit` and runtime `TokenLimitState`.
+2. If `period == 0`, the limit is one-time and no period rollover is applied.
+3. If `period > 0` and `block.timestamp >= periodEnd`, implementations MUST reset `remainingInPeriod` to `limit` and advance `periodEnd` by whole multiples of `period` so that `periodEnd > block.timestamp`.
+4. If `amount > remainingInPeriod`, implementations MUST revert `SpendingLimitExceeded()`.
+5. Otherwise, implementations MUST decrement `remainingInPeriod` by `amount`.
 
-### Destination Validation Logic
+`updateSpendingLimit(account,key,token,newLimit)` semantics:
 
-When a transaction is submitted with an Access Key:
+1. MUST update the configured `limit` for that `(account,key,token)`.
+2. MUST set `remainingInPeriod = newLimit`.
+3. MUST NOT change `period`.
+4. MUST NOT change `periodEnd`.
+5. Therefore changing `period` requires re-authorizing the key (or removing and recreating that token limit entry).
 
-```
-function validateDestination(key, destination):
-    allowed = getAllowedDestinations(key)
-    
-    if allowed.length == 0:
-        return true  // Unrestricted
-    
-    for addr in allowed:
-        if addr == destination:
-            return true
-    
-    revert DestinationNotAllowed()
-```
+### Call Validation Logic
+
+Call-scope checks use map lookups keyed by `(account_key, target, selector)` plus optional selector-level recipient allowlists.
+
+Scoped-call validation is a transaction-validity check performed before execution. If any call fails validation, the transaction is invalid and MUST NOT enter execution.
+
+
+#### Access-Key Contract Creation Ban
+
+If a transaction is signed with an access key (`key != Address::ZERO`), contract creation MUST be rejected in all configurations.
+
+This ban applies regardless of:
+
+1. Whether `allowed_calls` is `None` or `Some(...)`.
+2. Whether any target scope has `selector_rules = None` (allow-any-selector).
+3. Whether the creation call appears in a batch.
+
+Only the root key (`key == Address::ZERO`) may submit contract-creation calls; this is not a global create ban.
+
+#### Single Call Validation
+
+For each call:
+
+1. If the transaction uses an access key and the call is contract creation, implementations MUST reject the transaction as invalid before execution.
+2. If `allowed_calls = None`, implementations MUST allow the call (subject to the contract-creation ban).
+3. If `allowed_calls = Some(...)`, implementations MUST enforce target and selector matching.
+4. If no target scope exists for `destination`, implementations MUST reject the transaction as invalid before execution.
+5. If the target scope is `selector_rules = None`, implementations MUST allow the call, including selectorless/fallback-style calldata.
+6. If the target scope is `selector_rules = Some(list)` and calldata does not provide at least 4 selector bytes, implementations MUST reject the transaction as invalid before execution.
+7. If the target scope is `selector_rules = Some(list)`, there MUST be a rule for the selector; otherwise implementations MUST reject the transaction as invalid before execution.
+8. If the matched rule has `recipients = None`, implementations MUST allow the call.
+9. If the matched rule has `recipients = Some(list)`, implementations MUST decode ABI argument `0` as an `address` and require membership in `list`.
+10. For a selector rule with `recipients = Some(list)`, if calldata is shorter than `4 + 32` bytes, implementations MUST reject the transaction as invalid before execution.
+11. For a selector rule with `recipients = Some(list)`, implementations MUST enforce canonical ABI `address` encoding for argument `0` (upper 12 bytes zero) before membership check; otherwise implementations MUST reject the transaction as invalid before execution.
+
+#### Batch Validation
+
+For AA transactions with multiple calls, each call MUST be validated independently before execution begins. If any call fails scope validation, the transaction is invalid and the batch MUST NOT enter execution.
+
+### Root-Controlled Scope Updates
+
+`setAllowedCalls` MUST be root-key-only and MUST apply create-or-replace semantics per target.
+
+1. `selectorRules = []` sets `selector_rules = None` semantics (any selector allowed on `target`).
+2. `removeAllowedCalls(keyId, target)` disables that target scope.
+3. Implementations MUST enforce at most one scope per target for each `(account, key)`.
+4. Selector rules MUST be unique by `selector` within a target scope.
+5. If any rule has `recipients = Some([..])`, `target` MUST be a TIP-20 token address.
+6. If any rule has `recipients = Some([..])`, its `selector` MUST be one of:
+   1. `0xa9059cbb` (`transfer(address,uint256)`)
+   2. `0x095ea7b3` (`approve(address,uint256)`)
+   3. `0x95777d59` (`transferWithMemo(address,uint256,bytes32)`)
+8. If any rule has `recipients = Some([..])`, each recipient in that list MUST be non-zero.
+9. If any rule has `recipients = Some([..])`, recipients in that list MUST be unique.
+10. If any selector-rule validity rule is violated, implementations MUST reject the authorization (or revert `setAllowedCalls`).
+
+Rationale for rule 2 (`selectorRules = []` disable):
+
+1. This avoids unbounded gas from deletion-time slot iteration.
+2. Prior selector rows may remain in state, but the target mode deterministically disables matching.
 
 ### Interaction Rules
 
-1. **Mixed limits**: Keys can have a mix of one-time and periodic limits for different tokens
-2. **Destination + limits**: Both constraints are evaluated independently; both must pass
-3. **Period updates**: Calling `updateSpendingLimit()` updates the per-period amount and resets the current period
-4. **Empty destinations**: An empty `allowedDestinations` array means the key is unrestricted (can call any address)
+1. Keys may mix one-time and periodic token limits.
+2. Spending limits and call scopes are independent checks; both must pass.
+3. `updateSpendingLimit()` updates limit and `remainingInPeriod`, but does not change `period` or `periodEnd`.
+4. `allowed_calls = None` is unrestricted for non-create calls; `Some([])` is explicit deny-all.
+5. Every scope has an explicit target address, so there is no wildcard-target precedence ambiguity.
+6. Per-target updates are create-or-replace and duplicate target scopes are not allowed.
+7. Selector-level recipient allowlists are optional and only valid for TIP-20 targets and the constrained selectors above.
+8. Selector-level recipient allowlists are checked after selector match and before call execution.
+9. This TIP does not introduce generic calldata predicates, offset math, or wildcard argument matching.
 
-## Gas Costs
+Wallet UX recommendation (non-consensus):
 
-| Operation | Additional Gas |
-|-----------|----------------|
-| `authorizeKey` with N destinations | ~20,000 + 5,000 × N |
-| `authorizeKey` with periodic limit | ~3,000 per periodic token |
-| Destination check (per tx) | ~2,100 + 200 × N |
-| Period reset (when triggered) | ~5,000 |
+1. Wallets SHOULD default to scoped keys (non-empty `selectorRules`) and require explicit user opt-in for unrestricted target scopes (`selectorRules = []`).
+
+## Gas And Complexity Bounds
+
+This TIP only specifies the additional intrinsic gas delta for call scopes in handler-side `key_authorization` charging.
+
+Existing key-authorization charging (signature verification, existing-key read, base key write, token-limit writes, and buffer) remains unchanged.
+
+Definitions:
+
+1. `SSTORE_SET = sstore_set_without_load_cost`.
+2. `S` = number of targets with configured call scope.
+3. `K` = total selector rules across all configured targets.
+4. `C` = total selector rules with `recipients = Some([..])`.
+5. `W` = total recipient entries across all constrained selector rules.
+6. `MAX_CALL_SCOPES = 8` target scopes per `(account, key)`.
+7. `MAX_SELECTOR_RULES_PER_SCOPE = 16` selector rules per target scope.
+8. `MAX_RECIPIENTS_PER_SELECTOR = 16` recipients per selector rule.
+   
+Scoped-call storage writes counted for intrinsic gas:
+
+1. Restricted-mode marker: `1` slot when `allowed_calls` is `Some(...)`.
+2. Each target scope writes `4` slots: target-set length, target-set value, target-set position, and target mode.
+3. Each selector rule writes `4` slots: selector-set length, selector-set value, selector-set position, and selector mode.
+4. Each recipient-constrained selector writes `1` additional slot for recipient-set length.
+5. Each recipient entry writes `2` slots: recipient-set value and recipient-set position.
+
+```text
+gas_key_authorization_new = gas_key_authorization_existing
+                          + SSTORE_SET * scope_slots
+
+scope_slots = 0                    if allowed_calls is None
+            = 1                    if allowed_calls is Some([])   // explicit restricted-mode marker
+            = 1 + 4*S + 4*K + C + 2*W    if allowed_calls is Some(scopes)
+```
+
+Justification for `1 + 4*S + 4*K + C + 2*W`: `1` stores restricted mode, each target scope materializes as four set/mode writes, each selector rule materializes as four set/mode writes, each constrained selector writes one recipient-set length slot, and each recipient writes two set-membership slots.
+
+Bounds:
+
+1. Implementations MUST reject authorizations with `S > MAX_CALL_SCOPES`.
+2. Implementations MUST reject any target scope with selector-rule count greater than `MAX_SELECTOR_RULES_PER_SCOPE`.
+3. Implementations MUST reject any selector rule with recipient count greater than `MAX_RECIPIENTS_PER_SELECTOR`.
+4. Implementations MUST reject any selector rule with `recipients = Some([..])` whose `target` is not a TIP-20 token address.
+5. Implementations MUST reject any selector rule with `recipients = Some([..])` and selector outside the fixed constrained-selector set.
+6. Implementations MUST reject duplicate selector rules for the same `(target, selector)`.
+7. Implementations MUST reject duplicate recipients inside a selector rule.
+8. These bounds are consensus constants.
+
+Constant rationale:
+
+1. `MAX_CALL_SCOPES` and `MAX_SELECTOR_RULES_PER_SCOPE` cap authorization-time storage growth and per-call validation work.
+2. `MAX_RECIPIENTS_PER_SELECTOR` caps recipient membership checks and storage writes for constrained selectors.
+3. Any future change to these constants requires a new TIP / hardfork-gated update.
+
+No additional flat gas is specified here for precompile methods (`setAllowedCalls`, `getAllowedCalls`, etc.); those are charged by normal EVM metering at execution time.
 
 ## Encoding
 
-### Transaction Authorization
+### Signing Format
 
-The `KeyAuthorization` struct is RLP-encoded in the transaction's authorization field:
+Authorization digest format:
 
+```text
+key_auth_digest = keccak256(rlp([
+  chain_id,
+  key_type,
+  key_id,
+  expiry?,
+  limits?,
+  allowed_calls?
+]))
+
+limits = rlp([token, limit])              if period == 0
+       = rlp([token, limit, period])      if period > 0
 ```
+
+RLP safety note:
+
+1. Implementations MUST use canonical RLP encoding for all fields.
+2. The signed payload is a typed RLP list; distinct field tuples produce distinct canonical encodings (no cross-field preimage ambiguity under canonical RLP).
+
+### Transaction Authorization RLP
+
+```text
 KeyAuthorization := RLP([
-    spendingLimits: [TokenLimit, ...],
-    expiry: uint64,
-    allowedDestinations: [address, ...]
+    chain_id: u64,
+    key_type: u8,
+    key_id: address,
+    expiry?: uint64,
+    limits?: [TokenLimit, ...],
+    allowed_calls?: [CallScope, ...]
 ])
 
 TokenLimit := RLP([
     token: address,
     limit: uint256,
-    remainingInPeriod: uint256,
-    period: uint64,
-    periodEnd: uint64
+    period: uint64
+])
+
+// Canonical one-time form omits `period` entirely.
+// Omitted `period` decodes to `period = 0`, i.e. a non-periodic one-time spending limit.
+TokenLimit(one-time) := RLP([
+    token: address,
+    limit: uint256
+])
+
+CallScope := RLP([
+    target: address,
+    selector_rules?: [SelectorRule, ...]
+])
+
+SelectorRule := RLP([
+    selector: bytes4,
+    recipients?: [address, ...]
 ])
 ```
 
+Optional encoding rules:
+
+1. Optional scalar fields (`expiry`) use `None => 0x80`.
+2. Optional list fields (`limits`, `selector_rules`, `recipients`) use `None => 0x80`.
+3. `allowed_calls = None` is omitted on wire.
+4. `Some([])` list values encode as RLP empty list (`0xc0`).
+5. `Some([x, ...])` list values encode as normal lists.
+6. For `TokenLimit`, one-time limits (`period == 0`) use the two-field form; explicit three-field encoding with `period = 0` is non-canonical.
+7. Each `SelectorRule.selector` MUST decode to exactly 4 bytes; otherwise the authorization MUST be rejected.
+8. `SelectorRule.recipients = Some([])` MUST be rejected.
+
 ---
-
-# Backward Compatibility
-
-This TIP requires a **hardfork** due to changes in transaction encoding and execution semantics.
-
-## RLP Encoding Changes
-
-### TokenLimit (2 fields → 5 fields)
-
-The current `TokenLimit` struct encodes as `[token, limit]`. This TIP extends it to `[token, limit, remainingInPeriod, period, periodEnd]`.
-
-**Breaking change**: Old nodes cannot decode new transactions with 5-field `TokenLimit`. New nodes must implement version-tolerant decoding:
-
-```
-On decode:
-  if list.len() == 2:
-    // V1 (legacy one-time limit)
-    remainingInPeriod = limit
-    period = 0
-    periodEnd = 0
-  else if list.len() == 5:
-    // V2 (periodic limit)
-    decode all fields
-  else:
-    error
-```
-
-Post-fork, all new `TokenLimit` encodings MUST use the 5-field format for consistency.
-
-### KeyAuthorization (trailing field addition)
-
-`KeyAuthorization` uses `#[rlp(trailing)]` which allows appending optional fields. Adding `allowedDestinations: Option<Vec<Address>>` as the last field is compatible with this pattern:
-
-- Old encodings (without `allowedDestinations`) decode as `allowedDestinations = None` (unrestricted)
-- New encodings with `allowedDestinations` will be rejected by old nodes
-
-## Compact/Database Encoding
-
-Although `TokenLimit` has `#[derive(reth_codecs::Compact)]`, it is **not used in production storage**. The storage path is:
-
-```
-TempoTransaction (derived Compact)
-  └─ key_authorization: Option<SignedKeyAuthorization>
-       └─ SignedKeyAuthorization (custom Compact impl → uses RLP internally)
-            └─ KeyAuthorization (RLP encoded)
-                 └─ limits: Option<Vec<TokenLimit>> (RLP encoded)
-```
-
-`SignedKeyAuthorization` implements a custom `Compact` that wraps RLP encoding. Therefore, `TokenLimit` is always serialized as RLP bytes in the database, not via its derived Compact layout.
-
-**Implication**: If we implement version-tolerant RLP decoding for `TokenLimit` (accept 2-field or 5-field lists), existing database entries will decode correctly. **No DB rebuild required** for this change.
 
 ## Precompile Storage Changes
 
-The current storage layout:
-- `keys[account][keyId] → AuthorizedKey` (packed slot)
-- `spending_limits[key][token] → U256` (remaining amount)
+Current layout:
 
-This TIP requires additional per-token state for periodic limits. **Additive storage approach** (no migration required):
+1. `keys[account][keyId] -> AuthorizedKey`
+2. `spending_limits[(account,keyId)][token] -> U256`
+
+Additive periodic-limit layout:
 
 | Mapping | Type | Description |
 |---------|------|-------------|
-| `spending_limits[key][token]` | `U256` | Reinterpreted as `remainingInPeriod` |
-| `spending_limit_max[key][token]` | `U256` | Per-period cap (new) |
-| `spending_limit_period[key][token]` | `u64` | Period duration in seconds (new) |
-| `spending_limit_period_end[key][token]` | `u64` | Current period end timestamp (new) |
+| `spending_limits[account_key][token]` | `U256` | Remaining amount / `remainingInPeriod` |
+| `spending_limit_period_state[account_key][token]` | struct `{ max, period, period_end }` | Periodic limit metadata |
 
-For destination scoping:
-| Mapping | Type | Description |
-|---------|------|-------------|
-| `allowed_destinations_len[key]` | `u64` | Number of allowed destinations |
-| `allowed_destinations[key][index]` | `Address` | Allowed destination at index |
+Call-scope storage is account-scoped and represented as nested sets/maps:
 
-Legacy keys (pre-fork) have `period = 0`, `max = 0`, and behave as one-time limits.
+| Path | Type | Description |
+|------|------|-------------|
+| `key_scopes[account_key].mode` | `u8` | `0 = unrestricted`, `1 = scoped`, `2 = deny-all` |
+| `key_scopes[account_key].targets` | `Set<address>` | Scoped target membership |
+| `key_scopes[account_key].target_scopes[target].mode` | `u8` | `0 = none`, `1 = any-selector`, `2 = explicit-selector-rules` |
+| `key_scopes[account_key].target_scopes[target].selectors` | `Set<u32>` | Explicit selector membership |
+| `key_scopes[account_key].target_scopes[target].selector_scopes[selector].mode` | `u8` | `1 = any-recipient`, `2 = constrained-recipient-set` |
+| `key_scopes[account_key].target_scopes[target].selector_scopes[selector].recipients` | `Set<address>` | Selector-level recipient membership |
+
+`account_key = keccak256(account || key_id)` to avoid cross-account collisions for shared key IDs.
+
+Implementations MAY maintain additional internal indexes or equivalent layouts so long as semantics remain unchanged.
 
 ## Hardfork-Gated Features
 
-The following MUST be gated behind the hardfork activation:
+The following MUST be fork-gated:
 
-1. **RLP decoding**: Accept 5-field `TokenLimit` and `allowedDestinations` in `KeyAuthorization`
-2. **Periodic limit reset logic**: Check `periodEnd` and reset `remainingInPeriod` on spend
-3. **Destination scoping enforcement**: Validate transaction `to` against `allowedDestinations`
-4. **New precompile storage writes**: Write to new storage slots for period/destination data
-5. **New precompile interface methods**: `getAllowedDestinations()`, updated `getRemainingLimit()` return type
+1. New `TokenLimit` decode/encode behavior.
+2. `allowed_calls` decode/encode behavior.
+3. `selector_rules` decode/encode behavior.
+4. Periodic reset logic.
+5. Call-scope validation logic.
+6. Selector-rule recipient-allowlist calldata validation logic.
+7. New precompile storage writes/reads for periodic + call-scope data.
+8. New precompile storage writes/reads for selector-level recipient allowlists.
+9. Updated precompile read APIs (`getAllowedCalls(account,key)`, richer `getRemainingLimit`).
+10. New mutator function `setAllowedCalls`, which can only be called by root key.
+11. Global ban on contract creation when using access keys.
+12. Selector-width enforcement (`selector length == 4` only).
+13. Scope/selector bound enforcement (`MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`).
+14. Constrained-selector allowlist and argument-0 canonical address checks.
+15. TIP-20 target verification for selector rules with recipient allowlists.
+16. Recipient count bound enforcement (`MAX_RECIPIENTS_PER_SELECTOR`).
 
-Pre-fork blocks MUST be replayed with old semantics to preserve state root consistency.
+Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 
 ---
 
 # Invariants
 
-1. **Period monotonicity**: `periodEnd` MUST only increase; it cannot be set to a past timestamp.
-
-2. **Limit conservation**: For periodic limits, `remainingInPeriod` MUST NOT exceed `limit` after any reset.
-
-3. **Destination enforcement**: If `allowedDestinations` is non-empty, transactions to addresses not in the list MUST revert.
-
-4. **Backward compatibility**: Keys authorized without the new fields MUST behave as unrestricted (`allowedDestinations = []`) with one-time limits (`period = 0`).
-
-5. **Expiry precedence**: Key expiry MUST be checked before spending limits or destination restrictions.
+1. `periodEnd` is monotonic and never set to the past.
+2. `remainingInPeriod <= limit` after any operation.
+3. Expiry check runs before spending and call-scope checks.
+4. If `key != Address::ZERO`, any contract-creation call MUST cause the transaction to be rejected as invalid before execution, regardless of `allowed_calls`.
+5. `allowed_calls = None` allows all non-create calls; `allowed_calls = Some(...)` requires target+selector-rule match and otherwise causes the transaction to be rejected as invalid before execution.
+6. In scoped mode, calldata must contain at least 4 selector bytes only when explicit selector matching is required; address-only scopes allow selectorless/fallback-style calldata.
+7. For each `(account, key)`, target scopes are unique, selector rules are unique per target, and recipients are unique per selector rule.
+8. `setAllowedCalls(..., scope.selectorRules = [])` allows any selector on that target; `removeAllowedCalls(keyId, target)` disables that target scope.
+9. Selector rules with recipient allowlists are valid only for TIP-20 targets and only for the fixed constrained selector set.
+10. For recipient-allowlisted rules, calldata argument `0` must be a canonically encoded ABI address and must be in the configured recipient set.
+11. In the Solidity ABI, `selectorRules[i].recipients = []` means that selector has no recipient restriction.
+12. Authorizations exceeding `MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`, or `MAX_RECIPIENTS_PER_SELECTOR` MUST be rejected.
 
 ## Test Cases
 
-1. **Periodic reset**: Verify that a periodic limit resets correctly after the period elapses
-2. **Partial period usage**: Verify that unused periodic allowance does not roll over
-3. **Destination allow**: Verify that transactions to allowed destinations succeed
-4. **Destination deny**: Verify that transactions to non-allowed destinations revert
-5. **Empty destinations**: Verify that empty `allowedDestinations` allows any destination
-6. **Mixed limits**: Verify that a key can have both one-time and periodic limits for different tokens
-7. **Upgrade path**: Verify that existing keys continue to function after upgrade
+1. Periodic reset after elapsed period.
+2. No rollover of unused periodic allowance.
+3. Address + multi-selector scope allow.
+4. Address-only allow (`selector_rules=None`).
+5. Deny when no scope matches.
+6. `allowed_calls=None` allows all non-create calls.
+7. `allowed_calls=Some([])` denies all calls.
+8. Mixed one-time and periodic token limits.
+9. Existing keys continue to function after the fork.
+10. Batch validation rejects the transaction before execution when any call is invalid.
+11. Shared key IDs across accounts cannot overwrite each other’s scopes.
+12. Reject `allowed_calls` entries with `S > MAX_CALL_SCOPES`.
+13. Reject any target scope with selector-rule count `> MAX_SELECTOR_RULES_PER_SCOPE`.
+14. Reject calls that do not provide at least 4 selector bytes when explicit selector matching is required.
+15. `setAllowedCalls(..., scope.selectorRules = [])` allows any selector on that target.
+16. `setAllowedCalls` create-or-replace semantics are enforced.
+17. `removeAllowedCalls(keyId, target)` removes that target scope and leaves the key in deny-all mode if no target scopes remain.
+19. Address-only scopes allow selectorless/fallback-style calls to the scoped target.
+20. Access-key transactions with CREATE as first call are rejected.
+21. Access-key transactions with any CREATE in a batch are rejected.
+22. For constrained TIP-20 selectors (`transfer`, `approve`, `transferWithMemo`), calls succeed iff calldata argument `0` is in the configured recipient set.
+23. Single-recipient and multi-recipient selector rules both enforce the same membership rule.
+24. Reject the transaction before execution when a selector rule with a recipient allowlist is matched and calldata is shorter than `4 + 32` bytes.
+25. Reject the transaction before execution when a selector rule with a recipient allowlist is matched and ABI argument `0` is not canonically encoded as an address.
+27. Reject selector rules with recipient allowlists for selectors outside the fixed constrained-selector set.
+28. Reject duplicate selector rules for the same `(target, selector)`.
+29. Reject duplicate recipients within a selector rule.
+30. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
 
 ## References
 
 - [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
+- [Tempo Transactions](https://docs.tempo.xyz/guide/tempo-transaction)
 - [IAccountKeychain.sol](tips/ref-impls/src/interfaces/IAccountKeychain.sol)
 - [GitHub Issue #1865](https://github.com/tempoxyz/tempo/issues/1865) - Periodic spending limits
 - [GitHub Issue #1491](https://github.com/tempoxyz/tempo/issues/1491) - Destination address scoping


### PR DESCRIPTION
# PR2: Periodic Spending Limits

Title: `feat(account-keychain): add periodic spending limits`
Base: `tanishk/tip-1011-spec-wire`
Head: `tanishk/tip-1011-periodic-limits`

## Why We Are Making This Change

This PR isolates the recurring-allowance part of TIP-1011. Periodic spending limits change state layout, rollover behavior, getters, and pool-side limit reads. Keeping that separate from call scopes makes it much easier to review correctness around accounting and storage compatibility.

## Why This Design

The key design choices are:
- Reuse the same `spending_limits[(account,key)][token]` row instead of inventing a second periodic-limit table.
- Keep `remaining` in the first slot via `SpendingLimitState` so legacy semantics remain aligned with existing reads.
- Treat rollover as derived state through `effective_limit_state` / `effective_remaining_limit` rather than requiring a separate maintenance path.
- Return `(remaining, periodEnd)` from the new getter so callers can understand the active billing window.
- Keep scoped-call methods stubbed here so this PR stays about balance accounting, not policy trees.

## Spec To Read First

Read these sections in `tips/tip-1011.md`:
1. `TokenLimit`
2. The runtime-state notes under `TokenLimit`
3. Any language describing `period == 0` vs `period > 0`

## How To Review This PR

1. Review `crates/precompiles/src/account_keychain/mod.rs` first and focus only on:
   - `SpendingLimitState`
   - authorization-time initialization
   - `update_spending_limit`
   - `get_remaining_limit_with_period`
   - rollover helpers like `effective_limit_state`
2. Review `crates/precompiles/src/account_keychain/dispatch.rs` only for the ABI plumbing needed to expose the new getter/selectors.
3. Review `crates/alloy/src/provider/ext.rs` to confirm the client-side getter shape matches the precompile.
4. Review `crates/transaction-pool/src/tempo_pool.rs` to confirm pending-transaction eviction now reads the structured remaining-limit state correctly.
5. Ignore scoped-call stubs in this PR; they are placeholders so the ABI compiles but they are not the feature under review here.
