### PR TITLE
fix(refactor): Clean up handle_finalized_block and add E2E test coverage

### DIFF
--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -126,6 +126,22 @@ where
     metrics: Metrics,
 }
 
+/// Groups the mutable and immutable references needed to process a
+/// finalized block during an epoch transition.
+struct FinalizedBlockContext<'a, TStorageContext, TSender>
+where
+    TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    TSender: Sender<PublicKey = PublicKey>,
+{
+    state: &'a state::State,
+    round: &'a state::Round,
+    round_channel: &'a mut TSender,
+    storage: &'a mut state::Storage<TStorageContext>,
+    dealer_state: &'a mut Option<state::Dealer>,
+    player_state: &'a mut Option<state::Player>,
+    block: Block,
+}
+
 impl<TContext> Actor<TContext>
 where
     TContext: commonware_runtime::BufferPooler
@@ -350,13 +366,15 @@ where
                                     } else {
                                         self.handle_finalized_block(
                                             msg.cause,
-                                            &state,
-                                            &round,
-                                            &mut round_sender,
-                                            storage,
-                                            &mut dealer_state,
-                                            &mut player_state,
-                                            block,
+                                            FinalizedBlockContext {
+                                                state: &state,
+                                                round: &round,
+                                                round_channel: &mut round_sender,
+                                                storage,
+                                                dealer_state: &mut dealer_state,
+                                                player_state: &mut player_state,
+                                                block,
+                                            },
                                         ).await
                                     };
                                     let should_break = match res {
@@ -594,32 +612,31 @@ where
         parent = &cause,
         skip_all,
         fields(
-            dkg.epoch = %round.epoch(),
-            block.height = %block.height(),
-            block.extra_data.bytes = block.header().extra_data().len(),
+            dkg.epoch = %ctx.round.epoch(),
+            block.height = %ctx.block.height(),
+            block.extra_data.bytes = ctx.block.header().extra_data().len(),
         ),
         err,
     )]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "easiest way to express this for now"
-    )]
-    // TODO(janis): replace this by a struct?
     async fn handle_finalized_block<TStorageContext, TSender>(
         &mut self,
         cause: Span,
-        state: &state::State,
-        round: &state::Round,
-        round_channel: &mut TSender,
-        storage: &mut state::Storage<TStorageContext>,
-        dealer_state: &mut Option<state::Dealer>,
-        player_state: &mut Option<state::Player>,
-        block: Block,
+        ctx: FinalizedBlockContext<'_, TStorageContext, TSender>,
     ) -> eyre::Result<Option<State>>
     where
         TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
         TSender: Sender<PublicKey = PublicKey>,
     {
+        let FinalizedBlockContext {
+            state,
+            round,
+            round_channel,
+            storage,
+            dealer_state,
+            player_state,
+            block,
+        } = ctx;
+
         let epoch_info = self
             .config
             .epoch_strategy
@@ -671,51 +688,122 @@ where
         }
 
         if block.height() != epoch_info.last() {
-            if !block.header().extra_data().is_empty() {
-                'handle_log: {
-                    let (dealer, log) =
-                        match read_dealer_log(block.header().extra_data().as_ref(), round) {
-                            Err(reason) => {
-                                warn!(
-                                    %reason,
-                                    "failed to read dealer log from block \
-                                    extraData header field");
-                                break 'handle_log;
-                            }
-                            Ok((dealer, log)) => (dealer, log),
-                        };
-                    storage
-                        .append_dealer_log(round.epoch(), dealer.clone(), log)
-                        .await
-                        .wrap_err("failed to append log to journal")?;
-                    if self.config.me.public_key() == dealer
-                        && let Some(dealer_state) = dealer_state
-                    {
-                        info!(
-                            "found own dealing in finalized block; deleting it \
-                            from state to not write it again"
-                        );
-                        dealer_state.take_finalized();
-                    }
-                }
-            }
-
-            storage
-                .append_finalized_block(round.epoch(), block)
-                .await
-                .wrap_err("failed to append finalized block to journal")?;
-
+            self.process_mid_epoch_block(storage, round, dealer_state, block)
+                .await?;
             return Ok(None);
         }
 
