### PR TITLE
fix(txpool): invalidate scoped access key transactions

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -84,6 +84,9 @@ crate::sol! {
         /// Emitted when a spending limit is updated
         event SpendingLimitUpdated(address indexed account, address indexed publicKey, address indexed token, uint256 newLimit);
 
+        /// Emitted when a key's persisted call-scope tree changes.
+        event AllowedCallsUpdated(address indexed account, address indexed publicKey);
+
         event AccessKeySpend(
             address indexed account,
             address indexed publicKey,

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1326,8 +1326,10 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{Address, Log, TxKind, U256};
-    use alloy::sol_types::SolEvent;
+    use alloy::{
+        primitives::{Address, Log, TxKind, U256},
+        sol_types::SolEvent,
+    };
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -457,6 +457,15 @@ impl AccountKeychain {
         })
     }
 
+    fn emit_allowed_calls_updated(&mut self, account: Address, key_id: Address) -> Result<()> {
+        self.emit_event(AccountKeychainEvent::AllowedCallsUpdated(
+            IAccountKeychain::AllowedCallsUpdated {
+                account,
+                publicKey: key_id,
+            },
+        ))
+    }
+
     /// Root-only create-or-replace updates for one or more target call scopes.
     pub fn set_allowed_calls(
         &mut self,
@@ -490,7 +499,8 @@ impl AccountKeychain {
             self.upsert_target_scope(key_hash, scope)?;
         }
 
-        self.key_scopes[key_hash].is_scoped.write(true)
+        self.key_scopes[key_hash].is_scoped.write(true)?;
+        self.emit_allowed_calls_updated(msg_sender, call.keyId)
     }
 
     /// Root-only removal of one target call scope.
@@ -510,7 +520,9 @@ impl AccountKeychain {
             return Ok(());
         }
 
-        self.remove_target_scope(key_hash, call.target)?;
+        if self.remove_target_scope(key_hash, call.target)? {
+            self.emit_allowed_calls_updated(msg_sender, call.keyId)?;
+        }
 
         Ok(())
     }
@@ -815,12 +827,13 @@ impl AccountKeychain {
     }
 
     /// Deletes one target scope and all nested selector/recipient rows beneath it.
-    fn remove_target_scope(&mut self, account_key: B256, target: Address) -> Result<()> {
+    fn remove_target_scope(&mut self, account_key: B256, target: Address) -> Result<bool> {
         if !self.key_scopes[account_key].targets.remove(&target)? {
-            return Ok(());
+            return Ok(false);
         }
 
-        self.clear_target_selectors(account_key, target)
+        self.clear_target_selectors(account_key, target)?;
+        Ok(true)
     }
 
     /// Clears every selector scope stored under one target.
@@ -1313,7 +1326,8 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{Address, TxKind, U256};
+    use alloy::primitives::{Address, Log, TxKind, U256};
+    use alloy::sol_types::SolEvent;
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};
@@ -3967,6 +3981,31 @@ mod tests {
                 )
                 .expect_err("unexpected success for removed target scope");
             assert_call_not_allowed(denied);
