### PR TITLE
feat(primitives): add `CallScope` and `SelectorRule` accessor methods

### DIFF
--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -51,6 +51,21 @@ pub struct CallScope {
 }
 
 impl CallScope {
+    /// Returns the target contract address.
+    pub fn target(&self) -> Address {
+        self.target
+    }
+
+    /// Returns `true` when any call to this target is allowed (no selector restrictions).
+    pub fn allows_all_selectors(&self) -> bool {
+        self.selector_rules.is_empty()
+    }
+
+    /// Returns the selector rules for this target.
+    pub fn selector_rules(&self) -> &[SelectorRule] {
+        &self.selector_rules
+    }
+
     fn heap_size(&self) -> usize {
         self.selector_rules.capacity() * size_of::<SelectorRule>()
             + self
@@ -83,6 +98,21 @@ pub struct SelectorRule {
 }
 
 impl SelectorRule {
+    /// Returns the 4-byte function selector.
+    pub fn selector(&self) -> [u8; 4] {
+        self.selector
+    }
+
+    /// Returns the allowed recipients for this selector.
+    pub fn recipients(&self) -> &[Address] {
+        &self.recipients
+    }
+
+    /// Returns `true` when any recipient is allowed (no recipient restriction).
+    pub fn allows_all_recipients(&self) -> bool {
+        self.recipients.is_empty()
+    }
+
     fn heap_size(&self) -> usize {
         self.recipients.capacity() * size_of::<Address>()
     }
@@ -930,5 +960,54 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.expected, expected);
         assert_eq!(err.got, 999);
+    }
+
+    #[test]
+    fn test_call_scope_accessors() {
+        let target = Address::repeat_byte(0x11);
+        let rule = SelectorRule {
+            selector: [0xaa, 0xbb, 0xcc, 0xdd],
+            recipients: vec![Address::repeat_byte(0x22)],
+        };
+        let scope = CallScope {
+            target,
+            selector_rules: vec![rule],
+        };
+
+        assert_eq!(scope.target(), target);
+        assert!(!scope.allows_all_selectors());
+        assert_eq!(scope.selector_rules().len(), 1);
+    }
+
+    #[test]
+    fn test_call_scope_allows_all_selectors_when_empty() {
+        let scope = CallScope {
+            target: Address::repeat_byte(0x11),
+            selector_rules: vec![],
+        };
+        assert!(scope.allows_all_selectors());
+    }
+
+    #[test]
+    fn test_selector_rule_accessors() {
+        let selector = [0x12, 0x34, 0x56, 0x78];
+        let recipients = vec![Address::repeat_byte(0x33), Address::repeat_byte(0x44)];
+        let rule = SelectorRule {
+            selector,
+            recipients: recipients.clone(),
+        };
+
+        assert_eq!(rule.selector(), selector);
+        assert_eq!(rule.recipients(), &recipients);
+        assert!(!rule.allows_all_recipients());
+    }
+
+    #[test]
+    fn test_selector_rule_allows_all_recipients_when_empty() {
+        let rule = SelectorRule {
+            selector: [0xaa, 0xbb, 0xcc, 0xdd],
+            recipients: vec![],
+        };
+        assert!(rule.allows_all_recipients());
     }
 }


### PR DESCRIPTION
Adds public getters for `CallScope` and `SelectorRule` to support downstream inspection of key permissions. Follows the encapsulation pattern from #3469.

### `CallScope`
- `target() -> Address` — returns the target address
- `allows_all_selectors() -> bool` — returns `true` when `selector_rules` is empty
- `selector_rules() -> &[SelectorRule]` — returns the selector rules

### `SelectorRule`
- `selector() -> [u8; 4]` — returns the 4-byte function selector
- `recipients() -> &[Address]` — returns the allowed recipients
- `allows_all_recipients() -> bool` — returns `true` when `recipients` is empty

### Tests
Unit tests for all new accessors added in `key_authorization::tests`.