+        self.resolve_epoch_outcome(state, round, storage, player_state, block)
+            .await
+            .map(Some)
+    }
+
+    /// Handles the second half of the epoch.
+    ///
+    /// During the Midpoint and Late phases each dealer node writes its signed
+    /// log into the extra data field of a finalized block. On every such
+    /// block this function:
+    ///
+    /// 1. Reads the dealer log from the block's extra data (if present) and
+    ///    persists it to the epoch journal so that all dealer logs are
+    ///    available at the boundary block to complete the ceremony.
+    /// 2. If the log belongs to this node, clears the dealer's own finalized
+    ///    log from in-memory state so it is not written to a block again.
+    /// 3. Appends the block itself to the epoch journal regardless of whether
+    ///    a log was present.
+    #[instrument(
+        skip_all,
+        fields(
+            dkg.epoch = %round.epoch(),
+            block.height = %block.height(),
+            block.extra_data.bytes = block.header().extra_data().len(),
+        ),
+        err,
+    )]
+    async fn process_mid_epoch_block<TStorageContext>(
+        &self,
+        storage: &mut state::Storage<TStorageContext>,
+        round: &state::Round,
+        dealer_state: &mut Option<state::Dealer>,
+        block: Block,
+    ) -> eyre::Result<()>
+    where
+        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    {
+        if !block.header().extra_data().is_empty() {
+            'handle_log: {
+                let (dealer, log) =
+                    match read_dealer_log(block.header().extra_data().as_ref(), round) {
+                        Err(reason) => {
+                            warn!(
+                                %reason,
+                                "failed to read dealer log from block \
+                                extraData header field");
+                            break 'handle_log;
+                        }
+                        Ok((dealer, log)) => (dealer, log),
+                    };
+                storage
+                    .append_dealer_log(round.epoch(), dealer.clone(), log)
+                    .await
+                    .wrap_err("failed to append log to journal")?;
+                if self.config.me.public_key() == dealer
+                    && let Some(dealer_state) = dealer_state
+                {
+                    info!(
+                        "found own dealing in finalized block; deleting it \
+                        from state to not write it again"
+                    );
+                    dealer_state.take_finalized();
+                }
+            }
+        }
+
+        storage
+            .append_finalized_block(round.epoch(), block)
+            .await
+            .wrap_err("failed to append finalized block to journal")?;
+
+        Ok(())
+    }
+
+    /// Handles the last height of an epoch.
+    ///
+    /// Returns a new [`State`] after finalizing the boundary block of the epoch.
+    ///
+    /// On reaching the boundary block of an epoch, the following steps occur:
+    /// 1. Reads the on-chain DKG outcome embedded in the boundary block.
+    /// 2. Computes the local DKG outcome from the dealer logs collected
+    ///    during the epoch and compares it against the on-chain result.
+    /// 3. Records whether the ceremony was a success or failure.
+    /// 4. Reads the next set of validators from the smart contract.
+    /// 5. Returns the new state that drives the next epoch's DKG round.
+    #[instrument(
+        skip_all,
+        fields(
+            dkg.epoch = %round.epoch(),
+            block.height = %block.height(),
+            block.extra_data.bytes = block.header().extra_data().len(),
+        ),
+        err,
+    )]
+    async fn resolve_epoch_outcome<TStorageContext>(
+        &mut self,
+        state: &state::State,
+        round: &state::Round,
+        storage: &mut state::Storage<TStorageContext>,
+        player_state: &mut Option<state::Player>,
+        block: Block,
+    ) -> eyre::Result<State>
+    where
+        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    {
         info!("reached last block of epoch; reading DKG outcome from header");
 
         let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
             &mut block.header().extra_data().as_ref(),
         )
         .expect("the last block of an epoch must contain the DKG outcome");
-
-        info!("reading validator from contract");
 
         let (local_output, mut share) = if let Some((outcome, share)) =
             storage.get_dkg_outcome(&state.epoch, &block.parent_digest())
@@ -804,7 +892,7 @@ where
             self.metrics.successes.inc();
         }
 
-        Ok(Some(state::State {
+        Ok(state::State {
             epoch: onchain_outcome.epoch,
             seed: Summary::random(&mut self.context),
             output: onchain_outcome.output.clone(),
@@ -812,7 +900,7 @@ where
             players: onchain_outcome.next_players,
             syncers: ordered::Set::default(),
             is_full_dkg: onchain_outcome.is_next_full_dkg,
-        }))
+        })
     }
 
     /// Looks for and handles a finalized boundary block.

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -776,8 +776,7 @@ where
     /// 2. Computes the local DKG outcome from the dealer logs collected
     ///    during the epoch and compares it against the on-chain result.
     /// 3. Records whether the ceremony was a success or failure.
