### PR TITLE
feat(node): enforce TIP-1011 restrictions

### DIFF
--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -310,6 +310,24 @@ mod tests {
         evm
     }
 
+    /// Create an EVM with T3 hardfork enabled and a funded account.
+    fn create_funded_evm_t3(address: Address) -> TempoEvm<CacheDB<EmptyDB>, ()> {
+        let db = CacheDB::new(EmptyDB::new());
+        let mut cfg = CfgEnv::<TempoHardfork>::default();
+        cfg.spec = TempoHardfork::T3;
+        cfg.gas_params = tempo_gas_params(TempoHardfork::T3);
+
+        let ctx = Context::mainnet()
+            .with_db(db)
+            .with_block(Default::default())
+            .with_cfg(cfg)
+            .with_tx(Default::default());
+
+        let mut evm = TempoEvm::new(ctx, ());
+        fund_account(&mut evm, address);
+        evm
+    }
+
     /// Create an EVM with a specific timestamp and a funded account.
     fn create_funded_evm_with_timestamp(
         address: Address,
@@ -975,6 +993,7 @@ mod tests {
             key_id: caller,
             expiry: None,
             limits: None,
+            allowed_calls: None,
         };
         let key_auth_webauthn_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
         let signed_key_auth =
@@ -1084,6 +1103,111 @@ mod tests {
             .storage_ref(NONCE_PRECOMPILE_ADDRESS, nonce_slot)
             .unwrap_or_default();
         assert_eq!(stored_nonce_2, U256::from(2));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_t3_key_authorization_deny_all_scopes_blocks_same_tx_call() -> eyre::Result<()> {
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+
+        let mut evm = create_funded_evm_t3(caller);
+
+        // Set up TIP20 for fee payment.
+        let block = TempoBlockEnv::default();
+        {
+            let ctx = &mut evm.ctx;
+            let internals = EvmInternals::new(&mut ctx.journaled_state, &block, &ctx.cfg, &ctx.tx);
+            let mut provider = EvmPrecompileStorageProvider::new_max_gas(internals, &ctx.cfg);
+
+            StorageCtx::enter(&mut provider, || {
+                TIP20Setup::path_usd(caller)
+                    .with_issuer(caller)
+                    .with_mint(caller, U256::from(10_000_000))
+                    .apply()
+            })?;
+        }
+
+        // Explicit deny-all marker in protocol payload: Some([]).
+        let key_auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::WebAuthn,
+            key_id: caller,
+            expiry: None,
+            limits: None,
+            allowed_calls: Some(Vec::new()),
+        };
+        let key_auth_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
+        let signed_key_auth = key_auth.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig));
+
+        let tx = TxBuilder::new()
+            .call_identity(&[0x01])
+            .key_authorization(signed_key_auth)
+            .gas_limit(1_000_000)
+            .build();
+
+        // Use keychain signature so call-scope validation runs in the same tx.
+        let signed_tx = key_pair.sign_tx_keychain(tx)?;
+        let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+        let err = evm
+            .transact_commit(tx_env)
+            .expect_err("deny-all scope should reject the call");
+
+        assert!(
+            matches!(
+                err,
+                revm::context::result::EVMError::Transaction(
+                    TempoInvalidTransaction::KeychainValidationFailed { .. }
+                )
+            ),
+            "expected KeychainValidationFailed, got: {err:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_same_tx_key_authorization_rejects_key_type_mismatch() -> eyre::Result<()> {
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+
+        let mut evm = create_funded_evm_t1(caller);
+
+        let key_auth = KeyAuthorization {
+            chain_id: 1,
+            key_type: SignatureType::Secp256k1,
+            key_id: caller,
+            expiry: None,
+            limits: None,
+            allowed_calls: None,
+        };
+        let key_auth_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
+        let signed_key_auth = key_auth.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig));
+
+        let tx = TxBuilder::new()
+            .call_identity(&[0x01])
+            .key_authorization(signed_key_auth)
+            .gas_limit(1_000_000)
+            .build();
+
+        let signed_tx = key_pair.sign_tx_keychain(tx)?;
+        let tx_env = TempoTxEnv::from_recovered_tx(&signed_tx, caller);
+
+        let err = evm
+            .transact_commit(tx_env)
+            .expect_err("mismatched key_type should reject same-tx auth+use");
+
+        assert!(
+            matches!(
+                err,
+                revm::context::result::EVMError::Transaction(
+                    TempoInvalidTransaction::KeychainValidationFailed { .. }
+                )
+            ),
+            "expected KeychainValidationFailed, got: {err:?}"
+        );
 
         Ok(())
     }
@@ -2092,6 +2216,7 @@ mod tests {
             key_id: access_key.address,
             expiry: None,
             limits: None,
+            allowed_calls: None,
         };
         let key_auth_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
         let signed_key_auth = key_auth.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig));
@@ -2183,6 +2308,7 @@ mod tests {
             key_id: access_key2.address,
             expiry: None, // Never expires (u64::MAX)
             limits: None, // No spending limits
+            allowed_calls: None,
         };
         let key_auth_sig2 = key_pair.sign_webauthn(key_auth2.signature_hash().as_slice())?;
         let signed_key_auth2 = key_auth2.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig2));
@@ -2292,6 +2418,7 @@ mod tests {
                 key_id: access_key.address,
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
             let key_auth_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
             let signed_key_auth = key_auth.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig));