+
+            let events = StorageCtx.get_events(ACCOUNT_KEYCHAIN_ADDRESS);
+            assert_eq!(events.len(), 3);
+
+            let set_event =
+                tempo_contracts::precompiles::IAccountKeychain::AllowedCallsUpdated::decode_log(
+                    &Log::new_unchecked(
+                        ACCOUNT_KEYCHAIN_ADDRESS,
+                        events[1].topics().to_vec(),
+                        events[1].data.clone(),
+                    ),
+                )?;
+            assert_eq!(set_event.account, account);
+            assert_eq!(set_event.publicKey, key_id);
+
+            let remove_event =
+                tempo_contracts::precompiles::IAccountKeychain::AllowedCallsUpdated::decode_log(
+                    &Log::new_unchecked(
+                        ACCOUNT_KEYCHAIN_ADDRESS,
+                        events[2].topics().to_vec(),
+                        events[2].data.clone(),
+                    ),
+                )?;
+            assert_eq!(remove_event.account, account);
+            assert_eq!(remove_event.publicKey, key_id);
 
             Ok(())
         })

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -48,6 +48,9 @@ pub struct TempoPoolUpdates {
     /// Revoked keychain keys.
     /// Indexed by account for efficient lookup.
     pub revoked_keys: RevokedKeys,
+    /// Keychain keys whose persisted call scopes changed.
+    /// Indexed by account for efficient lookup.
+    pub scope_changes: RevokedKeys,
     /// Spending limit changes.
     /// When a spending limit changes, transactions from that key paying with that token
     /// may become unexecutable if the new limit is below their value.
@@ -90,6 +93,7 @@ impl TempoPoolUpdates {
     pub fn is_empty(&self) -> bool {
         self.expired_txs.is_empty()
             && self.revoked_keys.is_empty()
+            && self.scope_changes.is_empty()
             && self.spending_limit_changes.is_empty()
             && self.validator_token_changes.is_empty()
             && self.user_token_changes.is_empty()
@@ -114,10 +118,12 @@ impl TempoPoolUpdates {
             .flatten()
             .flat_map(|receipt| &receipt.logs)
         {
-            // Key revocations and spending limit changes
+            // Key revocations, scope changes, and spending limit changes
             if log.address == ACCOUNT_KEYCHAIN_ADDRESS {
                 if let Ok(event) = IAccountKeychain::KeyRevoked::decode_log(log) {
                     updates.revoked_keys.insert(event.account, event.publicKey);
+                } else if let Ok(event) = IAccountKeychain::AllowedCallsUpdated::decode_log(log) {
+                    updates.scope_changes.insert(event.account, event.publicKey);
                 } else if let Ok(event) = IAccountKeychain::SpendingLimitUpdated::decode_log(log) {
                     updates.spending_limit_changes.insert(
                         event.account,
@@ -198,6 +204,7 @@ impl TempoPoolUpdates {
     /// Returns true if there are any invalidation events that require scanning the pool.
     pub fn has_invalidation_events(&self) -> bool {
         !self.revoked_keys.is_empty()
+            || !self.scope_changes.is_empty()
             || !self.spending_limit_changes.is_empty()
             || !self.spending_limit_spends.is_empty()
             || !self.validator_token_changes.is_empty()
@@ -766,13 +773,15 @@ where
                     );
                 }
 
-                // 5. Evict revoked keys and spending limit updates from paused pool
+                // 5. Evict revoked keys, scope changes, and spending limit updates from paused pool
                 if !updates.revoked_keys.is_empty()
+                    || !updates.scope_changes.is_empty()
                     || !updates.spending_limit_changes.is_empty()
                     || !updates.spending_limit_spends.is_empty()
                 {
                     state.paused_pool.evict_invalidated(
                         &updates.revoked_keys,
+                        &updates.scope_changes,
                         &updates.spending_limit_changes,
                         &updates.spending_limit_spends,
                     );
@@ -804,7 +813,7 @@ where
                 metrics.amm_cache_update_duration_seconds.record(amm_start.elapsed());
 
                 // 9. Evict invalidated transactions in a single pool scan
-                // This checks revoked keys, spending limit changes, validator token changes,
+                // This checks revoked keys, scope changes, spending limit changes, validator token changes,
                 // blacklist additions, and whitelist removals together to avoid scanning
                 // all transactions multiple times per block.
                 if updates.has_invalidation_events() {
@@ -812,6 +821,7 @@ where
                     debug!(
                         target: "txpool",
                         revoked_keys = updates.revoked_keys.len(),
+                        scope_changes = updates.scope_changes.len(),
                         spending_limit_changes = updates.spending_limit_changes.len(),
                         spending_limit_spends = updates.spending_limit_spends.len(),
                         validator_token_changes = updates.validator_token_changes.len(),
@@ -1448,6 +1458,17 @@ mod tests {
                 Address::random(),
                 Some(Address::random()),
             );
+            assert!(updates.has_invalidation_events());
+        }
+
+        #[test]
+        fn has_invalidation_events_includes_scope_changes() {
+            let mut updates = TempoPoolUpdates::new();
+            assert!(!updates.has_invalidation_events());
+
+            updates
+                .scope_changes
+                .insert(Address::random(), Address::random());
             assert!(updates.has_invalidation_events());
         }
 

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -7,7 +7,7 @@
 
 use crate::{RevokedKeys, SpendingLimitUpdates, transaction::TempoPooledTransaction};
 use alloy_primitives::{Address, TxHash, map::HashMap};
-use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+use reth_transaction_pool::ValidPoolTransaction;
 use std::{sync::Arc, time::Instant};
 
 /// Duration after which paused transactions are expired and removed.
@@ -193,7 +193,7 @@ impl PausedFeeTokenPool {
 
     /// Removes transactions matching invalidation criteria from the paused pool.
     ///
-    /// This handles revoked keys, spending limit updates, and spending limit spends
+    /// This handles revoked keys, scope changes, spending limit updates, and spending limit spends
     /// in a single pass. The `spending_limit_spends` parameter captures (account, key_id,
     /// fee_token) combos from keychain txs that were included in the block and decremented
     /// limits via `verify_and_update_spending()`.
@@ -202,10 +202,12 @@ impl PausedFeeTokenPool {
     pub fn evict_invalidated(
         &mut self,
         revoked_keys: &RevokedKeys,
+        scope_changes: &RevokedKeys,
         spending_limit_updates: &SpendingLimitUpdates,
         spending_limit_spends: &SpendingLimitUpdates,
     ) -> usize {
         if revoked_keys.is_empty()
+            && scope_changes.is_empty()
             && spending_limit_updates.is_empty()
             && spending_limit_spends.is_empty()
         {
@@ -224,18 +226,13 @@ impl PausedFeeTokenPool {
                 let matches_limit_spend =
                     subject.matches_spending_limit_update(spending_limit_spends);
                 let sender_paid = if matches_limit_update || matches_limit_spend {
-                    let sender = *entry.tx.transaction.sender_ref();
-                    entry
-                        .tx
-                        .transaction
-                        .inner()
-                        .fee_payer(sender)
-                        .map_or(true, |fee_payer| fee_payer == sender)
+                    entry.tx.transaction.sender_pays_own_fees()
                 } else {
                     false
                 };
 
                 let invalidated = subject.matches_revoked(revoked_keys)
+                    || scope_changes.contains(subject.account, subject.key_id)
                     || (sender_paid && (matches_limit_update || matches_limit_spend));
 
                 !invalidated
@@ -442,8 +439,12 @@ mod tests {
         let mut spends = SpendingLimitUpdates::new();
         spends.insert(user_address, key_id, Some(fee_token));
 
-        let evicted =
-            pool.evict_invalidated(&RevokedKeys::new(), &SpendingLimitUpdates::new(), &spends);
+        let evicted = pool.evict_invalidated(
+            &RevokedKeys::new(),
+            &RevokedKeys::new(),
+            &SpendingLimitUpdates::new(),
+            &spends,
+        );
 
         assert_eq!(
             evicted, 1,
@@ -477,8 +478,12 @@ mod tests {
         let mut spends = SpendingLimitUpdates::new();
         spends.insert(user_address, key_id, Some(fee_token));
 
-        let evicted =
-            pool.evict_invalidated(&RevokedKeys::new(), &SpendingLimitUpdates::new(), &spends);
+        let evicted = pool.evict_invalidated(
+            &RevokedKeys::new(),
+            &RevokedKeys::new(),
+            &SpendingLimitUpdates::new(),
+            &spends,
+        );
 
         assert_eq!(evicted, 0, "Sponsored keychain tx should not be evicted");
         assert_eq!(pool.len(), 1);
@@ -509,11 +514,54 @@ mod tests {
         let mut updates = SpendingLimitUpdates::new();
         updates.insert(user_address, key_id, Some(fee_token));
 
-        let evicted =
-            pool.evict_invalidated(&RevokedKeys::new(), &updates, &SpendingLimitUpdates::new());
+        let evicted = pool.evict_invalidated(
+            &RevokedKeys::new(),
+            &RevokedKeys::new(),
+            &updates,
+            &SpendingLimitUpdates::new(),
+        );
 
         assert_eq!(evicted, 0, "Sponsored keychain tx should not be evicted");
         assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn test_evict_invalidated_with_scope_changes() {
+        let mut pool = PausedFeeTokenPool::new();
+        let user_address = Address::random();
+        let fee_token = Address::random();
+
+        let keychain_tx = create_valid_keychain_tx(user_address, fee_token, true);
+        pool.insert_batch(
+            fee_token,
+            vec![PausedEntry {
+                tx: keychain_tx,
+                valid_before: None,
+            }],
+        );
+
+        let key_id = pool
+            .all_entries()
+            .next()
+            .and_then(|entry| entry.tx.transaction.keychain_subject())
+            .map(|subject| subject.key_id)
+            .expect("keychain tx should have keychain subject");
+
+        let mut scope_changes = RevokedKeys::new();
+        scope_changes.insert(user_address, key_id);
+
+        let evicted = pool.evict_invalidated(
+            &RevokedKeys::new(),
+            &scope_changes,
+            &SpendingLimitUpdates::new(),
+            &SpendingLimitUpdates::new(),
+        );
+
+        assert_eq!(
+            evicted, 1,
+            "Scope changes should evict matching keychain txs"
+        );
+        assert_eq!(pool.len(), 0);
     }
 
     #[test]

--- a/crates/transaction-pool/src/paused.rs
+++ b/crates/transaction-pool/src/paused.rs
@@ -226,7 +226,7 @@ impl PausedFeeTokenPool {
                 let matches_limit_spend =
                     subject.matches_spending_limit_update(spending_limit_spends);
                 let sender_paid = if matches_limit_update || matches_limit_spend {
-                    entry.tx.transaction.sender_pays_own_fees()
+                    entry.tx.transaction.sender_is_fee_payer()
                 } else {
                     false
                 };

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -289,7 +289,7 @@ where
             if !updates.spending_limit_spends.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_spends)
-                && tx.transaction.sender_pays_own_fees()
+                && tx.transaction.sender_is_fee_payer()
                 && let Some(ref mut provider) = state_provider
                 && exceeds_spending_limit(
                     provider,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -155,11 +155,12 @@ where
     ///
     /// This performs a single scan of all pooled transactions and checks for:
     /// 1. **Revoked keychain keys**: AA transactions signed with keys that have been revoked
-    /// 2. **Spending limit updates**: AA transactions signed with keys whose spending limit
+    /// 2. **Call-scope changes**: AA transactions signed with keys whose persisted scopes changed
+    /// 3. **Spending limit updates**: AA transactions signed with keys whose spending limit
     ///    changed for a token matching the transaction's fee token
-    ///    2b. **Spending limit spends**: AA transactions whose remaining spending limit (re-read
+    ///    3b. **Spending limit spends**: AA transactions whose remaining spending limit (re-read
     ///    from state) is now insufficient after included keychain txs decremented it
-    /// 3. **Validator token changes**: Transactions that would fail due to insufficient
+    /// 4. **Validator token changes**: Transactions that would fail due to insufficient
     ///    liquidity in the new (user_token, validator_token) AMM pool
     ///
     /// All checks are combined into one scan to avoid iterating the pool multiple times
@@ -234,6 +235,7 @@ where
 
         let mut to_remove = Vec::new();
         let mut revoked_count = 0;
+        let mut scope_change_count = 0;
         let mut spending_limit_count = 0;
         let mut spending_limit_spend_count = 0;
         let mut liquidity_count = 0;
@@ -256,7 +258,19 @@ where
                 continue;
             }
 
-            // Check 2: Spending limit updates
+            // Check 2: Key scope changes
+            if !updates.scope_changes.is_empty()
+                && let Some(ref subject) = keychain_subject
+                && updates
+                    .scope_changes
+                    .contains(subject.account, subject.key_id)
+            {
+                to_remove.push(*tx.hash());
+                scope_change_count += 1;
+                continue;
+            }
+
+            // Check 3: Spending limit updates
             // Only evict if the transaction's fee token matches the token whose limit changed.
             if !updates.spending_limit_changes.is_empty()
                 && let Some(ref subject) = keychain_subject
@@ -267,7 +281,7 @@ where
                 continue;
             }
 
-            // Check 2b: Spending limit spends
+            // Check 3b: Spending limit spends
             // When a keychain tx is included, verify_and_update_spending() decrements the
             // remaining limit but emits no event. We re-read the current remaining limit
             // from state for affected (account, key_id, fee_token) combos and evict if
@@ -275,6 +289,7 @@ where
             if !updates.spending_limit_spends.is_empty()
                 && let Some(ref subject) = keychain_subject
                 && subject.matches_spending_limit_update(&updates.spending_limit_spends)
+                && tx.transaction.sender_pays_own_fees()
                 && let Some(ref mut provider) = state_provider
                 && exceeds_spending_limit(
                     provider,
@@ -424,6 +439,7 @@ where
                 target: "txpool",
                 total = to_remove.len(),
                 revoked_count,
+                scope_change_count,
                 spending_limit_count,
                 spending_limit_spend_count,
                 liquidity_count,

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -155,6 +155,14 @@ impl TempoPooledTransaction {
         })
     }
 
+    /// Returns whether this transaction pays its own fees.
+    pub fn sender_pays_own_fees(&self) -> bool {
+        let sender = self.sender();
+        self.inner()
+            .fee_payer(sender)
+            .map_or(true, |fee_payer| fee_payer == sender)
+    }
+
     /// Returns the unique identifier for this AA transaction.
     pub(crate) fn aa_transaction_id(&self) -> Option<AA2dTransactionId> {
         let nonce_key = self.nonce_key()?;

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -155,8 +155,8 @@ impl TempoPooledTransaction {
         })
     }
 
-    /// Returns whether this transaction pays its own fees.
-    pub fn sender_pays_own_fees(&self) -> bool {
+    /// Returns whether the sender is the fee payer for this transaction.
+    pub fn sender_is_fee_payer(&self) -> bool {
         let sender = self.sender();
         self.inner()
             .fee_payer(sender)

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -202,6 +202,12 @@ where
         // Validate each scope as a unit so target and selector constraints stay grouped.
         let mut seen_targets = HashSet::with_capacity(scopes.len());
         for scope in scopes {
+            if scope.target.is_zero() {
+                return Ok(Err(TempoPoolTransactionError::Keychain(
+                    "call scope target cannot be the zero address",
+                )));
+            }
+
             if !seen_targets.insert(scope.target) {
                 return Ok(Err(TempoPoolTransactionError::Keychain(
                     "duplicate call scope targets are not allowed",
@@ -3809,6 +3815,63 @@ mod tests {
                     ))
                 ),
                 "Expected duplicate target rejection, got: {result:?}"
+            );
+        }
+
+        #[test]
+        fn test_key_authorization_t3_rejects_zero_target_scope() {
+            let (access_key_signer, access_key_address) = generate_keypair();
+            let (user_signer, user_address) = generate_keypair();
+
+            let key_auth = KeyAuthorization {
+                chain_id: 42431,
+                key_type: SignatureType::Secp256k1,
+                key_id: access_key_address,
+                expiry: None,
+                limits: None,
+                allowed_calls: Some(vec![CallScope {
+                    target: Address::ZERO,
+                    selector_rules: vec![],
+                }]),
+            };
+
+            let auth_sig_hash = key_auth.signature_hash();
+            let auth_signature = user_signer
+                .sign_hash_sync(&auth_sig_hash)
+                .expect("signing failed");
+            let signed_key_auth =
+                key_auth.into_signed(PrimitiveSignature::Secp256k1(auth_signature));
+
+            let transaction = create_aa_with_keychain_signature(
+                user_address,
+                &access_key_signer,
+                Some(signed_key_auth),
+            );
+
+            let validator = setup_validator_with_keychain_storage_spec(
+                &transaction,
+                user_address,
+                access_key_address,
+                None,
+                moderato_with_t3(),
+            );
+            let mut state_provider = validator.inner.client().latest().unwrap();
+
+            let result = validate_against_keychain_default_fee_context(
+                &validator,
+                &transaction,
+                &mut state_provider,
+            )
+            .expect("should not be a provider error");
+
+            assert!(
+                matches!(
+                    result,
+                    Err(TempoPoolTransactionError::Keychain(
+                        "call scope target cannot be the zero address"
+                    ))
+                ),
+                "Expected zero-target rejection, got: {result:?}"
             );
         }
 


### PR DESCRIPTION
Supersedes #3422


This PR adds an `AllowedCallsUpdated` event that is emitted when calling `set_allowed_calls`/`remove_allowed_calls`. This event is used it to evict affected keychain transactions from both the main pool and paused pool when call scopes change.

Note that eviction is conservative and any transaction signed by the affected key is removed regardless of whether it's still valid under the new scope. This avoids per-tx re-validation against precompile storage. Valid transactions can be resubmitted by the sender. Scope changes are rare root-key admin operations so the overhead is negligible.
Also rejects zero-address call-scope targets at txpool admission and skips spending-limit rechecks for sponsored transactions so pool behavior stays aligned with runtime.