### PR TITLE
docs(tip-1043): add Tempo block access lists draft

### DIFF
--- a/tips/tip-1043.md
+++ b/tips/tip-1043.md
@@ -1,0 +1,162 @@
+---
+id: TIP-1043
+title: Tempo Block Access Lists
+description: Tempo-specific decomposition of block access lists into implicit and residual components.
+authors: Brian (@mediocregopher)
+status: Draft
+related: EIP-7928
+---
+
+# TIP-1043: Tempo Block Access Lists
+
+## Abstract
+
+This TIP defines Tempo BALs as a deterministic decomposition of an upstream [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) Block-Level Access List into an **Implicit Access List** (`IAL`) and a **Residual Access List** (`RAL`). Tempo blocks carry the `RAL`, not the full `BAL`. During validation, the validator reconstructs the effective `BAL` from its locally-derived `IAL` plus the block's `RAL`.
+
+This draft also brings into scope the portions of TIP-20 transfer paths whose accesses are already statically inferable from transaction bytes.
+
+## Motivation
+
+Ethereum BALs assume the full access list must be shipped because arbitrary contracts do not generally have statically predictable state access patterns. Tempo is different: a large share of accesses come from protocol paths with deterministic storage layouts whose touched slots can be derived from the transaction envelope and calldata before execution.
+
+If Tempo can treat those accesses as implicit without weakening correctness, it can reduce BAL bandwidth overhead while preserving the main BAL benefits: deterministic validation, parallel I/O preparation, parallel execution, and executionless state updates.
+
+## Assumptions
+
+- This TIP depends on EIP-7928 reaching a stable final form. Tempo BALs inherit the upstream BAL structure, ordering, and validation rules; this TIP only specifies the `IAL`/`RAL` split on top of that base.
+- Any access placed in the `IAL` must be derivable as a pure function of the block's transactions using a canonical protocol rule. No implementation-local heuristics are allowed.
+- Compatible `IAL` upgrades may move entries from `RAL` into `IAL`, but they MUST NOT move previously-implicit entries back into `RAL` or change what those previously-implicit entries mean. This lets newer validators accept blocks built with an older `IAL` rule set.
+
+---
+
+# Specification
+
+Tempo inherits the upstream `BAL` format from EIP-7928. This TIP defines a canonical decomposition of that `BAL` into two components:
+
+- `IAL`: the subset of BAL entries that Tempo defines as statically derivable from the block's transactions.
+- `RAL`: the subset of BAL entries not derivable by those rules.
+
+`IAL` and `RAL` are both **partial BALs**. Logically, each uses the same nested account/change structure as `BAL`; they differ only in which entries they contain. Empty account entries MAY be omitted from a partial BAL.
+
+## Canonical Decomposition
+
+Tempo blocks MUST carry the `RAL`, not the full `BAL`.
+
+For the builder, the following relationships MUST hold:
+
+```text
+BAL = IAL_builder union RAL
+RAL = BAL - IAL_builder
+```
+
+The builder MUST:
+
+1. Compute `IAL_builder` from the block's transactions using the canonical protocol algorithm.
+2. Construct `RAL` as `subtract_bal(BAL, IAL_builder)`.
+
+The validator MUST:
+
+1. Recompute `IAL_validator` from the same block transactions using the validator's canonical protocol algorithm.
+2. Use an `IAL_validator` rule set that is compatible with the builder's `IAL_builder`: it may infer additional entries beyond the builder, but it MUST preserve every builder-implicit entry with the same meaning.
+3. Reconstruct `BAL` by computing `union_bal(IAL_validator, RAL)`.
+4. Reject the block if the reconstructed `BAL` differs from the BAL implied by execution.
+
+`IAL` and `RAL` MAY overlap during validation. This is valid only if the overlap is non-conflicting: overlapping entries must imply the same BAL entry. The validator MUST normalize such overlap by deduplicating identical entries and MUST reject conflicting overlap.
+
+Equivalently, validator-side reconstruction is:
+
+```text
+BAL = union_bal(IAL_validator, RAL)
+where IAL_validator is compatible with IAL_builder
+```
+
+## Partial BAL Operations
+
+### `union_bal(X, Y)`
+
+`union_bal` takes two partial BALs `X` and `Y` and produces a BAL-structured result by deterministic fieldwise merge:
+
+1. Group entries by address.
+2. For each address, merge each BAL field independently.
+3. For `storage_changes`, group first by storage key, then merge the per-slot `StorageChange` lists.
+4. For each merged field, deduplicate identical entries.
+5. If overlapping entries disagree, reject as conflicting.
+6. Sort the final result using the same ordering rules as upstream BALs.
+
+Two overlapping entries are **identical** iff they encode the same BAL entry. For example, two `storage_reads` overlap identically when they contain the same storage key for the same address; two `StorageChange` entries overlap identically when they refer to the same address, storage key, block access index, and post-value.
+
+### `subtract_bal(BAL, IAL)`
+
+`subtract_bal` takes a full `BAL` and a partial `IAL` and produces a partial `RAL` by deterministic fieldwise subtraction:
+
+1. Group both inputs by address.
+2. For each BAL address entry, subtract any identical entries present in `IAL` from the corresponding BAL fields.
+3. For `storage_changes`, subtraction is performed per storage key and then per `StorageChange` entry.
+4. Entries not present in `IAL` remain in `RAL` unchanged.
+5. Empty fields, empty slots, and empty account entries are omitted from `RAL`.
+6. Sort the final result using the same ordering rules as upstream BALs.
+
+`subtract_bal` MUST reject malformed `IAL` input that contains an entry inconsistent with the BAL domain for the same field.
+
+## Initial IAL Scope
+
+This TIP includes in scope the portions of TIP-20 `transfer` and `transferWithMemo` paths that are already statically inferable from transaction bytes under finalized Tempo rules. Any TIP-20 access that is not yet covered by such a rule remains in `RAL`.
+
+### TIP-20 `transfer` and `transferWithMemo`
+
+The relevant TIP-20 method signatures are:
+
+```solidity
+function transfer(address to, uint256 amount) external returns (bool);
+function transferWithMemo(address to, uint256 amount, bytes32 memo) external;
+```
+
+Per the TIP-20 specification and reference implementation, `transferWithMemo` behaves like `transfer` with an additional memo event. The `memo` field does not change which storage locations are selected by the transfer path.
+
+For a transaction at position `i` in `ExecutionPayloadV4.transactions`, define `block_access_index = i + 1` as in EIP-7928. The current TIP-20 transfer-family `IAL` extraction algorithm is:
+
+1. Decode the transaction envelope from `ExecutionPayloadV4.transactions[i]` far enough to recover:
+   - the transaction destination `to`, and
+   - the transaction calldata `input`.
+2. Apply Tempo's TIP-20 destination classifier to `to`. If `to` does not satisfy that TIP-20 prefix rule, return the empty partial BAL.
+3. Read the 4-byte selector from `input[0:4]`.
+4. If the selector is neither `ITIP20.transfer.selector` nor `ITIP20.transferWithMemo.selector`, return the empty partial BAL.
+5. Enforce exact ABI length:
+   - `transfer`: `len(input) == 4 + 32 + 32`
+   - `transferWithMemo`: `len(input) == 4 + 32 + 32 + 32`
+6. Decode `recipient_raw` from ABI word 0:
+   - bytes `[4:36]` of `input`
+   - interpreted as the standard ABI-encoded `address to` argument.
+7. Ignore later calldata words for `IAL` selection. In the current scope, `amount` and `memo` do not affect which partial-BAL entries are emitted.
+8. Emit a partial BAL consisting of the following `AccountChanges` entries:
+   - One `AccountChanges` entry for the TIP-20 token account at address `to`.
+   - `storage_reads` for the token account MUST include:
+       - `transferPolicyId` (slot 0)
+       - `paused` (slot 4)
+9. If `recipient_raw` matches the TIP-1022 virtual-address format, emit an additional `AccountChanges` entry for the TIP-1022 registry precompile account.
+   - Let `masterId = recipient_raw[0:4]`.
+   - Let `registry_slot = 0`, corresponding to the `mapping(bytes4 => address) _masters` storage slot in the reference `AddressRegistry` implementation.
+   - The registry `storage_reads` MUST include the TIP-1022 registry lookup slot:
+
+```text
+master_lookup_slot = keccak256(abi.encode(masterId, registry_slot))
+```
+
+In EIP-7928 notation, the current transfer-family `IAL` contribution is therefore a list of read-only `AccountChanges` fragments.
+
+This draft intentionally does **not** yet include TIP-20 transfer-path writes in `IAL`. In particular, sender balance updates, recipient balance updates, reward-accounting writes, and policy-registry expansions remain in `RAL` because their final `storage_changes` entries are not yet derivable from transaction bytes alone under a finalized canonical rule set.
+
+## Scope Boundary
+
+This TIP does not yet enumerate every Tempo protocol path that may become implicit. Any access pattern which does not already have a finalized, canonical derivation rule MUST remain explicit in `RAL`.
+
+This TIP does not specify FeeAMM batching, deferred settlement, or any other optimization that changes which accesses become residual versus implicit. Those can be proposed separately once this base partition is settled.
+
+# Invariants
+
+1. **Builder Residual Rule**: Relative to the builder's `IAL`, `RAL` MUST be exactly `BAL - IAL_builder`.
+2. **Compatibility Rule**: A newer validator may infer additional entries into `IAL`, but it MUST NOT stop inferring or reinterpret entries that an older compatible builder would have treated as implicit.
+3. **Derived BAL**: The validator MUST derive the effective `BAL` from `IAL + RAL`, not from a separately transmitted full BAL.
+4. **Conflict-Free Overlap**: `IAL` and `RAL` MAY overlap only when the overlap is non-conflicting and `union_bal` resolves that overlap to the same BAL entry.
+5. **Fail Closed**: Any access that is not covered by the builder's finalized canonical `IAL` rule set MUST remain in `RAL`.
+6. **Upstream Consistency**: Tempo MUST NOT activate this TIP against a moving or incompatible upstream BAL format; the final Tempo encoding and validation rules must track the finalized EIP-7928 base.