@@ -2412,6 +2539,7 @@ mod tests {
                 key_id: access_key.address,
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
             let key_auth_sig = key_pair.sign_webauthn(key_auth.signature_hash().as_slice())?;
             let signed_key_auth = key_auth.into_signed(PrimitiveSignature::WebAuthn(key_auth_sig));

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -37,7 +37,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles::{
     ECRECOVER_GAS,
-    account_keychain::{AccountKeychain, TokenLimit, authorizeKeyCall},
+    account_keychain::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall},
     error::TempoPrecompileError,
     nonce::{EXPIRING_NONCE_MAX_EXPIRY_SECS, INonce::getNonceCall, NonceManager},
     storage::{PrecompileStorageProvider, StorageCtx, evm::EvmPrecompileStorageProvider},
@@ -163,7 +163,24 @@ fn calculate_key_authorization_gas(
         let sload_cost =
             gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
 
-        sig_gas + sload_cost + sstore_cost * (1 + num_limits) + BUFFER
+        let limit_slots = if spec.is_t3() {
+            // T3 periodic limits write 2 storage slots per token:
+            // spending_limits[token].remaining + packed {max, period, period_end}
+            num_limits.saturating_mul(2)
+        } else {
+            num_limits
+        };
+
+        let mut total = sig_gas + sload_cost + sstore_cost * (1 + limit_slots) + BUFFER;
+
+        // T3+: include scoped-call storage rows in intrinsic gas.
+        if spec.is_t3() {
+            total = total.saturating_add(
+                sstore_cost.saturating_mul(key_auth.authorization.call_scope_storage_slots()),
+            );
+        }
+
+        total
     } else {
         // Pre-T1B: Original heuristic constants
         KEY_AUTH_BASE_GAS + sig_gas + num_limits * KEY_AUTH_PER_LIMIT_GAS
@@ -927,6 +944,24 @@ where
                 .validate_chain_id(cfg.chain_id(), spec.is_t1c())
                 .map_err(TempoInvalidTransaction::from)?;
 
+            // T3 gates all TIP-1011 fields. Before activation, transaction semantics must stay
+            // unchanged, so periodic limits and call scopes are rejected.
+            if !spec.is_t3() {
+                if key_auth.has_periodic_limits() {
+                    return Err(TempoInvalidTransaction::KeychainValidationFailed {
+                        reason: "periodic token limits are not active before T3".to_string(),
+                    }
+                    .into());
+                }
+
+                if key_auth.has_call_scopes() {
+                    return Err(TempoInvalidTransaction::KeychainValidationFailed {
+                        reason: "call scopes are not active before T3".to_string(),
+                    }
+                    .into());
+                }
+            }
+
             let keychain_checkpoint = if spec.is_t1() {
                 Some(journal.checkpoint())
             } else {
@@ -1008,18 +1043,59 @@ where
                             .map(|limit| TokenLimit {
                                 token: limit.token,
                                 amount: limit.limit,
+                                period: limit.period,
                             })
                             .collect()
                     })
                     .unwrap_or_default();
 
+                let precompile_allowed_calls = key_auth
+                    .allowed_calls
+                    .as_ref()
+                    .map(|scopes| {
+                        scopes
+                            .iter()
+                            .filter_map(|scope| match scope.selector_rules.as_ref() {
+                                Some(rules) if rules.is_empty() => None,
+                                _ => Some(tempo_precompiles::account_keychain::CallScope {
+                                    target: scope.target,
+                                    selectorRules: scope
+                                        .selector_rules
+                                        .as_ref()
+                                        .map(|rules| {
+                                            rules
+                                                .iter()
+                                                .map(|rule| {
+                                                    tempo_precompiles::account_keychain::SelectorRule {
+                                                        selector: rule.selector.into(),
+                                                        recipients: rule
+                                                            .recipients
+                                                            .clone()
+                                                            .unwrap_or_default(),
+                                                    }
+                                                })
+                                                .collect()
+                                        })
+                                        .unwrap_or_default(),
+                                }),
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let enforce_allowed_calls = key_auth.allowed_calls.is_some();
+
                 // Create the authorize key call
                 let authorize_call = authorizeKeyCall {
                     keyId: access_key_addr,
                     signatureType: signature_type,
-                    expiry,
-                    enforceLimits: enforce_limits,
-                    limits: precompile_limits,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: enforce_limits,
+                        limits: precompile_limits,
+                        enforceAllowedCalls: enforce_allowed_calls,
+                        allowedCalls: precompile_allowed_calls,
+                    },
                 };
 
                 // Call precompile to authorize the key (same phase as nonce increment)
@@ -1084,8 +1160,9 @@ where
                     .map_err(|_| TempoInvalidTransaction::AccessKeyRecoveryFailed)?
             };
 
-            // Check if this transaction includes a KeyAuthorization for the same key
-            // If so, skip keychain validation here - the key was just validated and authorized
+            // Check if this transaction includes a KeyAuthorization for the same key.
+            // Same-tx auth+use still needs key-type parity checks, but we avoid a full keychain
+            // existence lookup here to preserve the pre-T1B out-of-gas behavior.
             let is_authorizing_this_key = tempo_tx_env
                 .key_authorization
                 .as_ref()
@@ -1099,8 +1176,22 @@ where
                 cfg,
                 tx,
                 |mut keychain: AccountKeychain| {
-                    // Skip keychain validation when authorizing this key in the same tx
-                    if !is_authorizing_this_key {
+                    if is_authorizing_this_key {
+                        if spec.is_t1()
+                            && tempo_tx_env
+                                .key_authorization
+                                .as_ref()
+                                .is_some_and(|key_auth| {
+                                    key_auth.key_type != keychain_sig.signature.signature_type()
+                                })
+                        {
+                            return Err(TempoInvalidTransaction::KeychainValidationFailed {
+                                reason: "key authorization key_type does not match the keychain signature type"
+                                    .to_string(),
+                            }
+                            .into());
+                        }
+                    } else {
                         // Validate that user_address has authorized this access key in the keychain
                         let user_address = &keychain_sig.user_address;
 
@@ -1130,7 +1221,25 @@ where
                     // The TIP20 precompile will read this during execution to enforce spending limits
                     keychain
                         .set_transaction_key(access_key_addr)
-                        .map_err(|e| EVMError::Custom(e.to_string()))
+                        .map_err(|e| EVMError::Custom(e.to_string()))?;
+
+                    if spec.is_t3() {
+                        let user_address = keychain_sig.user_address;
+                        for (to, input) in tx.calls() {
+                            keychain
+                                .validate_call_scope_for_transaction(
+                                    user_address,
+                                    access_key_addr,
+                                    to,
+                                    input,
+                                )
+                                .map_err(|e| TempoInvalidTransaction::KeychainValidationFailed {
+                                    reason: format!("{e:?}"),
+                                })?;
+                        }
+                    }
+
+                    Ok::<(), EVMError<DB::Error, TempoInvalidTransaction>>(())
                 },
             )?;
         }
@@ -2303,10 +2412,12 @@ mod tests {
             TokenLimit {
                 token: Address::random(),
                 limit: U256::from(100),
+                period: 0,
             },
             TokenLimit {
                 token: Address::random(),
                 limit: U256::from(200),
+                period: 0,
             },
         ];
 
@@ -2317,6 +2428,7 @@ mod tests {
             key_id,
             expiry: Some(expiry),
             limits: Some(limits.clone()),
+            allowed_calls: None,
         }
         .signature_hash();
 
@@ -2327,6 +2439,7 @@ mod tests {
             key_id,
             expiry: Some(expiry),
             limits: Some(limits.clone()),
+            allowed_calls: None,
         }
         .signature_hash();
 
@@ -2339,6 +2452,7 @@ mod tests {
             key_id,
             expiry: Some(expiry),
             limits: Some(limits),
+            allowed_calls: None,
         }
         .signature_hash();
         assert_ne!(
@@ -2439,6 +2553,7 @@ mod tests {
                         .map(|_| TokenLimit {
                             token: Address::random(),
                             limit: U256::from(1000),
+                            period: 0,
                         })
                         .collect(),
                 )
@@ -2451,6 +2566,7 @@ mod tests {
                     key_id: Address::random(),
                     expiry: None,
                     limits,
+                    allowed_calls: None,
                 },
                 signature: PrimitiveSignature::Secp256k1(
                     alloy_primitives::Signature::test_signature(),
@@ -2523,6 +2639,41 @@ mod tests {
             let expected = ECRECOVER_GAS + sload + sstore * (1 + num_limits as u64) + BUFFER;
             assert_eq!(gas, expected, "T1B with {num_limits} limits");
         }
+
+        for num_limits in 0..=3 {
+            let gas = calculate_key_authorization_gas(
+                &create_key_auth(num_limits),
+                &t1b_gas_params,
+                TempoHardfork::T3,
+            );
+            let expected = ECRECOVER_GAS + sload + sstore * (1 + 2 * num_limits as u64) + BUFFER;
+            assert_eq!(gas, expected, "T3 with {num_limits} limits");
+        }
+
+        let scoped = SignedKeyAuthorization {
+            authorization: KeyAuthorization {
+                chain_id: 1,
+                key_type: SignatureType::Secp256k1,
+                key_id: Address::random(),
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![tempo_primitives::transaction::CallScope {
+                    target: Address::random(),
+                    selector_rules: Some(vec![tempo_primitives::transaction::SelectorRule {
+                        selector: [0xa9, 0x05, 0x9c, 0xbb],
+                        recipients: Some(vec![Address::random(), Address::random()]),
+                    }]),
+                }]),
+            },
+            signature: PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()),
+        };
+
+        let gas = calculate_key_authorization_gas(&scoped, &t1b_gas_params, TempoHardfork::T3);
+        // 1 key write + 14 scope slots:
+        // account mode(1) + target insert+mode(4) + selector insert+mode(4)
+        // + constrained selector recipient-length(1) + recipients values+positions(2*2).
+        let expected = ECRECOVER_GAS + sload + sstore * (1 + 14) + BUFFER;
+        assert_eq!(gas, expected, "T3 scope writes should be fully charged");
     }
 
     #[test]
@@ -2554,12 +2705,15 @@ mod tests {
                     TokenLimit {
                         token: Address::random(),
                         limit: U256::from(1000),
+                        period: 0,
                     },
                     TokenLimit {
                         token: Address::random(),
                         limit: U256::from(2000),
+                        period: 0,
                     },
                 ]),
+                allowed_calls: None,
             },
             signature: PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()),
         };
