### PR TITLE
feat(primitives): add TIP-1011 wire format and ABI

### DIFF
--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -4,7 +4,7 @@ use crate::rpc::{TempoHeaderResponse, TempoTransactionReceipt, TempoTransactionR
 use alloy_consensus::{ReceiptWithBloom, TxType, error::UnsupportedTransactionType};
 
 use alloy_network::{
-    BuildResult, Ethereum, EthereumWallet, IntoWallet, Network, NetworkWallet, TransactionBuilder,
+    BuildResult, EthereumWallet, IntoWallet, Network, NetworkWallet, TransactionBuilder,
     TransactionBuilderError, UnbuiltTransactionError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
@@ -292,33 +292,6 @@ impl RecommendedFillers for TempoNetwork {
     }
 }
 
-impl NetworkWallet<TempoNetwork> for EthereumWallet {
-    fn default_signer_address(&self) -> Address {
-        NetworkWallet::<Ethereum>::default_signer_address(self)
-    }
-
-    fn has_signer_for(&self, address: &Address) -> bool {
-        NetworkWallet::<Ethereum>::has_signer_for(self, address)
-    }
-
-    fn signer_addresses(&self) -> impl Iterator<Item = Address> {
-        NetworkWallet::<Ethereum>::signer_addresses(self)
-    }
-
-    #[doc(alias = "sign_tx_from")]
-    async fn sign_transaction_from(
-        &self,
-        sender: Address,
-        mut tx: TempoTypedTransaction,
-    ) -> alloy_signer::Result<TempoTxEnvelope> {
-        let signer = self.signer_by_address(sender).ok_or_else(|| {
-            alloy_signer::Error::other(format!("Missing signing credential for {sender}"))
-        })?;
-        let sig = signer.sign_transaction(tx.as_dyn_signable_mut()).await?;
-        Ok(tx.into_envelope(sig))
-    }
-}
-
 impl IntoWallet<TempoNetwork> for PrivateKeySigner {
     type NetworkWallet = EthereumWallet;
 
@@ -526,6 +499,7 @@ mod tests {
                     key_id: Address::ZERO,
                     expiry: None,
                     limits: None,
+                    allowed_calls: None,
                 },
                 signature: PrimitiveSignature::Secp256k1(Signature::new(
                     U256::ZERO,

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -586,6 +586,7 @@ mod tests {
                 key_id: address!("0x1111111111111111111111111111111111111111"),
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             },
             signature: PrimitiveSignature::default(),
         };
@@ -659,47 +660,6 @@ mod tests {
         assert_eq!(
             roundtrip.calls, batch,
             "multi-call AA must not gain phantom calls on round-trip"
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "tempo-compat")]
-    fn test_aa_roundtrip_via_tx_env() {
-        use reth_evm::EvmEnv;
-        use reth_rpc_convert::TryIntoTxEnv;
-
-        let calls = vec![
-            Call {
-                to: address!("0x1111111111111111111111111111111111111111").into(),
-                value: U256::ZERO,
-                input: Bytes::from(vec![0xaa]),
-            },
-            Call {
-                to: address!("0x2222222222222222222222222222222222222222").into(),
-                value: U256::ZERO,
-                input: Bytes::from(vec![0xbb]),
-            },
-        ];
-
-        let tx = TempoTransaction {
-            chain_id: 4217,
-            nonce: 1,
-            gas_limit: 100_000,
-            max_fee_per_gas: 1_000_000_000,
-            max_priority_fee_per_gas: 1_000_000,
-            calls: calls.clone(),
-            ..Default::default()
-        };
-
-        let req = TempoTransactionRequest::from(tx);
-
-        let evm_env = EvmEnv::default();
-        let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
-        let aa_calls = tx_env.tempo_tx_env.expect("tempo_tx_env").aa_calls;
-
-        assert_eq!(
-            aa_calls, calls,
-            "roundtrip via try_into_tx_env must preserve exact call list"
         );
     }
 }

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -1,5 +1,9 @@
+#![allow(clippy::too_many_arguments)]
+
 pub use IAccountKeychain::{
     IAccountKeychainErrors as AccountKeychainError, IAccountKeychainEvents as AccountKeychainEvent,
+    authorizeKey_0Call as legacyAuthorizeKeyCall, authorizeKey_1Call as authorizeKeyCall,
+    getRemainingLimitWithPeriodCall, getRemainingLimitWithPeriodReturn as getRemainingLimitReturn,
 };
 
 crate::sol! {
@@ -21,10 +25,43 @@ crate::sol! {
             WebAuthn,
         }
 
+        /// Legacy token spending limit structure used before T3.
+        struct LegacyTokenLimit {
+            address token;
+            uint256 amount;
+        }
+
         /// Token spending limit structure
         struct TokenLimit {
             address token;
             uint256 amount;
+            uint64 period;
+        }
+
+        /// Selector-level recipient rule.
+        struct SelectorRule {
+            bytes4 selector;
+            /// Empty means no recipient restriction for this selector.
+            /// To block the selector entirely, remove the selector rule instead of passing `[]`.
+            address[] recipients;
+        }
+
+        /// Per-target call scope.
+        struct CallScope {
+            address target;
+            /// Empty means no selector restriction for this target.
+            /// To block the target entirely, omit this scope from `allowedCalls` or call
+            /// `removeAllowedCalls` for incremental updates.
+            SelectorRule[] selectorRules;
+        }
+
+        /// Optional access-key restrictions configured at authorization time.
+        struct KeyRestrictions {
+            uint64 expiry;
+            bool enforceLimits;
+            TokenLimit[] limits;
+            bool enforceAllowedCalls;
+            CallScope[] allowedCalls;
         }
 
         /// Key information structure
@@ -44,18 +81,32 @@ crate::sol! {
         /// Emitted when a spending limit is updated
         event SpendingLimitUpdated(address indexed account, address indexed publicKey, address indexed token, uint256 newLimit);
 
-        /// Authorize a new key for the caller's account
-        /// @param keyId The key identifier (address derived from public key)
-        /// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
-        /// @param expiry Block timestamp when the key expires (u64::MAX for never expires)
-        /// @param enforceLimits Whether to enforce spending limits for this key
-        /// @param limits Initial spending limits for tokens (only used if enforceLimits is true)
+        /// Emitted when an access key spends against a token limit.
+        event AccessKeySpend(
+            address indexed account,
+            address indexed publicKey,
+            address indexed token,
+            uint256 amount,
+            uint256 remainingLimit
+        );
+
+        /// Legacy authorize-key entrypoint used before T3.
         function authorizeKey(
             address keyId,
             SignatureType signatureType,
             uint64 expiry,
             bool enforceLimits,
-            TokenLimit[] calldata limits
+            LegacyTokenLimit[] calldata limits
+        ) external;
+
+        /// Authorize a new key for the caller's account with T3 extensions.
+        /// @param keyId The key identifier (address derived from public key)
+        /// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
+        /// @param config Access-key expiry and optional limits / call restrictions
+        function authorizeKey(
+            address keyId,
+            SignatureType signatureType,
+            KeyRestrictions calldata config
         ) external;
 
         /// Revoke an authorized key
@@ -72,22 +123,48 @@ crate::sol! {
             uint256 newLimit
         ) external;
 
+        /// Set or replace allowed calls for a key+target pair.
+        /// @dev `scope.selectorRules = []` does NOT block the target; it allows any selector on that target.
+        /// @dev To block the target entirely, call `removeAllowedCalls`. To block one selector,
+        ///      omit that selector rule from `scope.selectorRules`.
+        function setAllowedCalls(
+            address keyId,
+            CallScope calldata scope
+        ) external;
+
+        /// Remove any configured call scope for a key+target pair.
+        function removeAllowedCalls(address keyId, address target) external;
+
         /// Get key information
         /// @param account The account address
         /// @param publicKey The public key
         /// @return Key information
         function getKey(address account, address keyId) external view returns (KeyInfo memory);
 
-        /// Get remaining spending limit
+        /// Get remaining spending limit using the legacy pre-T3 return shape.
         /// @param account The account address
         /// @param publicKey The public key
         /// @param token The token address
-        /// @return Remaining spending amount
         function getRemainingLimit(
             address account,
             address keyId,
             address token
-        ) external view returns (uint256);
+        ) external view returns (uint256 remaining);
+
+        /// Get remaining spending limit together with the active period end.
+        /// @param account The account address
+        /// @param publicKey The public key
+        /// @param token The token address
+        /// @return remaining Remaining spending amount
+        /// @return periodEnd Period end timestamp for periodic limits (0 for one-time)
+        function getRemainingLimitWithPeriod(
+            address account,
+            address keyId,
+            address token
+        ) external view returns (uint256 remaining, uint64 periodEnd);
+
+        /// Returns configured call scopes for an account key.
+        function getAllowedCalls(address account, address keyId) external view returns (CallScope[] memory);
 
         /// Get the key used in the current transaction
         /// @return The keyId used in the current transaction
@@ -99,11 +176,17 @@ crate::sol! {
         error KeyNotFound();
         error KeyExpired();
         error SpendingLimitExceeded();
+        error InvalidSpendingLimit();
         error InvalidSignatureType();
         error ZeroPublicKey();
         error ExpiryInPast();
         error KeyAlreadyRevoked();
         error SignatureTypeMismatch(uint8 expected, uint8 actual);
+        error CallNotAllowed();
+        error InvalidCallScope();
+        error ScopeLimitExceeded();
+        error SelectorLimitExceeded();
+        error RecipientLimitExceeded();
     }
 }
 
@@ -138,6 +221,11 @@ impl AccountKeychainError {
         Self::SpendingLimitExceeded(IAccountKeychain::SpendingLimitExceeded {})
     }
 
+    /// Creates an error for spending limits that exceed the TIP-20 u128 supply cap.
+    pub const fn invalid_spending_limit() -> Self {
+        Self::InvalidSpendingLimit(IAccountKeychain::InvalidSpendingLimit {})
+    }
+
     /// Creates an error for invalid signature type.
     pub const fn invalid_signature_type() -> Self {
         Self::InvalidSignatureType(IAccountKeychain::InvalidSignatureType {})
@@ -158,5 +246,30 @@ impl AccountKeychainError {
     /// This prevents replay attacks where a revoked key's authorization is reused.
     pub const fn key_already_revoked() -> Self {
         Self::KeyAlreadyRevoked(IAccountKeychain::KeyAlreadyRevoked {})
+    }
+
+    /// Creates an error for disallowed call attempts by scoped access keys.
+    pub const fn call_not_allowed() -> Self {
+        Self::CallNotAllowed(IAccountKeychain::CallNotAllowed {})
+    }
+
+    /// Creates an error for invalid scope configuration.
+    pub const fn invalid_call_scope() -> Self {
+        Self::InvalidCallScope(IAccountKeychain::InvalidCallScope {})
+    }
+
+    /// Creates an error for scope count limit violations.
+    pub const fn scope_limit_exceeded() -> Self {
+        Self::ScopeLimitExceeded(IAccountKeychain::ScopeLimitExceeded {})
+    }
+
+    /// Creates an error for selector count limit violations.
+    pub const fn selector_limit_exceeded() -> Self {
+        Self::SelectorLimitExceeded(IAccountKeychain::SelectorLimitExceeded {})
+    }
+
+    /// Creates an error for recipient count limit violations.
+    pub const fn recipient_limit_exceeded() -> Self {
+        Self::RecipientLimitExceeded(IAccountKeychain::RecipientLimitExceeded {})
     }
 }

--- a/crates/node/tests/it/key_authorization.rs
+++ b/crates/node/tests/it/key_authorization.rs
@@ -34,6 +34,7 @@ fn build_create_key_auth_tx(
         key_id: Address::random(),
         expiry: None,
         limits: None,
+        allowed_calls: None,
     };
     let sig = signer.sign_hash_sync(&key_auth.signature_hash())?;
     let signed_key_auth = key_auth.into_signed(PrimitiveSignature::Secp256k1(sig));

--- a/crates/node/tests/it/tempo_transaction/helpers.rs
+++ b/crates/node/tests/it/tempo_transaction/helpers.rs
@@ -192,6 +192,7 @@ pub(crate) fn create_signed_key_authorization(
                 .map(|_| TokenLimit {
                     token: Address::ZERO,
                     limit: U256::ZERO,
+                    period: 0,
                 })
                 .collect(),
         )
@@ -203,6 +204,7 @@ pub(crate) fn create_signed_key_authorization(
         key_id: Address::random(), // Random key being authorized
         expiry: None,              // Never expires
         limits,
+        allowed_calls: None,
     };
 
     // Sign the key authorization
@@ -311,6 +313,7 @@ pub(crate) fn create_key_authorization(
         key_id: access_key_addr,
         expiry,
         limits: spending_limits,
+        allowed_calls: None,
     };
 
     // Root key signs the authorization
@@ -585,6 +588,7 @@ pub(crate) fn create_default_token_limit(
     vec![TokenLimit {
         token: DEFAULT_FEE_TOKEN,
         limit: funded / U256::from(2),
+        period: 0,
     }]
 }
 

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -1681,6 +1681,7 @@ async fn test_aa_keychain_spending_limit_toctou_dos() -> eyre::Result<()> {
         Some(vec![tempo_primitives::transaction::TokenLimit {
             token: DEFAULT_FEE_TOKEN,
             limit: initial_spending_limit,
+            period: 0,
         }]),
     )?;
 

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -699,15 +699,21 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
         KeySetup::ZeroPubKey => {
             use tempo_precompiles::{
                 ACCOUNT_KEYCHAIN_ADDRESS,
-                account_keychain::{SignatureType as KCSignatureType, authorizeKeyCall},
+                account_keychain::{
+                    KeyRestrictions, SignatureType as KCSignatureType, authorizeKeyCall,
+                },
             };
 
             let authorize_call = authorizeKeyCall {
                 keyId: Address::ZERO,
                 signatureType: KCSignatureType::P256,
-                expiry: u64::MAX,
-                enforceLimits: true,
-                limits: vec![],
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![],
+                    enforceAllowedCalls: false,
+                    allowedCalls: vec![],
+                },
             };
             tx.calls = vec![Call {
                 to: ACCOUNT_KEYCHAIN_ADDRESS.into(),
@@ -735,6 +741,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                 SpendingLimits::Custom(amount) => Some(vec![TokenLimit {
                     token: DEFAULT_FEE_TOKEN,
                     limit: *amount,
+                    period: 0,
                 }]),
             };
 
@@ -867,6 +874,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: access_addr,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     };
                     let wrong_sig = wrong_root.sign_hash_sync(&key_auth.signature_hash())?;
                     let invalid_key_auth =
@@ -895,6 +903,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: addr_3,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     }
                     .signature_hash();
 
@@ -912,6 +921,7 @@ pub(crate) async fn run_raw_case<E: TestEnv>(
                         key_id: addr_3,
                         expiry: None,
                         limits: None,
+                        allowed_calls: None,
                     }
                     .into_signed(PrimitiveSignature::P256(P256SignatureWithPreHash {
                         r: B256::from_slice(&wrong_sig_bytes[0..32]),

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -3,13 +3,13 @@ use crate::transaction::PrimitiveSignature;
 use alloc::vec::Vec;
 use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::{Address, B256, U256, keccak256};
-use alloy_rlp::Encodable;
+use alloy_rlp::{Buf, Decodable, EMPTY_STRING_CODE, Encodable};
 
 /// Token spending limit for access keys
 ///
 /// Defines a per-token spending limit for an access key provisioned via key_authorization.
 /// This limit is enforced by the AccountKeychain precompile when the key is used.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -21,6 +21,129 @@ pub struct TokenLimit {
 
     /// Maximum spending amount for this token (enforced over the key's lifetime)
     pub limit: U256,
+
+    /// Period duration in seconds.
+    ///
+    /// `0` means one-time limit. `>0` means the limit resets periodically.
+    pub period: u64,
+}
+
+impl Decodable for TokenLimit {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        let remaining = buf.len();
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let mut fields = &buf[..header.payload_length];
+
+        let token = Decodable::decode(&mut fields)?;
+        let limit = Decodable::decode(&mut fields)?;
+        // Backward-compatible decode: legacy payloads omit period and map to one-time limits.
+        let period = if fields.is_empty() {
+            0
+        } else {
+            let period: u64 = Decodable::decode(&mut fields)?;
+            if period == 0 {
+                return Err(alloy_rlp::Error::Custom(
+                    "token limit period=0 must be encoded in legacy two-field form",
+                ));
+            }
+            period
+        };
+
+        if !fields.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(Self {
+            token,
+            limit,
+            period,
+        })
+    }
+}
+
+impl Encodable for TokenLimit {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let payload_length = self.token.length()
+            + self.limit.length()
+            + if self.period == 0 {
+                0
+            } else {
+                self.period.length()
+            };
+
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(out);
+
+        self.token.encode(out);
+        self.limit.encode(out);
+        if self.period != 0 {
+            self.period.encode(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.token.length()
+            + self.limit.length()
+            + if self.period == 0 {
+                0
+            } else {
+                self.period.length()
+            };
+
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .length_with_payload()
+    }
+}
+
+/// Per-target call scope for an access key.
+///
+/// `selector_rules` uses tri-state semantics:
+/// - `None` => allow any selector for this target
+/// - `Some([])` => deny all selectors for this target
+/// - `Some([..])` => allow exactly the listed selector rules
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[rlp(trailing)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct CallScope {
+    /// Target contract address.
+    pub target: Address,
+    /// Optional selector rules for this target.
+    pub selector_rules: Option<Vec<SelectorRule>>,
+}
+
+/// Selector-level rule within a [`CallScope`].
+///
+/// `recipients` semantics:
+/// - `None` => no recipient constraint
+/// - `Some([..])` => first ABI address argument must be in this list
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[rlp(trailing)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct SelectorRule {
+    /// 4-byte function selector.
+    pub selector: [u8; 4],
+    /// Optional recipient allowlist.
+    pub recipients: Option<Vec<Address>>,
 }
 
 /// Key authorization for provisioning access keys
@@ -28,11 +151,12 @@ pub struct TokenLimit {
 /// Used in TempoTransaction to add a new key to the AccountKeychain precompile.
 /// The transaction must be signed by the root key to authorize adding this access key.
 ///
-/// RLP encoding: `[key_type, key_id, expiry?, limits?]`
+/// RLP encoding: `[chain_id, key_type, key_id, expiry?, limits?, allowed_calls?]`
 /// - Non-optional fields come first, followed by optional (trailing) fields
 /// - `expiry`: `None` (omitted or 0x80) = key never expires, `Some(timestamp)` = expires at timestamp
 /// - `limits`: `None` (omitted or 0x80) = unlimited spending, `Some([])` = no spending, `Some([...])` = specific limits
-#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+/// - `allowed_calls`: `None` = unrestricted, `Some([])` = deny-all, `Some([...])` = scoped calls
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable)]
 #[rlp(trailing)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -60,6 +184,74 @@ pub struct KeyAuthorization {
     /// - `Some([])` = no spending allowed (enforce_limits=true but no tokens allowed)
     /// - `Some([TokenLimit{...}])` = specific limits enforced
     pub limits: Option<Vec<TokenLimit>>,
+
+    /// Optional call scopes for this key.
+    /// - `None` (RLP 0x80) = unrestricted calls
+    /// - `Some([])` = scoped mode with no allowed calls (deny-all)
+    /// - `Some([CallScope{...}])` = explicit target/selector scope list
+    pub allowed_calls: Option<Vec<CallScope>>,
+}
+
+impl Decodable for KeyAuthorization {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        fn decode_optional_field<T: Decodable>(fields: &mut &[u8]) -> alloy_rlp::Result<Option<T>> {
+            if fields.is_empty() {
+                return Ok(None);
+            }
+            if fields.first() == Some(&EMPTY_STRING_CODE) {
+                fields.advance(1);
+                return Ok(None);
+            }
+
+            Ok(Some(Decodable::decode(fields)?))
+        }
+
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        let remaining = buf.len();
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let mut fields = &buf[..header.payload_length];
+
+        let chain_id = Decodable::decode(&mut fields)?;
+        let key_type = Decodable::decode(&mut fields)?;
+        let key_id = Decodable::decode(&mut fields)?;
+
+        let expiry: Option<u64> = decode_optional_field(&mut fields)?;
+        let limits: Option<Vec<TokenLimit>> = decode_optional_field(&mut fields)?;
+
+        let allowed_calls = if fields.is_empty() {
+            None
+        } else {
+            if fields.first() == Some(&EMPTY_STRING_CODE) {
+                return Err(alloy_rlp::Error::Custom(
+                    "key authorization allowed_calls=None must be omitted on wire",
+                ));
+            }
+
+            Some(Decodable::decode(&mut fields)?)
+        };
+
+        if !fields.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(Self {
+            chain_id,
+            key_type,
+            key_id,
+            expiry,
+            limits,
+            allowed_calls,
+        })
+    }
 }
 
 impl KeyAuthorization {
@@ -68,6 +260,18 @@ impl KeyAuthorization {
         let mut buf = Vec::new();
         self.encode(&mut buf);
         keccak256(&buf)
+    }
+
+    /// Returns whether any token limit uses periodic reset semantics.
+    pub fn has_periodic_limits(&self) -> bool {
+        self.limits
+            .as_ref()
+            .is_some_and(|limits| limits.iter().any(|limit| limit.period != 0))
+    }
+
+    /// Returns whether this authorization carries explicit call-scope restrictions.
+    pub fn has_call_scopes(&self) -> bool {
+        self.allowed_calls.is_some()
     }
 
     /// Returns whether this key has unlimited spending (limits is None)
@@ -113,6 +317,42 @@ impl KeyAuthorization {
         Ok(())
     }
 
+    /// Returns the number of storage rows written for scoped-call state.
+    ///
+    /// This mirrors the writes performed by `authorize_key -> replace_allowed_calls ->
+    /// upsert_target_scope` in the account keychain precompile.
+    pub fn call_scope_storage_slots(&self) -> u64 {
+        match self.allowed_calls.as_ref() {
+            None => 0,
+            Some(scopes) if scopes.is_empty() => 1,
+            Some(scopes) => {
+                let mut selectors = 0u64;
+                let mut constrained_selectors = 0u64;
+                let mut recipients = 0u64;
+
+                for scope in scopes {
+                    if let Some(rules) = scope.selector_rules.as_ref() {
+                        selectors += rules.len() as u64;
+                        for rule in rules {
+                            if let Some(rule_recipients) = rule.recipients.as_ref() {
+                                constrained_selectors += 1;
+                                recipients += rule_recipients.len() as u64;
+                            }
+                        }
+                    }
+                }
+
+                // Storage write accounting:
+                // - account mode write: 1
+                // - each target insertion + target mode write: 3 + 1
+                // - each selector insertion + selector mode write: 3 + 1
+                // - recipient-constrained selectors also write recipient set length: +1 per selector
+                // - recipient set values+positions: +2 per recipient
+                1 + scopes.len() as u64 * 4 + selectors * 4 + constrained_selectors + recipients * 2
+            }
+        }
+    }
+
     /// Calculates a heuristic for the in-memory size of the key authorization
     pub fn size(&self) -> usize {
         size_of::<Self>()
@@ -120,6 +360,25 @@ impl KeyAuthorization {
                 .limits
                 .as_ref()
                 .map_or(0, |limits| limits.capacity() * size_of::<TokenLimit>())
+            + self.allowed_calls.as_ref().map_or(0, |scopes| {
+                scopes.capacity() * size_of::<CallScope>()
+                    + scopes
+                        .iter()
+                        .map(|scope| {
+                            scope.selector_rules.as_ref().map_or(0, |rules| {
+                                rules.capacity() * size_of::<SelectorRule>()
+                                    + rules
+                                        .iter()
+                                        .map(|rule| {
+                                            rule.recipients.as_ref().map_or(0, |recipients| {
+                                                recipients.capacity() * size_of::<Address>()
+                                            })
+                                        })
+                                        .sum::<usize>()
+                            })
+                        })
+                        .sum::<usize>()
+            })
     }
 }
 
@@ -171,24 +430,6 @@ impl SignedKeyAuthorization {
     }
 }
 
-#[cfg(feature = "reth-codec")]
-impl reth_codecs::Compact for SignedKeyAuthorization {
-    fn to_compact<B>(&self, buf: &mut B) -> usize
-    where
-        B: alloy_rlp::BufMut + AsMut<[u8]>,
-    {
-        // Use RLP encoding for compact representation
-        self.encode(buf);
-        self.length()
-    }
-
-    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
-        let item = alloy_rlp::Decodable::decode(&mut buf)
-            .expect("Failed to decode KeyAuthorization from compact");
-        (item, buf)
-    }
-}
-
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -199,6 +440,7 @@ impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
             // Ensure that Some(0) is not generated as it's becoming `None` after RLP roundtrip.
             expiry: u.arbitrary::<Option<u64>>()?.filter(|v| *v != 0),
             limits: u.arbitrary()?,
+            allowed_calls: u.arbitrary()?,
         })
     }
 }
