### PR TITLE
fix(account-keychain): propagate refund system errors

### DIFF
--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1300,14 +1300,11 @@ mod tests {
     use super::*;
     use crate::{
         error::TempoPrecompileError,
-        storage::{PrecompileStorageProvider, StorageCtx, hashmap::HashMapStorageProvider},
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{Address, B256, LogData, TxKind, U256};
-    use revm::{
-        context::journaled_state::JournalCheckpoint,
-        state::{AccountInfo, Bytecode},
-    };
+    use alloy::primitives::{Address, B256, TxKind, U256};
+    use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};
 
@@ -1333,117 +1330,6 @@ mod tests {
                 );
             }
             _ => panic!("Expected AccountKeychainError, got: {error:?}"),
-        }
-    }
-
-    struct FailingSloadStorageProvider {
-        inner: HashMapStorageProvider,
-        fail_on_sload: Option<(Address, U256)>,
-    }
-
-    impl FailingSloadStorageProvider {
-        fn new(chain_id: u64) -> Self {
-            Self {
-                inner: HashMapStorageProvider::new(chain_id),
-                fail_on_sload: None,
-            }
-        }
-
-        fn fail_next_sload_at(&mut self, address: Address, slot: U256) {
-            self.fail_on_sload = Some((address, slot));
-        }
-    }
-
-    impl PrecompileStorageProvider for FailingSloadStorageProvider {
-        fn chain_id(&self) -> u64 {
-            self.inner.chain_id()
-        }
-
-        fn timestamp(&self) -> U256 {
-            self.inner.timestamp()
-        }
-
-        fn beneficiary(&self) -> Address {
-            self.inner.beneficiary()
-        }
-
-        fn block_number(&self) -> u64 {
-            self.inner.block_number()
-        }
-
-        fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()> {
-            self.inner.set_code(address, code)
-        }
-
-        fn with_account_info(
-            &mut self,
-            address: Address,
-            f: &mut dyn FnMut(&AccountInfo),
-        ) -> Result<()> {
-            self.inner.with_account_info(address, f)
-        }
-
-        fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
-            if self.fail_on_sload == Some((address, key)) {
-                return Err(TempoPrecompileError::Fatal("injected sload failure".into()));
-            }
-            self.inner.sload(address, key)
-        }
-
-        fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
-            self.inner.tload(address, key)
-        }
-
-        fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
-            self.inner.sstore(address, key, value)
-        }
-
-        fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
-            self.inner.tstore(address, key, value)
-        }
-
-        fn emit_event(&mut self, address: Address, event: LogData) -> Result<()> {
-            self.inner.emit_event(address, event)
-        }
-
-        fn deduct_gas(&mut self, gas: u64) -> Result<()> {
-            self.inner.deduct_gas(gas)
-        }
-
-        fn refund_gas(&mut self, gas: i64) {
-            self.inner.refund_gas(gas)
-        }
-
-        fn gas_used(&self) -> u64 {
-            self.inner.gas_used()
-        }
-
-        fn gas_refunded(&self) -> i64 {
-            self.inner.gas_refunded()
-        }
-
-        fn spec(&self) -> TempoHardfork {
-            self.inner.spec()
-        }
-
-        fn is_static(&self) -> bool {
-            self.inner.is_static()
-        }
-
-        fn checkpoint(&mut self) -> JournalCheckpoint {
-            self.inner.checkpoint()
-        }
-
-        fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint) {
-            self.inner.checkpoint_commit(checkpoint)
-        }
-
-        fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
-            self.inner.checkpoint_revert(checkpoint)
-        }
-
-        fn keccak256(&mut self, data: &[u8]) -> Result<B256> {
-            self.inner.keccak256(data)
         }
     }
 