@@ -3247,6 +3401,7 @@ mod tests {
                     Some((0..num_limits).map(|i| PrimTokenLimit {
                         token: Address::with_last_byte(i as u8),
                         limit: U256::from(1000),
+                        period: 0,
                     }).collect())
                 };
 
@@ -3257,6 +3412,7 @@ mod tests {
                         key_id: Address::ZERO,
                         expiry: None,
                         limits,
+                        allowed_calls: None,
                     },
                     signature: PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()),
                 }
@@ -3315,8 +3471,10 @@ mod tests {
                         Some((0..num_limits).map(|i| PrimTokenLimit {
                             token: Address::with_last_byte(i as u8),
                             limit: U256::from(1000),
+                            period: 0,
                         }).collect())
                     },
+                    allowed_calls: None,
                 },
                 signature,
             };

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -2,6 +2,8 @@ use crate::{
     amm::AmmLiquidityCache,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
+use std::collections::HashSet;
+
 use alloy_consensus::Transaction;
 
 use alloy_primitives::{Address, U256};
@@ -21,11 +23,15 @@ use tempo_chainspec::{
 };
 use tempo_evm::TempoEvmConfig;
 #[cfg(test)]
-use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, account_keychain::AuthorizedKey};
+use tempo_precompiles::account_keychain::{AuthorizedKey, SpendingLimitState};
 use tempo_precompiles::{
-    account_keychain::AccountKeychain,
+    account_keychain::{
+        AccountKeychain, MAX_CALL_SCOPES, MAX_RECIPIENTS_PER_SELECTOR,
+        MAX_SELECTOR_RULES_PER_SCOPE, is_constrained_tip20_selector,
+    },
     nonce::{INonce, NonceManager},
     storage::Handler,
+    tip20_factory::TIP20Factory,
 };
 use tempo_primitives::{
     Block,
@@ -154,6 +160,189 @@ where
         Ok(())
     }
 