--- a/tips/tip-1043.md
+++ b/tips/tip-1043.md
@@ -116,6 +116,7 @@ Per the TIP-20 specification and reference implementation, `transferWithMemo` be
 For a transaction at position `i` in `ExecutionPayloadV4.transactions`, define `block_access_index = i + 1` as in EIP-7928. The current TIP-20 transfer-family `IAL` extraction algorithm is:
 
 1. Decode the transaction envelope from `ExecutionPayloadV4.transactions[i]` far enough to recover:
+   - the transaction sender `sender`,
    - the transaction destination `to`, and
    - the transaction calldata `input`.
 2. Apply Tempo's TIP-20 destination classifier to `to`. If `to` does not satisfy that TIP-20 prefix rule, return the empty partial BAL.
@@ -128,23 +129,38 @@ For a transaction at position `i` in `ExecutionPayloadV4.transactions`, define `
    - bytes `[4:36]` of `input`
    - interpreted as the standard ABI-encoded `address to` argument.
 7. Ignore later calldata words for `IAL` selection. In the current scope, `amount` and `memo` do not affect which partial-BAL entries are emitted.
-8. Emit a partial BAL consisting of the following `AccountChanges` entries:
-   - One `AccountChanges` entry for the TIP-20 token account at address `to`.
-   - `storage_reads` for the token account MUST include:
-       - `transferPolicyId` (slot 0)
-       - `paused` (slot 4)
-9. If `recipient_raw` matches the TIP-1022 virtual-address format, emit an additional `AccountChanges` entry for the TIP-1022 registry precompile account.
-   - Let `masterId = recipient_raw[0:4]`.
-   - Let `registry_slot = 0`, corresponding to the `mapping(bytes4 => address) _masters` storage slot in the reference `AddressRegistry` implementation.
-   - The registry `storage_reads` MUST include the TIP-1022 registry lookup slot:
+8. Let the following TIP-20 storage-layout constants be taken from the current TIP-20 storage layout:
+   - `transfer_policy_slot = 7`, with `transferPolicyId` packed into that slot at byte offset 20.
+   - `paused_slot = 12`, containing `paused`.
+   - `global_reward_per_token_slot = 15`, containing `globalRewardPerToken`.
+   - `user_reward_info_slot = 17`, corresponding to `mapping(address => UserRewardInfo) userRewardInfo`.
+9. Emit one `AccountChanges` entry for the TIP-20 token account at address `to`.
+10. `storage_reads` for that token-account entry MUST include:
+    - `transfer_policy_slot`
+    - `paused_slot`
+    - `global_reward_per_token_slot`
+11. Let `sender_reward_base = keccak256(abi.encode(sender, user_reward_info_slot))`.
+12. `storage_reads` for the token-account entry MUST include the sender reward-metadata slots:
+    - `sender_reward_base + 0`, corresponding to `userRewardInfo[sender].rewardRecipient`
+    - `sender_reward_base + 1`, corresponding to `userRewardInfo[sender].rewardPerToken`
+13. If `recipient_raw` matches the TIP-1022 virtual-address format, emit an additional `AccountChanges` entry for the TIP-1022 registry precompile account.
+    - Let `masterId = recipient_raw[0:4]`.
+    - Let `registry_slot = 0`, corresponding to the `mapping(bytes4 => address) _masters` storage slot in the reference `AddressRegistry` implementation.
+    - The registry `storage_reads` MUST include the TIP-1022 registry lookup slot:
 
 ```text
 master_lookup_slot = keccak256(abi.encode(masterId, registry_slot))
 ```
 
+    - In this branch, the recipient-side reward-metadata reads remain in `RAL`, because the transfer implementation reads them from the resolved master address rather than directly from `recipient_raw`.
+14. Otherwise, when `recipient_raw` does not match the TIP-1022 virtual-address format, let `recipient_reward_base = keccak256(abi.encode(recipient_raw, user_reward_info_slot))`.
+15. In that non-virtual-recipient branch, `storage_reads` for the token-account entry MUST also include the recipient reward-metadata slots:
+    - `recipient_reward_base + 0`, corresponding to `userRewardInfo[recipient_raw].rewardRecipient`
+    - `recipient_reward_base + 1`, corresponding to `userRewardInfo[recipient_raw].rewardPerToken`
+
 In EIP-7928 notation, the current transfer-family `IAL` contribution is therefore a list of read-only `AccountChanges` fragments.
 
-This draft intentionally does **not** yet include TIP-20 transfer-path writes in `IAL`. In particular, sender balance updates, recipient balance updates, reward-accounting writes, and policy-registry expansions remain in `RAL` because their final `storage_changes` entries are not yet derivable from transaction bytes alone under a finalized canonical rule set.
+This draft intentionally does **not** yet include TIP-20 transfer-path writes in `IAL`. In particular, sender balance updates, recipient balance updates, reward-accounting writes, TIP-403 policy-registry expansions, and recipient-side reward metadata for the virtual-recipient branch remain in `RAL` because those accesses or their final `storage_changes` entries are not yet derivable from transaction bytes alone under a finalized canonical rule set.
 
 ## Scope Boundary
 

--- a/tips/tip-1043.md
+++ b/tips/tip-1043.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1043
 title: Tempo Block Access Lists
-description: Tempo-specific decomposition of block access lists into implicit and residual components.
+description: Tempo-specific handling of block access lists with locally inferred reads and an on-wire residual payload.
 authors: Brian (@mediocregopher)
 status: Draft
 related: EIP-7928
@@ -11,96 +11,71 @@ related: EIP-7928
 
 ## Abstract
 
-This TIP defines Tempo BALs as a deterministic decomposition of an upstream [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) Block-Level Access List into an **Implicit Access List** (`IAL`) and a **Residual Access List** (`RAL`). Tempo blocks carry the `RAL`, not the full `BAL`. During validation, the validator reconstructs the effective `BAL` from its locally-derived `IAL` plus the block's `RAL`.
+This TIP defines Tempo BAL handling around an **Implicit Access List** (`IAL`) and a **Residual Access List** (`RAL`). Tempo blocks carry the `RAL`, not the full upstream [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) Block-Level Access List (`BAL`). Validators locally compute and apply the `IAL`, but for in-scope TIP-20 transfer-family transactions the block-carried `RAL` intentionally excludes all transfer-path `storage_reads`, including those inferable into `IAL`.
 
-This draft also brings into scope the portions of TIP-20 transfer paths whose accesses are already statically inferable from transaction bytes.
+Accordingly, `IAL` and `RAL` are not complementary partitions of the upstream `BAL`, i.e. `(IAL ∪ RAL) ⊆ BAL`.
 
 ## Motivation
 
-Ethereum BALs assume the full access list must be shipped because arbitrary contracts do not generally have statically predictable state access patterns. Tempo is different: a large share of accesses come from protocol paths with deterministic storage layouts whose touched slots can be derived from the transaction envelope and calldata before execution.
+Ethereum BALs assume the full access list must be shipped because arbitrary contracts do not generally have statically predictable state access patterns. Tempo is different: a large share of protocol access comes from deterministic precompile paths whose touched slots can be derived from the transaction envelope and calldata before execution.
 
-If Tempo can treat those accesses as implicit without weakening correctness, it can reduce BAL bandwidth overhead while preserving the main BAL benefits: deterministic validation, parallel I/O preparation, parallel execution, and executionless state updates.
+If Tempo can infer and locally apply those reads while omitting them from the block-carried payload, it can reduce BAL bandwidth overhead while still enabling deterministic local I/O preparation for those protocol paths.
 
 ## Assumptions
 
-- This TIP depends on EIP-7928 reaching a stable final form. Tempo BALs inherit the upstream BAL structure, ordering, and validation rules; this TIP only specifies the `IAL`/`RAL` split on top of that base.
-- Any access placed in the `IAL` must be derivable as a pure function of the block's transactions using a canonical protocol rule. No implementation-local heuristics are allowed.
-- Compatible `IAL` upgrades may move entries from `RAL` into `IAL`, but they MUST NOT move previously-implicit entries back into `RAL` or change what those previously-implicit entries mean. This lets newer validators accept blocks built with an older `IAL` rule set.
+- This TIP depends on EIP-7928 reaching a stable final form. Tempo BALs inherit the upstream BAL structure, ordering, and validation rules; this TIP only specifies Tempo's local `IAL` handling and block-carried `RAL` exclusions on top of that base.
+- Any `IAL` rule specified by this TIP is a validator-side rule for local I/O preparation. `IAL` MUST NOT affect block validity except through the separately specified `RAL` validation rules.
+- Implementations MAY infer additional local access hints, but such implementation-local hints are not part of this TIP's `IAL` and MUST NOT change the expected `RAL`.
+- The `RAL` exclusion rule defined by this TIP is wire-visible and MUST be applied identically by builders and validators.
 
 ---
 
 # Specification
 
-Tempo inherits the upstream `BAL` format from EIP-7928. This TIP defines a canonical decomposition of that `BAL` into two components:
+Tempo inherits the upstream `BAL` format from EIP-7928. This TIP defines two Tempo-specific artifacts around that upstream structure:
 
-- `IAL`: the subset of BAL entries that Tempo defines as statically derivable from the block's transactions.
-- `RAL`: the subset of BAL entries not derivable by those rules.
+- `IAL`: a locally-derived partial BAL fragment that Tempo implementations may compute and apply during block processing for local I/O preparation.
+- `RAL`: the partial BAL payload carried in the block after applying the canonical exclusion rules in this TIP.
 
-`IAL` and `RAL` are both **partial BALs**. Logically, each uses the same nested account/change structure as `BAL`; they differ only in which entries they contain. Empty account entries MAY be omitted from a partial BAL.
+When represented, both `IAL` and `RAL` use the same nested account/change structure as upstream `BAL`. Empty account entries MAY be omitted.
 
-## Canonical Decomposition
+`IAL` is local-only for this TIP's initial scope. It is not itself serialized into the block, it is not required to be a set-theoretic complement of the block-carried `RAL`, and it MUST NOT change block validity or the expected `RAL`.
+
+## Canonical RAL Construction
 
 Tempo blocks MUST carry the `RAL`, not the full `BAL`.
 
-For the builder, the following relationships MUST hold:
+The `block_access_list_hash` in the block header MUST be computed from the RLP-encoded `RAL` carried with the block:
 
 ```text
