### PR TITLE
fix: add T3 and T4 to TEMPO_HARDFORKS in tempo.nu

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -280,7 +280,7 @@ def read-bench-marker [datadir: string] {
 # ============================================================================
 
 # Ordered list of all Tempo hardforks (must match TempoHardfork enum in crates/chainspec)
-const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2"]
+const TEMPO_HARDFORKS = ["T0" "T1" "T1A" "T1B" "T1C" "T2" "T3" "T4"]
 
 # Map a hardfork name to generate-genesis CLI args.
 # Forks up to and including the given fork are active at genesis (time=0).


### PR DESCRIPTION
The `TEMPO_HARDFORKS` list in `tempo.nu` was missing T3 and T4, so `hardfork-to-genesis-args` couldn't generate `--t3-time` / `--t4-time` flags for `generate-devnet`/`generate-genesis`.

Prompted by: kuyziss