### PR TITLE
fix: re-validate transactions on policy change

### DIFF
--- a/crates/node/tests/it/pool.rs
+++ b/crates/node/tests/it/pool.rs
@@ -6,7 +6,7 @@ use alloy::{
         local::{MnemonicBuilder, PrivateKeySigner},
     },
 };
-use alloy_eips::Decodable2718;
+use alloy_eips::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, TxKind, U256};
 use reth_chainspec::EthChainSpec;
 use reth_ethereum::{
@@ -399,6 +399,214 @@ async fn test_evict_tx_on_validator_token_change() -> eyre::Result<()> {
         "Transaction should NOT be evicted when validator token change is from a non-active validator"
     );
     assert_eq!(*pooled_txs_after[0].hash(), tx_hash);
+
+    Ok(())
+}
+
+/// Test that pending transactions are evicted when a fee token's transfer policy changes
+/// from allow-all to whitelist-based, effectively invalidating all transactions using
+/// that fee token — except for transactions from whitelisted senders.
+///
+/// 1. Two disconnected nodes start at genesis
+/// 2. Node2 mines a single block containing a TempoTransaction that creates a whitelist
+///    policy, whitelists one sender + the fee manager, and applies the policy to
+///    DEFAULT_FEE_TOKEN
+/// 3. Node1 accumulates 10 AA transactions (indices 1–9 non-whitelisted, index 10
+///    whitelisted) using DEFAULT_FEE_TOKEN
+/// 4. Node1 imports node2's block (with the policy change)
+/// 5. The 9 non-whitelisted transactions are evicted; the whitelisted one survives
+#[tokio::test(flavor = "multi_thread")]
+async fn test_evict_txs_on_transfer_policy_change() -> eyre::Result<()> {
+    use alloy::sol_types::SolCall;
+    use tempo_contracts::precompiles::{ITIP20, ITIP403Registry};
+    use tempo_precompiles::{TIP403_REGISTRY_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
+
+    reth_tracing::init_test_tracing();
+
+    // Two disconnected nodes — no tx propagation
+    let mut multi = crate::utils::TestNodeBuilder::new()
+        .with_node_count(2)
+        .build_multi_node()
+        .await?;
+
+    let node1 = multi.nodes.remove(0);
+    let mut node2 = multi.nodes.remove(0);
+
+    let admin_signer = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+
+    // The whitelisted user is mnemonic index 10
+    let whitelisted_signer = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(10)?
+        .build()?;
+    let whitelisted_addr = whitelisted_signer.address();
+
+    // === Step 1: On node2, mine a block with a single AA tx that creates a whitelist
+    //     policy, whitelists one sender + fee manager, and applies it ===
+
+    // The first user-created policy gets ID 2 (0=REJECT_ALL, 1=ALLOW_ALL are reserved)
+    let new_policy_id = 2u64;
+
+    let policy_tx = TempoTransaction {
+        chain_id: 1337,
+        max_priority_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+        max_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+        gas_limit: 5_000_000,
+        calls: vec![
+            // Call 1: create a whitelist policy
+            Call {
+                to: TxKind::Call(TIP403_REGISTRY_ADDRESS),
+                value: U256::ZERO,
+                input: ITIP403Registry::createPolicyCall {
+                    admin: admin_signer.address(),
+                    policyType: ITIP403Registry::PolicyType::WHITELIST,
+                }
+                .abi_encode()
+                .into(),
+            },
+            // Call 2: whitelist the chosen sender
+            Call {
+                to: TxKind::Call(TIP403_REGISTRY_ADDRESS),
+                value: U256::ZERO,
+                input: ITIP403Registry::modifyPolicyWhitelistCall {
+                    policyId: new_policy_id,
+                    account: whitelisted_addr,
+                    allowed: true,
+                }
+                .abi_encode()
+                .into(),
+            },
+            // Call 3: whitelist the fee manager (recipient of fee transfers)
+            Call {
+                to: TxKind::Call(TIP403_REGISTRY_ADDRESS),
+                value: U256::ZERO,
+                input: ITIP403Registry::modifyPolicyWhitelistCall {
+                    policyId: new_policy_id,
+                    account: TIP_FEE_MANAGER_ADDRESS,
+                    allowed: true,
+                }
+                .abi_encode()
+                .into(),
+            },
+            // Call 4: change DEFAULT_FEE_TOKEN's transfer policy to the new whitelist
+            Call {
+                to: TxKind::Call(DEFAULT_FEE_TOKEN),
+                value: U256::ZERO,
+                input: ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: new_policy_id,
+                }
+                .abi_encode()
+                .into(),
+            },
+        ],
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        ..Default::default()
+    };
+
+    let sig = admin_signer.sign_hash_sync(&policy_tx.signature_hash())?;
+    let envelope: TempoTxEnvelope = policy_tx.into_signed(sig.into()).into();
+    let mut encoded = Vec::new();
+    envelope.encode_2718(&mut encoded);
+
+    node2.rpc.inject_tx(encoded.into()).await?;
+    let policy_payload = node2.build_and_submit_payload().await?;
+    let policy_block_hash = policy_payload.block().hash();
+
+    // === Step 2: On node1, add 10 AA transactions using DEFAULT_FEE_TOKEN ===
+    // Indices 1–9: non-whitelisted senders (should be evicted)
+    // Index 10: whitelisted sender (should survive)
+
+    let mut evictable_hashes = Vec::new();
+
+    for i in 1..=9u32 {
+        let user_signer = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+            .index(i)?
+            .build()?;
+
+        let tx_aa = TempoTransaction {
+            chain_id: 1337,
+            max_priority_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+            max_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+            gas_limit: 1_000_000,
+            calls: vec![Call {
+                to: TxKind::Call(Address::ZERO),
+                value: U256::ZERO,
+                input: alloy_primitives::Bytes::new(),
+            }],
+            fee_token: Some(DEFAULT_FEE_TOKEN),
+            ..Default::default()
+        };
+
+        let signature = user_signer.sign_hash_sync(&tx_aa.signature_hash())?;
+        let envelope: TempoTxEnvelope = tx_aa.into_signed(signature.into()).into();
+        let recovered = envelope.try_into_recovered()?;
+        let tx_hash = *recovered.tx_hash();
+
+        node1
+            .inner
+            .pool
+            .add_consensus_transaction(recovered, TransactionOrigin::Local)
+            .await?;
+
+        evictable_hashes.push(tx_hash);
+    }
+
+    // Submit the whitelisted sender's transaction
+    let whitelisted_tx = TempoTransaction {
+        chain_id: 1337,
+        max_priority_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+        max_fee_per_gas: TEMPO_T1_BASE_FEE as u128,
+        gas_limit: 1_000_000,
+        calls: vec![Call {
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: alloy_primitives::Bytes::new(),
+        }],
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        ..Default::default()
+    };
+
+    let wl_sig = whitelisted_signer.sign_hash_sync(&whitelisted_tx.signature_hash())?;
+    let wl_envelope: TempoTxEnvelope = whitelisted_tx.into_signed(wl_sig.into()).into();
+    let wl_recovered = wl_envelope.try_into_recovered()?;
+    let whitelisted_hash = *wl_recovered.tx_hash();
+
+    node1
+        .inner
+        .pool
+        .add_consensus_transaction(wl_recovered, TransactionOrigin::Local)
+        .await?;
+
+    // Verify all 10 transactions are in node1's pool
+    for hash in &evictable_hashes {
+        assert!(node1.inner.pool.contains(hash), "tx should be in pool before import");
+    }
+    assert!(
+        node1.inner.pool.contains(&whitelisted_hash),
+        "whitelisted tx should be in pool before import"
+    );
+
+    // === Step 3: Import node2's block into node1 — should trigger eviction ===
+    node1.submit_payload(policy_payload).await?;
+    node1
+        .update_forkchoice(policy_block_hash, policy_block_hash)
+        .await?;
+
+    // Pool maintenance runs asynchronously; give it a moment to re-validate
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    // Non-whitelisted transactions should be evicted
+    for hash in &evictable_hashes {
+        assert!(
+            !node1.inner.pool.contains(hash),
+            "non-whitelisted tx should be evicted after policy change"
+        );
+    }
+
+    // Whitelisted transaction should still be in the pool
+    assert!(
+        node1.inner.pool.contains(&whitelisted_hash),
+        "whitelisted tx should survive the policy change"
+    );
 
     Ok(())
 }