-    /// 4. Reads the next set of validators from the smart contract.
-    /// 5. Returns the new state that drives the next epoch's DKG round.
+    /// 4. Returns the new state that drives the next epoch's DKG round.
     #[instrument(
         skip_all,
         fields(
@@ -804,6 +803,8 @@ where
             &mut block.header().extra_data().as_ref(),
         )
         .expect("the last block of an epoch must contain the DKG outcome");
+
+        info!("reading validator from contract");
 
         let (local_output, mut share) = if let Some((outcome, share)) =
             storage.get_dkg_outcome(&state.epoch, &block.parent_digest())

--- a/crates/e2e/src/tests/dkg/common.rs
+++ b/crates/e2e/src/tests/dkg/common.rs
@@ -136,6 +136,24 @@ pub(crate) fn assert_no_dkg_failures(context: &Context) {
     }
 }
 
+/// Aggregates the values of all metrics matching the given name suffix across all validators.
+pub(crate) fn sum_metric_with_suffix(context: &Context, suffix: &str) -> u64 {
+    let metrics = context.encode();
+    let mut total = 0u64;
+
+    for line in metrics.lines() {
+        let Some((metric, value)) = parse_metric_line(line) else {
+            continue;
+        };
+
+        if metric.ends_with(suffix) {
+            total += value;
+        }
+    }
+
+    total
+}
+
 /// Asserts that no DKG ceremony failures have occurred.
 #[track_caller]
 pub(crate) fn assert_no_dkg_failure(metric: &str, value: &str) {

--- a/crates/e2e/src/tests/dkg/handle_finalized_block.rs
+++ b/crates/e2e/src/tests/dkg/handle_finalized_block.rs
@@ -41,7 +41,6 @@ impl MidEpochBlockTest {
 
         let setup = Setup::new()
             .how_many_signers(self.how_many_signers)
-            .t2_time(0)
             .epoch_length(self.epoch_length);
 
         let cfg = Config::default().with_seed(setup.seed);
@@ -84,7 +83,7 @@ impl MidEpochBlockTest {
 fn early_phase_dealer_distributes_shares() {
     let _ = tempo_eyre::install();
 
-    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+    let setup = Setup::new().how_many_signers(4).epoch_length(20);
 
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);
@@ -117,7 +116,7 @@ fn early_phase_dealer_distributes_shares() {
 fn midpoint_and_late_phase_dealer_finalization() {
     let _ = tempo_eyre::install();
 
-    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+    let setup = Setup::new().how_many_signers(4).epoch_length(20);
 
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);
@@ -168,7 +167,6 @@ impl RestartMidEpochTest {
 
         let setup = Setup::new()
             .how_many_signers(self.how_many_signers)
-            .t2_time(0)
             .epoch_length(self.epoch_length);
 
         let cfg = Config::default().with_seed(setup.seed);
@@ -231,7 +229,6 @@ impl BoundaryBlockTest {
 
         let setup = Setup::new()
             .how_many_signers(self.how_many_signers)
-            .t2_time(0)
             .epoch_length(self.epoch_length);
 
         let cfg = Config::default().with_seed(setup.seed);
@@ -315,7 +312,7 @@ fn dealer_log_in_block_extra_data_is_stored() {
     let _ = tempo_eyre::install();
 
     // 4 signers so each node acts as both dealer and player.
-    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+    let setup = Setup::new().how_many_signers(4).epoch_length(20);
 
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);
@@ -348,7 +345,7 @@ fn dealer_log_in_block_extra_data_is_stored() {
 fn own_dealer_log_in_block_is_cleared_from_state() {
     let _ = tempo_eyre::install();
 
-    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+    let setup = Setup::new().how_many_signers(4).epoch_length(20);
 
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);

--- a/crates/e2e/src/tests/dkg/handle_finalized_block.rs
+++ b/crates/e2e/src/tests/dkg/handle_finalized_block.rs
@@ -1,0 +1,364 @@
+//! E2E tests for the DKG actor's per-block processing logic across epoch phases.
+
+use commonware_macros::test_traced;
+use commonware_runtime::{
+    Runner as _,
+    deterministic::{Config, Runner},
+};
+use futures::future::join_all;
+
+use super::common::{
+    assert_no_dkg_failures, sum_metric_with_suffix, wait_for_outcome,
+    wait_for_validators_to_reach_epoch,
+};
+use crate::{Setup, setup_validators};
+
+/// Tests that the epoch counter only advances on the last block of each epoch.
+///
+/// Runs 4 validators for 2 epochs and verifies that the on-chain DKG outcome
+/// at each boundary block carries the next epoch number, confirming that
+/// mid-epoch blocks do not trigger an epoch transition.
+#[test_traced]
+fn mid_epoch_blocks_do_not_advance_epoch() {
+    MidEpochBlockTest {
+        how_many_signers: 4,
+        epoch_length: 20,
+        wait_until_epoch: 2,
+    }
+    .run();
+}
+
+struct MidEpochBlockTest {
+    how_many_signers: u32,
+    epoch_length: u64,
+    /// How many epochs to let run to confirm behaviour is stable.
+    wait_until_epoch: u64,
+}
+
+impl MidEpochBlockTest {
+    fn run(self) {
+        let _ = tempo_eyre::install();
+
+        let setup = Setup::new()
+            .how_many_signers(self.how_many_signers)
+            .t2_time(0)
+            .epoch_length(self.epoch_length);
+
+        let cfg = Config::default().with_seed(setup.seed);
+        let executor = Runner::from(cfg);
+
+        executor.start(|mut context| async move {
+            let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+            join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+            // Wait for validators to complete several full epochs.
+            wait_for_validators_to_reach_epoch(
+                &context,
+                self.wait_until_epoch,
+                self.how_many_signers,
+            )
+            .await;
+
+            // Verify on-chain DKG outcome epoch number at each boundary block.
+            for epoch in 0..self.wait_until_epoch {
+                let outcome =
+                    wait_for_outcome(&context, &validators, epoch, self.epoch_length).await;
+
+                assert_eq!(
+                    outcome.epoch.get(),
+                    epoch + 1,
+                    "DKG outcome at end of epoch {epoch} must carry the next epoch number"
+                );
+            }
+
+            assert_no_dkg_failures(&context);
+        })
+    }
+}
+
+/// Tests that dealer nodes distribute shares during the early phase of a DKG ceremony.
+///
+/// Runs 4 validators for 1 epoch and verifies that at least one node acted as
+/// a dealer by checking the dealer activity counter is non-zero.
+#[test_traced]
+fn early_phase_dealer_distributes_shares() {
+    let _ = tempo_eyre::install();
+
+    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+        // Run one complete epoch so dealers have had a chance to distribute.
+        wait_for_validators_to_reach_epoch(&context, 1, 4).await;
+
+        // Verify at least one node acted as a dealer during the epoch.
+        let how_often_dealer =
+            sum_metric_with_suffix(&context, "_dkg_manager_how_often_dealer_total");
+        assert!(
+            how_often_dealer > 0,
+            "expected at least one validator to have acted as dealer \
+             (how_often_dealer_total={how_often_dealer})"
+        );
+
+        assert_no_dkg_failures(&context);
+    })
+}
+
+/// Tests that dealer nodes finalize their state in the midpoint and late phases.
+///
+/// Runs 4 validators for 2 epochs and verifies that at least one DKG ceremony
+/// completed successfully by checking the ceremony success counter is non-zero.
+#[test_traced]
+fn midpoint_and_late_phase_dealer_finalization() {
+    let _ = tempo_eyre::install();
+
+    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+        // Two epochs to confirm dealer finalization is stable across reshares.
+        wait_for_validators_to_reach_epoch(&context, 2, 4).await;
+
+        // Verify at least one ceremony completed successfully.
+        let successes = sum_metric_with_suffix(&context, "_dkg_manager_ceremony_successes_total");
+        assert!(
+            successes > 0,
+            "expected at least one successful ceremony, confirming dealer finalization \
+             ran in Midpoint/Late phase (ceremony_successes_total={successes})"
+        );
+
+        assert_no_dkg_failures(&context);
+    })
+}
+
+/// Tests that a restarted node silently ignores blocks from prior epochs.
+///
+/// Runs 4 validators, restarts one after the first epoch completes, and
+/// verifies all 4 nodes advance to epoch 3 without errors.
+#[test_traced]
+fn restarted_node_ignores_prior_epoch_blocks() {
+    RestartMidEpochTest {
+        how_many_signers: 4,
+        epoch_length: 20,
+        restart_after_epoch: 1,
+    }
+    .run();
+}
+
+struct RestartMidEpochTest {
+    how_many_signers: u32,
+    epoch_length: u64,
+    /// Restart the first validator after this epoch completes.
+    restart_after_epoch: u64,
+}
+
+impl RestartMidEpochTest {
+    fn run(self) {
+        let _ = tempo_eyre::install();
+
+        let setup = Setup::new()
+            .how_many_signers(self.how_many_signers)
+            .t2_time(0)
+            .epoch_length(self.epoch_length);
+
+        let cfg = Config::default().with_seed(setup.seed);
+        let executor = Runner::from(cfg);
+
+        executor.start(|mut context| async move {
+            let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+            join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+            // Let all validators complete the first epoch before restarting.
+            wait_for_validators_to_reach_epoch(
+                &context,
+                self.restart_after_epoch + 1,
+                self.how_many_signers,
+            )
+            .await;
+
+            // Restart the first validator.
+            validators[0].stop().await;
+            validators[0].start(&context).await;
+
+            // Verify the restarted node rejoins and all nodes advance to the next epoch.
+            wait_for_validators_to_reach_epoch(
+                &context,
+                self.restart_after_epoch + 2,
+                self.how_many_signers,
+            )
+            .await;
+
+            assert_no_dkg_failures(&context);
+        })
+    }
+}
+
+/// Tests that the boundary block of each epoch correctly resolves the DKG outcome.
+///
+/// Runs 4 validators for 3 epochs and verifies:
+/// 1. The outcome epoch number advances by one at each boundary block.
+/// 2. The next set of validators is populated after each transition.
+/// 3. The group public key remains stable across reshares.
+#[test_traced]
+fn boundary_block_resolves_epoch_outcome_and_advances_state() {
+    BoundaryBlockTest {
+        how_many_signers: 4,
+        epoch_length: 20,
+        epochs_to_run: 3,
+    }
+    .run();
+}
+
+struct BoundaryBlockTest {
+    how_many_signers: u32,
+    epoch_length: u64,
+    epochs_to_run: u64,
+}
+
+impl BoundaryBlockTest {
+    fn run(self) {
+        let _ = tempo_eyre::install();
+
+        let setup = Setup::new()
+            .how_many_signers(self.how_many_signers)
+            .t2_time(0)
+            .epoch_length(self.epoch_length);
+
+        let cfg = Config::default().with_seed(setup.seed);
+        let executor = Runner::from(cfg);
+
+        executor.start(|mut context| async move {
+            let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+            join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+            wait_for_validators_to_reach_epoch(&context, self.epochs_to_run, self.how_many_signers)
+                .await;
+
+            // Verify invariants at each epoch boundary.
+            let mut prev_pubkey = None;
+
+            for epoch in 0..self.epochs_to_run {
+                let outcome =
+                    wait_for_outcome(&context, &validators, epoch, self.epoch_length).await;
+
+                // Outcome epoch must be current epoch + 1.
+                assert_eq!(
+                    outcome.epoch.get(),
+                    epoch + 1,
+                    "outcome at end of epoch {epoch} must carry epoch {}",
+                    epoch + 1,
+                );
+
+                // Next-players set must be populated.
+                assert!(
+                    !outcome.next_players.is_empty(),
+                    "next_players must be populated by resolve_epoch_outcome \
+                     at end of epoch {epoch}"
+                );
+
+                // Group public key must be stable across reshares.
+                let pubkey = *outcome.sharing().public();
+                if let Some(prev) = prev_pubkey {
+                    assert_eq!(
+                        prev,
+                        pubkey,
+                        "group public key must be stable across reshare epochs \
+                         (changed between epoch {} and {epoch})",
+                        epoch - 1,
+                    );
+                }
+                prev_pubkey = Some(pubkey);
+
+                tracing::info!(
+                    epoch,
+                    next_epoch = outcome.epoch.get(),
+                    ?pubkey,
+                    "Verified resolve_epoch_outcome output"
+                );
+            }
+
+            assert_no_dkg_failures(&context);
+        })
+    }
+}
+
+/// Tests epoch boundary resolution with a single-signer setup.
+///
+/// Runs 1 validator for 3 epochs with 10-block epochs and verifies the same
+/// boundary block invariants as the multi-signer test.
+#[test_traced]
+fn resolve_epoch_outcome_single_signer() {
+    BoundaryBlockTest {
+        how_many_signers: 1,
+        epoch_length: 10,
+        epochs_to_run: 3,
+    }
+    .run();
+}
+
+/// Tests that dealer logs written into block extra data are stored and used to complete the ceremony.
+///
+/// Runs 4 validators for 1 epoch and verifies that no DKG failures occur
+/// and the ceremony produces a valid outcome for epoch 1.
+#[test_traced]
+fn dealer_log_in_block_extra_data_is_stored() {
+    let _ = tempo_eyre::install();
+
+    // 4 signers so each node acts as both dealer and player.
+    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+        // Wait for one full epoch.
+        wait_for_validators_to_reach_epoch(&context, 1, 4).await;
+
+        // Verify no failures and the ceremony produced a valid outcome.
+        assert_no_dkg_failures(&context);
+
+        // Verify the outcome epoch advanced.
+        let outcome = wait_for_outcome(&context, &validators, 0, 20).await;
+        assert_eq!(
+            outcome.epoch.get(),
+            1,
+            "ceremony must have produced an outcome for epoch 1"
+        );
+    })
+}
+
+/// Tests that a dealer's own log is cleared from state after it appears in a finalized block.
+///
+/// Runs 4 validators for 2 epochs and verifies no DKG failures occur,
+/// confirming stale logs do not re-appear during the next epoch's reshare.
+#[test_traced]
+fn own_dealer_log_in_block_is_cleared_from_state() {
+    let _ = tempo_eyre::install();
+
+    let setup = Setup::new().how_many_signers(4).t2_time(0).epoch_length(20);
+
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+
+        // Run two full epochs to confirm no stale logs re-appear during reshare.
+        wait_for_validators_to_reach_epoch(&context, 2, 4).await;
+        assert_no_dkg_failures(&context);
+    })
+}

