### PR TITLE
fix(ci): add continue-on-error to tempo-foundry-test job

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -144,6 +144,7 @@ jobs:
     if: github.repository == 'tempoxyz/tempo' && needs.check-specs-changes.outputs.should_run == 'true'
     runs-on: depot-ubuntu-latest-8
     timeout-minutes: 60
+    continue-on-error: true
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
tempo-foundry fails to build against latest tempo (b6640b1) due to `alloy-evm` 0.29→0.30 incompatibility introduced by the reth deps update in #3332. The `tempo-foundry-test` job is already listed in alls-green's `allowed-failures`, but alls-green v1.2.2 has a [known bug](https://github.com/re-actors/alls-green/pull/23) that still blocks the merge queue.

Adding `continue-on-error: true` at the job level is the GitHub-native workaround — it makes the job non-blocking for the `specs-success` gate while keeping visibility.

Root cause: tempo now uses `alloy-evm 0.30` (which removed the `op` feature), but `alloy-op-evm 0.28` (used by tempo-foundry) still requires `alloy-evm` with `features = ["op"]`. No compatible `alloy-op-evm` version exists on crates.io yet.

Prompted by: tanishk