### PR TITLE
chore: release `tempo-alloy@1.6.0`, `tempo-contracts@1.6.0` and 1 more

### DIFF
--- a/.changelog/nonzero-validity-window-bounds.md
+++ b/.changelog/nonzero-validity-window-bounds.md
@@ -1,6 +1,0 @@
----
-tempo-primitives: minor
-tempo-alloy: patch
----
-
-Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11917,7 +11917,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12214,7 +12214,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",

--- a/crates/alloy/CHANGELOG.md
+++ b/crates/alloy/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Patch Changes
 
-- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @DerekCofausper, [#3554](https://github.com/tempoxyz/tempo/pull/3554))
+- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @legion2002, [#3501](https://github.com/tempoxyz/tempo/pull/3501))
+- Bump alloy to 2.0.0, reth to rev `bfb7ab7`, and related dependencies (`reth-codecs` 0.2.0, `reth-primitives-traits` 0.2.0, `alloy-evm` 0.31.0, `revm-inspectors` 0.37.0). Adapt code for upstream API changes including the `TransactionBuilder`/`NetworkTransactionBuilder` trait split, new `BlockHeader` methods (`block_access_list_hash`, `slot_number`), the `slot_number` field on payload builder attributes, the `ExecutionWitnessMode` parameter on `witness`, and `PartialEq` on `TempoBlockEnv`. (by @0xrusowsky, @figtracer, @stevencartavia [#3569](https://github.com/tempoxyz/tempo/pull/3569))
 
 ## `tempo-alloy@1.5.1`
 
 ### Patch Changes
 
 - Add call-scope support to keychain SDK: `authorize_key`, `revoke_key`, `set_allowed_calls`, `CallScopeBuilder`, and `KeyRestrictions` builders. Extend `TempoTransactionRequest` with key-type, key-data, and key-authorization builder methods. (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
-

--- a/crates/alloy/CHANGELOG.md
+++ b/crates/alloy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `tempo-alloy@1.6.0`
+
+### Patch Changes
+
+- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @DerekCofausper, [#3554](https://github.com/tempoxyz/tempo/pull/3554))
+
 ## `tempo-alloy@1.5.1`
 
 ### Patch Changes

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tempo-alloy"
 description = "Tempo extensions of Alloy"
 
-version = "1.5.1"
+version = "1.6.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/contracts/CHANGELOG.md
+++ b/crates/contracts/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## `tempo-contracts@1.6.0`
+
+
 ## `tempo-contracts@1.5.1`
 
 ### Patch Changes

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tempo-contracts"
 description = "Tempo blockchain contract bindings and ABI definitions"
 
-version = "1.5.1"
+version = "1.6.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Minor Changes
 
-- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @DerekCofausper, [#3554](https://github.com/tempoxyz/tempo/pull/3554))
+- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @legion2002, [#3501](https://github.com/tempoxyz/tempo/pull/3501))
+
+### Patch Changes
+
+- Bump alloy to 2.0.0, reth to rev `bfb7ab7`, and related dependencies (`reth-codecs` 0.2.0, `reth-primitives-traits` 0.2.0, `alloy-evm` 0.31.0, `revm-inspectors` 0.37.0). Adapt code for upstream API changes including the `TransactionBuilder`/`NetworkTransactionBuilder` trait split, new `BlockHeader` methods (`block_access_list_hash`, `slot_number`), the `slot_number` field on payload builder attributes, the `ExecutionWitnessMode` parameter on `witness`, and `PartialEq` on `TempoBlockEnv`. (by @0xrusowsky, @figtracer, @stevencartavia [#3569](https://github.com/tempoxyz/tempo/pull/3569))
 
 ## `tempo-primitives@1.5.1`
 
@@ -12,4 +16,3 @@
 
 - Add call-scope support to keychain SDK: `authorize_key`, `revoke_key`, `set_allowed_calls`, `CallScopeBuilder`, and `KeyRestrictions` builders. Extend `TempoTransactionRequest` with key-type, key-data, and key-authorization builder methods. (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
 - Implement TIP-1011 enhanced access key permissions with exact permission matching for keychain operations. (by @0xrusowsky, [#3495](https://github.com/tempoxyz/tempo/pull/3495))
-

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `tempo-primitives@1.6.0`
+
+### Minor Changes
+
+- Store `TempoTransaction.valid_before` and `valid_after` as `Option<NonZeroU64>` so omitted validity bounds remain distinct from zero in RLP and serde handling. Reject zero-valued validity bounds when building AA transactions from `TempoTransactionRequest`. (by @DerekCofausper, [#3554](https://github.com/tempoxyz/tempo/pull/3554))
+
 ## `tempo-primitives@1.5.1`
 
 ### Patch Changes

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tempo-primitives"
 description = "Tempo primitive types"
 
-version = "1.5.1"
+version = "1.6.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
This PR was opened by the Changelogs release workflow.

When you're ready to release, merge this PR and the packages will be published.

---

