### PR TITLE
chore: bump version to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11667,7 +11667,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11771,7 +11771,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-bench"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11798,7 +11798,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11871,7 +11871,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -11883,7 +11883,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11913,7 +11913,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11927,7 +11927,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11970,7 +11970,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12001,7 +12001,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "clap",
  "dirs-next",
@@ -12020,7 +12020,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "eyre",
  "indenter",
@@ -12028,7 +12028,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -12041,7 +12041,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -12106,7 +12106,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12140,7 +12140,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12158,7 +12158,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12188,7 +12188,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12235,7 +12235,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12267,7 +12267,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "clap",
@@ -12291,7 +12291,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "eyre",
  "jiff",
@@ -12300,7 +12300,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12339,7 +12339,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -12351,7 +12351,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps workspace version from 1.5.2 to 1.5.3. No dependency changes — only workspace crate versions in Cargo.toml and Cargo.lock.

Prompted by: Emma