+    fn validate_t3_key_authorization_shape(
+        &self,
+        auth: &tempo_primitives::transaction::SignedKeyAuthorization,
+    ) -> Result<(), TempoPoolTransactionError> {
+        let Some(scopes) = auth.allowed_calls.as_ref() else {
+            return Ok(());
+        };
+
+        if scopes.len() > MAX_CALL_SCOPES as usize {
+            return Err(TempoPoolTransactionError::Keychain(
+                "too many call scopes in key authorization",
+            ));
+        }
+
+        let mut seen_targets = HashSet::with_capacity(scopes.len());
+        for scope in scopes {
+            if !seen_targets.insert(scope.target) {
+                return Err(TempoPoolTransactionError::Keychain(
+                    "duplicate call scope targets are not allowed",
+                ));
+            }
+
+            let Some(selector_rules) = scope.selector_rules.as_ref() else {
+                continue;
+            };
+
+            if selector_rules.len() > MAX_SELECTOR_RULES_PER_SCOPE as usize {
+                return Err(TempoPoolTransactionError::Keychain(
+                    "too many selector rules in call scope",
+                ));
+            }
+
+            let mut seen_selectors = HashSet::with_capacity(selector_rules.len());
+            for rule in selector_rules {
+                if !seen_selectors.insert(rule.selector) {
+                    return Err(TempoPoolTransactionError::Keychain(
+                        "duplicate selector rules are not allowed",
+                    ));
+                }
+
+                let Some(recipients) = rule.recipients.as_ref() else {
+                    continue;
+                };
+
+                if recipients.is_empty() {
+                    return Err(TempoPoolTransactionError::Keychain(
+                        "recipient-constrained selector rule requires non-empty recipients",
+                    ));
+                }
+
+                if recipients.len() > MAX_RECIPIENTS_PER_SELECTOR as usize {
+                    return Err(TempoPoolTransactionError::Keychain(
+                        "too many recipients in selector rule",
+                    ));
+                }
+
+                if !is_constrained_tip20_selector(rule.selector) {
+                    return Err(TempoPoolTransactionError::Keychain(
+                        "recipient-constrained selector rules require TIP-20 target and constrained selector",
+                    ));
+                }
+
+                let mut seen_recipients = HashSet::with_capacity(recipients.len());
+                for recipient in recipients {
+                    if recipient.is_zero() || !seen_recipients.insert(*recipient) {
+                        return Err(TempoPoolTransactionError::Keychain(
+                            "selector rule recipients must be non-zero and unique",
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_t3_key_authorization_tip20_targets(
+        &self,
+        auth: &tempo_primitives::transaction::SignedKeyAuthorization,
+        state_provider: &mut impl StateProvider,
+        spec: TempoHardfork,
+    ) -> Result<Result<(), TempoPoolTransactionError>, ProviderError> {
+        let Some(scopes) = auth.allowed_calls.as_ref() else {
+            return Ok(Ok(()));
+        };
+
+        let mut checked_targets = HashSet::new();
+        for scope in scopes {
+            let requires_deployed_tip20 = scope
+                .selector_rules
+                .as_ref()
+                .is_some_and(|rules| rules.iter().any(|rule| rule.recipients.is_some()));
+
+            if !requires_deployed_tip20 || !checked_targets.insert(scope.target) {
+                continue;
+            }
+
+            let is_tip20 = state_provider
+                .with_read_only_storage_ctx(spec, || TIP20Factory::new().is_tip20(scope.target))
+                .map_err(ProviderError::other)?;
+
+            if !is_tip20 {
+                return Ok(Err(TempoPoolTransactionError::Keychain(
+                    "recipient-constrained selector rules require a deployed TIP-20 target",
+                )));
+            }
+        }
+
+        Ok(Ok(()))
+    }
+
+    fn call_scope_allows_call(
+        scopes: Option<&[tempo_primitives::transaction::CallScope]>,
+        to: &alloy_primitives::TxKind,
+        input: &[u8],
+    ) -> bool {
+        if to.is_create() {
+            return false;
+        }
+
+        let Some(scopes) = scopes else {
+            return true;
+        };
+        if scopes.is_empty() {
+            return false;
+        }
+
+        let Some(target) = to.to().copied() else {
+            return false;
+        };
+
+        let Some(scope) = scopes.iter().find(|scope| scope.target == target) else {
+            return false;
+        };
+
+        let Some(selector_rules) = scope.selector_rules.as_deref() else {
+            return true;
+        };
+        if selector_rules.is_empty() || input.len() < 4 {
+            return false;
+        }
+
+        let selector = [input[0], input[1], input[2], input[3]];
+        let Some(rule) = selector_rules.iter().find(|rule| rule.selector == selector) else {
+            return false;
+        };
+
+        let Some(recipients) = rule.recipients.as_deref() else {
+            return true;
+        };
+        if input.len() < 36 {
+            return false;
+        }
+
+        let recipient_word = &input[4..36];
+        if recipient_word[..12].iter().any(|byte| *byte != 0) {
+            return false;
+        }
+
+        recipients.contains(&Address::from_slice(&recipient_word[12..]))
+    }
+
+    fn validate_inline_t3_call_scopes(
+        tx: &TempoTransaction,
+        auth: &tempo_primitives::transaction::SignedKeyAuthorization,
+    ) -> Result<(), TempoPoolTransactionError> {
+        for call in &tx.calls {
+            if call.to.is_create() {
+                return Err(TempoPoolTransactionError::Keychain(
+                    "contract creation not allowed with access keys",
+                ));
+            }
+
+            if !Self::call_scope_allows_call(auth.allowed_calls.as_deref(), &call.to, &call.input) {
+                return Err(TempoPoolTransactionError::Keychain(
+                    "call not allowed by key scope",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Validates AA transactions against the keychain: signature recovery, key authorization,
     /// on-chain key existence/revocation/expiry, and spending limits.
     ///
@@ -197,6 +386,31 @@ where
                 return Ok(Err(TempoPoolTransactionError::Keychain(
                     "KeyAuthorization chain_id does not match current chain",
                 )));
+            }
+
+            // TIP-1011 fields are T3-gated. Keep pre-T3 admission semantics unchanged.
+            if !spec.is_t3() {
+                if auth.has_periodic_limits() {
+                    return Ok(Err(TempoPoolTransactionError::Keychain(
+                        "periodic token limits are not active before T3",
+                    )));
+                }
+
+                if auth.has_call_scopes() {
+                    return Ok(Err(TempoPoolTransactionError::Keychain(
+                        "call scopes are not active before T3",
+                    )));
+                }
+            } else {
+                if let Err(err) = self.validate_t3_key_authorization_shape(auth) {
+                    return Ok(Err(err));
+                }
+
+                if let Err(err) =
+                    self.validate_t3_key_authorization_tip20_targets(auth, state_provider, spec)?
+                {
+                    return Ok(Err(err));
+                }
             }
 
             // Validate KeyAuthorization expiry, reject if expiring within the propagation
@@ -247,6 +461,12 @@ where
                 )));
             }
 
+            if spec.is_t1() && auth.key_type != sig.signature.signature_type() {
+                return Ok(Err(TempoPoolTransactionError::Keychain(
+                    "key authorization key_type does not match the keychain signature type",
+                )));
+            }
+
             if authorized_key.expiry > 0 {
                 return Ok(Err(TempoPoolTransactionError::Keychain(
                     "access key already exists",
@@ -280,6 +500,12 @@ where
                 {
                     return Ok(Err(err));
                 }
+            }
+
+            if spec.is_t3()
+                && let Err(err) = Self::validate_inline_t3_call_scopes(tx.tx(), auth)
+            {
+                return Ok(Err(err));
             }
 
             return Ok(Ok(()));
@@ -318,17 +544,45 @@ where
         // Check spending limit for fee token if enforce_limits is enabled.
         // This prevents transactions that would exceed the spending limit from entering the pool.
         if fee_payer == transaction.sender() && authorized_key.enforce_limits {
-            // Compute the storage slot for the spending limit
-            let limit_key = AccountKeychain::spending_limit_key(transaction.sender(), key_id);
             let remaining_limit = state_provider
                 .with_read_only_storage_ctx(spec, || {
-                    AccountKeychain::new().spending_limits[limit_key][fee_token].read()
+                    AccountKeychain::new().effective_remaining_limit(
+                        transaction.sender(),
+                        key_id,
+                        fee_token,
+                        current_time,
+                    )
                 })
                 .map_err(ProviderError::other)?;
 
             if let Err(err) = self.validate_spending_limit(transaction, fee_token, remaining_limit)
             {
                 return Ok(Err(err));
+            }
+        }
+
+        if spec.is_t3() {
+            let call_scope_result: tempo_precompiles::Result<()> = state_provider
+                .with_read_only_storage_ctx(spec, || {
+                    let keychain = AccountKeychain::new();
+                    for call in &tx.tx().calls {
+                        keychain.validate_call_scope_for_transaction(
+                            transaction.sender(),
+                            key_id,
+                            &call.to,
+                            &call.input,
+                        )?;
+                    }
+                    Ok(())
+                });
+
+            if let Err(err) = call_scope_result {
+                if err.is_system_error() {
+                    return Err(ProviderError::other(err));
+                }
+                return Ok(Err(TempoPoolTransactionError::Keychain(
+                    "call not allowed by key scope",
+                )));
             }
         }
 
@@ -876,7 +1130,7 @@ where
 
         match self
             .amm_liquidity_cache
-            .has_enough_liquidity(fee_token, cost, &state_provider)
+            .has_enough_liquidity(fee_token, cost, &mut state_provider)
         {
             Ok(true) => {}
             Ok(false) => {
@@ -1156,7 +1410,10 @@ pub fn ensure_intrinsic_gas_tempo_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::TxBuilder, transaction::TempoPoolTransactionError};
+    use crate::{
+        test_utils::{MockProviderStorageExt, TxBuilder},
+        transaction::TempoPoolTransactionError,
+    };
     use alloy_consensus::{Header, Signed, Transaction, TxLegacy};
     use alloy_primitives::{Address, B256, TxKind, U256, address, uint};
     use alloy_signer::Signature;
@@ -1168,7 +1425,7 @@ mod tests {
     use std::sync::Arc;
     use tempo_chainspec::spec::{MODERATO, TEMPO_T1_TX_GAS_LIMIT_CAP};
     use tempo_precompiles::{
-        PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
+        PATH_USD_ADDRESS,
         tip20::{TIP20Token, slots as tip20_slots},
         tip403_registry::{ITIP403Registry, PolicyData, TIP403Registry},
     };
@@ -1606,22 +1863,16 @@ mod tests {
         );
 
         // Add TIP403Registry with blacklist policy containing fee_payer
-        let policy_data = PolicyData {
-            policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
-            admin: Address::ZERO,
-        };
-        let policy_data_slot = TIP403Registry::new().policy_records[policy_id]
-            .base
-            .base_slot();
-        let policy_set_slot = TIP403Registry::new().policy_set[policy_id][fee_payer].slot();
-
-        provider.add_account(
-            TIP403_REGISTRY_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO).extend_storage([
-                (policy_data_slot.into(), policy_data.encode_to_slot()),
-                (policy_set_slot.into(), U256::from(1)), // in blacklist = true
-            ]),
-        );
+        provider
+            .setup_storage(TempoHardfork::default(), || {
+                let mut registry = TIP403Registry::new();
+                registry.policy_records[policy_id].base.write(PolicyData {
+                    policy_type: ITIP403Registry::PolicyType::BLACKLIST as u8,
+                    admin: Address::ZERO,
+                })?;
+                registry.policy_set[policy_id][fee_payer].write(true)
+            })
+            .unwrap();
 
         // Create validator and validate
         let inner =
@@ -2345,10 +2596,13 @@ mod tests {
         use alloy_signer::SignerSync;
         use alloy_signer_local::PrivateKeySigner;
         use reth_chainspec::ForkCondition;
+        use reth_primitives_traits::Recovered;
         use reth_transaction_pool::error::PoolTransactionError;
         use tempo_chainspec::hardfork::TempoHardfork;
+        use tempo_precompiles::error::TempoPrecompileError;
         use tempo_primitives::transaction::{
-            KeyAuthorization, SignatureType, SignedKeyAuthorization, TempoTransaction, TokenLimit,
+            CallScope, KeyAuthorization, SignatureType, SignedKeyAuthorization, TempoTransaction,
+            TokenLimit,
             tempo_transaction::Call,
             tt_signature::{
                 KeychainSignature, KeychainVersion, PrimitiveSignature, TempoSignature,
@@ -2362,6 +2616,15 @@ mod tests {
             spec.inner
                 .hardforks
                 .extend([(TempoHardfork::T1C, ForkCondition::Timestamp(0))]);
+            spec
+        }
+
+        /// Returns a MODERATO chain spec with T3 activated at timestamp 0.
+        fn moderato_with_t3() -> TempoChainSpec {
+            let mut spec = Arc::unwrap_or_clone(MODERATO.clone());
+            spec.inner
+                .hardforks
+                .extend([(TempoHardfork::T3, ForkCondition::Timestamp(0))]);
             spec
         }
 
@@ -2486,13 +2749,13 @@ mod tests {
             transaction: &TempoPooledTransaction,
             user_address: Address,
             key_id: Address,
-            authorized_key_slot_value: Option<U256>,
+            authorized_key: Option<AuthorizedKey>,
         ) -> TempoTransactionValidator<MockEthProvider<TempoPrimitives, TempoChainSpec>> {
             setup_validator_with_keychain_storage_spec(
                 transaction,
                 user_address,
                 key_id,
-                authorized_key_slot_value,
+                authorized_key,
                 moderato_with_t1c(),
             )
         }
@@ -2501,7 +2764,7 @@ mod tests {
             transaction: &TempoPooledTransaction,
             user_address: Address,
             key_id: Address,
-            authorized_key_slot_value: Option<U256>,
+            authorized_key: Option<AuthorizedKey>,
             chain_spec: TempoChainSpec,
         ) -> TempoTransactionValidator<MockEthProvider<TempoPrimitives, TempoChainSpec>> {
             let provider = MockEthProvider::<TempoPrimitives>::new().with_chain_spec(chain_spec);
@@ -2513,14 +2776,13 @@ mod tests {
             );
             provider.add_block(B256::random(), Default::default());
 
-            // If slot value provided, setup AccountKeychain storage
-            if let Some(slot_value) = authorized_key_slot_value {
-                let storage_slot = AccountKeychain::new().keys[user_address][key_id].base_slot();
-                provider.add_account(
-                    ACCOUNT_KEYCHAIN_ADDRESS,
-                    ExtendedAccount::new(0, U256::ZERO)
-                        .extend_storage([(storage_slot.into(), slot_value)]),
-                );
+            // If authorized key provided, setup AccountKeychain storage
+            if let Some(authorized_key) = authorized_key {
+                provider
+                    .setup_storage(TempoHardfork::default(), || {
+                        AccountKeychain::new().keys[user_address][key_id].write(authorized_key)
+                    })
+                    .unwrap();
             }
 
             let inner =
@@ -2582,19 +2844,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with a valid authorized key (expiry > 0, not revoked)
-            let slot_value = AuthorizedKey {
-                signature_type: 0, // secp256k1
-                expiry: u64::MAX,  // never expires
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0, // secp256k1
+                    expiry: u64::MAX,  // never expires
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -2619,19 +2878,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with a revoked key
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: 0, // revoked keys have expiry=0
-                enforce_limits: false,
-                is_revoked: true,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: 0, // revoked keys have expiry=0
+                    enforce_limits: false,
+                    is_revoked: true,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -2660,19 +2916,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with expiry = 0 (key doesn't exist)
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: 0, // expiry = 0 means key doesn't exist
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: 0, // expiry = 0 means key doesn't exist
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -2737,6 +2990,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None, // never expires
                 limits: None, // unlimited
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2784,6 +3038,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2799,19 +3054,16 @@ mod tests {
                 Some(signed_key_auth),
             );
 
-            let existing_key_slot = AuthorizedKey {
-                signature_type: 0,
-                expiry: u64::MAX,
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(existing_key_slot),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -2845,7 +3097,9 @@ mod tests {
                 limits: Some(vec![TokenLimit {
                     token: fee_token,
                     limit: U256::ZERO,
+                    period: 0,
                 }]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2899,6 +3153,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: Some(vec![]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -2956,7 +3211,9 @@ mod tests {
                 limits: Some(vec![TokenLimit {
                     token: non_fee_token,
                     limit: U256::MAX,
+                    period: 0,
                 }]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3019,12 +3276,15 @@ mod tests {
                     TokenLimit {
                         token: fee_token,
                         limit: U256::ZERO,
+                        period: 0,
                     },
                     TokenLimit {
                         token: fee_token,
                         limit: fee_cost + U256::from(100),
+                        period: 0,
                     },
                 ]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3075,7 +3335,9 @@ mod tests {
                 limits: Some(vec![TokenLimit {
                     token: resolved_fee_token,
                     limit: U256::MAX,
+                    period: 0,
                 }]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3127,7 +3389,9 @@ mod tests {
                 limits: Some(vec![TokenLimit {
                     token: fee_token,
                     limit: U256::ZERO,
+                    period: 0,
                 }]),
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3167,12 +3431,405 @@ mod tests {
             Ok(())
         }
 
+        #[test]
+        fn test_key_authorization_t3_rejects_too_many_call_scopes() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let mut scopes = Vec::new();
+            for _ in 0..=MAX_CALL_SCOPES {
+                scopes.push(CallScope {
+                    target: Address::random(),
+                    selector_rules: None,
+                });
+            }
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(scopes),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "too many call scopes in key authorization"
+                    ))
+                ),
+                "Expected too many call scopes rejection, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_rejects_duplicate_scope_targets() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+            let duplicate_target = Address::random();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![
+                    CallScope {
+                        target: duplicate_target,
+                        selector_rules: None,
+                    },
+                    CallScope {
+                        target: duplicate_target,
+                        selector_rules: None,
+                    },
+                ]),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "duplicate call scope targets are not allowed"
+                    ))
+                ),
+                "Expected duplicate target rejection, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_rejects_inline_disallowed_call_scope() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![CallScope {
+                    target: address!("0000000000000000000000000000000000000002"),
+                    selector_rules: None,
+                }]),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "call not allowed by key scope"
+                    ))
+                ),
+                "Expected call-scope rejection, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_rejects_inline_contract_creation() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: None,
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let tx_aa = TempoTransaction {
+                chain_id: 42431,
+                max_priority_fee_per_gas: 1_000_000_000,
+                max_fee_per_gas: 20_000_000_000,
+                gas_limit: 1_000_000,
+                calls: vec![Call {
+                    to: TxKind::Create,
+                    value: U256::ZERO,
+                    input: alloy_primitives::Bytes::new(),
+                }],
+                nonce_key: U256::ZERO,
+                nonce: 0,
+                fee_token: Some(address!("0000000000000000000000000000000000000002")),
+                fee_payer_signature: None,
+                valid_after: None,
+                valid_before: None,
+                access_list: Default::default(),
+                tempo_authorization_list: vec![],
+                key_authorization: Some(signed_key_auth),
+            };
+
+            let unsigned = AASigned::new_unhashed(
+                tx_aa.clone(),
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    Signature::test_signature(),
+                )),
+            );
+            let sig_hash = KeychainSignature::signing_hash(unsigned.signature_hash(), user_address);
+            let signature = access_key_signer
+                .sign_hash_sync(&sig_hash)
+                .expect("signing failed");
+            let signed = AASigned::new_unhashed(
+                tx_aa,
+                TempoSignature::Keychain(KeychainSignature::new(
+                    user_address,
+                    PrimitiveSignature::Secp256k1(signature),
+                )),
+            );
+            let transaction = TempoPooledTransaction::new(Recovered::new_unchecked(
+                tempo_primitives::TempoTxEnvelope::AA(signed),
+                user_address,
+            ));
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "contract creation not allowed with access keys"
+                    ))
+                ),
+                "Expected create-call rejection, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_accepts_inline_allowed_call_scope() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![CallScope {
+                    target: address!("0000000000000000000000000000000000000001"),
+                    selector_rules: None,
+                }]),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                result.is_ok(),
+                "Expected allowed call-scope transaction to pass, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_rejects_recipient_scope_for_undeployed_tip20() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+            let mut target_bytes = [0u8; 20];
+            target_bytes[0] = 0x20;
+            target_bytes[1] = 0xc0;
+            target_bytes[19] = 0x42;
+            let undeployed_tip20 = Address::from(target_bytes);
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![CallScope {
+                    target: undeployed_tip20,
+                    selector_rules: Some(vec![tempo_primitives::transaction::SelectorRule {
+                        selector: [0xa9, 0x05, 0x9c, 0xbb],
+                        recipients: Some(vec![address!(
+                            "00000000000000000000000000000000000000aa"
+                        )]),
+                    }]),
+                }]),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "recipient-constrained selector rules require a deployed TIP-20 target"
+                    ))
+                ),
+                "Expected undeployed TIP-20 rejection, got: {result:?}"
+            );
+        }
+
         /// Setup a validator using the DEV chain spec (T1C active at genesis).
         fn setup_validator_with_keychain_storage_t1c(
             transaction: &TempoPooledTransaction,
             user_address: Address,
             key_id: Address,
-            authorized_key_slot_value: Option<U256>,
+            authorized_key: Option<AuthorizedKey>,
         ) -> TempoTransactionValidator<MockEthProvider<TempoPrimitives, TempoChainSpec>> {
             use tempo_chainspec::spec::DEV;
 
@@ -3180,7 +3837,7 @@ mod tests {
                 transaction,
                 user_address,
                 key_id,
-                authorized_key_slot_value,
+                authorized_key,
                 Arc::unwrap_or_clone(DEV.clone()),
             )
         }
