### PR TITLE
fix(transaction-pool): replace unwrap with proper error handling in add_validated_transaction

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -502,6 +502,7 @@ where
 
                     Ok(AddedTransactionOutcome { hash, state })
                 } else {
+                    let hash = *transaction.hash();
                     self.protocol_pool
                         .inner()
                         .add_transactions(
@@ -516,16 +517,17 @@ where
                             }),
                         )
                         .pop()
-                        .unwrap()
+                        .ok_or_else(|| PoolError::new(hash, PoolErrorKind::DiscardedOnInsert))?
                 }
             }
             invalid => {
+                let hash = invalid.tx_hash();
                 // this forwards for event listener updates
                 self.protocol_pool
                     .inner()
                     .add_transactions(origin, Some(invalid))
                     .pop()
-                    .unwrap()
+                    .ok_or_else(|| PoolError::new(hash, PoolErrorKind::DiscardedOnInsert))?
             }
         }
     }


### PR DESCRIPTION
Closes #2347.

Replaces two **.pop().unwrap()** calls in **add_validated_transaction** with **.ok_or_else()** that returns a PoolError instead of panicking.

While the current Reth implementation of add_transactions always returns one result per input, relying on .unwrap() in production code risks a node crash if the upstream contract ever changes. The fix extracts the transaction hash before the value is moved, then uses .ok_or_else(|| PoolError::new(hash, PoolErrorKind::DiscardedOnInsert)) to surface a proper error.

Both call sites (Valid branch at line 518 and catch-all invalid branch at line 527) are addressed.