### PR TITLE
feat(consensus): enrich validator command with DKG role info

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -865,7 +865,7 @@ pub(crate) struct ValidatorInfo {
     #[arg()]
     id: ValidatorId,
 
-    /// Chain to query (presto, testnet, moderato, or path to chainspec file)
+    /// Chain to query (mainnet, testnet, moderato, or path to chainspec file)
     #[arg(long, short, default_value = "mainnet", value_parser = tempo_chainspec::spec::chain_value_parser)]
     chain: Arc<TempoChainSpec>,
 
@@ -1087,7 +1087,7 @@ struct ValidatorEntry {
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct ValidatorsInfo {
-    /// Chain to query (presto, testnet, moderato, or path to chainspec file)
+    /// Chain to query (mainnet, testnet, moderato, or path to chainspec file)
     #[arg(long, short, default_value = "mainnet", value_parser = tempo_chainspec::spec::chain_value_parser)]
     chain: Arc<TempoChainSpec>,
 

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -881,10 +881,8 @@ pub(crate) struct ValidatorInfo {
 /// Output for the single-validator lookup enriched with DKG role and epoch context.
 #[derive(Debug, Serialize)]
 struct SingleValidatorOutput {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    current_epoch: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    current_height: Option<u64>,
+    current_epoch: u64,
+    current_height: u64,
     #[serde(flatten)]
     validator: ValidatorEntry,
 }
@@ -975,69 +973,65 @@ impl ValidatorInfo {
         let validator = read_validator_from_contract(&provider, self.id).await?;
         let pubkey_bytes = validator.publicKey.0;
 
-        let (current_epoch, current_height, is_dkg_dealer, is_dkg_player, in_committee) =
-            if self.no_dkg_information {
-                (None, None, None, None, None)
-            } else {
-                use alloy_consensus::BlockHeader;
+        let latest_block_number = provider
+            .get_block_number()
+            .await
+            .wrap_err("failed to get latest block number")?;
 
-                let latest_block_number = provider
-                    .get_block_number()
-                    .await
-                    .wrap_err("failed to get latest block number")?;
+        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
+        let current_height = Height::new(latest_block_number);
+        let current_epoch_info = epoch_strategy
+            .containing(current_height)
+            .ok_or_else(|| eyre!("failed to determine epoch for height {latest_block_number}"))?;
+        let current_epoch = current_epoch_info.epoch();
 
-                let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
-                let current_height = Height::new(latest_block_number);
-                let current_epoch_info = epoch_strategy.containing(current_height).ok_or_else(
-                    || eyre!("failed to determine epoch for height {latest_block_number}"),
-                )?;
+        let mut is_dkg_dealer = None;
+        let mut is_dkg_player = None;
+        let mut in_committee = None;
 
-                let current_epoch = current_epoch_info.epoch();
-                let boundary_height = current_epoch
-                    .previous()
-                    .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
-                    .unwrap_or_default();
+        if !self.no_dkg_information {
+            use alloy_consensus::BlockHeader;
 
-                let boundary_block = provider
-                    .get_block_by_number(boundary_height.get().into())
-                    .hashes()
-                    .await
-                    .wrap_err_with(|| {
-                        format!(
-                            "failed to get block header at height {}",
-                            boundary_height.get()
-                        )
-                    })?
-                    .ok_or_eyre("boundary block not found")?;
+            let boundary_height = current_epoch
+                .previous()
+                .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
+                .unwrap_or_default();
 
-                let extra_data = boundary_block.header.extra_data();
-                if extra_data.is_empty() {
-                    return Err(eyre!(
-                        "boundary block at height {} has no DKG outcome in extra_data",
+            let boundary_block = provider
+                .get_block_by_number(boundary_height.get().into())
+                .hashes()
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to get block header at height {}",
                         boundary_height.get()
-                    ));
-                }
+                    )
+                })?
+                .ok_or_eyre("boundary block not found")?;
 
-                let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
-                    .wrap_err("failed to decode DKG outcome from extra_data")?;
+            let extra_data = boundary_block.header.extra_data();
+            if extra_data.is_empty() {
+                return Err(eyre!(
+                    "boundary block at height {} has no DKG outcome in extra_data",
+                    boundary_height.get()
+                ));
+            }
 
-                let key = PublicKey::decode(&mut &pubkey_bytes[..])
-                    .wrap_err("failed decoding on-chain ed25519 key")?;
+            let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+                .wrap_err("failed to decode DKG outcome from extra_data")?;
 
-                let in_committee = dkg_outcome.players().position(&key).is_some();
+            let key = PublicKey::decode(&mut &pubkey_bytes[..])
+                .wrap_err("failed decoding on-chain ed25519 key")?;
 
-                (
-                    Some(current_epoch.get()),
-                    Some(current_height.get()),
-                    Some(in_committee),
-                    Some(dkg_outcome.next_players().position(&key).is_some()),
-                    Some(in_committee),
-                )
-            };
+            let committee = dkg_outcome.players().position(&key).is_some();
+            is_dkg_dealer = Some(committee);
+            is_dkg_player = Some(dkg_outcome.next_players().position(&key).is_some());
+            in_committee = Some(committee);
+        }
 
         let output = SingleValidatorOutput {
-            current_epoch,
-            current_height,
+            current_epoch: current_epoch.get(),
+            current_height: current_height.get(),
             validator: ValidatorEntry {
                 onchain_address: validator.validatorAddress,
                 public_key: alloy_primitives::hex::encode(pubkey_bytes),

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -4,7 +4,6 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
     str::FromStr,
-    sync::Arc,
 };
 
 use alloy_primitives::{Address, B256, Bytes};
@@ -26,7 +25,7 @@ use reth_cli_runner::CliRunner;
 use reth_ethereum_cli::ExtendedCommand;
 use serde::Serialize;
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
+use tempo_chainspec::spec::TempoChainSpecParser;
 use tempo_commonware_node_config::SigningKey;
 use tempo_contracts::precompiles::{
     IValidatorConfig::{self},
@@ -865,10 +864,6 @@ pub(crate) struct ValidatorInfo {
     #[arg()]
     id: ValidatorId,
 
-    /// Chain to query (mainnet, testnet, moderato, or path to chainspec file)
-    #[arg(long, short, default_value = "mainnet", value_parser = tempo_chainspec::spec::chain_value_parser)]
-    chain: Arc<TempoChainSpec>,
-
     /// RPC URL to query.
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
@@ -889,16 +884,23 @@ struct SingleValidatorOutput {
 
 impl ValidatorInfo {
     async fn run(self) -> eyre::Result<()> {
-        let epoch_length = self
-            .chain
-            .info
-            .epoch_length()
-            .ok_or_eyre("epochLength not found in chainspec")?;
-
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect(&self.rpc_url)
             .await
             .wrap_err("failed to connect to RPC")?;
+
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .wrap_err("failed to get chain id")?;
+
+        let chain = tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
+            .ok_or_else(|| eyre!("unknown chain id {chain_id}"))?;
+
+        let epoch_length = chain
+            .info
+            .epoch_length()
+            .ok_or_eyre("epochLength not found in chainspec")?;
 
         let is_v2_initialized = is_validator_config_v2_activated(&provider).await?;
 
@@ -1103,10 +1105,6 @@ struct ValidatorEntry {
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct ValidatorsInfo {
-    /// Chain to query (mainnet, testnet, moderato, or path to chainspec file)
-    #[arg(long, short, default_value = "mainnet", value_parser = tempo_chainspec::spec::chain_value_parser)]
-    chain: Arc<TempoChainSpec>,
-
     /// RPC URL to query. Defaults to <https://rpc.presto.tempo.xyz>
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
@@ -1121,16 +1119,23 @@ impl ValidatorsInfo {
         use alloy_consensus::BlockHeader;
         use alloy_provider::ProviderBuilder;
 
-        let epoch_length = self
-            .chain
-            .info
-            .epoch_length()
-            .ok_or_eyre("epochLength not found in chainspec")?;
-
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect(&self.rpc_url)
             .await
             .wrap_err("failed to connect to RPC")?;
+
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .wrap_err("failed to get chain id")?;
+
+        let chain = tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
+            .ok_or_else(|| eyre!("unknown chain id {chain_id}"))?;
+
+        let epoch_length = chain
+            .info
+            .epoch_length()
+            .ok_or_eyre("epochLength not found in chainspec")?;
 
         let latest_block_number = provider
             .get_block_number()

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -872,13 +872,19 @@ pub(crate) struct ValidatorInfo {
     /// RPC URL to query.
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
+
+    /// Skip crosschecking the validator with the last DKG round.
+    #[arg(long)]
+    no_dkg_information: bool,
 }
 
 /// Output for the single-validator lookup enriched with DKG role and epoch context.
 #[derive(Debug, Serialize)]
 struct SingleValidatorOutput {
-    current_epoch: u64,
-    current_height: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_epoch: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_height: Option<u64>,
     #[serde(flatten)]
     validator: ValidatorEntry,
 }
@@ -970,6 +976,29 @@ impl ValidatorInfo {
 
         let validator = read_validator_from_contract(&provider, self.id).await?;
 
+        if self.no_dkg_information {
+            let pubkey_bytes = validator.publicKey.0;
+            let output = SingleValidatorOutput {
+                current_epoch: None,
+                current_height: None,
+                validator: ValidatorEntry {
+                    onchain_address: validator.validatorAddress,
+                    public_key: alloy_primitives::hex::encode(pubkey_bytes),
+                    inbound_address: validator.ingress,
+                    outbound_address: validator.egress,
+                    fee_recipient: Some(validator.feeRecipient),
+                    index: Some(validator.index),
+                    active: validator.deactivatedAtHeight == 0,
+                    is_dkg_dealer: None,
+                    is_dkg_player: None,
+                    in_committee: None,
+                },
+            };
+
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            return Ok(());
+        }
+
         let latest_block_number = provider
             .get_block_number()
             .await
@@ -1017,8 +1046,8 @@ impl ValidatorInfo {
         let in_committee = dkg_outcome.players().position(&key).is_some();
 
         let output = SingleValidatorOutput {
-            current_epoch: current_epoch.get(),
-            current_height: current_height.get(),
+            current_epoch: Some(current_epoch.get()),
+            current_height: Some(current_height.get()),
             validator: ValidatorEntry {
                 onchain_address: validator.validatorAddress,
                 public_key: alloy_primitives::hex::encode(pubkey_bytes),
@@ -1027,9 +1056,9 @@ impl ValidatorInfo {
                 fee_recipient: Some(validator.feeRecipient),
                 index: Some(validator.index),
                 active: validator.deactivatedAtHeight == 0,
-                is_dkg_dealer: in_committee,
-                is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
-                in_committee,
+                is_dkg_dealer: Some(in_committee),
+                is_dkg_player: Some(dkg_outcome.next_players().position(&key).is_some()),
+                in_committee: Some(in_committee),
             },
         };
 
@@ -1078,11 +1107,14 @@ struct ValidatorEntry {
     /// Whether the validator is active in the current contract state
     active: bool,
     // Whether the validator is a dealer in the current epoch.
-    is_dkg_dealer: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_dkg_dealer: Option<bool>,
     /// Whether the validator is a player in the current epoch.
-    is_dkg_player: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_dkg_player: Option<bool>,
     /// Whether the validator is in the committee for the given epoch.
-    in_committee: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    in_committee: Option<bool>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1216,9 +1248,9 @@ impl ValidatorsInfo {
                         fee_recipient: None,
                         index: None,
                         active: validator.active,
-                        is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
-                        is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
-                        in_committee,
+                        is_dkg_dealer: Some(dkg_outcome.players().position(&key).is_some()),
+                        is_dkg_player: Some(dkg_outcome.next_players().position(&key).is_some()),
+                        in_committee: Some(in_committee),
                     });
                 }
             }
@@ -1274,9 +1306,9 @@ impl ValidatorsInfo {
                     fee_recipient: None,
                     index: None,
                     active: true,
-                    is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
-                    is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
-                    in_committee,
+                    is_dkg_dealer: Some(dkg_outcome.players().position(&key).is_some()),
+                    is_dkg_player: Some(dkg_outcome.next_players().position(&key).is_some()),
+                    in_committee: Some(in_committee),
                 });
             }
         }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -4,6 +4,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
 };
 
 use alloy_primitives::{Address, B256, Bytes};
@@ -25,7 +26,7 @@ use reth_cli_runner::CliRunner;
 use reth_ethereum_cli::ExtendedCommand;
 use serde::Serialize;
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::spec::TempoChainSpecParser;
+use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use tempo_commonware_node_config::SigningKey;
 use tempo_contracts::precompiles::{
     IValidatorConfig::{self},
@@ -868,6 +869,11 @@ pub(crate) struct ValidatorInfo {
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
 
+    /// Chain spec override for local/unknown chains (mainnet, testnet, moderato, or path to
+    /// chainspec file). Resolved automatically from the RPC chain id when omitted.
+    #[arg(long, short, value_parser = tempo_chainspec::spec::chain_value_parser)]
+    chain: Option<Arc<TempoChainSpec>>,
+
     /// Skip crosschecking the validator with the last DKG round.
     #[arg(long)]
     no_dkg_information: bool,
@@ -894,8 +900,11 @@ impl ValidatorInfo {
             .await
             .wrap_err("failed to get chain id")?;
 
-        let chain = tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
-            .ok_or_else(|| eyre!("unknown chain id {chain_id}"))?;
+        let chain = match self.chain {
+            Some(chain) => chain,
+            None => tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
+                .ok_or_else(|| eyre!("unknown chain id {chain_id}, pass --chain explicitly"))?,
+        };
 
         let epoch_length = chain
             .info
@@ -1109,6 +1118,11 @@ pub(crate) struct ValidatorsInfo {
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
 
+    /// Chain spec override for local/unknown chains (mainnet, testnet, moderato, or path to
+    /// chainspec file). Resolved automatically from the RPC chain id when omitted.
+    #[arg(long, short, value_parser = tempo_chainspec::spec::chain_value_parser)]
+    chain: Option<Arc<TempoChainSpec>>,
+
     /// Whether to include historic validators (deactivated and not in the current committee).
     #[arg(long)]
     with_historic: bool,
@@ -1129,8 +1143,11 @@ impl ValidatorsInfo {
             .await
             .wrap_err("failed to get chain id")?;
 
-        let chain = tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
-            .ok_or_else(|| eyre!("unknown chain id {chain_id}"))?;
+        let chain = match self.chain {
+            Some(chain) => chain,
+            None => tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
+                .ok_or_else(|| eyre!("unknown chain id {chain_id}, pass --chain explicitly"))?,
+        };
 
         let epoch_length = chain
             .info

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -22,6 +22,7 @@ use commonware_cryptography::{
 use commonware_math::algebra::Random as _;
 use commonware_utils::NZU64;
 use eyre::{OptionExt as _, Report, WrapErr as _, eyre};
+use reth_chainspec::EthChainSpec;
 use reth_cli_runner::CliRunner;
 use reth_ethereum_cli::ExtendedCommand;
 use serde::Serialize;
@@ -901,7 +902,15 @@ impl ValidatorInfo {
             .wrap_err("failed to get chain id")?;
 
         let chain = match self.chain {
-            Some(chain) => chain,
+            Some(chain) => {
+                let spec_chain_id = chain.chain().id();
+                if spec_chain_id != chain_id {
+                    eprintln!(
+                        "warning: --chain spec has chain id {spec_chain_id} but RPC returned {chain_id}"
+                    );
+                }
+                chain
+            }
             None => tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
                 .ok_or_else(|| eyre!("unknown chain id {chain_id}, pass --chain explicitly"))?,
         };
@@ -1144,7 +1153,15 @@ impl ValidatorsInfo {
             .wrap_err("failed to get chain id")?;
 
         let chain = match self.chain {
-            Some(chain) => chain,
+            Some(chain) => {
+                let spec_chain_id = chain.chain().id();
+                if spec_chain_id != chain_id {
+                    eprintln!(
+                        "warning: --chain spec has chain id {spec_chain_id} but RPC returned {chain_id}"
+                    );
+                }
+                chain
+            }
             None => tempo_chainspec::spec::chainspec_from_chain_id(chain_id)
                 .ok_or_else(|| eyre!("unknown chain id {chain_id}, pass --chain explicitly"))?,
         };

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -891,8 +891,6 @@ struct SingleValidatorOutput {
 
 impl ValidatorInfo {
     async fn run(self) -> eyre::Result<()> {
-        use alloy_consensus::BlockHeader;
-
         let epoch_length = self
             .chain
             .info
@@ -975,79 +973,71 @@ impl ValidatorInfo {
         }
 
         let validator = read_validator_from_contract(&provider, self.id).await?;
+        let pubkey_bytes = validator.publicKey.0;
 
-        if self.no_dkg_information {
-            let pubkey_bytes = validator.publicKey.0;
-            let output = SingleValidatorOutput {
-                current_epoch: None,
-                current_height: None,
-                validator: ValidatorEntry {
-                    onchain_address: validator.validatorAddress,
-                    public_key: alloy_primitives::hex::encode(pubkey_bytes),
-                    inbound_address: validator.ingress,
-                    outbound_address: validator.egress,
-                    fee_recipient: Some(validator.feeRecipient),
-                    index: Some(validator.index),
-                    active: validator.deactivatedAtHeight == 0,
-                    is_dkg_dealer: None,
-                    is_dkg_player: None,
-                    in_committee: None,
-                },
+        let (current_epoch, current_height, is_dkg_dealer, is_dkg_player, in_committee) =
+            if self.no_dkg_information {
+                (None, None, None, None, None)
+            } else {
+                use alloy_consensus::BlockHeader;
+
+                let latest_block_number = provider
+                    .get_block_number()
+                    .await
+                    .wrap_err("failed to get latest block number")?;
+
+                let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
+                let current_height = Height::new(latest_block_number);
+                let current_epoch_info = epoch_strategy.containing(current_height).ok_or_else(
+                    || eyre!("failed to determine epoch for height {latest_block_number}"),
+                )?;
+
+                let current_epoch = current_epoch_info.epoch();
+                let boundary_height = current_epoch
+                    .previous()
+                    .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
+                    .unwrap_or_default();
+
+                let boundary_block = provider
+                    .get_block_by_number(boundary_height.get().into())
+                    .hashes()
+                    .await
+                    .wrap_err_with(|| {
+                        format!(
+                            "failed to get block header at height {}",
+                            boundary_height.get()
+                        )
+                    })?
+                    .ok_or_eyre("boundary block not found")?;
+
+                let extra_data = boundary_block.header.extra_data();
+                if extra_data.is_empty() {
+                    return Err(eyre!(
+                        "boundary block at height {} has no DKG outcome in extra_data",
+                        boundary_height.get()
+                    ));
+                }
+
+                let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+                    .wrap_err("failed to decode DKG outcome from extra_data")?;
+
+                let key = PublicKey::decode(&mut &pubkey_bytes[..])
+                    .wrap_err("failed decoding on-chain ed25519 key")?;
+
+                let in_committee = dkg_outcome.players().position(&key).is_some();
+
+                (
+                    Some(current_epoch.get()),
+                    Some(current_height.get()),
+                    Some(in_committee),
+                    Some(dkg_outcome.next_players().position(&key).is_some()),
+                    Some(in_committee),
+                )
             };
 
-            println!("{}", serde_json::to_string_pretty(&output)?);
-            return Ok(());
-        }
-
-        let latest_block_number = provider
-            .get_block_number()
-            .await
-            .wrap_err("failed to get latest block number")?;
-
-        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
-        let current_height = Height::new(latest_block_number);
-        let current_epoch_info = epoch_strategy
-            .containing(current_height)
-            .ok_or_else(|| eyre!("failed to determine epoch for height {latest_block_number}"))?;
-
-        let current_epoch = current_epoch_info.epoch();
-        let boundary_height = current_epoch
-            .previous()
-            .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
-            .unwrap_or_default();
-
-        let boundary_block = provider
-            .get_block_by_number(boundary_height.get().into())
-            .hashes()
-            .await
-            .wrap_err_with(|| {
-                format!(
-                    "failed to get block header at height {}",
-                    boundary_height.get()
-                )
-            })?
-            .ok_or_eyre("boundary block not found")?;
-
-        let extra_data = boundary_block.header.extra_data();
-        if extra_data.is_empty() {
-            return Err(eyre!(
-                "boundary block at height {} has no DKG outcome in extra_data",
-                boundary_height.get()
-            ));
-        }
-
-        let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
-            .wrap_err("failed to decode DKG outcome from extra_data")?;
-
-        let pubkey_bytes = validator.publicKey.0;
-        let key = PublicKey::decode(&mut &pubkey_bytes[..])
-            .wrap_err("failed decoding on-chain ed25519 key")?;
-
-        let in_committee = dkg_outcome.players().position(&key).is_some();
-
         let output = SingleValidatorOutput {
-            current_epoch: Some(current_epoch.get()),
-            current_height: Some(current_height.get()),
+            current_epoch,
+            current_height,
             validator: ValidatorEntry {
                 onchain_address: validator.validatorAddress,
                 public_key: alloy_primitives::hex::encode(pubkey_bytes),
@@ -1056,9 +1046,9 @@ impl ValidatorInfo {
                 fee_recipient: Some(validator.feeRecipient),
                 index: Some(validator.index),
                 active: validator.deactivatedAtHeight == 0,
-                is_dkg_dealer: Some(in_committee),
-                is_dkg_player: Some(dkg_outcome.next_players().position(&key).is_some()),
-                in_committee: Some(in_committee),
+                is_dkg_dealer,
+                is_dkg_player,
+                in_committee,
             },
         };
 

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -864,13 +864,43 @@ pub(crate) struct ValidatorInfo {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
+
+    /// Chain to query (presto, testnet, moderato, or path to chainspec file)
+    #[arg(long, short, default_value = "mainnet", value_parser = tempo_chainspec::spec::chain_value_parser)]
+    chain: Arc<TempoChainSpec>,
+
     /// RPC URL to query.
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
 }
 
+/// Output for the single-validator lookup enriched with DKG role info.
+#[derive(Debug, Serialize)]
+struct SingleValidatorOutput {
+    onchain_address: Address,
+    public_key: String,
+    inbound_address: String,
+    outbound_address: String,
+    fee_recipient: Address,
+    index: u64,
+    active: bool,
+    current_epoch: u64,
+    current_height: u64,
+    is_dkg_dealer: bool,
+    is_dkg_player: bool,
+    in_committee: bool,
+}
+
 impl ValidatorInfo {
     async fn run(self) -> eyre::Result<()> {
+        use alloy_consensus::BlockHeader;
+
+        let epoch_length = self
+            .chain
+            .info
+            .epoch_length()
+            .ok_or_eyre("epochLength not found in chainspec")?;
+
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect(&self.rpc_url)
             .await
@@ -947,7 +977,67 @@ impl ValidatorInfo {
         }
 
         let validator = read_validator_from_contract(&provider, self.id).await?;
-        println!("{}", serde_json::to_string_pretty(&validator)?);
+
+        let latest_block_number = provider
+            .get_block_number()
+            .await
+            .wrap_err("failed to get latest block number")?;
+
+        let epoch_strategy = FixedEpocher::new(NZU64!(epoch_length));
+        let current_height = Height::new(latest_block_number);
+        let current_epoch_info = epoch_strategy
+            .containing(current_height)
+            .ok_or_else(|| eyre!("failed to determine epoch for height {latest_block_number}"))?;
+
+        let current_epoch = current_epoch_info.epoch();
+        let boundary_height = current_epoch
+            .previous()
+            .map(|epoch| epoch_strategy.last(epoch).expect("valid epoch"))
+            .unwrap_or_default();
+
+        let boundary_block = provider
+            .get_block_by_number(boundary_height.get().into())
+            .hashes()
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to get block header at height {}",
+                    boundary_height.get()
+                )
+            })?
+            .ok_or_eyre("boundary block not found")?;
+
+        let extra_data = boundary_block.header.extra_data();
+        if extra_data.is_empty() {
+            return Err(eyre!(
+                "boundary block at height {} has no DKG outcome in extra_data",
+                boundary_height.get()
+            ));
+        }
+
+        let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+            .wrap_err("failed to decode DKG outcome from extra_data")?;
+
+        let pubkey_bytes = validator.publicKey.0;
+        let key = PublicKey::decode(&mut &pubkey_bytes[..])
+            .wrap_err("failed decoding on-chain ed25519 key")?;
+
+        let output = SingleValidatorOutput {
+            onchain_address: validator.validatorAddress,
+            public_key: alloy_primitives::hex::encode(pubkey_bytes),
+            inbound_address: validator.ingress,
+            outbound_address: validator.egress,
+            fee_recipient: validator.feeRecipient,
+            index: validator.index,
+            active: validator.deactivatedAtHeight == 0,
+            current_epoch: current_epoch.get(),
+            current_height: current_height.get(),
+            is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
+            is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
+            in_committee: dkg_outcome.players().position(&key).is_some(),
+        };
+
+        println!("{}", serde_json::to_string_pretty(&output)?);
 
         Ok(())
     }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -874,21 +874,13 @@ pub(crate) struct ValidatorInfo {
     rpc_url: String,
 }
 
-/// Output for the single-validator lookup enriched with DKG role info.
+/// Output for the single-validator lookup enriched with DKG role and epoch context.
 #[derive(Debug, Serialize)]
 struct SingleValidatorOutput {
-    onchain_address: Address,
-    public_key: String,
-    inbound_address: String,
-    outbound_address: String,
-    fee_recipient: Address,
-    index: u64,
-    active: bool,
     current_epoch: u64,
     current_height: u64,
-    is_dkg_dealer: bool,
-    is_dkg_player: bool,
-    in_committee: bool,
+    #[serde(flatten)]
+    validator: ValidatorEntry,
 }
 
 impl ValidatorInfo {
@@ -1022,19 +1014,23 @@ impl ValidatorInfo {
         let key = PublicKey::decode(&mut &pubkey_bytes[..])
             .wrap_err("failed decoding on-chain ed25519 key")?;
 
+        let in_committee = dkg_outcome.players().position(&key).is_some();
+
         let output = SingleValidatorOutput {
-            onchain_address: validator.validatorAddress,
-            public_key: alloy_primitives::hex::encode(pubkey_bytes),
-            inbound_address: validator.ingress,
-            outbound_address: validator.egress,
-            fee_recipient: validator.feeRecipient,
-            index: validator.index,
-            active: validator.deactivatedAtHeight == 0,
             current_epoch: current_epoch.get(),
             current_height: current_height.get(),
-            is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
-            is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
-            in_committee: dkg_outcome.players().position(&key).is_some(),
+            validator: ValidatorEntry {
+                onchain_address: validator.validatorAddress,
+                public_key: alloy_primitives::hex::encode(pubkey_bytes),
+                inbound_address: validator.ingress,
+                outbound_address: validator.egress,
+                fee_recipient: Some(validator.feeRecipient),
+                index: Some(validator.index),
+                active: validator.deactivatedAtHeight == 0,
+                is_dkg_dealer: in_committee,
+                is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
+                in_committee,
+            },
         };
 
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -1073,9 +1069,15 @@ struct ValidatorEntry {
     inbound_address: String,
     /// Outbound IP address
     outbound_address: String,
+    /// Fee recipient address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fee_recipient: Option<Address>,
+    /// Validator index
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u64>,
     /// Whether the validator is active in the current contract state
     active: bool,
-    // Whether the validator is a dealer in th ecurrent epoch.
+    // Whether the validator is a dealer in the current epoch.
     is_dkg_dealer: bool,
     /// Whether the validator is a player in the current epoch.
     is_dkg_player: bool,
@@ -1211,6 +1213,8 @@ impl ValidatorsInfo {
                         public_key: alloy_primitives::hex::encode(pubkey_bytes),
                         inbound_address: validator.inboundAddress,
                         outbound_address: validator.outboundAddress,
+                        fee_recipient: None,
+                        index: None,
                         active: validator.active,
                         is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
                         is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),
@@ -1267,6 +1271,8 @@ impl ValidatorsInfo {
                     public_key: alloy_primitives::hex::encode(pubkey_bytes),
                     inbound_address: validator.ingress,
                     outbound_address: validator.egress,
+                    fee_recipient: None,
+                    index: None,
                     active: true,
                     is_dkg_dealer: dkg_outcome.players().position(&key).is_some(),
                     is_dkg_player: dkg_outcome.next_players().position(&key).is_some(),

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -574,15 +574,16 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::expect_fun_call)]
     fn chainspec_from_chain_id_roundtrips_supported_chains() {
         use reth_chainspec::EthChainSpec;
 
         for &name in super::SUPPORTED_CHAINS {
             let spec = super::chain_value_parser(name)
-                .unwrap_or_else(|e| panic!("chain_value_parser({name}) failed: {e}"));
+                .expect(&format!("failed to parse chain `{name}`"));
 
             let resolved = super::chainspec_from_chain_id(spec.chain().id())
-                .unwrap_or_else(|| panic!("chainspec_from_chain_id failed for {name}"));
+                .expect(&format!("failed to parse chain `{name}`"));
 
             assert_eq!(spec.chain(), resolved.chain(), "chain mismatch for {name}");
         }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -572,4 +572,23 @@ mod tests {
             assert_eq!(cs.inner.chain(), moderato.inner.chain());
         }
     }
+
+    #[test]
+    fn chainspec_from_chain_id_roundtrips_supported_chains() {
+        use reth_chainspec::EthChainSpec;
+
+        for &name in super::SUPPORTED_CHAINS {
+            let spec = super::chain_value_parser(name)
+                .unwrap_or_else(|e| panic!("chain_value_parser({name}) failed: {e}"));
+
+            let resolved = super::chainspec_from_chain_id(spec.chain().id())
+                .unwrap_or_else(|| panic!("chainspec_from_chain_id failed for {name}"));
+
+            assert_eq!(
+                spec.chain(),
+                resolved.chain(),
+                "chain mismatch for {name}"
+            );
+        }
+    }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -579,8 +579,8 @@ mod tests {
         use reth_chainspec::EthChainSpec;
 
         for &name in super::SUPPORTED_CHAINS {
-            let spec = super::chain_value_parser(name)
-                .expect(&format!("failed to parse chain `{name}`"));
+            let spec =
+                super::chain_value_parser(name).expect(&format!("failed to parse chain `{name}`"));
 
             let resolved = super::chainspec_from_chain_id(spec.chain().id())
                 .expect(&format!("failed to parse chain `{name}`"));

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -164,6 +164,17 @@ impl reth_cli::chainspec::ChainSpecParser for TempoChainSpecParser {
     }
 }
 
+/// Resolve a [`TempoChainSpec`] from a chain id.
+///
+/// Returns `None` for unknown chain ids.
+pub fn chainspec_from_chain_id(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
+    match chain_id {
+        4217 => Some(PRESTO.clone()),
+        42431 => Some(MODERATO.clone()),
+        _ => None,
+    }
+}
+
 pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
     let genesis: Genesis = serde_json::from_str(include_str!("./genesis/moderato.json"))
         .expect("`./genesis/moderato.json` must be present and deserializable");

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -584,11 +584,7 @@ mod tests {
             let resolved = super::chainspec_from_chain_id(spec.chain().id())
                 .unwrap_or_else(|| panic!("chainspec_from_chain_id failed for {name}"));
 
-            assert_eq!(
-                spec.chain(),
-                resolved.chain(),
-                "chain mismatch for {name}"
-            );
+            assert_eq!(spec.chain(), resolved.chain(), "chain mismatch for {name}");
         }
     }
 }


### PR DESCRIPTION
The `tempo consensus validator` command now includes `is_dkg_dealer`, `is_dkg_player`, and `in_committee` fields — same role info as `validators-info` but for a single node lookup. Adds `--chain` flag for epoch length resolution.

Prompted by: Janis