@@ -3219,6 +3876,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
             let auth_sig_hash = key_auth.signature_hash();
             let auth_signature = user_signer
@@ -3417,6 +4075,7 @@ mod tests {
                 key_id: different_key_id, // Different from access_key_address
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3470,6 +4129,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None,
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3507,6 +4167,59 @@ mod tests {
                     ))
                 ),
                 "Invalid KeyAuthorization signature should be rejected"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_same_tx_key_type_mismatch_rejected() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 1337,
+                key_type: SignatureType::P256,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: None,
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_t1c(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "key authorization key_type does not match the keychain signature type"
+                    ))
+                ),
+                "Expected key-type mismatch rejection, got: {result:?}"
             );
         }
 
@@ -3567,18 +4280,16 @@ mod tests {
             // The actual mismatch scenario would require manually constructing an invalid state.
 
             // Setup with valid key for the actual sender
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: u64::MAX,
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 real_user,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -3600,7 +4311,7 @@ mod tests {
             transaction: &TempoPooledTransaction,
             user_address: Address,
             key_id: Address,
-            authorized_key_slot_value: Option<U256>,
+            authorized_key: Option<AuthorizedKey>,
             tip_timestamp: u64,
         ) -> TempoTransactionValidator<MockEthProvider<TempoPrimitives, TempoChainSpec>> {
             let provider =
@@ -3626,14 +4337,13 @@ mod tests {
             };
             provider.add_block(B256::random(), block);
 
-            // If slot value provided, setup AccountKeychain storage
-            if let Some(slot_value) = authorized_key_slot_value {
-                let storage_slot = AccountKeychain::new().keys[user_address][key_id].base_slot();
-                provider.add_account(
-                    ACCOUNT_KEYCHAIN_ADDRESS,
-                    ExtendedAccount::new(0, U256::ZERO)
-                        .extend_storage([(storage_slot.into(), slot_value)]),
-                );
+            // If authorized key provided, setup AccountKeychain storage
+            if let Some(authorized_key) = authorized_key {
+                provider
+                    .setup_storage(TempoHardfork::default(), || {
+                        AccountKeychain::new().keys[user_address][key_id].write(authorized_key)
+                    })
+                    .unwrap();
             }
 
             let inner =
@@ -3666,19 +4376,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with an expired key (expiry in the past)
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: current_time - 1, // Expired (in the past)
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage_and_timestamp(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: current_time - 1, // Expired (in the past)
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
                 current_time,
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
@@ -3708,19 +4415,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with expiry == current_time (edge case: expired)
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: current_time, // Expiry at exactly current time should be rejected
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage_and_timestamp(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: current_time, // Expiry at exactly current time should be rejected
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
                 current_time,
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
@@ -3749,19 +4453,16 @@ mod tests {
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
             // Setup storage with a future expiry
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: current_time + 100, // Valid (in the future)
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage_and_timestamp(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: current_time + 100, // Valid (in the future)
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
                 current_time,
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
@@ -3791,6 +4492,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time - 1), // Expired
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3843,6 +4545,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time), // Expired at exactly current time
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3894,6 +4597,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(current_time + 100), // Valid (in the future)
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3944,6 +4648,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: Some(expiry),
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -3995,6 +4700,7 @@ mod tests {
                 key_id: access_key_address,
                 expiry: None, // Never expires
                 limits: None,
+                allowed_calls: None,
             };
 
             let auth_sig_hash = key_auth.signature_hash();
@@ -4049,30 +4755,26 @@ mod tests {
             );
             provider.add_block(B256::random(), Default::default());
 
-            // Setup AccountKeychain storage with AuthorizedKey
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: u64::MAX,
-                enforce_limits,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
-            let key_storage_slot = AccountKeychain::new().keys[user_address][key_id].base_slot();
-            let mut storage = vec![(key_storage_slot.into(), slot_value)];
-
-            // Add spending limit if provided
-            if let Some((token, limit)) = spending_limit {
-                let limit_key = AccountKeychain::spending_limit_key(user_address, key_id);
-                let limit_slot: U256 =
-                    AccountKeychain::new().spending_limits[limit_key][token].slot();
-                storage.push((limit_slot.into(), limit));
-            }
-
-            provider.add_account(
-                ACCOUNT_KEYCHAIN_ADDRESS,
-                ExtendedAccount::new(0, U256::ZERO).extend_storage(storage),
-            );
+            // Setup `AccountKeychain` storage with `AuthorizedKey` and optional spending limit
+            provider
+                .setup_storage(TempoHardfork::default(), || {
+                    let mut keychain = AccountKeychain::new();
+                    keychain.keys[user_address][key_id].write(AuthorizedKey {
+                        signature_type: 0,
+                        expiry: u64::MAX,
+                        enforce_limits,
+                        is_revoked: false,
+                    })?;
+                    if let Some((token, limit)) = spending_limit {
+                        let limit_key = AccountKeychain::spending_limit_key(user_address, key_id);
+                        keychain.spending_limits[limit_key][token].write(SpendingLimitState {
+                            remaining: limit,
+                            ..Default::default()
+                        })?;
+                    }
+                    Ok::<(), TempoPrecompileError>(())
+                })
+                .unwrap();
 
             let inner =
                 EthTransactionValidatorBuilder::new(provider.clone(), TempoEvmConfig::mainnet())
@@ -4376,19 +5078,16 @@ mod tests {
             let transaction =
                 create_aa_with_keychain_signature(user_address, &access_key_signer, None);
 
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: u64::MAX,
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             let validator = setup_validator_with_keychain_storage(
                 &transaction,
                 user_address,
                 access_key_address,
-                Some(slot_value),
+                Some(AuthorizedKey {
+                    signature_type: 0,
+                    expiry: u64::MAX,
+                    enforce_limits: false,
+                    is_revoked: false,
+                }),
             );
             let mut state_provider = validator.inner.client().latest().unwrap();
 
@@ -4434,14 +5133,6 @@ mod tests {
             let transaction =
                 create_aa_with_v1_keychain_signature(user_address, &access_key_signer, None);
 
-            let slot_value = AuthorizedKey {
-                signature_type: 0,
-                expiry: u64::MAX,
-                enforce_limits: false,
-                is_revoked: false,
-            }
-            .encode_to_slot();
-
             // Pre-T1C validator with keychain storage
             let provider =
                 MockEthProvider::<TempoPrimitives>::new().with_chain_spec(moderato_without_t1c());
@@ -4450,13 +5141,18 @@ mod tests {
                 ExtendedAccount::new(transaction.nonce(), U256::ZERO),
             );
             provider.add_block(B256::random(), Default::default());
-            let storage_slot =
-                AccountKeychain::new().keys[user_address][access_key_address].base_slot();
-            provider.add_account(
-                ACCOUNT_KEYCHAIN_ADDRESS,
-                ExtendedAccount::new(0, U256::ZERO)
-                    .extend_storage([(storage_slot.into(), slot_value)]),
-            );
+            provider
+                .setup_storage(TempoHardfork::default(), || {
+                    AccountKeychain::new().keys[user_address][access_key_address].write(
+                        AuthorizedKey {
+                            signature_type: 0,
+                            expiry: u64::MAX,
+                            enforce_limits: false,
+                            is_revoked: false,
+                        },
+                    )
+                })
+                .unwrap();
             let inner =
                 EthTransactionValidatorBuilder::new(provider.clone(), TempoEvmConfig::mainnet())
                     .disable_balance_check()
@@ -5068,7 +5764,7 @@ mod tests {
         // Verify has_enough_liquidity would bypass (return true) for this token
         // because it matches a validator token. This confirms the vulnerability we're testing.
         let liquidity_result =
-            amm_cache.has_enough_liquidity(paused_validator_token, U256::from(1000), &state);
+            amm_cache.has_enough_liquidity(paused_validator_token, U256::from(1000), &mut state);
         assert!(
             liquidity_result.is_ok() && liquidity_result.unwrap(),
             "Token in unique_tokens should bypass liquidity check and return true"


### PR DESCRIPTION
# PR3: Runtime Enforcement

Title: `feat(node): enforce TIP-1011 restrictions`
Base: `tanishk/tip-1011-precompiles`
Head: `tanishk/tip-1011-rest`

## Why We Are Making This Change

After the protocol shape and precompile semantics are established, this PR teaches the node to enforce them during validation and execution. That keeps reviewers focused on runtime correctness: gas, hardfork gating, same-transaction authorization, and txpool admission.

## Why This Design

The main design choices are:
- Gate new semantics at the handler/validator boundary so pre-T3 behavior remains unchanged.
- Charge intrinsic gas for authorization-time writes up front.
- Mirror key-auth validation in txpool admission so invalid transactions are filtered before propagation.
- Keep the runtime layer small and reviewable by depending on the earlier PRs for all underlying semantics.

## Spec To Read First

Before reviewing code, skim:
1. T3 activation requirements
2. `allowed_calls` deny-all vs unrestricted behavior
3. periodic-limit semantics

## How To Review This PR

1. Review `crates/revm/src/handler.rs` first:
   - hardfork gating
   - intrinsic gas accounting
   - same-tx auth+use behavior
   - per-call scope enforcement
2. Review `crates/transaction-pool/src/validator.rs` next:
   - key-auth shape checks
   - TIP-20 target checks
   - inline call-scope admission checks
   - spending-limit and scope validation paths
3. Review `crates/revm/src/evm.rs` last as regression coverage for these runtime paths.
4. Avoid re-reviewing the precompile internals here unless a runtime check seems inconsistent with them.