--- a/crates/e2e/src/tests/dkg/mod.rs
+++ b/crates/e2e/src/tests/dkg/mod.rs
@@ -4,5 +4,6 @@ pub(crate) mod common;
 mod dynamic;
 mod fast_sync_after_full_dkg;
 mod full_ceremony;
+mod handle_finalized_block;
 mod share_loss;
 mod static_transitions;


### PR DESCRIPTION
Closes #2697

###Summary
The `handle_finalized_block` function in the DKG manager actor was a single large function. This PR resolves refactoring the function and adding E2E test coverage.

###Solution

- Introduced `FinalizedBlockContext` struct ->  groups the 7 individual arguments of `handle_finalized_block` into a single context struct, removing the `clippy::too_many_arguments` suppression and fulfilling the TODO comment.
- Extracted `process_mid_epoch_block` ->  the mid-epoch path (reading dealer logs from block extra data, persisting them to the journal, clearing own log from state) is now a standalone method.
- Extracted `resolve_epoch_outcome` ->  the boundary block path (reading the on-chain DKG outcome, computing local output, updating metrics, reading the validator contract) is now a standalone method.

###Tests Added
8 new E2E tests covering the per-block processing logic:

- `mid_epoch_blocks_do_not_advance_epoch`               -> 	Epoch counter only advances on the last block of each epoch
- `early_phase_dealer_distributes_shares`                      ->       Dealers distribute shares during the early phase
- `midpoint_and_late_phase_dealer_finalization`           ->      Dealers finalize state in midpoint and late phases
- `restarted_node_ignores_prior_epoch_blocks`            ->       Restarted node silently ignores blocks from prior epochs
- `boundary_block_resolves_epoch_outcome_and_advances_state`       ->      Boundary block resolves DKG outcome, advances epoch, populates next players, keeps group public key stable

- `resolve_epoch_outcome_single_signer`                      ->       Same boundary block invariants with a single-signer setup
- `dealer_log_in_block_extra_data_is_stored`                 ->       Dealer logs written into block extra data are stored and used to complete the ceremony

- `own_dealer_log_in_block_is_cleared_from_state`      ->      A dealer's own log is cleared from state after it appears in a finalized block