### PR TITLE
fix: use consistent rlp encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ alloy-hardforks = "0.4.7"
 alloy-network = { version = "1.8.2", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-provider = { version = "1.8.2", default-features = false }
-alloy-rlp = { version = "0.3.13", default-features = false }
+alloy-rlp = { version = "0.3.15", default-features = false }
 alloy-rpc-types-engine = "1.8.2"
 alloy-rpc-types-eth = { version = "1.8.2" }
 alloy-serde = { version = "1.8.2", default-features = false }

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -118,7 +118,7 @@ pub struct KeyAuthorization {
     /// Unix timestamp when key expires.
     /// - `None` (RLP 0x80) = key never expires (stored as u64::MAX in precompile)
     /// - `Some(timestamp)` = key expires at this timestamp
-    /// 
+    ///
     /// Note: Some(0) will get decoded as None after RLP roundtrip.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub expiry: Option<u64>,
@@ -293,7 +293,11 @@ mod rlp {
 
     impl From<&TokenLimit> for TokenLimitWire {
         fn from(value: &TokenLimit) -> Self {
-            let TokenLimit { token, limit, period } = value;
+            let TokenLimit {
+                token,
+                limit,
+                period,
+            } = value;
             Self {
                 token: *token,
                 limit: *limit,
@@ -342,7 +346,14 @@ mod rlp {
 
     impl<'a> From<&'a KeyAuthorization> for KeyAuthorizationWire<'a> {
         fn from(value: &'a KeyAuthorization) -> Self {
-            let KeyAuthorization { chain_id, key_type, key_id, expiry, limits, allowed_calls } = value;
+            let KeyAuthorization {
+                chain_id,
+                key_type,
+                key_id,
+                expiry,
+                limits,
+                allowed_calls,
+            } = value;
             Self {
                 chain_id: *chain_id,
                 key_type: *key_type,
@@ -353,7 +364,7 @@ mod rlp {
             }
         }
     }
-    
+
     impl<'a> From<KeyAuthorizationWire<'a>> for KeyAuthorization {
         fn from(value: KeyAuthorizationWire<'a>) -> Self {
             Self {
@@ -361,8 +372,12 @@ mod rlp {
                 key_type: value.key_type,
                 key_id: value.key_id,
                 expiry: value.expiry.map(|expiry| expiry.get()),
-                limits: value.limits.map(|limits| limits.into_owned().into_iter().collect()),
-                allowed_calls: value.allowed_calls.map(|allowed_calls| allowed_calls.into_owned().into_iter().collect()),
+                limits: value
+                    .limits
+                    .map(|limits| limits.into_owned().into_iter().collect()),
+                allowed_calls: value
+                    .allowed_calls
+                    .map(|allowed_calls| allowed_calls.into_owned().into_iter().collect()),
             }
         }
     }
@@ -561,17 +576,15 @@ mod tests {
     fn test_token_limit_decode_accepts_explicit_zero_period_field() {
         let token = Address::random();
         let limit = U256::from(42);
-        let period = 0u64;
 
         let mut encoded = Vec::new();
         alloy_rlp::Header {
             list: true,
-            payload_length: token.length() + limit.length() + period.length(),
+            payload_length: token.length() + limit.length(),
         }
         .encode(&mut encoded);
         token.encode(&mut encoded);
         limit.encode(&mut encoded);
-        period.encode(&mut encoded);
 
         let decoded: TokenLimit =
             <TokenLimit as Decodable>::decode(&mut encoded.as_slice()).expect("decode token limit");
@@ -793,11 +806,6 @@ mod tests {
         chain_id.encode(&mut payload);
         key_type.encode(&mut payload);
         key_id.encode(&mut payload);
-        payload.extend_from_slice(&[
-            alloy_rlp::EMPTY_STRING_CODE,
-            alloy_rlp::EMPTY_STRING_CODE,
-            alloy_rlp::EMPTY_STRING_CODE,
-        ]);
 
         let mut encoded = Vec::new();
         alloy_rlp::Header {
@@ -818,7 +826,7 @@ mod tests {
 
         let mut reencoded = Vec::new();
         decoded.encode(&mut reencoded);
-        assert!(reencoded.len() < encoded.len());
+        assert_eq!(reencoded.len(), encoded.len());
     }
 
     #[test]

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -99,8 +99,7 @@ impl SelectorRule {
 /// - `limits`: `None` (omitted or 0x80) = unlimited spending, `Some([])` = no spending, `Some([...])` = specific limits
 /// - `allowed_calls`: `None` (canonically omitted, explicit 0x80 accepted) = unrestricted,
 ///   `Some([])` = scoped with no allowed calls, `Some([...])` = scoped calls
-#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
-#[rlp(trailing)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(test, reth_codecs::add_arbitrary_tests(rlp))]
@@ -119,6 +118,8 @@ pub struct KeyAuthorization {
     /// Unix timestamp when key expires.
     /// - `None` (RLP 0x80) = key never expires (stored as u64::MAX in precompile)
     /// - `Some(timestamp)` = key expires at this timestamp
+    /// 
+    /// Note: Some(0) will get decoded as None after RLP roundtrip.
     #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity::opt"))]
     pub expiry: Option<u64>,
 
@@ -235,7 +236,6 @@ pub struct KeyAuthorizationChainIdError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
-#[rlp(trailing)]
 #[cfg_attr(test, reth_codecs::add_arbitrary_tests(compact, rlp))]
 pub struct SignedKeyAuthorization {
     /// Key authorization for provisioning access keys
@@ -276,18 +276,30 @@ impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
 }
 
 mod rlp {
-    use super::TokenLimit;
-    use alloy_primitives::{Address, U256};
+    use super::*;
+    use alloc::borrow::Cow;
     use alloy_rlp::{Decodable, Encodable};
+    use core::num::NonZeroU64;
 
     #[derive(
         Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable,
     )]
-    #[rlp(trailing)]
+    #[rlp(trailing(canonical))]
     struct TokenLimitWire {
         token: Address,
         limit: U256,
-        period: Option<u64>,
+        period: Option<NonZeroU64>,
+    }
+
+    impl From<&TokenLimit> for TokenLimitWire {
+        fn from(value: &TokenLimit) -> Self {
+            let TokenLimit { token, limit, period } = value;
+            Self {
+                token: *token,
+                limit: *limit,
+                period: NonZeroU64::new(*period),
+            }
+        }
     }
 
     impl From<TokenLimitWire> for TokenLimit {
@@ -295,17 +307,7 @@ mod rlp {
             Self {
                 token: value.token,
                 limit: value.limit,
-                period: value.period.unwrap_or(0),
-            }
-        }
-    }
-
-    impl From<&TokenLimit> for TokenLimitWire {
-        fn from(value: &TokenLimit) -> Self {
-            Self {
-                token: value.token,
-                limit: value.limit,
-                period: (value.period != 0).then_some(value.period),
+                period: value.period.map(|period| period.get()).unwrap_or(0),
             }
         }
     }
@@ -323,6 +325,61 @@ mod rlp {
 
         fn length(&self) -> usize {
             TokenLimitWire::from(self).length()
+        }
+    }
+
+    #[derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+    #[rlp(trailing(canonical))]
+    #[expect(clippy::owned_cow)]
+    struct KeyAuthorizationWire<'a> {
+        chain_id: u64,
+        key_type: SignatureType,
+        key_id: Address,
+        expiry: Option<NonZeroU64>,
+        limits: Option<Cow<'a, Vec<TokenLimit>>>,
+        allowed_calls: Option<Cow<'a, Vec<CallScope>>>,
+    }
+
+    impl<'a> From<&'a KeyAuthorization> for KeyAuthorizationWire<'a> {
+        fn from(value: &'a KeyAuthorization) -> Self {
+            let KeyAuthorization { chain_id, key_type, key_id, expiry, limits, allowed_calls } = value;
+            Self {
+                chain_id: *chain_id,
+                key_type: *key_type,
+                key_id: *key_id,
+                expiry: expiry.and_then(NonZeroU64::new),
+                limits: limits.as_ref().map(Cow::Borrowed),
+                allowed_calls: allowed_calls.as_ref().map(Cow::Borrowed),
+            }
+        }
+    }
+    
+    impl<'a> From<KeyAuthorizationWire<'a>> for KeyAuthorization {
+        fn from(value: KeyAuthorizationWire<'a>) -> Self {
+            Self {
+                chain_id: value.chain_id,
+                key_type: value.key_type,
+                key_id: value.key_id,
+                expiry: value.expiry.map(|expiry| expiry.get()),
+                limits: value.limits.map(|limits| limits.into_owned().into_iter().collect()),
+                allowed_calls: value.allowed_calls.map(|allowed_calls| allowed_calls.into_owned().into_iter().collect()),
+            }
+        }
+    }
+
+    impl Encodable for KeyAuthorization {
+        fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+            KeyAuthorizationWire::from(self).encode(out)
+        }
+
+        fn length(&self) -> usize {
+            KeyAuthorizationWire::from(self).length()
+        }
+    }
+
+    impl Decodable for KeyAuthorization {
+        fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+            Ok(KeyAuthorizationWire::decode(buf)?.into())
         }
     }
 }


### PR DESCRIPTION
Changes `KeyAuthorization` and `TokenLimit` to use consistent rlp encoding which ensures that each value can only be represented with a single RLP payload

This would be breaking for tooking that was encoding `expiry: None` as 0x80 instead of omitting it

Fixes SIGP 204