### PR TITLE
feat(xtask): add decode-cert subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12438,6 +12438,7 @@ version = "1.5.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
+ "bytes",
  "clap",
  "coins-bip32",
  "commonware-codec",
@@ -12450,6 +12451,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "reth-evm",
  "reth-network-peers",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -34,6 +34,7 @@ alloy = { workspace = true, features = [
   "getrandom",
 ] }
 alloy-primitives = { workspace = true, features = ["asm-keccak"] }
+bytes.workspace = true
 coins-bip32.workspace = true
 clap = { workspace = true, features = ["derive"] }
 commonware-codec.workspace = true
@@ -46,6 +47,7 @@ eyre.workspace = true
 indicatif = { workspace = true, features = ["rayon"] }
 itertools.workspace = true
 rand_08.workspace = true
+rand_core.workspace = true
 rayon.workspace = true
 reth-evm.workspace = true
 reth-network-peers = { workspace = true, features = ["secp256k1"] }

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -12,7 +12,7 @@ use commonware_consensus::simplex::{
 };
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_utils::{Array, Span};
-use eyre::{Context, eyre};
+use eyre::Context;
 use serde::Serialize;
 
 /// Minimal re-implementation of `tempo-commonware-node`'s `Digest` to avoid pulling in the full
@@ -101,7 +101,7 @@ impl DecodeCert {
         let bytes = const_hex::decode(&self.hex).wrap_err("invalid hex input")?;
 
         let f = Finalization::<TempoScheme, Digest>::decode(&bytes[..])
-            .map_err(|e| eyre!("failed to decode finalization: {e}"))?;
+            .wrap_err("failed to decode certificate")?;
 
         let json = CertJson {
             epoch: f.proposal.round.epoch().get(),
@@ -111,7 +111,10 @@ impl DecodeCert {
             threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
         };
 
-        println!("{}", serde_json::to_string_pretty(&json)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json).wrap_err("failed to encode certificate as json")?
+        );
 
         Ok(())
     }

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -1,6 +1,6 @@
 //! Decode a hex-encoded consensus certificate and print its JSON representation to stdout.
 //!
-//! Certificates are encoded via `commonware_codec::Encode` and hex-encoded. This tool decodes
+//! Certificates are assumed to be encoded via [`commonware_codec::Encode`] and hex-encoded. This tool decodes
 //! them back into structured JSON for inspection.
 
 use alloy_primitives::B256;