@@ -3189,7 +3075,7 @@ mod tests {
 
     #[test]
     fn test_refund_spending_limit_propagates_system_errors() -> eyre::Result<()> {
-        let mut storage = FailingSloadStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new(1);
         let eoa = Address::random();
         let access_key = Address::random();
         let token = Address::random();

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1184,6 +1184,7 @@ impl AccountKeychain {
         let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
         let key = match self.load_active_key(account, transaction_key, current_timestamp) {
             Ok(key) => key,
+            Err(err) if err.is_system_error() => return Err(err),
             Err(_) => return Ok(()),
         };
 
@@ -1299,11 +1300,14 @@ mod tests {
     use super::*;
     use crate::{
         error::TempoPrecompileError,
-        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        storage::{PrecompileStorageProvider, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{Address, TxKind, U256};
-    use revm::state::Bytecode;
+    use alloy::primitives::{Address, B256, LogData, TxKind, U256};
+    use revm::{
+        context::journaled_state::JournalCheckpoint,
+        state::{AccountInfo, Bytecode},
+    };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};
 
@@ -1329,6 +1333,117 @@ mod tests {
                 );
             }
             _ => panic!("Expected AccountKeychainError, got: {error:?}"),
+        }
+    }
+
+    struct FailingSloadStorageProvider {
+        inner: HashMapStorageProvider,
+        fail_on_sload: Option<(Address, U256)>,
+    }
+
+    impl FailingSloadStorageProvider {
+        fn new(chain_id: u64) -> Self {
+            Self {
+                inner: HashMapStorageProvider::new(chain_id),
+                fail_on_sload: None,
+            }
+        }
+
+        fn fail_next_sload_at(&mut self, address: Address, slot: U256) {
+            self.fail_on_sload = Some((address, slot));
+        }
+    }
+
+    impl PrecompileStorageProvider for FailingSloadStorageProvider {
+        fn chain_id(&self) -> u64 {
+            self.inner.chain_id()
+        }
+
+        fn timestamp(&self) -> U256 {
+            self.inner.timestamp()
+        }
+
+        fn beneficiary(&self) -> Address {
+            self.inner.beneficiary()
+        }
+
+        fn block_number(&self) -> u64 {
+            self.inner.block_number()
+        }
+
+        fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()> {
+            self.inner.set_code(address, code)
+        }
+
+        fn with_account_info(
+            &mut self,
+            address: Address,
+            f: &mut dyn FnMut(&AccountInfo),
+        ) -> Result<()> {
+            self.inner.with_account_info(address, f)
+        }
+
+        fn sload(&mut self, address: Address, key: U256) -> Result<U256> {
+            if self.fail_on_sload == Some((address, key)) {
+                return Err(TempoPrecompileError::Fatal("injected sload failure".into()));
+            }
+            self.inner.sload(address, key)
+        }
+
+        fn tload(&mut self, address: Address, key: U256) -> Result<U256> {
+            self.inner.tload(address, key)
+        }
+
+        fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
+            self.inner.sstore(address, key, value)
+        }
+
+        fn tstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
+            self.inner.tstore(address, key, value)
+        }
+
+        fn emit_event(&mut self, address: Address, event: LogData) -> Result<()> {
+            self.inner.emit_event(address, event)
+        }
+
+        fn deduct_gas(&mut self, gas: u64) -> Result<()> {
+            self.inner.deduct_gas(gas)
+        }
+
+        fn refund_gas(&mut self, gas: i64) {
+            self.inner.refund_gas(gas)
+        }
+
+        fn gas_used(&self) -> u64 {
+            self.inner.gas_used()
+        }
+
+        fn gas_refunded(&self) -> i64 {
+            self.inner.gas_refunded()
+        }
+
+        fn spec(&self) -> TempoHardfork {
+            self.inner.spec()
+        }
+
+        fn is_static(&self) -> bool {
+            self.inner.is_static()
+        }
+
+        fn checkpoint(&mut self) -> JournalCheckpoint {
+            self.inner.checkpoint()
+        }
+
+        fn checkpoint_commit(&mut self, checkpoint: JournalCheckpoint) {
+            self.inner.checkpoint_commit(checkpoint)
+        }
+
+        fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
+            self.inner.checkpoint_revert(checkpoint)
+        }
+
+        fn keccak256(&mut self, data: &[u8]) -> Result<B256> {
+            self.inner.keccak256(data)
         }
     }
 
