### PR TITLE
docs(tip-1041): add batch tip-403 policy updates

### DIFF
--- a/tips/tip-1041.md
+++ b/tips/tip-1041.md
@@ -1,0 +1,95 @@
+---
+id: TIP-1041
+title: Batch TIP-403 Policy Updates
+description: Adds batch whitelist and blacklist update functions to the TIP-403 policy registry.
+authors: Mallesh Pai
+status: Draft
+related: TIP-403
+protocolVersion: TBD
+---
+
+# TIP-1041: Batch TIP-403 Policy Updates
+
+## Abstract
+
+This TIP adds two batch update functions to the TIP-403 policy registry: one for whitelist policies and one for blacklist policies. Each function applies a single boolean state to every address in the provided array within one transaction. The batch functions are defined as array-ordered repetition of the existing single-account update methods, so they reuse existing authorization rules, policy-type checks, and per-account events.
+
+## Motivation
+
+`createPolicyWithAccounts` already allows initializing many accounts in one call, but policy changes after creation still require one transaction per account via `modifyPolicyWhitelist` and `modifyPolicyBlacklist`. That makes large allowlist or denylist changes expensive and prevents atomic updates when many accounts must be changed together.
+
+A generic multicall wrapper does not solve this problem. The TIP-403 registry authorizes updates against `msg.sender`, so wrapping multiple updates in an external contract causes the registry to see the wrapper as the caller instead of the policy admin.
+
+Compared with batching many single-account updates in a Tempo transaction, a dedicated batch call also avoids repeated outer-call calldata and per-call overhead, though each account still pays the same underlying write and event costs.
+
+This TIP keeps the change minimal. It does not add mixed-operation batches, per-account flags, or new event types. Callers that need both additions and removals can make separate batch calls.
+
+## Assumptions
+
+- The existing TIP-403 registry authorization model remains unchanged: the caller must be the policy admin, and policy type checks are enforced exactly as they are for the single-account methods.
+- The existing `WhitelistUpdated` and `BlacklistUpdated` events remain the canonical update events. No new batch-specific event is introduced.
+- Empty `accounts` arrays are valid and are treated as a no-op.
+
+---
+
+# Specification
+
+## Interface Additions
+
+The TIP-403 registry interface is extended with two new functions:
+
+```solidity
+/// @notice Modifies the whitelist status of multiple accounts for a whitelist policy
+/// @param policyId The ID of the whitelist policy to modify
+/// @param accounts The accounts to update
+/// @param allowed Whether to allow (true) or disallow (false) every account in `accounts`
+function modifyPolicyWhitelistBatch(
+    uint64 policyId,
+    address[] calldata accounts,
+    bool allowed
+) external;
+
+/// @notice Modifies the blacklist status of multiple accounts for a blacklist policy
+/// @param policyId The ID of the blacklist policy to modify
+/// @param accounts The accounts to update
+/// @param restricted Whether to restrict (true) or unrestrict (false) every account in `accounts`
+function modifyPolicyBlacklistBatch(
+    uint64 policyId,
+    address[] calldata accounts,
+    bool restricted
+) external;
+```
+
+## Behavior
+
+`modifyPolicyWhitelistBatch(policyId, accounts, allowed)` MUST behave exactly as if the registry executed the following logic inside a single transaction:
+
+```solidity
+for (uint256 i = 0; i < accounts.length; i++) {
+    modifyPolicyWhitelist(policyId, accounts[i], allowed);
+}
+```
+
+`modifyPolicyBlacklistBatch(policyId, accounts, restricted)` MUST behave exactly as if the registry executed the following logic inside a single transaction:
+
+```solidity
+for (uint256 i = 0; i < accounts.length; i++) {
+    modifyPolicyBlacklist(policyId, accounts[i], restricted);
+}
+```
+
+This equivalence has the following consequences:
+
+- The same authorization and policy-type checks as the existing single-account methods apply.
+- The same revert conditions as the existing single-account methods apply.
+- The same `WhitelistUpdated` or `BlacklistUpdated` event is emitted once per processed account, in array order.
+- Duplicate accounts are permitted. Each occurrence is processed independently, and the final policy state is the result of the last occurrence in the array.
+- If `accounts.length == 0`, the call is a no-op and emits no events.
+- Because the batch call executes in a single transaction, the update is atomic: if the call reverts, none of the account updates take effect.
+
+# Invariants
+
+1. `modifyPolicyWhitelistBatch` MUST produce the same final storage state and emitted events as iterating `modifyPolicyWhitelist` over the same `accounts` array in order.
+2. `modifyPolicyBlacklistBatch` MUST produce the same final storage state and emitted events as iterating `modifyPolicyBlacklist` over the same `accounts` array in order.
+3. Empty arrays MUST be accepted and MUST leave storage unchanged.
+4. If a batch call reverts, no account updates from that call may persist.

--- a/tips/tip-1041.md
+++ b/tips/tip-1041.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP adds two batch update functions to the TIP-403 policy registry: one for whitelist policies and one for blacklist policies. Each function applies a single boolean state to every address in the provided array within one transaction. The batch functions are defined as array-ordered repetition of the existing single-account update methods, so they reuse existing authorization rules, policy-type checks, and per-account events.
+This TIP adds two batch update functions to the TIP-403 policy registry: one each for whitelist policies and one for blacklist policies. Each function applies a single boolean state to every address in the provided array within one transaction. The batch functions are defined as array-ordered repetition of the existing single-account update methods, so they reuse existing authorization rules, policy-type checks, and per-account events.
 
 ## Motivation
 
@@ -22,7 +22,7 @@ A generic multicall wrapper does not solve this problem. The TIP-403 registry au
 
 Compared with batching many single-account updates in a Tempo transaction, a dedicated batch call also avoids repeated outer-call calldata and per-call overhead, though each account still pays the same underlying write and event costs.
 
-This TIP keeps the change minimal. It does not add mixed-operation batches, per-account flags, or new event types. Callers that need both additions and removals can make separate batch calls.
+This TIP keeps the change minimal. It does not add mixed-operation batches, per-account flags, or new event types. Users that need both additions and removals can make separate batch calls.
 
 ## Assumptions
 


### PR DESCRIPTION
Adds TIP-1041 for batch updates to TIP-403 whitelist and blacklist policies.

The TIP keeps the scope narrow by adding only two batch registry methods, reusing existing per-account semantics and events, and noting the limited gas savings relative to Tempo transaction batching.
