### PR TITLE
deps: update reth from main (2026-04-12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7625,7 +7625,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7959,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8055,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8195,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8371,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8420,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8448,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8469,7 +8469,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8510,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "clap",
  "eyre",
@@ -8533,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8549,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8578,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8608,7 +8608,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8694,7 +8694,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8726,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8764,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "serde",
  "serde_json",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8816,7 +8816,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "bytes",
  "futures",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8853,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "bindgen",
  "cc",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "futures",
  "metrics",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8883,7 +8883,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8979,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9002,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "bytes",
  "eyre",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9382,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9609,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9873,7 +9873,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "clap",
  "eyre",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "clap",
  "eyre",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7035bbc#7035bbcf3a1183bff33350514da794605e9eabbd"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,56 +120,56 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
 reth-codecs = { version = "0.1.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
 reth-primitives-traits = { version = "0.1.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7035bbc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`7035bbc...a550b7a`](https://github.com/paradigmxyz/reth/compare/7035bbc...a550b7a)

🔗 Amp thread: https://ampcode.com/threads/T-019d7fdd-ce42-778a-8498-a045ff23d551
**Perf**
- Disable target attribute in OTLP spans ([#23462](https://github.com/paradigmxyz/reth/pull/23462))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019d7fdd-e336-731d-b004-70642cf99519
- **Reth dependency revision bumped** from `7035bbc` to `a550b7a` across all 48 `reth-*` crates in the workspace `Cargo.toml`
- **Non-breaking upgrade**: the single commit between these revisions is a performance tweak that disables `target` and `threads` attributes on OTLP tracing spans and exempts a new Rust advisory (`RUSTSEC-2026-0097`) in `deny.toml` — no API changes, no removed methods, no signature changes
- **No source code changes required**: the revision bump is a drop-in update with no downstream migration needed

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/24298243057)
