### PR TITLE
chore: bump commonware deps to monorepo HEAD (f4e49d2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,8 +2394,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b67e4fed57f8d77c8d92b7bdd7512aee03d9d27ce4c0d3d8f93dd50358e9efc"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2411,8 +2410,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af69c7b97ba7225a934e29fad444f35b5d365322efaaf724e1af66c99c8c6c3"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2426,8 +2424,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b7b9371af121e60f7bb3f28ff891f03ba5f9b51cc22053994007d3083c30b"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2448,8 +2445,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdbc3361f501adce253ff92e652a997758e57c1e6298a4bc06836952b66b0c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2479,8 +2475,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9bba8bf1ad51f54c57bee0824987bb397bedb60a09917d6a93509828a2dff"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2514,8 +2509,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8da60f9fe8357927327729fa7838b44555f4c578e4b07c12a2964664230a98"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2524,8 +2518,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2537,8 +2530,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a44f73b02286843967888c7aa750a7a91a5cd3ac8b9bc48cd1d81331836bbb"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2551,8 +2543,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493b3ff98ef12a54162d9eae90175a6ff56e12df90f7b3381eff3cea84a8deb"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2578,8 +2569,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a590a49ee5d5389a2b966008b3367275772da7f336719fdb0f046ad257f6849"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2589,8 +2579,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e386bcb3a39c2ef1315df245cee346a8d9143961defebeabde518e189f6f54"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2610,8 +2599,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "axum",
  "bytes",
@@ -2647,8 +2635,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3be226adc2994ba3b8181f9388855c7f62c5b041ebd8c6a2956651bd8cf95fe"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2672,8 +2659,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24852a37e87406ba53fc95a53574016362cc9f527faf68d298fb1a3f50159950"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -2692,8 +2678,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192eb390e3e0277770982e5e63de72f3c116c810873f3250318cae9ff0206560"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "axum",
  "bytes",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.3.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=76fc5ea24c3a45cf5560f3da316e7d7f123c566e#76fc5ea24c3a45cf5560f3da316e7d7f123c566e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=f4e49d2d8ce81b1ff594adb436e7f7560b23703c#f4e49d2d8ce81b1ff594adb436e7f7560b23703c"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,15 +346,15 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse-parallel = { path = "../reth/crates/trie/sparse-parallel" }
 
 [patch.crates-io]
-# Commonware right after after PR #3298 was merged
-# commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
-# commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "240e0207ee10c3c37a42867ce4de97b581c06b32" }
+# Commonware at HEAD after PR #3572 was merged
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,15 +346,15 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse-parallel = { path = "../reth/crates/trie/sparse-parallel" }
 
 [patch.crates-io]
-# Commonware at HEAD after PR #3572 was merged
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "76fc5ea24c3a45cf5560f3da316e7d7f123c566e" }
+# Commonware at HEAD after PR #3594 was merged
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }

--- a/crates/commonware-node/src/config.rs
+++ b/crates/commonware-node/src/config.rs
@@ -9,7 +9,7 @@
 //! by the execution client/reth. This genesis block is entirely the domain
 //! of the chainspec, which is separate from the config.
 
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use governor::Quota;
 
@@ -25,7 +25,8 @@ pub const SUBBLOCKS_CHANNEL_IDENT: commonware_p2p::Channel = 6;
 
 pub(crate) const NUMBER_CONCURRENT_FETCHES: usize = 4;
 
-pub(crate) const PEERSETS_TO_TRACK: usize = 3;
+pub(crate) const PEERSETS_TO_TRACK: NonZeroUsize =
+    NonZeroUsize::new(3).expect("value is not zero");
 
 pub(crate) const BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB
 

--- a/crates/commonware-node/src/config.rs
+++ b/crates/commonware-node/src/config.rs
@@ -9,8 +9,9 @@
 //! by the execution client/reth. This genesis block is entirely the domain
 //! of the chainspec, which is separate from the config.
 
-use std::num::{NonZeroU32, NonZeroUsize};
+use std::num::NonZeroU32;
 
+use commonware_utils::NZUsize;
 use governor::Quota;
 
 // Hardcoded values to configure commonware's alto toy chain. These could be made into
@@ -25,8 +26,7 @@ pub const SUBBLOCKS_CHANNEL_IDENT: commonware_p2p::Channel = 6;
 
 pub(crate) const NUMBER_CONCURRENT_FETCHES: usize = 4;
 
