### PR TITLE
perf(consensus): increase resolve time to 440ms with shared sparse trie

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -252,6 +252,17 @@ fn main() -> eyre::Result<()> {
         );
     }
 
+    // When the sparse trie is shared with the payload builder, state root
+    // calculation is pipelined and completes faster. Give the builder more
+    // time to execute transactions (200ms → 440ms) since the sealing phase
+    // after interrupt is shorter.
+    if let Commands::Node(node_cmd) = &mut cli.command
+        && node_cmd.engine.share_sparse_trie_with_payload_builder
+    {
+        node_cmd.ext.consensus.time_to_prepare_proposal_transactions =
+            "440ms".parse().expect("valid duration");
+    }
+
     // If telemetry is enabled, set logs OTLP (conflicts_with in TelemetryArgs prevents both being set)
     let mut telemetry_config = None;
     if let Commands::Node(node_cmd) = &cli.command


### PR DESCRIPTION
When `--engine.share-sparse-trie-with-payload-builder` is enabled, state root calculation is pipelined and finishes faster. This overrides the default 200ms `time_to_prepare_proposal_transactions` to 440ms so the builder can execute more transactions before being interrupted.

Prompted by: joshie