@@ -218,6 +460,7 @@ mod tests {
             key_id: Address::random(),
             expiry,
             limits,
+            allowed_calls: None,
         }
     }
 
@@ -273,6 +516,7 @@ mod tests {
                 Some(vec![TokenLimit {
                     token: Address::ZERO,
                     limit: U256::from(100),
+                    period: 0,
                 }])
             )
             .has_unlimited_spending()
@@ -284,6 +528,42 @@ mod tests {
         assert!(!make_auth(Some(0), None).never_expires()); // 0 is still Some
     }
 
+    #[test]
+    fn test_size_does_not_double_count_call_scope_structs() {
+        let recipients = vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)];
+        let mut rules = Vec::with_capacity(3);
+        rules.push(SelectorRule {
+            selector: [1, 2, 3, 4],
+            recipients: Some(recipients),
+        });
+
+        let mut scopes = Vec::with_capacity(2);
+        scopes.push(CallScope {
+            target: Address::repeat_byte(0x33),
+            selector_rules: Some(rules),
+        });
+
+        let auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::repeat_byte(0x44),
+            expiry: None,
+            limits: None,
+            allowed_calls: Some(scopes),
+        };
+
+        let scope_rules = auth.allowed_calls.as_ref().unwrap();
+        let selector_rules = scope_rules[0].selector_rules.as_ref().unwrap();
+        let recipients = selector_rules[0].recipients.as_ref().unwrap();
+
+        let expected = size_of::<KeyAuthorization>()
+            + scope_rules.capacity() * size_of::<CallScope>()
+            + selector_rules.capacity() * size_of::<SelectorRule>()
+            + recipients.capacity() * size_of::<Address>();
+
+        assert_eq!(auth.size(), expected);
+    }
+
     fn make_auth_with_chain_id(chain_id: u64) -> KeyAuthorization {
         KeyAuthorization {
             chain_id,
@@ -291,7 +571,96 @@ mod tests {
             key_id: Address::random(),
             expiry: None,
             limits: None,
+            allowed_calls: None,
         }
+    }
+
+    #[test]
+    fn test_token_limit_legacy_decode_defaults_period_to_zero() {
+        let token = Address::random();
+        let limit = U256::from(42);
+
+        // Legacy pre-T3 payloads encode TokenLimit as [token, limit].
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: token.length() + limit.length(),
+        }
+        .encode(&mut encoded);
+        token.encode(&mut encoded);
+        limit.encode(&mut encoded);
+
+        let decoded: TokenLimit =
+            Decodable::decode(&mut encoded.as_slice()).expect("decode legacy token limit");
+        assert_eq!(decoded.token, token);
+        assert_eq!(decoded.limit, limit);
+        assert_eq!(decoded.period, 0);
+    }
+
+    #[test]
+    fn test_token_limit_encoding_omits_zero_period() {
+        let token_limit = TokenLimit {
+            token: Address::random(),
+            limit: U256::from(1234),
+            period: 0,
+        };
+
+        let mut encoded = Vec::new();
+        token_limit.encode(&mut encoded);
+
+        let mut payload = &encoded[..];
+        let header = alloy_rlp::Header::decode(&mut payload).expect("decode list header");
+        assert!(header.list);
+        assert_eq!(
+            header.payload_length,
+            token_limit.token.length() + token_limit.limit.length()
+        );
+    }
+
+    #[test]
+    fn test_token_limit_decode_rejects_explicit_zero_period_field() {
+        let token = Address::random();
+        let limit = U256::from(42);
+        let period = 0u64;
+
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: token.length() + limit.length() + period.length(),
+        }
+        .encode(&mut encoded);
+        token.encode(&mut encoded);
+        limit.encode(&mut encoded);
+        period.encode(&mut encoded);
+
+        let err: alloy_rlp::Error =
+            <TokenLimit as Decodable>::decode(&mut encoded.as_slice()).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)));
+    }
+
+    #[test]
+    fn test_key_authorization_decode_rejects_explicit_unrestricted_allowed_calls_field() {
+        let chain_id = 1u64;
+        let key_type = SignatureType::Secp256k1;
+        let key_id = Address::random();
+
+        let mut payload = Vec::new();
+        chain_id.encode(&mut payload);
+        key_type.encode(&mut payload);
+        key_id.encode(&mut payload);
+        payload.extend_from_slice(&[EMPTY_STRING_CODE, EMPTY_STRING_CODE, EMPTY_STRING_CODE]);
+
+        let mut encoded = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: payload.len(),
+        }
+        .encode(&mut encoded);
+        encoded.extend_from_slice(&payload);
+
+        let err: alloy_rlp::Error =
+            <KeyAuthorization as Decodable>::decode(&mut encoded.as_slice()).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -15,7 +15,8 @@ pub use tt_signature::{
 pub use alloy_eips::eip7702::Authorization;
 pub use envelope::{TIP20_PAYMENT_PREFIX, TempoTxEnvelope, TempoTxType, TempoTypedTransaction};
 pub use key_authorization::{
-    KeyAuthorization, KeyAuthorizationChainIdError, SignedKeyAuthorization, TokenLimit,
+    CallScope, KeyAuthorization, KeyAuthorizationChainIdError, SelectorRule,
+    SignedKeyAuthorization, TokenLimit,
 };
 pub use tempo_transaction::{
     Call, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -794,13 +794,6 @@ impl Decodable for TempoTransaction {
     }
 }
 
-#[cfg(feature = "reth")]
-impl reth_primitives_traits::InMemorySize for TempoTransaction {
-    fn size(&self) -> usize {
-        Self::size(self)
-    }
-}
-
 // Custom Arbitrary implementation to ensure calls is never empty and CREATE validation passes
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for TempoTransaction {
@@ -1615,7 +1608,9 @@ mod tests {
             limits: Some(vec![crate::transaction::TokenLimit {
                 token: address!("0000000000000000000000000000000000000003"),
                 limit: U256::from(10000),
+                period: 0,
             }]),
+            allowed_calls: None,
             key_id: address!("0000000000000000000000000000000000000004"),
         }
         .into_signed(PrimitiveSignature::Secp256k1(Signature::test_signature()));

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -1,47 +1,56 @@
 ---
 id: TIP-1011
 title: Enhanced Access Key Permissions
-description: Extends Access Keys with periodic spending limits and destination address scoping for subscription-based and restricted access patterns.
-authors: Tanishk Goyal 
+description: Extends Access Keys with periodic spending limits, destination/function scoping, and limited calldata recipient scoping.
+authors: Tanishk Goyal
 status: Draft
-related: TIP-1000, AccountKeychain, IAccountKeychain.sol
-protocolVersion: TBD (requires hardfork)
+related: Tempo Transaction Spec
+protocolVersion: T3
 ---
 
 # TIP-1011: Enhanced Access Key Permissions
 
 ## Abstract
 
-This TIP extends Access Keys with two new permission features: (1) **periodic spending limits** that automatically reset after a configurable time period, enabling subscription-based access patterns, and (2) **destination address scoping** that restricts keys to only interact with specific contract addresses.
+This TIP extends Access Keys with three permission features:
+
+1. **Periodic spending limits** that reset on fixed intervals.
+2. **Call scoping** that limits what addresses a key can call and which selectors it can use.
+3. **Limited calldata recipient scoping** for token transfer/approval selectors.
+
 
 ## Motivation
 
-Currently, Access Keys support spending limits (per-TIP-20 token caps) and expiry timestamps. However, these primitives are insufficient for common real-world patterns:
+Currently Access Keys support per-token limits and expiry, but miss two practical controls.
 
 ### Periodic Spending Limits
 
-The existing `TokenLimit` specifies a one-time spending cap that depletes permanently. This model doesn't support subscription-based patterns where:
-
-- A service needs recurring access to a fixed amount per billing cycle
-- Users want to authorize "up to X tokens per month" without re-authorizing
-- dApps implement subscription models (e.g., streaming services, SaaS payments)
+One-time limits cannot express recurring allowances.
 
 **Use cases:**
-1. **Subscription services**: Authorize a streaming service to charge 10 USDC/month
-2. **Recurring donations**: Allow an NPO to withdraw up to 5 USDC weekly
-3. **Payroll systems**: Enable payroll contracts to transfer salaries monthly
-4. **Rate-limited APIs**: Authorize API access keys with per-period token budgets
 
-### Destination Address Scoping
+1. Subscription billing (`10 USDC / month`).
+2. Payroll schedules (monthly budgeted payouts).
+3. Rate-limited agent/API budgets.
 
-Users have requested the ability to bind Access Keys to specific destinations (e.g., "only allow transactions to Uniswap"). This provides more granular permission scoping similar to Solana's delegate primitive.
+### Call Scoping (Target + Selector Set)
 
-**Use cases:**
-1. **DeFi integrations**: Allow a trading bot key to only interact with specific DEX contracts
-2. **Gaming**: Scope a session key to only interact with a game contract
-3. **Subscription services**: Allow a key to only call a specific payment contract
+Users need finer controls than "any call". They want keys like:
 
-**Current workaround**: Deploy a proxy contract that enforces destination restrictions, adding gas overhead and complexity.
+1. "Only call `swap()` and `exactInput()` on DEX X."
+2. "Only call gameplay methods on contract Y."
+3. "Only perform plain transfers, not token extension methods."
+4. "Only vote() on governance contracts."
+
+**Current workaround**: Deploy a proxy contract that enforces destination/function restrictions, adding gas overhead and complexity.
+
+### Recipient-Bound Token Calls
+
+Target + selector scoping still allows an access key to move funds to arbitrary recipients for token methods like `transfer` and `approve`.
+
+Users need a narrower policy: the key may call transfer/approve selectors, but only when the recipient/spender matches a configured address.
+
+This TIP intentionally adds a narrow calldata rule (first ABI `address` argument equality) instead of a generic calldata policy language.
 
 ---
 
@@ -49,265 +58,563 @@ Users have requested the ability to bind Access Keys to specific destinations (e
 
 ## Extended Data Structures
 
+Conventions used in this section:
+
+1. Protocol/RLP structs are written with Rust-like `Option<...>` notation.
+2. Solidity ABI structs are listed separately where ABI cannot directly represent protocol `Option` semantics.
+
 ### TokenLimit
 
 **Current:**
+
 ```solidity
 struct TokenLimit {
     address token;
-    uint256 limit;
+    uint256 amount;
 }
 ```
 
 **Proposed:**
+
 ```solidity
 struct TokenLimit {
     address token;
-    uint256 limit;      // Per-period limit when period > 0, one-time limit otherwise
-    uint256 remainingInPeriod;  // Remaining allowance in current period
-    uint64 period;      // Period duration in seconds (0 = one-time limit)
-    uint64 periodEnd;   // Timestamp when current period expires
+    uint256 amount;  // One-time cap when period == 0, per-period cap when period > 0
+    uint64 period;  // Period duration in seconds (0 = one-time limit)
 }
 ```
 
+Design note: `period` is specified as an explicit field (instead of packed into `token`) to keep encoding/auditing straightforward and avoid migration risk for existing limit semantics.
+
+Runtime state is derived and stored by the precompile (not signed):
+
+```text
+TokenLimitState {
+    remainingInPeriod: uint256,
+    periodEnd: uint64,
+}
+```
+
+Initialization and persistence:
+
+1. `TokenLimitState` is initialized when the key is authorized (or a limit is created via root mutation), not lazily at first spend.
+2. `period == 0` initializes `remainingInPeriod = limit` and `periodEnd = 0`.
+3. `period > 0` initializes `remainingInPeriod = limit` and `periodEnd = authorize_time + period`.
+4. For a given `(account,key,token)`, there is exactly one active `TokenLimit`; duplicate token entries in a single authorization MUST be rejected.
+
+### CallScope
+
+Call scoping is defined with optional fields (protocol-level / RLP model):
+
+```text
+CallScope {
+    target: address,
+    selector_rules: Option<Vec<SelectorRule>>,   // None => any selector on this target
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct CallScope {
+    address target;
+    SelectorRule[] selectorRules;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `selectorRules = []` maps to `selector_rules = None` (allow any selector on `target`, not "block all").
+2. `selectorRules = [r1, ...]` maps to `selector_rules = Some([r1, ...])`.
+3. To remove a target scope in the Solidity precompile API, callers MUST use `removeAllowedCalls(keyId, target)`.
+
+`selector_rules` behavior intentionally mirrors `limits` tri-state semantics:
+
+1. `None`: allow any selector.
+2. `Some([])`: allow no selectors (matches nothing for that scope).
+3. `Some([r1, r2, ...])`: allow exactly the listed selector rules.
+
+In the Solidity precompile API, omitting a target scope blocks that target; `selectorRules = []` does not.
+
+### SelectorRule
+
+```text
+SelectorRule {
+    selector: bytes4,
+    recipients: Option<Vec<address>>, // None => any recipient, Some([a1, ...]) => only listed recipients
+}
+```
+
+Solidity ABI representation for precompile methods:
+
+```solidity
+struct SelectorRule {
+    bytes4 selector;
+    address[] recipients;
+}
+```
+
+Normalization from Solidity ABI to protocol model:
+
+1. `recipients = []` maps to `recipients = None`. Note: empty array maps to allowing all recipients in solidity. To block all recipients, omit/remove that selector rule.
+2. `recipients = [a1, ...]` maps to `recipients = Some([a1, ...])`.
+
+`SelectorRule.recipients` behavior:
+
+1. `None` => no calldata recipient checks for this selector.
+2. `Some([a1, a2, ...])` => enforce `arg0` recipient membership for this selector.
+3. Selector rules MUST be unique per target (`selector` appears at most once).
+
+Supported constrained selectors in this TIP:
+
+1. `0xa9059cbb` => `transfer(address,uint256)`
+2. `0x095ea7b3` => `approve(address,uint256)`
+3. `0x95777d59` => `transferWithMemo(address,uint256,bytes32)`
+
+If a selector rule uses `recipients = Some([..])`, then:
+
+1. `target` MUST be a TIP-20 token address.
+2. `selector` MUST be one of the constrained selectors above.
+3. Otherwise, key authorization MUST be rejected.
+
+For these selectors, the constrained field is ABI argument `0` (the first `address` argument).
+
+Selector width is fixed at 4 bytes.
+
+1. Each `SelectorRule.selector` MUST be exactly 4 bytes.
+2. Implementations MUST revert when decoding or accepting any selector whose length is not exactly 4 bytes.
+3. Selectorless calls (`calldata.length < 4`) and fallback/receive routing are scope-matchable only for address-only scopes (`selector_rules = None`). They MUST be rejected when explicit selector matching is required.
+4. Contracts with non-standard selector parsing are NOT supported.
+
+Examples:
+
+1. `{ target: 0x123, selector_rules: Some([{selector: 0xaabbccdd, recipients: None}, {selector: 0xeeff0011, recipients: None}]) }`: allow two selectors on one target.
+2. `{ target: 0x123, selector_rules: None }`: address-only scoping (any calldata shape on `0x123`, including selectorless/fallback-style calls).
+3. `{ target: 0x123, selector_rules: Some([]) }`: matches no selector on `0x123`.
+4. `allowedCalls = None`: unrestricted key.
+5. `allowedCalls = Some([])`: key is authorized but cannot make scoped calls.
+6. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xReceiver])}]) }`: allow `transfer` only when `to == 0xReceiver`.
+7. `{ target: tokenX, selector_rules: Some([{selector: 0xa9059cbb, recipients: Some([0xA, 0xB])}]) }`: allow `transfer` only when `to` is in `{0xA, 0xB}`.
+8. Distinct target scopes are independent: allowing selector `s` on target `A` never allows selector `s` on target `B`.
+
 ### KeyAuthorization
 
-**Current fields retained:**
-- `spendingLimits`: `TokenLimit[]`
-- `expiry`: `uint64`
+Existing fields remain, with a trailing optional call-scope field:
 
-**New field:**
-```solidity
-struct KeyAuthorization {
-    TokenLimit[] spendingLimits;
-    uint64 expiry;
-    address[] allowedDestinations; // Empty array = unrestricted
+```text
+KeyAuthorization {
+    chain_id: u64,
+    key_type: SignatureType,
+    key_id: address,
+    expiry: Option<u64>,
+    limits: Option<Vec<TokenLimit>>,
+    allowed_calls: Option<Vec<CallScope>>,  // New trailing field
 }
 ```
 
 ## Interface Changes
 
+### Events
+
+```solidity
+/// @notice Emitted when an access key spends tokens against a spending limit
+/// @param account The account whose key was used
+/// @param publicKey The public key (address) that initiated the spend
+/// @param token The token address being spent
+/// @param amount The amount spent in this transaction
+/// @param remainingLimit The remaining spending limit after this spend
+event AccessKeySpend(
+    address indexed account,
+    address indexed publicKey,
+    address indexed token,
+    uint256 amount,
+    uint256 remainingLimit
+);
+```
+
+This event MUST be emitted whenever an access-key transaction deducts from a spending limit (one-time or periodic).
+
 ### IAccountKeychain.sol
 
 ```solidity
 /// @notice Authorizes a key with enhanced permissions
-/// @param key The public key to authorize
+/// @param keyId The key identifier (address derived from public key)
+/// @param signatureType 0: secp256k1, 1: P256, 2: WebAuthn
 /// @param expiry Block timestamp when key expires
+/// @param enforceLimits Whether spending limits are enforced for this key
 /// @param spendingLimits Token spending limits (may include periodic limits)
-/// @param allowedDestinations Addresses the key may call (empty = unrestricted)
+/// @param enforceAllowedCalls Whether call-scope restrictions are enabled for this key
+/// @param allowedCalls Per-target call scopes for this key.
 function authorizeKey(
-    bytes calldata key,
+    address keyId,
+    SignatureType signatureType,
     uint64 expiry,
+    bool enforceLimits,
     TokenLimit[] calldata spendingLimits,
-    address[] calldata allowedDestinations
+    bool enforceAllowedCalls,
+    CallScope[] calldata allowedCalls
 ) external;
 
-/// @notice Returns the allowed destinations for a key
-/// @param key The public key to query
-/// @return destinations Array of allowed destination addresses (empty = unrestricted)
-function getAllowedDestinations(bytes calldata key) external view returns (address[] memory destinations);
+/// @notice Creates or replaces one target scope for a key
+/// @dev Root key only. If `target` does not exist, creates a new scope; otherwise replaces it atomically.
+/// @dev `scope.selectorRules = []` allows any selector on `scope.target`; it does not block the target.
+/// @dev If a selector rule has `recipients`, `target` MUST be TIP-20 and `selector` MUST be transfer/approve (+memo).
+/// @dev For each selector rule, `recipients = []` means no recipient restriction.
+function setAllowedCalls(
+    address keyId,
+    CallScope calldata scope
+) external;
 
-/// @notice Returns the remaining limit for a token, accounting for period resets
-/// @param key The public key to query
-/// @param token The token address
-/// @return remaining The remaining spending limit for the current period
-/// @return periodEnd The timestamp when the current period ends (0 if one-time limit)
-function getRemainingLimit(bytes calldata key, address token) external view returns (uint256 remaining, uint64 periodEnd);
+/// @notice Removes one target scope for a key
+function removeAllowedCalls(address keyId, address target) external;
+
+/// @notice Returns allowed call scopes for an account+key
+/// @dev Explicit deny-all (`allowed_calls = Some([])`) is returned as the sentinel
+///      `{ target: address(0), selectorRules: [] }`
+///      so callers can distinguish it from unrestricted mode (`[]`).
+function getAllowedCalls(
+    address account,
+    address keyId
+) external view returns (CallScope[] memory calls);
+
+/// @notice Returns remaining limit for a token, accounting for period resets
+function getRemainingLimit(
+    address account,
+    address keyId,
+    address token
+) external view returns (uint256 remaining, uint64 periodEnd);
 ```
 
 ## Semantic Behavior
 
 ### Periodic Limit Reset Logic
 
-When a spending attempt occurs:
+On each spend attempt for `(account, key, token)`:
 
-```
-function verifyAndUpdateSpending(key, token, amount):
-    limit = getTokenLimit(key, token)
-    
-    if limit.period > 0:  // Periodic limit
-        if block.timestamp >= limit.periodEnd:
-            // Reset period
-            limit.periodEnd = block.timestamp + limit.period
-            limit.remainingInPeriod = limit.limit  // Reset to per-period allowance
-    
-    if amount > limit.remainingInPeriod:
-        revert SpendingLimitExceeded()
-    
-    limit.remainingInPeriod -= amount
-```
+1. Implementations MUST load the configured `TokenLimit` and runtime `TokenLimitState`.
+2. If `period == 0`, the limit is one-time and no period rollover is applied.
+3. If `period > 0` and `block.timestamp >= periodEnd`, implementations MUST reset `remainingInPeriod` to `limit` and advance `periodEnd` by whole multiples of `period` so that `periodEnd > block.timestamp`.
+4. If `amount > remainingInPeriod`, implementations MUST revert `SpendingLimitExceeded()`.
+5. Otherwise, implementations MUST decrement `remainingInPeriod` by `amount`.
 
-### Destination Validation Logic
+`updateSpendingLimit(account,key,token,newLimit)` semantics:
 
-When a transaction is submitted with an Access Key:
+1. MUST update the configured `limit` for that `(account,key,token)`.
+2. MUST set `remainingInPeriod = newLimit`.
+3. MUST NOT change `period`.
+4. MUST NOT change `periodEnd`.
+5. Therefore changing `period` requires re-authorizing the key (or removing and recreating that token limit entry).
 
-```
-function validateDestination(key, destination):
-    allowed = getAllowedDestinations(key)
-    
-    if allowed.length == 0:
-        return true  // Unrestricted
-    
-    for addr in allowed:
-        if addr == destination:
-            return true
-    
-    revert DestinationNotAllowed()
-```
+### Call Validation Logic
+
+Call-scope checks use map lookups keyed by `(account_key, target, selector)` plus optional selector-level recipient allowlists.
+
+Scoped-call validation is a transaction-validity check performed before execution. If any call fails validation, the transaction is invalid and MUST NOT enter execution.
+
+
+#### Access-Key Contract Creation Ban
+
+If a transaction is signed with an access key (`key != Address::ZERO`), contract creation MUST be rejected in all configurations.
+
+This ban applies regardless of:
+
+1. Whether `allowed_calls` is `None` or `Some(...)`.
+2. Whether any target scope has `selector_rules = None` (allow-any-selector).
+3. Whether the creation call appears in a batch.
+
+Only the root key (`key == Address::ZERO`) may submit contract-creation calls; this is not a global create ban.
+
+#### Single Call Validation
+
+For each call:
+
+1. If the transaction uses an access key and the call is contract creation, implementations MUST reject the transaction as invalid before execution.
+2. If `allowed_calls = None`, implementations MUST allow the call (subject to the contract-creation ban).
+3. If `allowed_calls = Some(...)`, implementations MUST enforce target and selector matching.
+4. If no target scope exists for `destination`, implementations MUST reject the transaction as invalid before execution.
+5. If the target scope is `selector_rules = None`, implementations MUST allow the call, including selectorless/fallback-style calldata.
+6. If the target scope is `selector_rules = Some(list)` and calldata does not provide at least 4 selector bytes, implementations MUST reject the transaction as invalid before execution.
+7. If the target scope is `selector_rules = Some(list)`, there MUST be a rule for the selector; otherwise implementations MUST reject the transaction as invalid before execution.
+8. If the matched rule has `recipients = None`, implementations MUST allow the call.
+9. If the matched rule has `recipients = Some(list)`, implementations MUST decode ABI argument `0` as an `address` and require membership in `list`.
+10. For a selector rule with `recipients = Some(list)`, if calldata is shorter than `4 + 32` bytes, implementations MUST reject the transaction as invalid before execution.
+11. For a selector rule with `recipients = Some(list)`, implementations MUST enforce canonical ABI `address` encoding for argument `0` (upper 12 bytes zero) before membership check; otherwise implementations MUST reject the transaction as invalid before execution.
+
+#### Batch Validation
+
+For AA transactions with multiple calls, each call MUST be validated independently before execution begins. If any call fails scope validation, the transaction is invalid and the batch MUST NOT enter execution.
+
+### Root-Controlled Scope Updates
+
+`setAllowedCalls` MUST be root-key-only and MUST apply create-or-replace semantics per target.
+
+1. `selectorRules = []` sets `selector_rules = None` semantics (any selector allowed on `target`).
+2. `removeAllowedCalls(keyId, target)` disables that target scope.
+3. Implementations MUST enforce at most one scope per target for each `(account, key)`.
+4. Selector rules MUST be unique by `selector` within a target scope.
+5. If any rule has `recipients = Some([..])`, `target` MUST be a TIP-20 token address.
+6. If any rule has `recipients = Some([..])`, its `selector` MUST be one of:
+   1. `0xa9059cbb` (`transfer(address,uint256)`)
+   2. `0x095ea7b3` (`approve(address,uint256)`)
+   3. `0x95777d59` (`transferWithMemo(address,uint256,bytes32)`)
+8. If any rule has `recipients = Some([..])`, each recipient in that list MUST be non-zero.
+9. If any rule has `recipients = Some([..])`, recipients in that list MUST be unique.
+10. If any selector-rule validity rule is violated, implementations MUST reject the authorization (or revert `setAllowedCalls`).
+
+Rationale for rule 2 (`selectorRules = []` disable):
+
+1. This avoids unbounded gas from deletion-time slot iteration.
+2. Prior selector rows may remain in state, but the target mode deterministically disables matching.
 
 ### Interaction Rules
 
-1. **Mixed limits**: Keys can have a mix of one-time and periodic limits for different tokens
-2. **Destination + limits**: Both constraints are evaluated independently; both must pass
-3. **Period updates**: Calling `updateSpendingLimit()` updates the per-period amount and resets the current period
-4. **Empty destinations**: An empty `allowedDestinations` array means the key is unrestricted (can call any address)
+1. Keys may mix one-time and periodic token limits.
+2. Spending limits and call scopes are independent checks; both must pass.
+3. `updateSpendingLimit()` updates limit and `remainingInPeriod`, but does not change `period` or `periodEnd`.
+4. `allowed_calls = None` is unrestricted for non-create calls; `Some([])` is explicit deny-all.
+5. Every scope has an explicit target address, so there is no wildcard-target precedence ambiguity.
+6. Per-target updates are create-or-replace and duplicate target scopes are not allowed.
+7. Selector-level recipient allowlists are optional and only valid for TIP-20 targets and the constrained selectors above.
+8. Selector-level recipient allowlists are checked after selector match and before call execution.
+9. This TIP does not introduce generic calldata predicates, offset math, or wildcard argument matching.
 
-## Gas Costs
+Wallet UX recommendation (non-consensus):
 
-| Operation | Additional Gas |
-|-----------|----------------|
-| `authorizeKey` with N destinations | ~20,000 + 5,000 × N |
-| `authorizeKey` with periodic limit | ~3,000 per periodic token |
-| Destination check (per tx) | ~2,100 + 200 × N |
-| Period reset (when triggered) | ~5,000 |
+1. Wallets SHOULD default to scoped keys (non-empty `selectorRules`) and require explicit user opt-in for unrestricted target scopes (`selectorRules = []`).
+
+## Gas And Complexity Bounds
+
+This TIP only specifies the additional intrinsic gas delta for call scopes in handler-side `key_authorization` charging.
+
+Existing key-authorization charging (signature verification, existing-key read, base key write, token-limit writes, and buffer) remains unchanged.
+
+Definitions:
+
+1. `SSTORE_SET = sstore_set_without_load_cost`.
+2. `S` = number of targets with configured call scope.
+3. `K` = total selector rules across all configured targets.
+4. `C` = total selector rules with `recipients = Some([..])`.
+5. `W` = total recipient entries across all constrained selector rules.
+6. `MAX_CALL_SCOPES = 8` target scopes per `(account, key)`.
+7. `MAX_SELECTOR_RULES_PER_SCOPE = 16` selector rules per target scope.
+8. `MAX_RECIPIENTS_PER_SELECTOR = 16` recipients per selector rule.
+   
+Scoped-call storage writes counted for intrinsic gas:
+
+1. Restricted-mode marker: `1` slot when `allowed_calls` is `Some(...)`.
+2. Each target scope writes `4` slots: target-set length, target-set value, target-set position, and target mode.
+3. Each selector rule writes `4` slots: selector-set length, selector-set value, selector-set position, and selector mode.
+4. Each recipient-constrained selector writes `1` additional slot for recipient-set length.
+5. Each recipient entry writes `2` slots: recipient-set value and recipient-set position.
+
+```text
+gas_key_authorization_new = gas_key_authorization_existing
+                          + SSTORE_SET * scope_slots
+
+scope_slots = 0                    if allowed_calls is None
+            = 1                    if allowed_calls is Some([])   // explicit restricted-mode marker
+            = 1 + 4*S + 4*K + C + 2*W    if allowed_calls is Some(scopes)
+```
+
+Justification for `1 + 4*S + 4*K + C + 2*W`: `1` stores restricted mode, each target scope materializes as four set/mode writes, each selector rule materializes as four set/mode writes, each constrained selector writes one recipient-set length slot, and each recipient writes two set-membership slots.
+
+Bounds:
+
+1. Implementations MUST reject authorizations with `S > MAX_CALL_SCOPES`.
+2. Implementations MUST reject any target scope with selector-rule count greater than `MAX_SELECTOR_RULES_PER_SCOPE`.
+3. Implementations MUST reject any selector rule with recipient count greater than `MAX_RECIPIENTS_PER_SELECTOR`.
+4. Implementations MUST reject any selector rule with `recipients = Some([..])` whose `target` is not a TIP-20 token address.
+5. Implementations MUST reject any selector rule with `recipients = Some([..])` and selector outside the fixed constrained-selector set.
+6. Implementations MUST reject duplicate selector rules for the same `(target, selector)`.
+7. Implementations MUST reject duplicate recipients inside a selector rule.
+8. These bounds are consensus constants.
+
+Constant rationale:
+
+1. `MAX_CALL_SCOPES` and `MAX_SELECTOR_RULES_PER_SCOPE` cap authorization-time storage growth and per-call validation work.
+2. `MAX_RECIPIENTS_PER_SELECTOR` caps recipient membership checks and storage writes for constrained selectors.
+3. Any future change to these constants requires a new TIP / hardfork-gated update.
+
+No additional flat gas is specified here for precompile methods (`setAllowedCalls`, `getAllowedCalls`, etc.); those are charged by normal EVM metering at execution time.
 
 ## Encoding
 
-### Transaction Authorization
+### Signing Format
 
-The `KeyAuthorization` struct is RLP-encoded in the transaction's authorization field:
+Authorization digest format:
 
+```text
+key_auth_digest = keccak256(rlp([
+  chain_id,
+  key_type,
+  key_id,
+  expiry?,
+  limits?,
+  allowed_calls?
+]))
+
+limits = rlp([token, limit])              if period == 0
+       = rlp([token, limit, period])      if period > 0
 ```
+
+RLP safety note:
+
+1. Implementations MUST use canonical RLP encoding for all fields.
+2. The signed payload is a typed RLP list; distinct field tuples produce distinct canonical encodings (no cross-field preimage ambiguity under canonical RLP).
+
+### Transaction Authorization RLP
+
+```text
 KeyAuthorization := RLP([
-    spendingLimits: [TokenLimit, ...],
-    expiry: uint64,
-    allowedDestinations: [address, ...]
+    chain_id: u64,
+    key_type: u8,
+    key_id: address,
+    expiry?: uint64,
+    limits?: [TokenLimit, ...],
+    allowed_calls?: [CallScope, ...]
 ])
 
 TokenLimit := RLP([
     token: address,
     limit: uint256,
-    remainingInPeriod: uint256,
-    period: uint64,
-    periodEnd: uint64
+    period: uint64
+])
+
+// Canonical one-time form omits `period` entirely.
+// Omitted `period` decodes to `period = 0`, i.e. a non-periodic one-time spending limit.
+TokenLimit(one-time) := RLP([
+    token: address,
+    limit: uint256
+])
+
+CallScope := RLP([
+    target: address,
+    selector_rules?: [SelectorRule, ...]
+])
+
+SelectorRule := RLP([
+    selector: bytes4,
+    recipients?: [address, ...]
 ])
 ```
 
+Optional encoding rules:
+
+1. Optional scalar fields (`expiry`) use `None => 0x80`.
+2. Optional list fields (`limits`, `selector_rules`, `recipients`) use `None => 0x80`.
+3. `allowed_calls = None` is omitted on wire.
+4. `Some([])` list values encode as RLP empty list (`0xc0`).
+5. `Some([x, ...])` list values encode as normal lists.
+6. For `TokenLimit`, one-time limits (`period == 0`) use the two-field form; explicit three-field encoding with `period = 0` is non-canonical.
+7. Each `SelectorRule.selector` MUST decode to exactly 4 bytes; otherwise the authorization MUST be rejected.
+8. `SelectorRule.recipients = Some([])` MUST be rejected.
+
 ---
-
-# Backward Compatibility
-
-This TIP requires a **hardfork** due to changes in transaction encoding and execution semantics.
-
-## RLP Encoding Changes
-
-### TokenLimit (2 fields → 5 fields)
-
-The current `TokenLimit` struct encodes as `[token, limit]`. This TIP extends it to `[token, limit, remainingInPeriod, period, periodEnd]`.
-
-**Breaking change**: Old nodes cannot decode new transactions with 5-field `TokenLimit`. New nodes must implement version-tolerant decoding:
-
-```
-On decode:
-  if list.len() == 2:
-    // V1 (legacy one-time limit)
-    remainingInPeriod = limit
-    period = 0
-    periodEnd = 0
-  else if list.len() == 5:
-    // V2 (periodic limit)
-    decode all fields
-  else:
-    error
-```
-
-Post-fork, all new `TokenLimit` encodings MUST use the 5-field format for consistency.
-
-### KeyAuthorization (trailing field addition)
-
-`KeyAuthorization` uses `#[rlp(trailing)]` which allows appending optional fields. Adding `allowedDestinations: Option<Vec<Address>>` as the last field is compatible with this pattern:
-
-- Old encodings (without `allowedDestinations`) decode as `allowedDestinations = None` (unrestricted)
-- New encodings with `allowedDestinations` will be rejected by old nodes
-
-## Compact/Database Encoding
-
-Although `TokenLimit` has `#[derive(reth_codecs::Compact)]`, it is **not used in production storage**. The storage path is:
-
-```
-TempoTransaction (derived Compact)
-  └─ key_authorization: Option<SignedKeyAuthorization>
-       └─ SignedKeyAuthorization (custom Compact impl → uses RLP internally)
-            └─ KeyAuthorization (RLP encoded)
-                 └─ limits: Option<Vec<TokenLimit>> (RLP encoded)
-```
-
-`SignedKeyAuthorization` implements a custom `Compact` that wraps RLP encoding. Therefore, `TokenLimit` is always serialized as RLP bytes in the database, not via its derived Compact layout.
-
-**Implication**: If we implement version-tolerant RLP decoding for `TokenLimit` (accept 2-field or 5-field lists), existing database entries will decode correctly. **No DB rebuild required** for this change.
 
 ## Precompile Storage Changes
 
-The current storage layout:
-- `keys[account][keyId] → AuthorizedKey` (packed slot)
-- `spending_limits[key][token] → U256` (remaining amount)
+Current layout:
 
-This TIP requires additional per-token state for periodic limits. **Additive storage approach** (no migration required):
+1. `keys[account][keyId] -> AuthorizedKey`
+2. `spending_limits[(account,keyId)][token] -> U256`
+
+Additive periodic-limit layout:
 
 | Mapping | Type | Description |
 |---------|------|-------------|
-| `spending_limits[key][token]` | `U256` | Reinterpreted as `remainingInPeriod` |
-| `spending_limit_max[key][token]` | `U256` | Per-period cap (new) |
-| `spending_limit_period[key][token]` | `u64` | Period duration in seconds (new) |
-| `spending_limit_period_end[key][token]` | `u64` | Current period end timestamp (new) |
+| `spending_limits[account_key][token]` | `U256` | Remaining amount / `remainingInPeriod` |
+| `spending_limit_period_state[account_key][token]` | struct `{ max, period, period_end }` | Periodic limit metadata |
 
-For destination scoping:
-| Mapping | Type | Description |
-|---------|------|-------------|
-| `allowed_destinations_len[key]` | `u64` | Number of allowed destinations |
-| `allowed_destinations[key][index]` | `Address` | Allowed destination at index |
+Call-scope storage is account-scoped and represented as nested sets/maps:
 
-Legacy keys (pre-fork) have `period = 0`, `max = 0`, and behave as one-time limits.
+| Path | Type | Description |
+|------|------|-------------|
+| `key_scopes[account_key].mode` | `u8` | `0 = unrestricted`, `1 = scoped`, `2 = deny-all` |
+| `key_scopes[account_key].targets` | `Set<address>` | Scoped target membership |
+| `key_scopes[account_key].target_scopes[target].mode` | `u8` | `0 = none`, `1 = any-selector`, `2 = explicit-selector-rules` |
+| `key_scopes[account_key].target_scopes[target].selectors` | `Set<u32>` | Explicit selector membership |
+| `key_scopes[account_key].target_scopes[target].selector_scopes[selector].mode` | `u8` | `1 = any-recipient`, `2 = constrained-recipient-set` |
+| `key_scopes[account_key].target_scopes[target].selector_scopes[selector].recipients` | `Set<address>` | Selector-level recipient membership |
+
+`account_key = keccak256(account || key_id)` to avoid cross-account collisions for shared key IDs.
+
+Implementations MAY maintain additional internal indexes or equivalent layouts so long as semantics remain unchanged.
 
 ## Hardfork-Gated Features
 
-The following MUST be gated behind the hardfork activation:
+The following MUST be fork-gated:
 
-1. **RLP decoding**: Accept 5-field `TokenLimit` and `allowedDestinations` in `KeyAuthorization`
-2. **Periodic limit reset logic**: Check `periodEnd` and reset `remainingInPeriod` on spend
-3. **Destination scoping enforcement**: Validate transaction `to` against `allowedDestinations`
-4. **New precompile storage writes**: Write to new storage slots for period/destination data
-5. **New precompile interface methods**: `getAllowedDestinations()`, updated `getRemainingLimit()` return type
+1. New `TokenLimit` decode/encode behavior.
+2. `allowed_calls` decode/encode behavior.
+3. `selector_rules` decode/encode behavior.
+4. Periodic reset logic.
+5. Call-scope validation logic.
+6. Selector-rule recipient-allowlist calldata validation logic.
+7. New precompile storage writes/reads for periodic + call-scope data.
+8. New precompile storage writes/reads for selector-level recipient allowlists.
+9. Updated precompile read APIs (`getAllowedCalls(account,key)`, richer `getRemainingLimit`).
+10. New mutator function `setAllowedCalls`, which can only be called by root key.
+11. Global ban on contract creation when using access keys.
+12. Selector-width enforcement (`selector length == 4` only).
+13. Scope/selector bound enforcement (`MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`).
+14. Constrained-selector allowlist and argument-0 canonical address checks.
+15. TIP-20 target verification for selector rules with recipient allowlists.
+16. Recipient count bound enforcement (`MAX_RECIPIENTS_PER_SELECTOR`).
 
-Pre-fork blocks MUST be replayed with old semantics to preserve state root consistency.
+Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 
 ---
 
 # Invariants
 
-1. **Period monotonicity**: `periodEnd` MUST only increase; it cannot be set to a past timestamp.
-
-2. **Limit conservation**: For periodic limits, `remainingInPeriod` MUST NOT exceed `limit` after any reset.
-
-3. **Destination enforcement**: If `allowedDestinations` is non-empty, transactions to addresses not in the list MUST revert.
-
-4. **Backward compatibility**: Keys authorized without the new fields MUST behave as unrestricted (`allowedDestinations = []`) with one-time limits (`period = 0`).
-
-5. **Expiry precedence**: Key expiry MUST be checked before spending limits or destination restrictions.
+1. `periodEnd` is monotonic and never set to the past.
+2. `remainingInPeriod <= limit` after any operation.
+3. Expiry check runs before spending and call-scope checks.
+4. If `key != Address::ZERO`, any contract-creation call MUST cause the transaction to be rejected as invalid before execution, regardless of `allowed_calls`.
+5. `allowed_calls = None` allows all non-create calls; `allowed_calls = Some(...)` requires target+selector-rule match and otherwise causes the transaction to be rejected as invalid before execution.
+6. In scoped mode, calldata must contain at least 4 selector bytes only when explicit selector matching is required; address-only scopes allow selectorless/fallback-style calldata.
+7. For each `(account, key)`, target scopes are unique, selector rules are unique per target, and recipients are unique per selector rule.
+8. `setAllowedCalls(..., scope.selectorRules = [])` allows any selector on that target; `removeAllowedCalls(keyId, target)` disables that target scope.
+9. Selector rules with recipient allowlists are valid only for TIP-20 targets and only for the fixed constrained selector set.
+10. For recipient-allowlisted rules, calldata argument `0` must be a canonically encoded ABI address and must be in the configured recipient set.
+11. In the Solidity ABI, `selectorRules[i].recipients = []` means that selector has no recipient restriction.
+12. Authorizations exceeding `MAX_CALL_SCOPES`, `MAX_SELECTOR_RULES_PER_SCOPE`, or `MAX_RECIPIENTS_PER_SELECTOR` MUST be rejected.
 
 ## Test Cases
 
-1. **Periodic reset**: Verify that a periodic limit resets correctly after the period elapses
-2. **Partial period usage**: Verify that unused periodic allowance does not roll over
-3. **Destination allow**: Verify that transactions to allowed destinations succeed
-4. **Destination deny**: Verify that transactions to non-allowed destinations revert
-5. **Empty destinations**: Verify that empty `allowedDestinations` allows any destination
-6. **Mixed limits**: Verify that a key can have both one-time and periodic limits for different tokens
-7. **Upgrade path**: Verify that existing keys continue to function after upgrade
+1. Periodic reset after elapsed period.
+2. No rollover of unused periodic allowance.
+3. Address + multi-selector scope allow.
+4. Address-only allow (`selector_rules=None`).
+5. Deny when no scope matches.
+6. `allowed_calls=None` allows all non-create calls.
+7. `allowed_calls=Some([])` denies all calls.
+8. Mixed one-time and periodic token limits.
+9. Existing keys continue to function after the fork.
+10. Batch validation rejects the transaction before execution when any call is invalid.
+11. Shared key IDs across accounts cannot overwrite each other’s scopes.
+12. Reject `allowed_calls` entries with `S > MAX_CALL_SCOPES`.
+13. Reject any target scope with selector-rule count `> MAX_SELECTOR_RULES_PER_SCOPE`.
+14. Reject calls that do not provide at least 4 selector bytes when explicit selector matching is required.
+15. `setAllowedCalls(..., scope.selectorRules = [])` allows any selector on that target.
+16. `setAllowedCalls` create-or-replace semantics are enforced.
+17. `removeAllowedCalls(keyId, target)` removes that target scope and leaves the key in deny-all mode if no target scopes remain.
+19. Address-only scopes allow selectorless/fallback-style calls to the scoped target.
+20. Access-key transactions with CREATE as first call are rejected.
+21. Access-key transactions with any CREATE in a batch are rejected.
+22. For constrained TIP-20 selectors (`transfer`, `approve`, `transferWithMemo`), calls succeed iff calldata argument `0` is in the configured recipient set.
+23. Single-recipient and multi-recipient selector rules both enforce the same membership rule.
+24. Reject the transaction before execution when a selector rule with a recipient allowlist is matched and calldata is shorter than `4 + 32` bytes.
+25. Reject the transaction before execution when a selector rule with a recipient allowlist is matched and ABI argument `0` is not canonically encoded as an address.
+27. Reject selector rules with recipient allowlists for selectors outside the fixed constrained-selector set.
+28. Reject duplicate selector rules for the same `(target, selector)`.
+29. Reject duplicate recipients within a selector rule.
+30. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
 
 ## References
 
 - [AccountKeychain docs](https://docs.tempo.xyz/protocol/transactions/AccountKeychain)
+- [Tempo Transactions](https://docs.tempo.xyz/guide/tempo-transaction)
 - [IAccountKeychain.sol](tips/ref-impls/src/interfaces/IAccountKeychain.sol)
 - [GitHub Issue #1865](https://github.com/tempoxyz/tempo/issues/1865) - Periodic spending limits
 - [GitHub Issue #1491](https://github.com/tempoxyz/tempo/issues/1491) - Destination address scoping


### PR DESCRIPTION
# PR1: TIP-1011 Protocol Shape

Title: `feat(primitives): add TIP-1011 wire format and ABI`
Base: `main`
Head: `tanishk/tip-1011-primitives`

## Why We Are Making This Change

This PR isolates the protocol surface of TIP-1011: what gets signed, how it is encoded, and what ABI shape callers use. Reviewers can verify the new semantics here without needing to reason about precompile state, gas accounting, or txpool behavior.

## Why This Design

The design goal is to make TIP-1011 reviewable from the outside in:
- The spec describes the intended semantics.
- The primitives define the signed payload and RLP rules.
- The contract ABI mirrors those semantics explicitly.
- Simple callsite fallout is updated in the same PR so reviewers can see the new shape used concretely.

## Spec To Read First

Read these sections in `tips/tip-1011.md`:
1. `Abstract`
2. `Extended Data Structures`
3. `TokenLimit`
4. `CallScope`
5. `SelectorRule`
6. `KeyAuthorization`

## How To Review This PR

1. Start with the spec and lock in the tri-state semantics:
   - `limits: None` vs `Some([])`
   - `allowed_calls: None` vs `Some([])`
   - legacy token-limit encoding vs T3 token-limit encoding
2. Review `crates/primitives/src/transaction/key_authorization.rs` for the signed payload shape and RLP logic.
3. Review `crates/contracts/src/precompiles/account_keychain.rs` for the ABI surface.
4. Treat the remaining files as mechanical adoption of the new shape.
5. Ignore enforcement questions in this PR; those land later in the stack.
