### PR TITLE
chore(precompiles): migrate manual hardfork gates to SelectorHardforkRule arrays

### DIFF
--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -37,10 +37,9 @@ impl Precompile for AccountKeychain {
             calldata,
             &[(
                 TempoHardfork::T3,
-                SelectorHardforkDiff {
-                    added: T3_ADDED_SELECTORS,
-                    removed: T3_REMOVED_SELECTORS,
-                },
+                SelectorHardforkDiff::new()
+                    .added(T3_ADDED_SELECTORS)
+                    .removed(T3_REMOVED_SELECTORS),
             )],
             IAccountKeychainCalls::abi_decode,
             |call| match call {

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -337,7 +337,24 @@ pub(crate) struct SelectorHardforkDiff<'a> {
 /// One hardfork boundary rule for selector gating.
 pub(crate) type SelectorHardforkRule<'a> = (TempoHardfork, SelectorHardforkDiff<'a>);
 
-impl SelectorHardforkDiff<'_> {
+impl<'a> SelectorHardforkDiff<'a> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            added: &[],
+            removed: &[],
+        }
+    }
+
+    pub(crate) const fn added(mut self, selectors: &'a [[u8; 4]]) -> Self {
+        self.added = selectors;
+        self
+    }
+
+    pub(crate) const fn removed(mut self, selectors: &'a [[u8; 4]]) -> Self {
+        self.removed = selectors;
+        self
+    }
+
     #[inline]
     fn rejects(self, selector: [u8; 4], active: bool) -> bool {
         let gated = if active { self.removed } else { self.added };
@@ -631,17 +648,11 @@ mod tests {
         const SELECTOR_GATED_TEST_RULES: &[SelectorHardforkRule<'static>] = &[
             (
                 TempoHardfork::T2,
-                SelectorHardforkDiff {
-                    added: &[ISelectorGatedTest::t2AddedCall::SELECTOR],
-                    removed: &[],
-                },
+                SelectorHardforkDiff::new().added(&[ISelectorGatedTest::t2AddedCall::SELECTOR]),
             ),
             (
                 TempoHardfork::T3,
-                SelectorHardforkDiff {
-                    added: &[],
-                    removed: &[ISelectorGatedTest::t3RemovedCall::SELECTOR],
-                },
+                SelectorHardforkDiff::new().removed(&[ISelectorGatedTest::t3RemovedCall::SELECTOR]),
             ),
         ];
 

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -58,10 +58,7 @@ impl Precompile for TIP20Token {
             calldata,
             &[(
                 TempoHardfork::T2,
-                SelectorHardforkDiff {
-                    added: T2_ADDED_SELECTORS,
-                    removed: &[],
-                },
+                SelectorHardforkDiff::new().added(T2_ADDED_SELECTORS),
             )],
             TIP20Call::decode,
             |call| match call {

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -1,19 +1,26 @@
 //! ABI dispatch for the [`TIP20Token`] precompile.
 
 use crate::{
-    Precompile, dispatch_call,
+    Precompile, SelectorHardforkDiff, dispatch_call,
     error::TempoPrecompileError,
     input_cost, metadata, mutate, mutate_void,
     storage::ContractStorage,
     tip20::{ITIP20, TIP20Token},
-    unknown_selector, view,
+    view,
 };
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{IRolesAuth::IRolesAuthCalls, ITIP20::ITIP20Calls, TIP20Error};
+
+const T2_ADDED_SELECTORS: &[[u8; 4]] = &[
+    ITIP20::permitCall::SELECTOR,
+    ITIP20::noncesCall::SELECTOR,
+    ITIP20::DOMAIN_SEPARATORCall::SELECTOR,
+];
 
 /// Decoded call variant — either a TIP-20 token call or a role-management call.
 enum TIP20Call {
@@ -47,170 +54,173 @@ impl Precompile for TIP20Token {
                 .into_precompile_result(self.storage.gas_used());
         }
 
-        dispatch_call(calldata, &[], TIP20Call::decode, |call| match call {
-            // Metadata functions (no calldata decoding needed)
-            TIP20Call::TIP20(ITIP20Calls::name(_)) => metadata::<ITIP20::nameCall>(|| self.name()),
-            TIP20Call::TIP20(ITIP20Calls::symbol(_)) => {
-                metadata::<ITIP20::symbolCall>(|| self.symbol())
-            }
-            TIP20Call::TIP20(ITIP20Calls::decimals(_)) => {
-                metadata::<ITIP20::decimalsCall>(|| self.decimals())
-            }
-            TIP20Call::TIP20(ITIP20Calls::currency(_)) => {
-                metadata::<ITIP20::currencyCall>(|| self.currency())
-            }
-            TIP20Call::TIP20(ITIP20Calls::totalSupply(_)) => {
-                metadata::<ITIP20::totalSupplyCall>(|| self.total_supply())
-            }
-            TIP20Call::TIP20(ITIP20Calls::supplyCap(_)) => {
-                metadata::<ITIP20::supplyCapCall>(|| self.supply_cap())
-            }
-            TIP20Call::TIP20(ITIP20Calls::transferPolicyId(_)) => {
-                metadata::<ITIP20::transferPolicyIdCall>(|| self.transfer_policy_id())
-            }
-            TIP20Call::TIP20(ITIP20Calls::paused(_)) => {
-                metadata::<ITIP20::pausedCall>(|| self.paused())
-            }
-
-            // View functions
-            TIP20Call::TIP20(ITIP20Calls::balanceOf(call)) => view(call, |c| self.balance_of(c)),
-            TIP20Call::TIP20(ITIP20Calls::allowance(call)) => view(call, |c| self.allowance(c)),
-            TIP20Call::TIP20(ITIP20Calls::quoteToken(call)) => view(call, |_| self.quote_token()),
-            TIP20Call::TIP20(ITIP20Calls::nextQuoteToken(call)) => {
-                view(call, |_| self.next_quote_token())
-            }
-            TIP20Call::TIP20(ITIP20Calls::PAUSE_ROLE(call)) => {
-                view(call, |_| Ok(Self::pause_role()))
-            }
-            TIP20Call::TIP20(ITIP20Calls::UNPAUSE_ROLE(call)) => {
-                view(call, |_| Ok(Self::unpause_role()))
-            }
-            TIP20Call::TIP20(ITIP20Calls::ISSUER_ROLE(call)) => {
-                view(call, |_| Ok(Self::issuer_role()))
-            }
-            TIP20Call::TIP20(ITIP20Calls::BURN_BLOCKED_ROLE(call)) => {
-                view(call, |_| Ok(Self::burn_blocked_role()))
-            }
-
-            // State changing functions
-            TIP20Call::TIP20(ITIP20Calls::transferFrom(call)) => {
-                mutate(call, msg_sender, |s, c| self.transfer_from(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::transfer(call)) => {
-                mutate(call, msg_sender, |s, c| self.transfer(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::approve(call)) => {
-                mutate(call, msg_sender, |s, c| self.approve(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::changeTransferPolicyId(call)) => {
-                mutate_void(call, msg_sender, |s, c| {
-                    self.change_transfer_policy_id(s, c)
-                })
-            }
-            TIP20Call::TIP20(ITIP20Calls::setSupplyCap(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.set_supply_cap(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::pause(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.pause(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::unpause(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.unpause(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::setNextQuoteToken(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.set_next_quote_token(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::completeQuoteTokenUpdate(call)) => {
-                mutate_void(call, msg_sender, |s, c| {
-                    self.complete_quote_token_update(s, c)
-                })
-            }
-            TIP20Call::TIP20(ITIP20Calls::mint(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.mint(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::mintWithMemo(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.mint_with_memo(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::burn(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.burn(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::burnWithMemo(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.burn_with_memo(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::burnBlocked(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.burn_blocked(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::transferWithMemo(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.transfer_with_memo(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::transferFromWithMemo(call)) => {
-                mutate(call, msg_sender, |sender, c| {
-                    self.transfer_from_with_memo(sender, c)
-                })
-            }
-            TIP20Call::TIP20(ITIP20Calls::distributeReward(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.distribute_reward(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::setRewardRecipient(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.set_reward_recipient(s, c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::claimRewards(call)) => {
-                mutate(call, msg_sender, |_, _| self.claim_rewards(msg_sender))
-            }
-            TIP20Call::TIP20(ITIP20Calls::globalRewardPerToken(call)) => {
-                view(call, |_| self.get_global_reward_per_token())
-            }
-            TIP20Call::TIP20(ITIP20Calls::optedInSupply(call)) => {
-                view(call, |_| self.get_opted_in_supply())
-            }
-            TIP20Call::TIP20(ITIP20Calls::userRewardInfo(call)) => view(call, |c| {
-                self.get_user_reward_info(c.account).map(|info| info.into())
-            }),
-            TIP20Call::TIP20(ITIP20Calls::getPendingRewards(call)) => {
-                view(call, |c| self.get_pending_rewards(c.account))
-            }
-
-            TIP20Call::TIP20(ITIP20Calls::permit(call)) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(ITIP20::permitCall::SELECTOR, self.storage.gas_used());
+        dispatch_call(
+            calldata,
+            &[(
+                TempoHardfork::T2,
+                SelectorHardforkDiff {
+                    added: T2_ADDED_SELECTORS,
+                    removed: &[],
+                },
+            )],
+            TIP20Call::decode,
+            |call| match call {
+                // Metadata functions (no calldata decoding needed)
+                TIP20Call::TIP20(ITIP20Calls::name(_)) => {
+                    metadata::<ITIP20::nameCall>(|| self.name())
                 }
-                mutate_void(call, msg_sender, |_s, c| self.permit(c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::nonces(call)) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(ITIP20::noncesCall::SELECTOR, self.storage.gas_used());
+                TIP20Call::TIP20(ITIP20Calls::symbol(_)) => {
+                    metadata::<ITIP20::symbolCall>(|| self.symbol())
                 }
-                view(call, |c| self.nonces(c))
-            }
-            TIP20Call::TIP20(ITIP20Calls::DOMAIN_SEPARATOR(call)) => {
-                if !self.storage.spec().is_t2() {
-                    return unknown_selector(
-                        ITIP20::DOMAIN_SEPARATORCall::SELECTOR,
-                        self.storage.gas_used(),
-                    );
+                TIP20Call::TIP20(ITIP20Calls::decimals(_)) => {
+                    metadata::<ITIP20::decimalsCall>(|| self.decimals())
                 }
-                view(call, |_| self.domain_separator())
-            }
+                TIP20Call::TIP20(ITIP20Calls::currency(_)) => {
+                    metadata::<ITIP20::currencyCall>(|| self.currency())
+                }
+                TIP20Call::TIP20(ITIP20Calls::totalSupply(_)) => {
+                    metadata::<ITIP20::totalSupplyCall>(|| self.total_supply())
+                }
+                TIP20Call::TIP20(ITIP20Calls::supplyCap(_)) => {
+                    metadata::<ITIP20::supplyCapCall>(|| self.supply_cap())
+                }
+                TIP20Call::TIP20(ITIP20Calls::transferPolicyId(_)) => {
+                    metadata::<ITIP20::transferPolicyIdCall>(|| self.transfer_policy_id())
+                }
+                TIP20Call::TIP20(ITIP20Calls::paused(_)) => {
+                    metadata::<ITIP20::pausedCall>(|| self.paused())
+                }
 
-            // RolesAuth functions
-            TIP20Call::RolesAuth(IRolesAuthCalls::hasRole(call)) => {
-                view(call, |c| self.has_role(c))
-            }
-            TIP20Call::RolesAuth(IRolesAuthCalls::getRoleAdmin(call)) => {
-                view(call, |c| self.get_role_admin(c))
-            }
-            TIP20Call::RolesAuth(IRolesAuthCalls::grantRole(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.grant_role(s, c))
-            }
-            TIP20Call::RolesAuth(IRolesAuthCalls::revokeRole(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.revoke_role(s, c))
-            }
-            TIP20Call::RolesAuth(IRolesAuthCalls::renounceRole(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.renounce_role(s, c))
-            }
-            TIP20Call::RolesAuth(IRolesAuthCalls::setRoleAdmin(call)) => {
-                mutate_void(call, msg_sender, |s, c| self.set_role_admin(s, c))
-            }
-        })
+                // View functions
+                TIP20Call::TIP20(ITIP20Calls::balanceOf(call)) => {
+                    view(call, |c| self.balance_of(c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::allowance(call)) => view(call, |c| self.allowance(c)),
+                TIP20Call::TIP20(ITIP20Calls::quoteToken(call)) => {
+                    view(call, |_| self.quote_token())
+                }
+                TIP20Call::TIP20(ITIP20Calls::nextQuoteToken(call)) => {
+                    view(call, |_| self.next_quote_token())
+                }
+                TIP20Call::TIP20(ITIP20Calls::PAUSE_ROLE(call)) => {
+                    view(call, |_| Ok(Self::pause_role()))
+                }
+                TIP20Call::TIP20(ITIP20Calls::UNPAUSE_ROLE(call)) => {
+                    view(call, |_| Ok(Self::unpause_role()))
+                }
+                TIP20Call::TIP20(ITIP20Calls::ISSUER_ROLE(call)) => {
+                    view(call, |_| Ok(Self::issuer_role()))
+                }
+                TIP20Call::TIP20(ITIP20Calls::BURN_BLOCKED_ROLE(call)) => {
+                    view(call, |_| Ok(Self::burn_blocked_role()))
+                }
+
+                // State changing functions
+                TIP20Call::TIP20(ITIP20Calls::transferFrom(call)) => {
+                    mutate(call, msg_sender, |s, c| self.transfer_from(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::transfer(call)) => {
+                    mutate(call, msg_sender, |s, c| self.transfer(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::approve(call)) => {
+                    mutate(call, msg_sender, |s, c| self.approve(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::changeTransferPolicyId(call)) => {
+                    mutate_void(call, msg_sender, |s, c| {
+                        self.change_transfer_policy_id(s, c)
+                    })
+                }
+                TIP20Call::TIP20(ITIP20Calls::setSupplyCap(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_supply_cap(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::pause(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.pause(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::unpause(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.unpause(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::setNextQuoteToken(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_next_quote_token(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::completeQuoteTokenUpdate(call)) => {
+                    mutate_void(call, msg_sender, |s, c| {
+                        self.complete_quote_token_update(s, c)
+                    })
+                }
+                TIP20Call::TIP20(ITIP20Calls::mint(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.mint(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::mintWithMemo(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.mint_with_memo(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::burn(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.burn(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::burnWithMemo(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.burn_with_memo(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::burnBlocked(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.burn_blocked(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::transferWithMemo(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.transfer_with_memo(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::transferFromWithMemo(call)) => {
+                    mutate(call, msg_sender, |sender, c| {
+                        self.transfer_from_with_memo(sender, c)
+                    })
+                }
+                TIP20Call::TIP20(ITIP20Calls::distributeReward(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.distribute_reward(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::setRewardRecipient(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_reward_recipient(s, c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::claimRewards(call)) => {
+                    mutate(call, msg_sender, |_, _| self.claim_rewards(msg_sender))
+                }
+                TIP20Call::TIP20(ITIP20Calls::globalRewardPerToken(call)) => {
+                    view(call, |_| self.get_global_reward_per_token())
+                }
+                TIP20Call::TIP20(ITIP20Calls::optedInSupply(call)) => {
+                    view(call, |_| self.get_opted_in_supply())
+                }
+                TIP20Call::TIP20(ITIP20Calls::userRewardInfo(call)) => view(call, |c| {
+                    self.get_user_reward_info(c.account).map(|info| info.into())
+                }),
+                TIP20Call::TIP20(ITIP20Calls::getPendingRewards(call)) => {
+                    view(call, |c| self.get_pending_rewards(c.account))
+                }
+
+                TIP20Call::TIP20(ITIP20Calls::permit(call)) => {
+                    mutate_void(call, msg_sender, |_s, c| self.permit(c))
+                }
+                TIP20Call::TIP20(ITIP20Calls::nonces(call)) => view(call, |c| self.nonces(c)),
+                TIP20Call::TIP20(ITIP20Calls::DOMAIN_SEPARATOR(call)) => {
+                    view(call, |_| self.domain_separator())
+                }
+
+                // RolesAuth functions
+                TIP20Call::RolesAuth(IRolesAuthCalls::hasRole(call)) => {
+                    view(call, |c| self.has_role(c))
+                }
+                TIP20Call::RolesAuth(IRolesAuthCalls::getRoleAdmin(call)) => {
+                    view(call, |c| self.get_role_admin(c))
+                }
+                TIP20Call::RolesAuth(IRolesAuthCalls::grantRole(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.grant_role(s, c))
+                }
+                TIP20Call::RolesAuth(IRolesAuthCalls::revokeRole(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.revoke_role(s, c))
+                }
+                TIP20Call::RolesAuth(IRolesAuthCalls::renounceRole(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.renounce_role(s, c))
+                }
+                TIP20Call::RolesAuth(IRolesAuthCalls::setRoleAdmin(call)) => {
+                    mutate_void(call, msg_sender, |s, c| self.set_role_admin(s, c))
+                }
+            },
+        )
     }
 }
 

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -34,10 +34,7 @@ impl Precompile for TIP403Registry {
             calldata,
             &[(
                 TempoHardfork::T2,
-                SelectorHardforkDiff {
-                    added: T2_ADDED_SELECTORS,
-                    removed: &[],
-                },
+                SelectorHardforkDiff::new().added(T2_ADDED_SELECTORS),
             )],
             ITIP403RegistryCalls::abi_decode,
             |call| match call {

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -1,19 +1,28 @@
 //! ABI dispatch for the [`TIP403Registry`] precompile.
 
 use crate::{
-    Precompile, dispatch_call, input_cost, mutate, mutate_void,
+    Precompile, SelectorHardforkDiff, dispatch_call, input_cost, mutate, mutate_void,
     tip403_registry::{AuthRole, TIP403Registry},
-    unknown_selector, view,
+    view,
 };
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::ITIP403Registry::{
     ITIP403RegistryCalls, compoundPolicyDataCall, createCompoundPolicyCall,
     isAuthorizedMintRecipientCall, isAuthorizedRecipientCall, isAuthorizedSenderCall,
 };
+
+const T2_ADDED_SELECTORS: &[[u8; 4]] = &[
+    isAuthorizedSenderCall::SELECTOR,
+    isAuthorizedRecipientCall::SELECTOR,
+    isAuthorizedMintRecipientCall::SELECTOR,
+    compoundPolicyDataCall::SELECTOR,
+    createCompoundPolicyCall::SELECTOR,
+];
 
 impl Precompile for TIP403Registry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -23,7 +32,13 @@ impl Precompile for TIP403Registry {
 
         dispatch_call(
             calldata,
-            &[],
+            &[(
+                TempoHardfork::T2,
+                SelectorHardforkDiff {
+                    added: T2_ADDED_SELECTORS,
+                    removed: &[],
+                },
+            )],
             ITIP403RegistryCalls::abi_decode,
             |call| match call {
                 ITIP403RegistryCalls::policyIdCounter(call) => {
@@ -34,47 +49,17 @@ impl Precompile for TIP403Registry {
                 ITIP403RegistryCalls::isAuthorized(call) => view(call, |c| {
                     self.is_authorized_as(c.policyId, c.user, AuthRole::Transfer)
                 }),
-                // TIP-1015: T2+ only
-                ITIP403RegistryCalls::isAuthorizedSender(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedSenderCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
-                    })
-                }
-                ITIP403RegistryCalls::isAuthorizedRecipient(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedRecipientCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
-                    })
-                }
-                ITIP403RegistryCalls::isAuthorizedMintRecipient(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            isAuthorizedMintRecipientCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
-                    view(call, |c| {
-                        self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
-                    })
-                }
+                // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
+                ITIP403RegistryCalls::isAuthorizedSender(call) => view(call, |c| {
+                    self.is_authorized_as(c.policyId, c.user, AuthRole::Sender)
+                }),
+                ITIP403RegistryCalls::isAuthorizedRecipient(call) => view(call, |c| {
+                    self.is_authorized_as(c.policyId, c.user, AuthRole::Recipient)
+                }),
+                ITIP403RegistryCalls::isAuthorizedMintRecipient(call) => view(call, |c| {
+                    self.is_authorized_as(c.policyId, c.user, AuthRole::MintRecipient)
+                }),
                 ITIP403RegistryCalls::compoundPolicyData(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            compoundPolicyDataCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
                     view(call, |c| self.compound_policy_data(c))
                 }
                 ITIP403RegistryCalls::createPolicy(call) => {
@@ -94,14 +79,8 @@ impl Precompile for TIP403Registry {
                 ITIP403RegistryCalls::modifyPolicyBlacklist(call) => {
                     mutate_void(call, msg_sender, |s, c| self.modify_policy_blacklist(s, c))
                 }
-                // TIP-1015: T2+ only
+                // TIP-1015: T2+ only (gated via T2_ADDED_SELECTORS)
                 ITIP403RegistryCalls::createCompoundPolicy(call) => {
-                    if !self.storage.spec().is_t2() {
-                        return unknown_selector(
-                            createCompoundPolicyCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
                     mutate(call, msg_sender, |s, c| self.create_compound_policy(s, c))
                 }
             },

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -27,10 +27,7 @@ impl Precompile for ValidatorConfig {
             calldata,
             &[(
                 TempoHardfork::T1,
-                SelectorHardforkDiff {
-                    added: T1_ADDED_SELECTORS,
-                    removed: &[],
-                },
+                SelectorHardforkDiff::new().added(T1_ADDED_SELECTORS),
             )],
             IValidatorConfigCalls::abi_decode,
             |call| match call {

--- a/crates/precompiles/src/validator_config/dispatch.rs
+++ b/crates/precompiles/src/validator_config/dispatch.rs
@@ -2,17 +2,20 @@
 
 use super::ValidatorConfig;
 use crate::{
-    Precompile, dispatch_call, error::TempoPrecompileError, input_cost, mutate_void,
-    unknown_selector, view,
+    Precompile, SelectorHardforkDiff, dispatch_call, error::TempoPrecompileError, input_cost,
+    mutate_void, view,
 };
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
 };
 use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IValidatorConfig::{
     IValidatorConfigCalls, changeValidatorStatusByIndexCall,
 };
+
+const T1_ADDED_SELECTORS: &[[u8; 4]] = &[changeValidatorStatusByIndexCall::SELECTOR];
 
 impl Precompile for ValidatorConfig {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -22,7 +25,13 @@ impl Precompile for ValidatorConfig {
 
         dispatch_call(
             calldata,
-            &[],
+            &[(
+                TempoHardfork::T1,
+                SelectorHardforkDiff {
+                    added: T1_ADDED_SELECTORS,
+                    removed: &[],
+                },
+            )],
             IValidatorConfigCalls::abi_decode,
             |call| match call {
                 // View functions
@@ -54,13 +63,6 @@ impl Precompile for ValidatorConfig {
                     mutate_void(call, msg_sender, |s, c| self.change_validator_status(s, c))
                 }
                 IValidatorConfigCalls::changeValidatorStatusByIndex(call) => {
-                    // T1+: changeValidatorStatusByIndex is only available in T1+
-                    if !self.storage.spec().is_t1() {
-                        return unknown_selector(
-                            changeValidatorStatusByIndexCall::SELECTOR,
-                            self.storage.gas_used(),
-                        );
-                    }
                     mutate_void(call, msg_sender, |s, c| {
                         self.change_validator_status_by_index(s, c)
                     })
@@ -228,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_selector_coverage() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1);
         StorageCtx::enter(&mut storage, || {
             let mut validator_config = ValidatorConfig::new();
 


### PR DESCRIPTION
Ref: #3531

Migrates the remaining inline `is_t1()`/`is_t2()` selector checks into static
`SelectorHardforkRule` arrays so `dispatch_call` rejects gated selectors before
ABI decode. Fixes the invariant where selector-only calldata for a gated function
would hit decode first and return an empty revert instead of `UnknownFunctionSelector`.

- **TIP20**: `permit`, `nonces`, `DOMAIN_SEPARATOR` → T2 added
- **TIP403Registry**: `isAuthorizedSender`, `isAuthorizedRecipient`, `isAuthorizedMintRecipient`, `compoundPolicyData`, `createCompoundPolicy` → T2 added
- **ValidatorConfig**: `changeValidatorStatusByIndex` → T1 added

Prompted by: rusowsky