@@ -3067,6 +3182,60 @@ mod tests {
                 U256::from(40),
                 "limit should be unchanged after expired key refund"
             );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_refund_spending_limit_propagates_system_errors() -> eyre::Result<()> {
+        let mut storage = FailingSloadStorageProvider::new(1);
+        let eoa = Address::random();
+        let access_key = Address::random();
+        let token = Address::random();
+
+        let key_slot = StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+
+            keychain.set_transaction_key(Address::ZERO)?;
+
+            let auth_call = authorizeKeyCall {
+                keyId: access_key,
+                signatureType: SignatureType::Secp256k1,
+                config: KeyRestrictions {
+                    expiry: u64::MAX,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token,
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    allowAnyCalls: true,
+                    allowedCalls: vec![],
+                },
+            };
+            keychain.authorize_key(eoa, auth_call)?;
+
+            keychain.set_transaction_key(access_key)?;
+            keychain.set_tx_origin(eoa)?;
+            keychain.authorize_transfer(eoa, token, U256::from(60))?;
+
+            Ok::<_, TempoPrecompileError>(keychain.keys[eoa][access_key].as_slot().slot())
+        })?;
+
+        storage.fail_next_sload_at(ACCOUNT_KEYCHAIN_ADDRESS, key_slot);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.set_transaction_key(access_key)?;
+            keychain.set_tx_origin(eoa)?;
+
+            let err = keychain
+                .refund_spending_limit(eoa, token, U256::from(25))
+                .unwrap_err();
+
+            assert!(matches!(err, TempoPrecompileError::Fatal(_)));
 
             Ok(())
         })

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -15,6 +15,8 @@ pub struct HashMapStorageProvider {
     internals: HashMap<(Address, U256), U256>,
     transient: HashMap<(Address, U256), U256>,
     accounts: HashMap<Address, AccountInfo>,
+    #[cfg(any(test, feature = "test-utils"))]
+    fail_on_sload: Option<(Address, U256)>,
     chain_id: u64,
     timestamp: U256,
     beneficiary: Address,
@@ -48,6 +50,8 @@ impl HashMapStorageProvider {
             internals: HashMap::new(),
             transient: HashMap::new(),
             accounts: HashMap::new(),
+            #[cfg(any(test, feature = "test-utils"))]
+            fail_on_sload: None,
             events: HashMap::new(),
             snapshots: Vec::new(),
             chain_id,
@@ -133,6 +137,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256, TempoPrecompileError> {
+        #[cfg(any(test, feature = "test-utils"))]
+        if self.fail_on_sload == Some((address, key)) {
+            return Err(TempoPrecompileError::Fatal("injected sload failure".into()));
+        }
+
         self.counter_sload += 1;
         Ok(self
             .internals
@@ -210,6 +219,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
 #[cfg(any(test, feature = "test-utils"))]
 impl HashMapStorageProvider {
+    pub fn fail_next_sload_at(&mut self, address: Address, slot: U256) {
+        self.fail_on_sload = Some((address, slot));
+    }
+
     /// Returns the account info for the given address, if it exists.
     pub fn get_account_info(&self, address: Address) -> Option<&AccountInfo> {
         self.accounts.get(&address)

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -15,7 +15,6 @@ pub struct HashMapStorageProvider {
     internals: HashMap<(Address, U256), U256>,
     transient: HashMap<(Address, U256), U256>,
     accounts: HashMap<Address, AccountInfo>,
-    #[cfg(any(test, feature = "test-utils"))]
     fail_on_sload: Option<(Address, U256)>,
     chain_id: u64,
     timestamp: U256,
@@ -50,7 +49,6 @@ impl HashMapStorageProvider {
             internals: HashMap::new(),
             transient: HashMap::new(),
             accounts: HashMap::new(),
-            #[cfg(any(test, feature = "test-utils"))]
             fail_on_sload: None,
             events: HashMap::new(),
             snapshots: Vec::new(),
@@ -137,7 +135,6 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Result<U256, TempoPrecompileError> {
-        #[cfg(any(test, feature = "test-utils"))]
         if self.fail_on_sload == Some((address, key)) {
             return Err(TempoPrecompileError::Fatal("injected sload failure".into()));
         }


### PR DESCRIPTION
Propagate system-level storage failures from refund_spending_limit while still treating revoked, missing, and expired keys as no-op refund cases.

Adds a regression test that injects an sload failure to ensure refund_spending_limit surfaces fatal storage errors instead of silently swallowing them.