### PR TITLE
chore(ci): pin branch-ref actions to SHA and Docker base images to digest

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: curl -fsSL https://ampcode.com/install.sh | bash
 
-      - uses: wevm/changelogs/check@master
+      - uses: wevm/changelogs/check@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # master
         with:
           ai: 'amp -x'
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,7 +136,7 @@ jobs:
   deny:
     permissions:
       contents: read
-    uses: tempoxyz/ci/.github/workflows/deny.yml@main
+    uses: tempoxyz/ci/.github/workflows/deny.yml@f7b868401133161610784f840fbf8ba5c45fdd4e # main
 
   zepter:
     name: zepter

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: true
 
-      - uses: wevm/changelogs@master
+      - uses: wevm/changelogs@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # master
         with:
           conventional-commit: true
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93" # MSRV
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
         --bin tempo-sidecar \
         --bin tempo-xtask
 
-FROM debian:bookworm-slim AS base
+FROM debian:bookworm-slim@sha256:13cb01d584d2c23f475c088c168a48f9a08f033a10460572fbfd10912ec5ba7c AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/contrib/cross/Dockerfile.x86_64-unknown-linux-gnu-sccache
+++ b/contrib/cross/Dockerfile.x86_64-unknown-linux-gnu-sccache
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main@sha256:cf5f346700e06d96647df2b6d9ff2be30b38c2d21c4140bc311bbcded160d217
 ARG DEBIAN_FRONTEND=noninteractive
 
 # note you can also use sccache-source.sh


### PR DESCRIPTION
Pins 4 branch-tracked GitHub Actions to commit SHA and 2 Docker base images to digest, per SEC-6 dependency audit.