### PR TITLE
fix(tip-1020): use InvalidFormat() for encoding errors

### DIFF
--- a/tips/tip-1020.md
+++ b/tips/tip-1020.md
@@ -68,13 +68,13 @@ The precompile MUST use the same verification logic as Tempo transaction signatu
 
 #### Keychain Signature Rejection
 
-The precompile MUST reject signatures with a Keychain type prefix (`0x03` or `0x04`). Keychain signatures are multi-step, stateful verification flows that cannot be reduced to a single pure cryptographic check. Thus, if a Keychain prefix is detected, the precompile MUST revert with `InvalidSignature()`.
+The precompile MUST reject signatures with a Keychain type prefix (`0x03` or `0x04`). Keychain signatures are multi-step, stateful verification flows that cannot be reduced to a single pure cryptographic check. Thus, if a Keychain prefix is detected, the precompile MUST revert with `InvalidFormat()`.
 
 Contracts that need to verify Keychain-based signatures can do so by composing this precompile with the AccountKeychain precompile: first, use the AccountKeychain precompile to resolve and validate the access key for the account, then use this precompile to verify the inner signature against the resolved key. This two-step pattern separates key management (stateful, account-scoped) from cryptographic verification (stateless, type-scoped), allowing each precompile to remain single-purpose.
 
 ### Calldata Limits
 
-The precompile MUST enforce strict size limits on the `signature` argument **before** any decoding or copying occurs. If the signature exceeds the limit for its type, the precompile MUST revert with `InvalidSignature()`.
+The precompile MUST enforce strict size limits on the `signature` argument **before** any decoding or copying occurs. If the signature exceeds the limit for its type, the precompile MUST revert with `InvalidFormat()`.
 
 | Type | Exact / Max Length |
 |------|-------------------|


### PR DESCRIPTION
Closes SIGP-223

Changes Keychain prefix rejection and calldata size limit violations to revert with `InvalidFormat()` instead of `InvalidSignature()`, matching the implementation.

Principle - `InvalidFormat` is for sig issues pre-validation, and `InvalidSignature` is for sig validation failures