-BAL = IAL_builder union RAL
-RAL = BAL - IAL_builder
+block_access_list_hash = keccak256(rlp.encode(RAL))
 ```
+
+For specification purposes, let `BAL_i` denote the upstream BAL fragment implied by transaction `i` before block-level aggregation and deduplication.
+
+Define `strip_tip20_transfer_reads(BAL_i)` as follows:
+
+1. Classify transaction `i` using the TIP-20 transfer-family classifier defined below.
+2. If transaction `i` does not match that classifier, return `BAL_i` unchanged.
+3. Otherwise, return a copy of `BAL_i` with every `storage_reads` entry removed.
+4. This stripping applies only to `storage_reads`. All other BAL fields, including `storage_changes`, remain unchanged.
 
 The builder MUST:
 
-1. Compute `IAL_builder` from the block's transactions using the canonical protocol algorithm.
-2. Construct `RAL` as `subtract_bal(BAL, IAL_builder)`.
+1. For each transaction `i`, derive `BAL_i` from execution and compute `RAL_i = strip_tip20_transfer_reads(BAL_i)`.
+2. Aggregate all `RAL_i` fragments into the block-carried `RAL` using the upstream BAL merge, deduplication, and ordering rules.
 
 The validator MUST:
 
-1. Recompute `IAL_validator` from the same block transactions using the validator's canonical protocol algorithm.
-2. Use an `IAL_validator` rule set that is compatible with the builder's `IAL_builder`: it may infer additional entries beyond the builder, but it MUST preserve every builder-implicit entry with the same meaning.
-3. Reconstruct `BAL` by computing `union_bal(IAL_validator, RAL)`.
-4. Reject the block if the reconstructed `BAL` differs from the BAL implied by execution.
+1. For each transaction `i`, execute the transaction while collecting the access-list information needed to compute the expected residual fragment `RAL_i` under `strip_tip20_transfer_reads`.
+2. Aggregate all expected `RAL_i` fragments using the upstream BAL merge, deduplication, and ordering rules.
+3. Reject the block if that aggregated result differs from the block-carried `RAL`.
 
-`IAL` and `RAL` MAY overlap during validation. This is valid only if the overlap is non-conflicting: overlapping entries must imply the same BAL entry. The validator MUST normalize such overlap by deduplicating identical entries and MUST reject conflicting overlap.
-
-Equivalently, validator-side reconstruction is:
-
-```text
-BAL = union_bal(IAL_validator, RAL)
-where IAL_validator is compatible with IAL_builder
-```
-
-## Partial BAL Operations
-
-### `union_bal(X, Y)`
-
-`union_bal` takes two partial BALs `X` and `Y` and produces a BAL-structured result by deterministic fieldwise merge:
-
-1. Group entries by address.
-2. For each address, merge each BAL field independently.
-3. For `storage_changes`, group first by storage key, then merge the per-slot `StorageChange` lists.
-4. For each merged field, deduplicate identical entries.
-5. If overlapping entries disagree, reject as conflicting.
-6. Sort the final result using the same ordering rules as upstream BALs.
-
-Two overlapping entries are **identical** iff they encode the same BAL entry. For example, two `storage_reads` overlap identically when they contain the same storage key for the same address; two `StorageChange` entries overlap identically when they refer to the same address, storage key, block access index, and post-value.
-
-### `subtract_bal(BAL, IAL)`
-
-`subtract_bal` takes a full `BAL` and a partial `IAL` and produces a partial `RAL` by deterministic fieldwise subtraction:
-
-1. Group both inputs by address.
-2. For each BAL address entry, subtract any identical entries present in `IAL` from the corresponding BAL fields.
-3. For `storage_changes`, subtraction is performed per storage key and then per `StorageChange` entry.
-4. Entries not present in `IAL` remain in `RAL` unchanged.
-5. Empty fields, empty slots, and empty account entries are omitted from `RAL`.
-6. Sort the final result using the same ordering rules as upstream BALs.
-
-`subtract_bal` MUST reject malformed `IAL` input that contains an entry inconsistent with the BAL domain for the same field.
+This validation rule intentionally does **not** reconstruct or require the full upstream `BAL`. In particular, TIP-20 transfer-family `storage_reads` validly remain absent from the block-carried `RAL` even when they were touched during execution.
 
 ## Initial IAL Scope
 
-This TIP includes in scope the portions of TIP-20 `transfer` and `transferWithMemo` paths that are already statically inferable from transaction bytes under finalized Tempo rules. Any TIP-20 access that is not yet covered by such a rule remains in `RAL`.
+This TIP includes in scope the portions of TIP-20 `transfer` and `transferWithMemo` paths that are already statically inferable from transaction bytes under finalized Tempo rules. Validators MAY compute and apply that local `IAL` for I/O preparation. Separately, for any transaction in this family, the block-carried `RAL` MUST exclude all transfer-path `storage_reads`, whether or not those reads are currently inferable into `IAL`.
 
 ### TIP-20 `transfer` and `transferWithMemo`
 
@@ -125,9 +100,7 @@ For a transaction at position `i` in `ExecutionPayloadV4.transactions`, define `
 5. Enforce exact ABI length:
    - `transfer`: `len(input) == 4 + 32 + 32`
    - `transferWithMemo`: `len(input) == 4 + 32 + 32 + 32`