-pub(crate) const PEERSETS_TO_TRACK: NonZeroUsize =
-    NonZeroUsize::new(3).expect("value is not zero");
+pub(crate) const PEERSETS_TO_TRACK: std::num::NonZeroUsize = NZUsize!(3);
 
 pub(crate) const BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB
 

--- a/crates/commonware-node/src/consensus/application/ingress.rs
+++ b/crates/commonware-node/src/consensus/application/ingress.rs
@@ -155,8 +155,10 @@ impl CertifiableAutomaton for Mailbox {
 
 impl Relay for Mailbox {
     type Digest = Digest;
+    type PublicKey = PublicKey;
+    type Plan = commonware_consensus::simplex::Plan<PublicKey>;
 
-    async fn broadcast(&mut self, digest: Self::Digest) {
+    async fn broadcast(&mut self, digest: Self::Digest, _plan: Self::Plan) {
         // TODO: panicking here is really not necessary. Just log at the ERROR or WARN levels instead?
         self.inner
             .send(Broadcast { payload: digest }.into())

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -12,7 +12,9 @@ use commonware_consensus::{
 use commonware_cryptography::{
     Signer as _,
     bls12381::{
-        dkg::{self, DealerLog, DealerPrivMsg, DealerPubMsg, Logs, PlayerAck, SignedDealerLog, observe},
+        dkg::{
+            self, DealerLog, DealerPrivMsg, DealerPubMsg, Logs, PlayerAck, SignedDealerLog, observe,
+        },
         primitives::{group::Share, variant::MinSig},
     },
     ed25519::{self, PrivateKey, PublicKey},
@@ -1195,7 +1197,11 @@ where
                 if let Some(outcome) = player_outcome {
                     outcome
                 } else {
-                    match observe::<_, _, N3f1, ed25519::Batch>(&mut self.context, logs, &Sequential) {
+                    match observe::<_, _, N3f1, ed25519::Batch>(
+                        &mut self.context,
+                        logs,
+                        &Sequential,
+                    ) {
                         Ok(output) => {
                             info!("local DKG ceremony was a success");
                             (output, state::ShareState::Plaintext(None))

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -733,9 +733,9 @@ where
                 logs.record(k.clone(), v.clone());
             }
 
-            let player_outcome = player_state.take().and_then(|player| {
+            let player_outcome = if let Some(player) = player_state.take() {
                 info!("we were a player in the ceremony; finalizing share");
-                match player.finalize(&mut rand_core::OsRng, logs.clone(), &Sequential) {
+                match player.finalize(&mut self.context, logs.clone(), &Sequential) {
                     Ok((new_output, new_share)) => {
                         info!("local DKG ceremony was a success");
                         Some((new_output, state::ShareState::Plaintext(Some(new_share))))
@@ -761,10 +761,14 @@ where
                         Some((state.output.clone(), state.share.clone()))
                     }
                 }
-            });
+            } else {
+                None
+            };
 
-            player_outcome.unwrap_or_else(move || {
-                match observe::<_, _, N3f1, ed25519::Batch>(&mut rand_core::OsRng, logs, &Sequential) {
+            if let Some(outcome) = player_outcome {
+                outcome
+            } else {
+                match observe::<_, _, N3f1, ed25519::Batch>(&mut self.context, logs, &Sequential) {
                     Ok(output) => {
                         info!("local DKG ceremony was a success");
                         (output, state::ShareState::Plaintext(None))
@@ -777,7 +781,7 @@ where
                         (state.output.clone(), state.share.clone())
                     }
                 }
-            })
+            }
         };
 
         if local_output != onchain_outcome.output {
@@ -1156,9 +1160,9 @@ where
             );
 
             let (output, share) = {
-                let player_outcome = player_state.and_then(|player| {
+                let player_outcome = if let Some(player) = player_state {
                     info!("we were a player in the ceremony; finalizing share");
-                    match player.finalize(&mut rand_core::OsRng, logs.clone(), &Sequential) {
+                    match player.finalize(&mut self.context, logs.clone(), &Sequential) {
                         Ok((new_output, new_share)) => {
                             info!("local DKG ceremony was a success");
                             Some((new_output, state::ShareState::Plaintext(Some(new_share))))
@@ -1184,10 +1188,14 @@ where
                             Some((state.output.clone(), state.share.clone()))
                         }
                     }
-                });
+                } else {
+                    None
+                };
 
-                player_outcome.unwrap_or_else(move || {
-                    match observe::<_, _, N3f1, ed25519::Batch>(&mut rand_core::OsRng, logs, &Sequential) {
+                if let Some(outcome) = player_outcome {
+                    outcome
+                } else {
+                    match observe::<_, _, N3f1, ed25519::Batch>(&mut self.context, logs, &Sequential) {
                         Ok(output) => {
                             info!("local DKG ceremony was a success");
                             (output, state::ShareState::Plaintext(None))
@@ -1200,7 +1208,7 @@ where
                             (state.output.clone(), state.share.clone())
                         }
                     }
-                })
+                }
             };
 
             storage.cache_dkg_outcome(state.epoch, request.digest, output.clone(), share);

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -12,10 +12,10 @@ use commonware_consensus::{
 use commonware_cryptography::{
     Signer as _,
     bls12381::{
-        dkg::{self, DealerLog, DealerPrivMsg, DealerPubMsg, PlayerAck, SignedDealerLog, observe},
+        dkg::{self, DealerLog, DealerPrivMsg, DealerPubMsg, Logs, PlayerAck, SignedDealerLog, observe},
         primitives::{group::Share, variant::MinSig},
     },
-    ed25519::{PrivateKey, PublicKey},
+    ed25519::{self, PrivateKey, PublicKey},
     transcript::Summary,
 };
 use commonware_math::algebra::Random as _;
@@ -728,14 +728,14 @@ where
             debug!("using cached DKG outcome");
             (outcome.clone(), share.clone())
         } else {
-            let logs = storage
-                .logs_for_epoch(round.epoch())
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<BTreeMap<_, _>>();
+            let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+            for (k, v) in storage.logs_for_epoch(round.epoch()) {
+                logs.record(k.clone(), v.clone());
+            }
 
             let player_outcome = player_state.take().and_then(|player| {
                 info!("we were a player in the ceremony; finalizing share");
-                match player.finalize(logs.clone(), &Sequential) {
+                match player.finalize(&mut rand_core::OsRng, logs.clone(), &Sequential) {
                     Ok((new_output, new_share)) => {
                         info!("local DKG ceremony was a success");
                         Some((new_output, state::ShareState::Plaintext(Some(new_share))))
@@ -764,7 +764,7 @@ where
             });
 
             player_outcome.unwrap_or_else(move || {
-                match observe::<_, _, N3f1>(round.info().clone(), logs, &Sequential) {
+                match observe::<_, _, N3f1, ed25519::Batch>(&mut rand_core::OsRng, logs, &Sequential) {
                     Ok(output) => {
                         info!("local DKG ceremony was a success");
                         (output, state::ShareState::Plaintext(None))
@@ -1103,13 +1103,13 @@ where
         {
             output
         } else {
-            let mut logs = storage
+            let mut raw_logs = storage
                 .logs_for_epoch(round.epoch())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect::<BTreeMap<_, _>>();
 
             'ensure_enough_logs: {
-                if logs.len() == round.dealers().len() {
+                if raw_logs.len() == round.dealers().len() {
                     info!("collected as many logs as there are dealers; concluding DKG");
                     break 'ensure_enough_logs;
                 }
@@ -1128,7 +1128,7 @@ where
                     if let Some(block) =
                         storage.get_notarized_reduced_block(&round.epoch(), &digest)
                     {
-                        logs.extend(block.log.clone());
+                        raw_logs.extend(block.log.clone());
                         height = if let Some(height) = block.height.previous() {
                             height
                         } else {
@@ -1139,6 +1139,11 @@ where
                         return Ok(Some((digest, request)));
                     }
                 }
+            }
+
+            let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+            for (k, v) in raw_logs {
+                logs.record(k, v);
             }
 
             // Create a player-state ad hoc: the DKG player object is not
@@ -1153,7 +1158,7 @@ where
             let (output, share) = {
                 let player_outcome = player_state.and_then(|player| {
                     info!("we were a player in the ceremony; finalizing share");
-                    match player.finalize(logs.clone(), &Sequential) {
+                    match player.finalize(&mut rand_core::OsRng, logs.clone(), &Sequential) {
                         Ok((new_output, new_share)) => {
                             info!("local DKG ceremony was a success");
                             Some((new_output, state::ShareState::Plaintext(Some(new_share))))
@@ -1182,7 +1187,7 @@ where
                 });
 
                 player_outcome.unwrap_or_else(move || {
-                    match observe::<_, _, N3f1>(round.info().clone(), logs, &Sequential) {
+                    match observe::<_, _, N3f1, ed25519::Batch>(&mut rand_core::OsRng, logs, &Sequential) {
                         Ok(output) => {
                             info!("local DKG ceremony was a success");
                             (output, state::ShareState::Plaintext(None))

--- a/crates/commonware-node/src/dkg/manager/actor/state.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/state.rs
@@ -1276,10 +1276,12 @@ impl Player {
     /// Finalize the player's participation in the DKG round.
     pub(super) fn finalize(
         self,
-        logs: BTreeMap<PublicKey, dkg::DealerLog<MinSig, PublicKey>>,
+        rng: &mut impl rand_core::CryptoRngCore,
+        logs: dkg::Logs<MinSig, PublicKey, N3f1>,
         strategy: &impl Strategy,
     ) -> Result<(Output<MinSig, PublicKey>, Share), dkg::Error> {
-        self.player.finalize::<N3f1>(logs, strategy)
+        self.player
+            .finalize::<N3f1, commonware_cryptography::ed25519::Batch>(rng, logs, strategy)
     }
 }
 

--- a/crates/commonware-node/src/epoch/manager/actor.rs
+++ b/crates/commonware-node/src/epoch/manager/actor.rs
@@ -360,6 +360,8 @@ where
 
                 fetch_concurrent: crate::config::NUMBER_CONCURRENT_FETCHES,
 
+                forwarding: commonware_consensus::simplex::config::ForwardingPolicy::Disabled,
+
                 strategy: Sequential,
             },
         );

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -164,7 +164,7 @@ async fn instantiate_network(
         listen: config.listen_address,
         max_message_size: config.max_message_size_bytes,
         mailbox_size: config.mailbox_size,
-        send_batch_size: std::num::NonZeroUsize::new(8).unwrap(),
+        send_batch_size: commonware_utils::NZUsize!(8),
         bypass_ip_check: config.bypass_ip_check,
         allow_private_ips: config.allow_private_ips,
         allow_dns: config.allow_dns,

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -164,6 +164,7 @@ async fn instantiate_network(
         listen: config.listen_address,
         max_message_size: config.max_message_size_bytes,
         mailbox_size: config.mailbox_size,
+        send_batch_size: std::num::NonZeroUsize::new(8).unwrap(),
         bypass_ip_check: config.bypass_ip_check,
         allow_private_ips: config.allow_private_ips,
         allow_dns: config.allow_dns,
@@ -174,12 +175,8 @@ async fn instantiate_network(
         max_concurrent_handshakes: config.max_concurrent_handshakes,
         block_duration: config.time_to_unblock_byzantine_peer.into_duration(),
         dial_frequency: config.wait_before_peers_redial.into_duration(),
-        query_frequency: config.wait_before_peers_discovery.into_duration(),
         ping_frequency: config.wait_before_peers_reping.into_duration(),
-        allowed_connection_rate_per_peer: commonware_runtime::Quota::with_period(
-            config.connection_per_peer_min_period.into_duration(),
-        )
-        .ok_or_eyre("connection min period must be non-zero")?,
+        peer_connection_cooldown: config.connection_per_peer_min_period.into_duration(),
         allowed_handshake_rate_per_ip: commonware_runtime::Quota::with_period(
             config.handshake_per_ip_min_period.into_duration(),
         )

--- a/crates/commonware-node/src/peer_manager/ingress.rs
+++ b/crates/commonware-node/src/peer_manager/ingress.rs
@@ -82,7 +82,7 @@ impl Provider for Mailbox {
     async fn subscribe(&mut self) -> PeerSetSubscription<Self::PublicKey> {
         let (tx, rx) = oneshot::channel();
 
-        let (_, fallback_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_, fallback_rx) = commonware_utils::channel::mpsc::unbounded_channel();
 
         if let Err(error) =
             self.inner

--- a/crates/commonware-node/src/peer_manager/ingress.rs
+++ b/crates/commonware-node/src/peer_manager/ingress.rs
@@ -1,12 +1,12 @@
 use commonware_consensus::{Reporter, marshal::Update};
-use commonware_p2p::{Address, AddressableManager, Provider};
-use commonware_utils::ordered::{Map, Set};
+use commonware_p2p::{
+    Address, AddressableManager, AddressableTrackedPeers, PeerSetSubscription, Provider,
+    TrackedPeers,
+};
+use commonware_utils::ordered::Map;
 use eyre::WrapErr as _;
 use futures::channel::{mpsc, oneshot};
 use tracing::{Span, error};
-
-type SubscribeReceiver =
-    commonware_utils::channel::mpsc::UnboundedReceiver<(u64, Set<PublicKey>, Set<PublicKey>)>;
 
 use commonware_cryptography::ed25519::PublicKey;
 
@@ -47,10 +47,10 @@ pub(super) enum Message {
     },
     PeerSet {
         id: u64,
-        response: oneshot::Sender<Option<Set<PublicKey>>>,
+        response: oneshot::Sender<Option<TrackedPeers<PublicKey>>>,
     },
     Subscribe {
-        response: oneshot::Sender<SubscribeReceiver>,
+        response: oneshot::Sender<PeerSetSubscription<PublicKey>>,
     },
     Finalized(Box<Update<Block>>),
 }
@@ -64,7 +64,7 @@ impl From<Update<Block>> for Message {
 impl Provider for Mailbox {
     type PublicKey = PublicKey;
 
-    async fn peer_set(&mut self, id: u64) -> Option<Set<Self::PublicKey>> {
+    async fn peer_set(&mut self, id: u64) -> Option<TrackedPeers<Self::PublicKey>> {
         let (tx, rx) = oneshot::channel();
         if let Err(error) =
             self.inner
@@ -79,16 +79,10 @@ impl Provider for Mailbox {
         rx.await.ok().flatten()
     }
 
-    async fn subscribe(
-        &mut self,
-    ) -> commonware_utils::channel::mpsc::UnboundedReceiver<(
-        u64,
-        Set<Self::PublicKey>,
-        Set<Self::PublicKey>,
-    )> {
+    async fn subscribe(&mut self) -> PeerSetSubscription<Self::PublicKey> {
         let (tx, rx) = oneshot::channel();
 
-        let (_, fallback_rx) = commonware_utils::channel::mpsc::unbounded_channel();
+        let (_, fallback_rx) = tokio::sync::mpsc::unbounded_channel();
 
         if let Err(error) =
             self.inner
@@ -114,12 +108,16 @@ impl Provider for Mailbox {
 }
 
 impl AddressableManager for Mailbox {
-    async fn track(&mut self, id: u64, peers: Map<Self::PublicKey, Address>) {
+    async fn track<R>(&mut self, id: u64, peers: R)
+    where
+        R: Into<AddressableTrackedPeers<Self::PublicKey>> + Send,
+    {
+        let addressable: AddressableTrackedPeers<Self::PublicKey> = peers.into();
         if let Err(error) = self
             .inner
             .unbounded_send(MessageWithCause::in_current_span(Message::Track {
                 id,
-                peers,
+                peers: addressable.primary,
             }))
             .wrap_err("actor no longer running")
         {

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -257,7 +257,7 @@ pub async fn setup_validators(
         simulated::Config {
             max_size: 1024 * 1024,
             disconnect_on_block: true,
-            tracked_peer_sets: Some(3),
+            tracked_peer_sets: std::num::NonZeroUsize::new(3).unwrap(),
         },
     );
     network.start();

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -257,7 +257,7 @@ pub async fn setup_validators(
         simulated::Config {
             max_size: 1024 * 1024,
             disconnect_on_block: true,
-            tracked_peer_sets: std::num::NonZeroUsize::new(3).unwrap(),
+            tracked_peer_sets: commonware_utils::NZUsize!(3),
         },
     );
     network.start();


### PR DESCRIPTION
Points all commonware crates to `commonwarexyz/monorepo@f4e49d2` via
`[patch.crates-io]` to test against the latest HEAD after
[commonwarexyz/monorepo#3594](https://github.com/commonwarexyz/monorepo/pull/3594)
was merged (includes [#3572](https://github.com/commonwarexyz/monorepo/pull/3572)).

NOTE: this points to the least commit on commonware's main branch but is still pending a full release.

Fixes compilation errors from breaking API changes in commonware:
- `Relay` trait gained `PublicKey` and `Plan` associated types
- `Provider::peer_set` returns `TrackedPeers` instead of `Set`
- `Provider::subscribe` returns `PeerSetSubscription`
- `AddressableManager::track` is now generic over `Into<AddressableTrackedPeers>`
- `observe`/`finalize` take `&mut rng`, `Logs` struct, and `BatchVerifier` generic
- `simplex::Config` requires new `forwarding` field
- `lookup::Config` removed `query_frequency` and `allowed_connection_rate_per_peer`, added `send_batch_size` and `peer_connection_cooldown`
- `tracked_peer_sets` changed from `usize` to `NonZeroUsize`

Prompted by: Janis