--- a/crates/node/tests/it/pool.rs
+++ b/crates/node/tests/it/pool.rs
@@ -419,7 +419,7 @@ async fn test_evict_tx_on_validator_token_change() -> eyre::Result<()> {
 async fn test_evict_txs_on_transfer_policy_change() -> eyre::Result<()> {
     use alloy::sol_types::SolCall;
     use tempo_contracts::precompiles::{ITIP20, ITIP403Registry};
-    use tempo_precompiles::{TIP403_REGISTRY_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
+    use tempo_precompiles::{TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS};
 
     reth_tracing::init_test_tracing();
 
@@ -578,7 +578,10 @@ async fn test_evict_txs_on_transfer_policy_change() -> eyre::Result<()> {
 
     // Verify all 10 transactions are in node1's pool
     for hash in &evictable_hashes {
-        assert!(node1.inner.pool.contains(hash), "tx should be in pool before import");
+        assert!(
+            node1.inner.pool.contains(hash),
+            "tx should be in pool before import"
+        );
     }
     assert!(
         node1.inner.pool.contains(&whitelisted_hash),

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -68,6 +68,10 @@ pub struct TempoPoolUpdates {
     pub whitelist_removals: Vec<(u64, Address)>,
     /// Fee token pause state changes: (token, is_paused).
     pub pause_events: Vec<(Address, bool)>,
+    /// Tokens whose transfer policy was changed via `changeTransferPolicyId()`.
+    /// Pending transactions using these tokens as fee tokens need to be re-validated
+    /// because the new policy may forbid the fee payer or fee manager.
+    pub transfer_policy_updates: HashSet<Address>,
     /// Fee token balance changes keyed by token.
     ///
     /// We only track the debited `from` account from TIP20 `Transfer` logs because credits to the
@@ -99,6 +103,7 @@ impl TempoPoolUpdates {
             && self.blacklist_additions.is_empty()
             && self.whitelist_removals.is_empty()
             && self.pause_events.is_empty()
+            && self.transfer_policy_updates.is_empty()
             && self.fee_balance_changes.is_empty()
             && self.spending_limit_spends.is_empty()
     }
@@ -160,6 +165,8 @@ impl TempoPoolUpdates {
             else if is_tip20_prefix(log.address) {
                 if let Ok(event) = ITIP20::PauseStateUpdate::decode_log(log) {
                     updates.pause_events.push((log.address, event.isPaused));
+                } else if ITIP20::TransferPolicyUpdate::decode_log(log).is_ok() {
+                    updates.transfer_policy_updates.insert(log.address);
                 } else if let Ok(event) = ITIP20::Transfer::decode_log(log) {
                     updates
                         .fee_balance_changes
@@ -582,6 +589,59 @@ where
                 }
                 metrics.pause_events_duration_seconds.record(pause_start.elapsed());
 
+                // 5b. Handle transfer policy updates
+                // When a token's transfer policy changes, pending transactions using that
+                // token may become invalid under the new policy. We remove them and re-add
+                // so they go through full validation against the updated policy.
+                if !updates.transfer_policy_updates.is_empty() {
+                    let all_txs = pool.all_transactions();
+                    let hashes: Vec<TxHash> = all_txs
+                        .pending
+                        .iter()
+                        .chain(all_txs.queued.iter())
+                        .filter(|tx| {
+                            tx.transaction
+                                .inner()
+                                .fee_token()
+                                .is_some_and(|t| updates.transfer_policy_updates.contains(&t))
+                        })
+                        .map(|tx| *tx.hash())
+                        .collect();
+
+                    if !hashes.is_empty() {
+                        let removed_txs = pool.remove_transactions(hashes);
+                        let count = removed_txs.len();
+
+                        for tx in &removed_txs {
+                            state.untrack(tx.hash());
+                        }
+
+                        metrics
+                            .transfer_policy_revalidated
+                            .increment(count as u64);
+
+                        let pool_clone = pool.clone();
+                        tokio::spawn(async move {
+                            let txs: Vec<_> = removed_txs
+                                .into_iter()
+                                .map(|tx| (tx.origin, tx.transaction.clone()))
+                                .collect();
+
+                            let results =
+                                pool_clone.add_transactions_with_origins(txs).await;
+
+                            let success =
+                                results.iter().filter(|r| r.is_ok()).count();
+                            debug!(
+                                target: "txpool",
+                                total = count,
+                                success,
+                                "Re-validated transactions after transfer policy update"
+                            );
+                        });
+                    }
+                }
+
                 // 6. Update 2D nonce pool (also removes included expiring nonce txs
                 // via slot changes on the nonce precompile)
                 let nonce_pool_start = Instant::now();
@@ -992,6 +1052,79 @@ mod tests {
                 "TIP20 transfer logs should only mark the debited sender as balance-changed"
             );
             assert!(updates.has_invalidation_events());
+        }
+
+        /// TransferPolicyUpdate events are parsed from TIP20 token logs.
+        #[test]
+        fn extracts_transfer_policy_updates() {
+            let fee_token = tempo_precompiles::PATH_USD_ADDRESS;
+            let updater = Address::random();
+            let new_policy_id = 42u64;
+            let log_data = ITIP20::TransferPolicyUpdate {
+                updater,
+                newPolicyId: new_policy_id,
+            }
+            .into_log_data();
+            let log =
+                Log::new_unchecked(fee_token, log_data.topics().to_vec(), log_data.data.clone());
+            let receipt = TempoReceipt {
+                tx_type: TempoTxType::Legacy,
+                success: true,
+                cumulative_gas_used: 21_000,
+                logs: vec![log],
+            };
+
+            let block = create_block_with_txs(1, vec![], vec![]);
+            let chain = create_test_chain_with_receipts(vec![block], vec![vec![receipt]]);
+            let updates = TempoPoolUpdates::from_chain(&chain);
+
+            assert!(
+                updates.transfer_policy_updates.contains(&fee_token),
+                "TransferPolicyUpdate should be tracked by token address"
+            );
+        }
+
+        /// Duplicate TransferPolicyUpdate events for the same token are deduplicated.
+        #[test]
+        fn transfer_policy_updates_deduplicates_by_token() {
+            let fee_token = tempo_precompiles::PATH_USD_ADDRESS;
+
+            let log_data_1 = ITIP20::TransferPolicyUpdate {
+                updater: Address::random(),
+                newPolicyId: 1,
+            }
+            .into_log_data();
+            let log_data_2 = ITIP20::TransferPolicyUpdate {
+                updater: Address::random(),
+                newPolicyId: 2,
+            }
+            .into_log_data();
+            let log1 = Log::new_unchecked(
+                fee_token,
+                log_data_1.topics().to_vec(),
+                log_data_1.data.clone(),
+            );
+            let log2 = Log::new_unchecked(
+                fee_token,
+                log_data_2.topics().to_vec(),
+                log_data_2.data.clone(),
+            );
+            let receipt = TempoReceipt {
+                tx_type: TempoTxType::Legacy,
+                success: true,
+                cumulative_gas_used: 21_000,
+                logs: vec![log1, log2],
+            };
+
+            let block = create_block_with_txs(1, vec![], vec![]);
+            let chain = create_test_chain_with_receipts(vec![block], vec![vec![receipt]]);
+            let updates = TempoPoolUpdates::from_chain(&chain);
+
+            assert_eq!(
+                updates.transfer_policy_updates.len(),
+                1,
+                "duplicate policy updates for the same token should be deduplicated"
+            );
         }
 
         /// Duplicate validator token changes must be deduplicated (last-write-wins).

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -110,4 +110,7 @@ pub struct TempoPoolMaintenanceMetrics {
 
     /// Number of paused transactions evicted due to the global cap.
     pub paused_pool_cap_evicted: Counter,
+
+    /// Number of transactions re-validated due to transfer policy updates.
+    pub transfer_policy_revalidated: Counter,
 }


### PR DESCRIPTION
fixes SIGP-193

On token policy changes, transactions using this token as a fee token might get invalidated.

This might affect a lot of transactions and checking every single one would require potentially expensive storage lookups, thus we don't want to perform this check in maintenance loop directly to ensure that we don't leave pool in an inconsistent state for too long

Instead, we are removing all of the transactions for this fee token from the transaction pool immediately and re-add them forcing full re-validation to run and filter out transactions that became invalid after the policy change