@@ -95,8 +95,7 @@ struct ProposalJson {
 #[derive(Serialize)]
 struct CertJson {
     proposal: ProposalJson,
-    /// The inner threshold BLS certificate (not the full notarization/finalization encoding).
-    threshold_certificate: String,
+    recovered_certificate: String,
 }
 
 impl DecodeCert {
@@ -113,7 +112,7 @@ impl DecodeCert {
                 parent_view: f.proposal.parent.get(),
                 payload: const_hex::encode_prefixed(f.proposal.payload.0),
             },
-            threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
+            recovered_certificate: const_hex::encode_prefixed(f.certificate.encode()),
         };
 
         println!(

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -1,5 +1,4 @@
-//! Decode a hex-encoded consensus certificate (notarization or finalization) and write JSON to
-//! disk.
+//! Decode a hex-encoded consensus certificate and print its JSON representation to stdout.
 //!
 //! Certificates are encoded via `commonware_codec::Encode` and hex-encoded. This tool decodes
 //! them back into structured JSON for inspection.
@@ -83,15 +82,19 @@ pub(crate) struct DecodeCert {
     hex: String,
 }
 
-type TempoScheme = Scheme<PublicKey, MinSig>;
-
-/// JSON-serializable representation of a decoded certificate.
+/// JSON-serializable representation of the proposal inside a certificate.
 #[derive(Serialize)]
-struct CertJson {
+struct ProposalJson {
     epoch: u64,
     view: u64,
     parent_view: u64,
     payload: String,
+}
+
+/// JSON-serializable representation of a decoded certificate.
+#[derive(Serialize)]
+struct CertJson {
+    proposal: ProposalJson,
     /// The inner threshold BLS certificate (not the full notarization/finalization encoding).
     threshold_certificate: String,
 }
@@ -100,14 +103,16 @@ impl DecodeCert {
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let bytes = const_hex::decode(&self.hex).wrap_err("invalid hex input")?;
 
-        let f = Finalization::<TempoScheme, Digest>::decode(&bytes[..])
+        let f = Finalization::<Scheme<PublicKey, MinSig>, Digest>::decode(&bytes[..])
             .wrap_err("failed to decode certificate")?;
 
         let json = CertJson {
-            epoch: f.proposal.round.epoch().get(),
-            view: f.proposal.round.view().get(),
-            parent_view: f.proposal.parent.get(),
-            payload: const_hex::encode_prefixed(f.proposal.payload.0),
+            proposal: ProposalJson {
+                epoch: f.proposal.round.epoch().get(),
+                view: f.proposal.round.view().get(),
+                parent_view: f.proposal.parent.get(),
+                payload: const_hex::encode_prefixed(f.proposal.payload.0),
+            },
             threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
         };
 

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -14,7 +14,6 @@ use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::Pu
 use commonware_utils::{Array, Span};
 use eyre::{Context, eyre};
 use serde::Serialize;
-use std::path::PathBuf;
 
 /// Minimal re-implementation of `tempo-commonware-node`'s `Digest` to avoid pulling in the full
 /// crate. A 32-byte wrapper around [`B256`] implementing the commonware codec + crypto traits.
@@ -82,10 +81,6 @@ pub(crate) struct DecodeCert {
     /// Hex-encoded certificate bytes (with or without 0x prefix).
     #[arg(long)]
     hex: String,
-
-    /// Output file path for the JSON representation.
-    #[arg(long, short)]
-    output: PathBuf,
 }
 
 type TempoScheme = Scheme<PublicKey, MinSig>;
@@ -116,11 +111,7 @@ impl DecodeCert {
             threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
         };
 
-        let output = serde_json::to_string_pretty(&json)?;
-        std::fs::write(&self.output, &output)
-            .wrap_err_with(|| format!("failed to write {}", self.output.display()))?;
-
-        println!("Wrote cert to {}", self.output.display());
+        println!("{}", serde_json::to_string_pretty(&json)?);
 
         Ok(())
     }

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -78,7 +78,6 @@ impl Write for Digest {
 #[derive(Debug, clap::Args)]
 pub(crate) struct DecodeCert {
     /// Hex-encoded certificate bytes (with or without 0x prefix).
-    #[arg(long)]
     hex: String,
 }
 

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use commonware_codec::{DecodeExt as _, Encode as _, FixedSize, Read, ReadExt as _, Write};
 use commonware_consensus::simplex::{
     scheme::bls12381_threshold::vrf::Scheme,
-    types::{Finalization, Notarization},
+    types::Finalization,
 };
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_utils::{Array, Span};
@@ -77,22 +77,11 @@ impl Write for Digest {
     }
 }
 
-/// The type of certificate to decode.
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
-pub(crate) enum CertKind {
-    Notarization,
-    Finalization,
-}
-
 #[derive(Debug, clap::Args)]
 pub(crate) struct DecodeCert {
     /// Hex-encoded certificate bytes (with or without 0x prefix).
     #[arg(long)]
     hex: String,
-
-    /// Type of certificate to decode.
-    #[arg(long, value_enum)]
-    kind: CertKind,
 
     /// Output file path for the JSON representation.
     #[arg(long, short)]
@@ -104,7 +93,6 @@ type TempoScheme = Scheme<PublicKey, MinSig>;
 /// JSON-serializable representation of a decoded certificate.
 #[derive(Serialize)]
 struct CertJson {
-    kind: &'static str,
     epoch: u64,
     view: u64,
     parent_view: u64,
@@ -117,40 +105,22 @@ impl DecodeCert {
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let bytes = const_hex::decode(&self.hex).wrap_err("invalid hex input")?;
 
-        let json = match self.kind {
-            CertKind::Notarization => {
-                let n = Notarization::<TempoScheme, Digest>::decode(&bytes[..])
-                    .map_err(|e| eyre!("failed to decode notarization: {e}"))?;
+        let f = Finalization::<TempoScheme, Digest>::decode(&bytes[..])
+            .map_err(|e| eyre!("failed to decode finalization: {e}"))?;
 
-                CertJson {
-                    kind: "notarization",
-                    epoch: n.proposal.round.epoch().get(),
-                    view: n.proposal.round.view().get(),
-                    parent_view: n.proposal.parent.get(),
-                    payload: const_hex::encode_prefixed(n.proposal.payload.0),
-                    threshold_certificate: const_hex::encode_prefixed(n.certificate.encode()),
-                }
-            }
-            CertKind::Finalization => {
-                let f = Finalization::<TempoScheme, Digest>::decode(&bytes[..])
-                    .map_err(|e| eyre!("failed to decode finalization: {e}"))?;
-
-                CertJson {
-                    kind: "finalization",
-                    epoch: f.proposal.round.epoch().get(),
-                    view: f.proposal.round.view().get(),
-                    parent_view: f.proposal.parent.get(),
-                    payload: const_hex::encode_prefixed(f.proposal.payload.0),
-                    threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
-                }
-            }
+        let json = CertJson {
+            epoch: f.proposal.round.epoch().get(),
+            view: f.proposal.round.view().get(),
+            parent_view: f.proposal.parent.get(),
+            payload: const_hex::encode_prefixed(f.proposal.payload.0),
+            threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
         };
 
         let output = serde_json::to_string_pretty(&json)?;
         std::fs::write(&self.output, &output)
             .wrap_err_with(|| format!("failed to write {}", self.output.display()))?;
 
-        println!("Wrote {} cert to {}", json.kind, self.output.display());
+        println!("Wrote cert to {}", self.output.display());
 
         Ok(())
     }

--- a/xtask/src/decode_cert.rs
+++ b/xtask/src/decode_cert.rs
@@ -1,0 +1,157 @@
+//! Decode a hex-encoded consensus certificate (notarization or finalization) and write JSON to
+//! disk.
+//!
+//! Certificates are encoded via `commonware_codec::Encode` and hex-encoded. This tool decodes
+//! them back into structured JSON for inspection.
+
+use alloy_primitives::B256;
+use commonware_codec::{DecodeExt as _, Encode as _, FixedSize, Read, ReadExt as _, Write};
+use commonware_consensus::simplex::{
+    scheme::bls12381_threshold::vrf::Scheme,
+    types::{Finalization, Notarization},
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_utils::{Array, Span};
+use eyre::{Context, eyre};
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Minimal re-implementation of `tempo-commonware-node`'s `Digest` to avoid pulling in the full
+/// crate. A 32-byte wrapper around [`B256`] implementing the commonware codec + crypto traits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+struct Digest(B256);
+
+impl Array for Digest {}
+impl Span for Digest {}
+
+impl AsRef<[u8]> for Digest {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl std::ops::Deref for Digest {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl std::fmt::Display for Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl commonware_math::algebra::Random for Digest {
+    fn random(mut rng: impl rand_core::CryptoRngCore) -> Self {
+        let mut array = B256::ZERO;
+        rng.fill_bytes(&mut *array);
+        Self(array)
+    }
+}
+
+impl commonware_cryptography::Digest for Digest {
+    const EMPTY: Self = Self(B256::ZERO);
+}
+
+impl FixedSize for Digest {
+    const SIZE: usize = 32;
+}
+
+impl Read for Digest {
+    type Cfg = ();
+    fn read_cfg(
+        buf: &mut impl bytes::Buf,
+        _cfg: &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let array = <[u8; 32]>::read(buf)?;
+        Ok(Self(B256::new(array)))
+    }
+}
+
+impl Write for Digest {
+    fn write(&self, buf: &mut impl bytes::BufMut) {
+        self.0.write(buf)
+    }
+}
+
+/// The type of certificate to decode.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub(crate) enum CertKind {
+    Notarization,
+    Finalization,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct DecodeCert {
+    /// Hex-encoded certificate bytes (with or without 0x prefix).
+    #[arg(long)]
+    hex: String,
+
+    /// Type of certificate to decode.
+    #[arg(long, value_enum)]
+    kind: CertKind,
+
+    /// Output file path for the JSON representation.
+    #[arg(long, short)]
+    output: PathBuf,
+}
+
+type TempoScheme = Scheme<PublicKey, MinSig>;
+
+/// JSON-serializable representation of a decoded certificate.
+#[derive(Serialize)]
+struct CertJson {
+    kind: &'static str,
+    epoch: u64,
+    view: u64,
+    parent_view: u64,
+    payload: String,
+    /// The inner threshold BLS certificate (not the full notarization/finalization encoding).
+    threshold_certificate: String,
+}
+
+impl DecodeCert {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let bytes = const_hex::decode(&self.hex).wrap_err("invalid hex input")?;
+
+        let json = match self.kind {
+            CertKind::Notarization => {
+                let n = Notarization::<TempoScheme, Digest>::decode(&bytes[..])
+                    .map_err(|e| eyre!("failed to decode notarization: {e}"))?;
+
+                CertJson {
+                    kind: "notarization",
+                    epoch: n.proposal.round.epoch().get(),
+                    view: n.proposal.round.view().get(),
+                    parent_view: n.proposal.parent.get(),
+                    payload: const_hex::encode_prefixed(n.proposal.payload.0),
+                    threshold_certificate: const_hex::encode_prefixed(n.certificate.encode()),
+                }
+            }
+            CertKind::Finalization => {
+                let f = Finalization::<TempoScheme, Digest>::decode(&bytes[..])
+                    .map_err(|e| eyre!("failed to decode finalization: {e}"))?;
+
+                CertJson {
+                    kind: "finalization",
+                    epoch: f.proposal.round.epoch().get(),
+                    view: f.proposal.round.view().get(),
+                    parent_view: f.proposal.parent.get(),
+                    payload: const_hex::encode_prefixed(f.proposal.payload.0),
+                    threshold_certificate: const_hex::encode_prefixed(f.certificate.encode()),
+                }
+            }
+        };
+
+        let output = serde_json::to_string_pretty(&json)?;
+        std::fs::write(&self.output, &output)
+            .wrap_err_with(|| format!("failed to write {}", self.output.display()))?;
+
+        println!("Wrote {} cert to {}", json.kind, self.output.display());
+
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 use std::net::SocketAddr;
 
 use crate::{
-    generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
+    decode_cert::DecodeCert, generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
     generate_localnet::GenerateLocalnet, generate_state_bloat::GenerateStateBloat,
     get_dkg_outcome::GetDkgOutcome,
 };
@@ -12,6 +12,7 @@ use clap::Parser as _;
 use commonware_codec::DecodeExt;
 use eyre::Context;
 
+mod decode_cert;
 mod generate_devnet;
 mod generate_genesis;
 mod generate_localnet;
@@ -23,6 +24,7 @@ mod get_dkg_outcome;
 async fn main() -> eyre::Result<()> {
     let args = Args::parse();
     match args.action {
+        Action::DecodeCert(args) => args.run().await.wrap_err("failed to decode certificate"),
         Action::GetDkgOutcome(args) => args.run().await.wrap_err("failed to get DKG outcome"),
         Action::GenerateGenesis(args) => args.run().await.wrap_err("failed generating genesis"),
         Action::GenerateDevnet(args) => args
@@ -53,6 +55,7 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Action {
+    DecodeCert(DecodeCert),
     GetDkgOutcome(GetDkgOutcome),
     GenerateGenesis(GenerateGenesis),
     GenerateDevnet(GenerateDevnet),


### PR DESCRIPTION
Adds a `decode-cert` xtask that takes a hex-encoded consensus certificate, decodes it as a notarization or finalization (commonware_codec), and writes structured JSON to disk.

Usage:
```
cargo xtask decode-cert --kind notarization --hex <hex> -o out.json
cargo xtask decode-cert --kind finalization --hex <hex> -o out.json
```

Includes a minimal local `Digest` type (mirrors `crates/commonware-node/src/consensus/digest.rs`) to avoid pulling in the full `tempo-commonware-node` crate.

Co-Authored-By: Richard Janis Goldschmidt <701177+SuperFluffy@users.noreply.github.com>

Prompted by: Janis