### PR TITLE
deps: update reth from main (2026-04-14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,21 +121,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
+checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -188,24 +188,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+checksum = "f4c16fa30b623e40a5b216da00f3b61870f5cbe863b59816ac1ecc2489515a40"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -326,15 +326,38 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "auto_impl",
  "borsh",
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -342,12 +365,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13146597a586a4166ac31b192883e08c044272d6b8c43de231ee1f43dd9a115"
+checksum = "adcd754dd6733c3f2d44dd99ddecb7d844428a9b3cdbcafbe65570886bf24b20"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -362,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "borsh",
  "serde",
@@ -403,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -418,19 +441,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -444,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -487,13 +510,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+checksum = "f2ba5468f78c8893be2d68a7f2fda61753336e5653f006af19781001b5f99e6c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -533,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
+checksum = "ffcefb5d3391a320eadb95d398e4135f8cc35c7bf29a6bdb357eadcfc5ee5638"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -577,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
+checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -603,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+checksum = "974df1e56405c27cb8242381f45d8b212ba9df5006046ccf704764a2a4634366"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -614,15 +637,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
+checksum = "5f1d057dcbacf8be8f689a7737e0d697fd40a2dc5b664c9035f182ff016649ea"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -632,39 +655,43 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
+checksum = "06bc10b0dca4f5bfc3cd30ed46eab5d651b5bb2cd300d683bdcdf5d2bfe6e82c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
+checksum = "7a8f7fa8ca056bb797a368aeed329e6ace6b62ee4271432ac36ab8ae87a5e60d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_json",
  "serde_with",
@@ -675,11 +702,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
+checksum = "301249e3c9e43661cfd7ebbb4746a00af6ce1ef58b5c968451882cd60438417d"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "serde",
  "serde_with",
@@ -687,18 +715,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
+checksum = "e59bc947935732cae5b072753e5e034c0b70a8b031c2839f45e2659ba07df9ae"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
@@ -707,17 +735,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -729,28 +757,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
+checksum = "286c40ce0d715217a5bfa9fb452779b11e6769e56680afa0de691ae8f3a848ac"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
+checksum = "ede0458c51bef23620aa6bd01a0b4f608be7bcb61d98e91b8530208ae545f3c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -758,13 +786,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
+checksum = "d3f4df183248b57f3e0b99054b1b6786769d3fdff6d01a702234068140c8ba76"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -775,6 +803,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+dependencies = [
+ "alloy-primitives",
  "arbitrary",
  "serde",
  "serde_json",
@@ -782,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -797,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -891,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
+checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -914,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -930,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
+checksum = "7b27802653330740c88c28394cdaf1d55190b15b48ef9b99a946f37c9cdb19fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -950,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
+checksum = "e4b71dc951db66795cfb52eef835f64cf15163bc93b656e061b457ce5ebff370"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -989,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3746,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_hashing"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
  "cpufeatures 0.2.17",
  "ring",
@@ -3770,21 +3809,6 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
@@ -3796,18 +3820,6 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5397,16 +5409,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -7625,10 +7639,10 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -7652,10 +7666,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -7684,11 +7698,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -7704,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7717,11 +7731,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -7800,7 +7814,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7810,9 +7824,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -7830,12 +7844,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96e584e01478c951911946a7864f18e967c1cd90965e136e2d1b51aa3da9126"
+checksum = "a29541038ab108b2e9d527c66b565e717e252e4eef6675377fc21f9ba587f792"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7851,9 +7865,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c342ae46f5a886b8bf506205b9501b1032b896defd0f4f156edb423007fef880"
+checksum = "5646d4aff98bd51050fc920bc3ffdff209f2343def9ed31b56eea13c4245c4da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7863,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7879,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7892,10 +7906,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -7905,10 +7919,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7931,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7959,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7985,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8015,9 +8029,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8030,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8055,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8079,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8103,10 +8117,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8138,10 +8152,10 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8195,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8223,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8246,10 +8260,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8271,11 +8285,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8283,6 +8297,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "futures",
+ "indexmap 2.14.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -8328,7 +8343,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8356,14 +8371,14 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "ethereum_ssz 0.10.1",
- "ethereum_ssz_derive 0.10.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "snap",
  "thiserror 2.0.18",
 ]
@@ -8371,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8387,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8409,7 +8424,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8420,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8448,11 +8463,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -8469,7 +8484,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8510,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "clap",
  "eyre",
@@ -8533,10 +8548,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8549,9 +8564,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -8565,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8578,10 +8593,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8608,10 +8623,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -8622,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8632,10 +8647,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -8656,10 +8671,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8676,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8694,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8707,10 +8722,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8726,10 +8741,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -8764,9 +8779,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -8778,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "serde",
  "serde_json",
@@ -8788,7 +8803,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8816,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "bytes",
  "futures",
@@ -8836,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8853,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "bindgen",
  "cc",
@@ -8862,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "futures",
  "metrics",
@@ -8874,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8883,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8897,10 +8912,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -8954,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8979,10 +8994,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9002,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9017,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9031,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9048,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9072,10 +9087,10 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9140,10 +9155,10 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9195,9 +9210,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9233,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9257,10 +9272,10 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9281,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "bytes",
  "eyre",
@@ -9310,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9322,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,7 +9361,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9358,10 +9373,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9382,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9391,12 +9406,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca36e245593498020c31e707154fc13391164eb90444da76d67361f646e7669"
+checksum = "e96ffdb2ce0cdcd814d39428dc1e9b660c85d85e0b75eb465a1ed0943a48c7bd"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9425,10 +9440,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9471,10 +9486,10 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -9500,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9531,12 +9546,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -9552,7 +9567,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -9609,10 +9624,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -9626,7 +9641,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -9640,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9703,9 +9718,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9734,12 +9749,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -9747,7 +9762,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -9780,10 +9795,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -9828,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9842,9 +9857,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -9857,9 +9872,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ebbc3cc6f1808c2838bf8da9928f3ef9b8a6f969c6522174c1598ddb34bc0f"
+checksum = "c870f120b2e179e44906b7b288b0dea6577573010272adda8fff536e86fedd05"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -9873,10 +9888,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -9925,9 +9940,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -9953,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9967,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9987,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10002,10 +10017,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10026,9 +10041,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10044,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10065,10 +10080,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.5",
@@ -10081,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10091,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "clap",
  "eyre",
@@ -10110,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "clap",
  "eyre",
@@ -10128,10 +10143,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10172,10 +10187,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10198,13 +10213,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -10225,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10245,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10274,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
+source = "git+https://github.com/paradigmxyz/reth?rev=bce7368#bce7368a820ae6118e3946a95c9b2b0fb4581e94"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10295,9 +10310,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a621aef55fe4da8935abede9d1d105f227bcb673f212b3575a748a6a2f8f688e"
+checksum = "3882441cf1d51fe24dfc6df9919e6f17edfdb6b121050bd34348e925e61c7af1"
 dependencies = [
  "zstd",
 ]
@@ -10372,7 +10387,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -10433,9 +10448,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.36.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
+checksum = "ac49e53897c4cc59dbd7a7bb097386755a4dfa2bc7088b298f341b5dfcda6f2c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11681,7 +11696,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11756,12 +11771,12 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -11789,7 +11804,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-bench"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11816,9 +11831,9 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -11836,7 +11851,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11889,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -11901,7 +11916,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11931,7 +11946,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11945,7 +11960,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11988,7 +12003,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12019,7 +12034,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "clap",
  "dirs-next",
@@ -12038,7 +12053,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "eyre",
  "indenter",
@@ -12046,7 +12061,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -12059,16 +12074,16 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -12124,7 +12139,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12158,9 +12173,9 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -12176,7 +12191,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12206,7 +12221,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12219,12 +12234,12 @@ name = "tempo-primitives"
 version = "1.5.1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12253,10 +12268,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12285,7 +12300,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "clap",
@@ -12309,7 +12324,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "eyre",
  "jiff",
@@ -12318,10 +12333,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",
@@ -12357,7 +12372,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -12369,7 +12384,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -13052,24 +13067,24 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "ethereum_ssz 0.9.1",
+ "ethereum_ssz",
  "smallvec",
  "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7625,7 +7625,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7959,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8015,7 +8015,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8055,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8195,7 +8195,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8371,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8420,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8448,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8469,7 +8469,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8510,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "clap",
  "eyre",
@@ -8533,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8549,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8565,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8578,7 +8578,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8608,7 +8608,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8694,7 +8694,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8726,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8764,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "serde",
  "serde_json",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8816,7 +8816,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "bytes",
  "futures",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8853,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "bindgen",
  "cc",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "futures",
  "metrics",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8883,7 +8883,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8979,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9002,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "bytes",
  "eyre",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9382,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9609,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9873,7 +9873,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "clap",
  "eyre",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "clap",
  "eyre",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+source = "git+https://github.com/paradigmxyz/reth?rev=a9bd38a#a9bd38a43e009d438d9f9ac9926dcaa92e08b1d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
-reth-codecs = { version = "0.1.0", default-features = false }
+reth-codecs = { version = "0.2.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
@@ -154,7 +154,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bce73
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
-reth-primitives-traits = { version = "0.1.0", default-features = false }
+reth-primitives-traits = { version = "0.2.0", default-features = false }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
@@ -175,26 +175,26 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368", feat
 ] }
 revm = { version = "36.0.0", features = ["optional_fee_charge"], default-features = false }
 