-6. Decode `recipient_raw` from ABI word 0:
-   - bytes `[4:36]` of `input`
-   - interpreted as the standard ABI-encoded `address to` argument.
+6. Decode `recipient_raw` from the first ABI argument word, `input[4:36]`. If the first 12 bytes of that 32-byte word are not all zero, return the empty partial BAL. Otherwise, set `recipient_raw` to the final 20 bytes of that word, interpreted as the standard ABI-encoded `address to` argument.
 7. Ignore later calldata words for `IAL` selection. In the current scope, `amount` and `memo` do not affect which partial-BAL entries are emitted.
 8. Let the following TIP-20 storage-layout constants be taken from the current TIP-20 storage layout:
    - `transfer_policy_slot = 7`, with `transferPolicyId` packed into that slot at byte offset 20.
@@ -152,27 +125,9 @@ For a transaction at position `i` in `ExecutionPayloadV4.transactions`, define `
 master_lookup_slot = keccak256(abi.encode(masterId, registry_slot))
 ```
 
-    - In this branch, the recipient-side reward-metadata reads remain in `RAL`, because the transfer implementation reads them from the resolved master address rather than directly from `recipient_raw`.
 14. Otherwise, when `recipient_raw` does not match the TIP-1022 virtual-address format, let `recipient_reward_base = keccak256(abi.encode(recipient_raw, user_reward_info_slot))`.
 15. In that non-virtual-recipient branch, `storage_reads` for the token-account entry MUST also include the recipient reward-metadata slots:
     - `recipient_reward_base + 0`, corresponding to `userRewardInfo[recipient_raw].rewardRecipient`
     - `recipient_reward_base + 1`, corresponding to `userRewardInfo[recipient_raw].rewardPerToken`
 
