### PR TITLE
docs(tip-1024): note gas cost changes in API compatibility section

### DIFF
--- a/tips/tip-1024.md
+++ b/tips/tip-1024.md
@@ -58,6 +58,7 @@ This also enables simplifying swap internals by removing per-tick tracking paths
 5. API compatibility:
    - External quote and swap method signatures remain unchanged.
    - Returned values remain semantically identical, except quote precision now matches swap precision exactly for the same state snapshot.
+   - Gas costs will change: `quote()` becomes more expensive (per-order traversal instead of per-level approximation) and `swap()` may become cheaper (no per-fill `totalLiquidity` writes). Callers SHOULD NOT depend on specific gas costs for these functions.
    - `getTickLevel` keeps its current return shape, including `totalLiquidity`.
    - `getTickLevel.totalLiquidity` MUST be computed on demand by traversing the tick's linked-list orders and summing `remaining`, rather than reading a maintained aggregate slot. The sum MUST use `uint256` accumulation and MUST NOT overflow — this is guaranteed by the invariant that individual order `remaining` values fit in `uint128` and the number of orders per tick is bounded by storage.
 


### PR DESCRIPTION
Adds a bullet to the API compatibility section noting that gas costs will change for quote() and swap(), per review feedback from @malleshpai.

Prompted by: Dan