-alloy = { version = "1.8.2", default-features = false }
-alloy-consensus = { version = "1.8.2", default-features = false }
-alloy-contract = { version = "1.8.2", default-features = false }
-alloy-eips = { version = "1.8.2", default-features = false }
-alloy-evm = { version = "0.30.0", default-features = false }
-revm-inspectors = "0.36.0"
-alloy-genesis = { version = "1.8.2", default-features = false }
+alloy = { version = "2.0.0", default-features = false }
+alloy-consensus = { version = "2.0.0", default-features = false }
+alloy-contract = { version = "2.0.0", default-features = false }
+alloy-eips = { version = "2.0.0", default-features = false }
+alloy-evm = { version = "0.31.0", default-features = false }
+revm-inspectors = "0.37.0"
+alloy-genesis = { version = "2.0.0", default-features = false }
 alloy-hardforks = "0.4.7"
-alloy-network = { version = "1.8.2", default-features = false }
+alloy-network = { version = "2.0.0", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "1.8.2", default-features = false }
+alloy-provider = { version = "2.0.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false }
-alloy-rpc-types-engine = "1.8.2"
-alloy-rpc-types-eth = { version = "1.8.2" }
-alloy-serde = { version = "1.8.2", default-features = false }
-alloy-signer = "1.8.2"
-alloy-signer-local = "1.8.2"
+alloy-rpc-types-engine = "2.0.0"
+alloy-rpc-types-eth = { version = "2.0.0" }
+alloy-serde = { version = "2.0.0", default-features = false }
+alloy-signer = "2.0.0"
+alloy-signer-local = "2.0.0"
 coins-bip32 = "0.12"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "1.8.2"
+alloy-transport = "2.0.0"
 
 commonware-broadcast = "2026.3.0"
 commonware-codec = "2026.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.5.3"
+version = "1.5.2"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -120,56 +120,56 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-codecs = { version = "0.1.1", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-primitives-traits = { version = "0.1.1", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-codecs = { version = "0.1.0", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-primitives-traits = { version = "0.1.0", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a550b7a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,56 +120,56 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-codecs = { version = "0.1.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 reth-primitives-traits = { version = "0.1.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a9bd38a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bce7368", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -16,7 +16,10 @@ use tempo_alloy::{
 use alloy::{
     consensus::BlockHeader,
     eips::Encodable2718,
-    network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TxSignerSync},
+    network::{
+        EthereumWallet, NetworkTransactionBuilder, ReceiptResponse, TransactionBuilder,
+        TxSignerSync,
+    },
     primitives::{Address, B256, BlockNumber, U256},
     providers::{
         DynProvider, PendingTransactionBuilder, PendingTransactionError, Provider, ProviderBuilder,

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -4,8 +4,8 @@ use crate::rpc::{TempoHeaderResponse, TempoTransactionReceipt, TempoTransactionR
 use alloy_consensus::{ReceiptWithBloom, TxType, error::UnsupportedTransactionType};
 
 use alloy_network::{
-    BuildResult, EthereumWallet, IntoWallet, Network, NetworkWallet, TransactionBuilder,
-    TransactionBuilderError, UnbuiltTransactionError,
+    BuildResult, EthereumWallet, IntoWallet, Network, NetworkTransactionBuilder, NetworkWallet,
+    TransactionBuilder, TransactionBuilderError, UnbuiltTransactionError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_provider::fillers::{
@@ -40,7 +40,7 @@ impl Network for TempoNetwork {
     type BlockResponse = Block<Transaction<TempoTxEnvelope>, Self::HeaderResponse>;
 }
 
-impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
+impl TransactionBuilder for TempoTransactionRequest {
     fn chain_id(&self) -> Option<ChainId> {
         TransactionBuilder::chain_id(&self.inner)
     }
@@ -136,14 +136,16 @@ impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
     fn set_access_list(&mut self, access_list: AccessList) {
         TransactionBuilder::set_access_list(&mut self.inner, access_list)
     }
+}
 
+impl NetworkTransactionBuilder<TempoNetwork> for TempoTransactionRequest {
     fn complete_type(&self, ty: TempoTxType) -> Result<(), Vec<&'static str>> {
         match ty {
             TempoTxType::AA => self.complete_aa(),
             TempoTxType::Legacy
             | TempoTxType::Eip2930
             | TempoTxType::Eip1559
-            | TempoTxType::Eip7702 => TransactionBuilder::complete_type(
+            | TempoTxType::Eip7702 => NetworkTransactionBuilder::complete_type(
                 &self.inner,
                 ty.try_into().expect("tempo tx types checked"),
             ),
@@ -151,11 +153,11 @@ impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
     }
 
     fn can_submit(&self) -> bool {
-        TransactionBuilder::can_submit(&self.inner)
+        NetworkTransactionBuilder::can_submit(&self.inner)
     }
 
     fn can_build(&self) -> bool {
-        TransactionBuilder::can_build(&self.inner) || self.can_build_aa()
+        NetworkTransactionBuilder::can_build(&self.inner) || self.can_build_aa()
     }
 
     fn output_tx_type(&self) -> TempoTxType {
@@ -173,7 +175,7 @@ impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
         {
             TempoTxType::AA
         } else {
-            match TransactionBuilder::output_tx_type(&self.inner) {
+            match NetworkTransactionBuilder::output_tx_type(&self.inner) {
                 TxType::Legacy => TempoTxType::Legacy,
                 TxType::Eip2930 => TempoTxType::Eip2930,
                 TxType::Eip1559 => TempoTxType::Eip1559,
@@ -190,9 +192,11 @@ impl TransactionBuilder<TempoNetwork> for TempoTransactionRequest {
             TempoTxType::Legacy
             | TempoTxType::Eip2930
             | TempoTxType::Eip1559
-            | TempoTxType::Eip7702 => TransactionBuilder::output_tx_type_checked(&self.inner)?
-                .try_into()
-                .ok(),
+            | TempoTxType::Eip7702 => {
+                NetworkTransactionBuilder::output_tx_type_checked(&self.inner)?
+                    .try_into()
+                    .ok()
+            }
         }
     }
 

--- a/crates/alloy/src/rpc/header.rs
+++ b/crates/alloy/src/rpc/header.rs
@@ -104,6 +104,14 @@ impl BlockHeader for TempoHeaderResponse {
     fn extra_data(&self) -> &Bytes {
         self.inner.extra_data()
     }
+
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.inner.block_access_list_hash()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
 }
 
 impl HeaderResponse for TempoHeaderResponse {

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -330,6 +330,12 @@ impl From<TempoTxEnvelope> for TempoTransactionRequest {
     }
 }
 
+impl From<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>> for TempoTransactionRequest {
+    fn from(tx: alloy_rpc_types_eth::Transaction<TempoTxEnvelope>) -> Self {
+        tx.into_inner().into()
+    }
+}
+
 pub trait FeeToken {
     fn fee_token(&self) -> Option<Address>;
 }

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -1,6 +1,6 @@
 use crate::rpc::{TempoHeaderResponse, TempoTransactionRequest};
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844, error::ValueError};
-use alloy_network::{TransactionBuilder, TxSigner};
+use alloy_network::{NetworkTransactionBuilder, TxSigner};
 use alloy_primitives::{Address, B256, Bytes, Signature};
 use core::num::NonZeroU64;
 use reth_evm::EvmEnv;

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -1,6 +1,6 @@
 use alloy::{
     consensus::{SignableTransaction, Transaction, TxEip1559, TxEnvelope},
-    network::{EthereumWallet, TransactionBuilder},
+    network::{EthereumWallet, NetworkTransactionBuilder},
     primitives::{Address, B256, U256},
     providers::{Provider, ProviderBuilder},
     signers::local::MnemonicBuilder,
@@ -47,7 +47,7 @@ where
                 .or(Some(TEMPO_T1_BASE_FEE as u128));
 
             let signed =
-                <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx_req, &signer_clone)
+                <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_req, &signer_clone)
                     .await?;
             Ok::<Bytes, eyre::Error>(signed.encoded_2718().into())
         }
@@ -163,7 +163,7 @@ where
         tx_request.max_priority_fee_per_gas = Some(TEMPO_T1_BASE_FEE as u128);
 
         let signed_tx =
-            <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx_request, &signer)
+            <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_request, &signer)
                 .await?;
         let tx_bytes: Bytes = signed_tx.encoded_2718().into();
         node.rpc.inject_tx(tx_bytes).await?;
@@ -190,7 +190,7 @@ async fn sign_and_inject(
         .or(Some(TEMPO_T1_BASE_FEE as u128));
 
     let signed_tx =
-        <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx_request, &signer_wallet)
+        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_request, &signer_wallet)
             .await?;
     let tx_hash = *signed_tx.tx_hash();
     let tx_bytes: Bytes = signed_tx.encoded_2718().into();

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -46,9 +46,11 @@ where
                 .max_priority_fee_per_gas
                 .or(Some(TEMPO_T1_BASE_FEE as u128));
 
-            let signed =
-                <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_req, &signer_clone)
-                    .await?;
+            let signed = <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(
+                tx_req,
+                &signer_clone,
+            )
+            .await?;
             Ok::<Bytes, eyre::Error>(signed.encoded_2718().into())
         }
     };
@@ -189,9 +191,11 @@ async fn sign_and_inject(
         .max_priority_fee_per_gas
         .or(Some(TEMPO_T1_BASE_FEE as u128));
 
-    let signed_tx =
-        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_request, &signer_wallet)
-            .await?;
+    let signed_tx = <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(
+        tx_request,
+        &signer_wallet,
+    )
+    .await?;
     let tx_hash = *signed_tx.tx_hash();
     let tx_bytes: Bytes = signed_tx.encoded_2718().into();
     node.rpc.inject_tx(tx_bytes).await?;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -484,6 +484,7 @@ fn default_attributes_generator(timestamp: u64) -> TempoPayloadAttributes {
         suggested_fee_recipient: alloy::primitives::Address::ZERO,
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(alloy::primitives::B256::ZERO),
+        slot_number: None,
     }
     .into()
 }

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -8,8 +8,8 @@ use reth_storage_api::{
     StateProvider, StateRootProvider, StorageRootProvider,
 };
 use reth_trie_common::{
-    AccountProof, HashedPostState, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
-    StorageProof, TrieInput, updates::TrieUpdates,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput, updates::TrieUpdates,
 };
 use std::time::Instant;
 use tracing::debug_span;
@@ -150,7 +150,7 @@ reth_storage_api::delegate_impls_to_as_ref!(
     StateProofProvider {
         fn proof(&self, input: TrieInput, address: Address, slots: &[B256]) -> ProviderResult<AccountProof>;
         fn multiproof(&self, input: TrieInput, targets: MultiProofTargets) -> ProviderResult<MultiProof>;
-        fn witness(&self, input: TrieInput, target: HashedPostState) -> ProviderResult<Vec<Bytes>>;
+        fn witness(&self, input: TrieInput, target: HashedPostState, mode: ExecutionWitnessMode) -> ProviderResult<Vec<Bytes>>;
     }
 );
 

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -83,6 +83,7 @@ impl TempoPayloadAttributes {
                 prev_randao: B256::ZERO,
                 withdrawals: Some(Default::default()),
                 parent_beacon_block_root: Some(B256::ZERO),
+                slot_number: None,
             },
             interrupt: InterruptHandle::default(),
             timestamp_millis_part: millis,
@@ -362,6 +363,7 @@ mod tests {
             prev_randao: B256::random(),
             withdrawals: Some(Default::default()),
             parent_beacon_block_root: Some(B256::random()),
+            slot_number: None,
         };
 
         let tempo_attrs: TempoPayloadAttributes = eth_attrs.clone().into();
@@ -402,6 +404,7 @@ mod tests {
                 suggested_fee_recipient: Address::random(),
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::random()),
+                slot_number: None,
             },
             timestamp_millis_part,
             ..Default::default()
@@ -441,6 +444,7 @@ mod tests {
                     amount: 500,
                 }]),
                 parent_beacon_block_root: Some(beacon_root),
+                slot_number: None,
             },
             timestamp_millis_part: 123,
             ..Default::default()
@@ -460,6 +464,7 @@ mod tests {
                 suggested_fee_recipient: Address::random(),
                 withdrawals: None,
                 parent_beacon_block_root: None,
+                slot_number: None,
             },
             timestamp_millis_part: 0,
             ..Default::default()

--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -133,6 +133,14 @@ impl BlockHeader for TempoHeader {
     fn extra_data(&self) -> &Bytes {
         self.inner.extra_data()
     }
+
+    fn block_access_list_hash(&self) -> Option<B256> {
+        self.inner.block_access_list_hash()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
 }
 
 impl Sealable for TempoHeader {
@@ -209,6 +217,8 @@ mod tests {
                 requests_hash: Some(b256!(
                     "0x3333333333333333333333333333333333333333333333333333333333333333"
                 )),
+                block_access_list_hash: None,
+                slot_number: None,
             },
         };
 


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`a550b7a...bce7368`](https://github.com/paradigmxyz/reth/compare/a550b7a...bce7368)

🔗 Amp thread: https://ampcode.com/threads/T-019d8a33-e82f-766d-9515-b9a1d206c7d8
**Trie**
- Parallelize `merge_ancestors_into_overlay` ([#21473](https://github.com/paradigmxyz/reth/pull/21473)) and terminate depth-first iterator on database error ([#22709](https://github.com/paradigmxyz/reth/pull/22709))

**Engine**
- Use `IndexSet` for deterministic block buffer child ordering ([#22676](https://github.com/paradigmxyz/reth/pull/22676))
- Add `fcuv4` and `EngineApiMessageVersion6` ([#23480](https://github.com/paradigmxyz/reth/pull/23480))

**Net**
- Add `enforce_enr_fork_id` to `DefaultNetworkArgs` ([#23477](https://github.com/paradigmxyz/reth/pull/23477))

**TxPool**
- Use `FxHashMap`/`FxHashSet` for `TxHash`-heavy containers ([#23037](https://github.com/paradigmxyz/reth/pull/23037))

**Stateless**
- Make witness generation conform to the draft specs ([#22289](https://github.com/paradigmxyz/reth/pull/22289))

**Deps**
- Weekly `cargo update` ([#23464](https://github.com/paradigmxyz/reth/pull/23464)); bump Alloy to 2.0.0 ([#23407](https://github.com/paradigmxyz/reth/pull/23407))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019d8a34-05c8-77e2-9448-7b2b56e00c8c
- **Reth SDK bumped** from rev `a550b7a` to `bce7368`; `reth-codecs` and `reth-primitives-traits` bumped from `0.1.1` to `0.2.0`
- **Alloy bumped** from `1.8.2` to `2.0.0`; `alloy-evm` from `0.30.0` to `0.31.0`; `revm-inspectors` from `0.36.0` to `0.37.0`
- **Workspace version** rolled back from `1.5.3` to `1.5.2`
- **`TransactionBuilder` trait split**: methods `complete_type`, `can_submit`, `can_build`, `output_tx_type`, `output_tx_type_checked`, and `build` moved to a new `NetworkTransactionBuilder<N>` trait; `TransactionBuilder` is now network-agnostic (no generic param)
- **`BlockHeader` trait gained two new methods**: `block_access_list_hash()` and `slot_number()`, implemented on `TempoHeader` and `TempoHeaderResponse`
- **`EthPayloadAttributes` gained `slot_number` field** — all construction sites updated with `slot_number: None`
- **`StateProofProvider::witness` signature changed**: added `ExecutionWitnessMode` parameter
- **`Header` struct** gained optional `block_access_list_hash` and `slot_number` fields
- **New `From<Transaction<TempoTxEnvelope>>` impl** added for `TempoTransactionRequest` to support the updated alloy `Transaction` wrapper

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/24380264135)
