### PR TITLE
test(rpc): gate remote fill compatibility cases

### DIFF
--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -80,7 +80,6 @@ async fn run_all_matrices(env: &mut impl TestEnv) -> eyre::Result<()> {
     check(env.run_nonce_rejection_scenario().await)?;
     check(env.run_fee_payer_negative_scenario().await)?;
     check(env.run_gas_fee_boundary_scenario().await)?;
-    check(env.run_fill_transaction_error_decoding_scenario().await)?;
     Ok(())
 }
 
@@ -89,7 +88,9 @@ async fn run_all_matrices(env: &mut impl TestEnv) -> eyre::Result<()> {
 #[test_case(ForkSchedule::Mainnet ; "mainnet")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_matrices_local(schedule: ForkSchedule) -> eyre::Result<()> {
-    run_all_matrices(&mut local::Localnet::with_schedule(schedule).await?).await
+    let mut env = local::Localnet::with_schedule(schedule).await?;
+    run_all_matrices(&mut env).await?;
+    env.run_fill_transaction_error_decoding_scenario().await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/node/tests/it/tempo_transaction/rpc.rs
+++ b/crates/node/tests/it/tempo_transaction/rpc.rs
@@ -63,6 +63,7 @@ pub(super) struct RpcEnv {
     provider: alloy::providers::RootProvider,
     chain_id: u64,
     hardfork: TempoHardfork,
+    supports_scoped_key_auth_rpc: bool,
 }
 
 impl RpcEnv {
@@ -95,12 +96,17 @@ impl RpcEnv {
             .get_block_by_number(Default::default())
             .await?
             .ok_or_else(|| eyre::eyre!("latest block missing"))?;
-        let hardfork = chain_spec.tempo_hardfork_at(latest_block.header.timestamp());
+        let latest_timestamp = latest_block.header.timestamp();
+        let hardfork = chain_spec.tempo_hardfork_at(latest_timestamp);
+        let supports_scoped_key_auth_rpc =
+            TempoHardfork::from_chain_and_timestamp(chain_id, latest_timestamp)
+                .is_some_and(|fork| fork.is_t3());
 
         Ok(Self {
             provider,
             chain_id,
             hardfork,
+            supports_scoped_key_auth_rpc,
         })
     }
 
@@ -135,7 +141,7 @@ impl super::types::TestEnv for RpcEnv {
     }
 
     fn supports_scoped_key_auth_rpc(&self) -> bool {
-        self.hardfork.is_t3()
+        self.supports_scoped_key_auth_rpc
     }
 
     async fn fund_account(&mut self, addr: Address) -> eyre::Result<U256> {


### PR DESCRIPTION
Remote devnet/testnet RPCs can lag main for a bit, so this gates selector-scoped key auth fill/estimate cases on known hardfork support instead of assuming the current branch's RPC behavior is deployed everywhere.

It also keeps the `eth_fillTransaction` revert-decoding regression local-only, so we still validate the branch's formatting behavior without failing against older remote environments.

This should remove the false negatives that were blocking PR #3500 and similar rebases.