-In EIP-7928 notation, the current transfer-family `IAL` contribution is therefore a list of read-only `AccountChanges` fragments.
-
-This draft intentionally does **not** yet include TIP-20 transfer-path writes in `IAL`. In particular, sender balance updates, recipient balance updates, reward-accounting writes, TIP-403 policy-registry expansions, and recipient-side reward metadata for the virtual-recipient branch remain in `RAL` because those accesses or their final `storage_changes` entries are not yet derivable from transaction bytes alone under a finalized canonical rule set.
-
-## Scope Boundary
-
-This TIP does not yet enumerate every Tempo protocol path that may become implicit. Any access pattern which does not already have a finalized, canonical derivation rule MUST remain explicit in `RAL`.
-
-This TIP does not specify FeeAMM batching, deferred settlement, or any other optimization that changes which accesses become residual versus implicit. Those can be proposed separately once this base partition is settled.
-
-# Invariants
-
-1. **Builder Residual Rule**: Relative to the builder's `IAL`, `RAL` MUST be exactly `BAL - IAL_builder`.
-2. **Compatibility Rule**: A newer validator may infer additional entries into `IAL`, but it MUST NOT stop inferring or reinterpret entries that an older compatible builder would have treated as implicit.
-3. **Derived BAL**: The validator MUST derive the effective `BAL` from `IAL + RAL`, not from a separately transmitted full BAL.
-4. **Conflict-Free Overlap**: `IAL` and `RAL` MAY overlap only when the overlap is non-conflicting and `union_bal` resolves that overlap to the same BAL entry.
-5. **Fail Closed**: Any access that is not covered by the builder's finalized canonical `IAL` rule set MUST remain in `RAL`.
-6. **Upstream Consistency**: Tempo MUST NOT activate this TIP against a moving or incompatible upstream BAL format; the final Tempo encoding and validation rules must track the finalized EIP-7928 base.
+In EIP-7928 notation, the current transfer-family `IAL` contribution is therefore a list of read-only `AccountChanges` fragments applied locally by validators.


### PR DESCRIPTION
Adds TIP-1043: Tempo Block Access Lists. Tempo blocks carry a residual access list (`RAL`) whose header hash is computed over the RLP-encoded `RAL`, while `IAL` is local-only validator I/O preparation and is not used to reconstruct a full upstream BAL.

The initial scope defines TIP-20 `transfer` and `transferWithMemo` handling: builders produce a valid `RAL`, validators compare against the expected residual, and transfer-path `storage_reads` are excluded from the block-carried payload.