### PR TITLE
chore: remove val config v1 from consensus

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -290,7 +290,6 @@ where
             context.with_label("peer_manager"),
             peer_manager::Config {
                 execution_node: execution_node.clone(),
-                executor: executor_mailbox.clone(),
                 oracle: self.peer_manager.clone(),
                 epoch_strategy: epoch_strategy.clone(),
                 last_finalized_height,

--- a/crates/commonware-node/src/dkg/manager/actor/mod.rs
+++ b/crates/commonware-node/src/dkg/manager/actor/mod.rs
@@ -1,6 +1,6 @@
-use std::{collections::BTreeMap, num::NonZeroU32, task::Poll, time::Duration};
+use std::{collections::BTreeMap, num::NonZeroU32, task::Poll};
 
-use alloy_consensus::{BlockHeader as _, Sealable as _};
+use alloy_consensus::BlockHeader as _;
 use alloy_primitives::B256;
 use bytes::{Buf, BufMut};
 use commonware_codec::{Encode as _, EncodeSize, Read, ReadExt as _, Write};
@@ -35,23 +35,16 @@ use futures::{
 };
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use rand_core::CryptoRngCore;
-use reth_ethereum::{
-    chainspec::EthChainSpec, network::NetworkInfo, rpc::eth::primitives::BlockNumHash,
-};
+use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
 use reth_provider::{BlockIdReader as _, HeaderProvider as _};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::TempoFullNode;
-use tempo_precompiles::{
-    validator_config::ValidatorConfig, validator_config_v2::ValidatorConfigV2,
-};
+use tempo_precompiles::validator_config_v2::ValidatorConfigV2;
 use tracing::{Level, Span, debug, info, info_span, instrument, warn, warn_span};
 
 use crate::{
     consensus::{Digest, block::Block},
-    validators::{
-        can_use_v2_at_block_hash, read_active_and_known_peers_at_block_hash_v1,
-        read_active_and_known_peers_at_block_hash_v2, read_validator_config_at_block_hash,
-    },
+    validators::{read_active_and_known_peers_at_block_hash, read_validator_config_at_block_hash},
 };
 
 mod state;
@@ -811,22 +804,13 @@ where
             self.metrics.successes.inc();
         }
 
-        let syncers = read_syncers_if_v2_not_initialized_with_retry(
-            &self.context,
-            &self.config.execution_node,
-            &block,
-            &self.metrics.attempts_to_read_validator_contract,
-        )
-        .await
-        .wrap_err("failed reading contract to determine syncers")?;
-
         Ok(Some(state::State {
             epoch: onchain_outcome.epoch,
             seed: Summary::random(&mut self.context),
             output: onchain_outcome.output.clone(),
             share,
             players: onchain_outcome.next_players,
-            syncers,
+            syncers: ordered::Set::default(),
             is_full_dkg: onchain_outcome.is_next_full_dkg,
         }))
     }
@@ -899,24 +883,13 @@ where
 
         info!("reading validators from contract");
 
-        // Only read syncers from the contract if t2 is not yet active and if
-        // val conf v2 has not yet been initialized.
-        let syncers = read_syncers_if_v2_not_initialized_with_retry(
-            &self.context,
-            &self.config.execution_node,
-            &block,
-            &self.metrics.attempts_to_read_validator_contract,
-        )
-        .await
-        .wrap_err("failed reading contract; must be able to read contract to continue")?;
-
         Ok(Some(state::State {
             epoch: onchain_outcome.epoch,
             seed: Summary::random(&mut self.context),
             output: onchain_outcome.output.clone(),
             share: state::ShareState::Plaintext(None),
             players: onchain_outcome.next_players,
-            syncers,
+            syncers: ordered::Set::default(),
             is_full_dkg: onchain_outcome.is_next_full_dkg,
         }))
     }
@@ -1233,8 +1206,9 @@ where
         );
 
         let next_players =
-            determine_next_players_at_hash(state, &self.config.execution_node, request.digest.0)
+            determine_next_players_at_hash(&self.config.execution_node, request.digest.0)
                 .wrap_err("could not determine who the next players are supposed to be")?;
+
         request
             .response
             .send(OnchainDkgOutcome {
@@ -1326,40 +1300,10 @@ where
             format!("failed to read header for latest boundary block number `{latest_boundary}`")
         })?;
 
-    let parent_of_boundary_header = node
-        .provider
-        .header_by_number(latest_boundary.saturating_sub(1))
-        .map_or_else(
-            |e| Err(eyre::Report::new(e)),
-            |header| header.ok_or_eyre("execution layer reported it had no header"),
-        )
-        .wrap_err_with(|| {
-            format!(
-                "failed to read header for the boundary's parent `{}`",
-                latest_boundary.saturating_sub(1)
-            )
-        })?;
-
     let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
         &mut boundary_header.extra_data().as_ref(),
     )
     .wrap_err("the boundary header did not contain the on-chain DKG outcome")?;
-
-    // NOTE: On init this is intended to fail fast: if a consensus state exists
-    // (such that there is a mismatch between CL and EL finalized block
-    // requiring a backfill and hence a retry), then
-    // `read_initial_state_and_set_floor` is never called.
-    //
-    // If a consensus state does not exist, then either EL has access to the
-    // state at the boundary or it does not. There is no mechanism that would
-    // allow it to get the block.
-    let syncers = read_syncers_if_v2_not_initialized(
-        1,
-        node,
-        parent_of_boundary_header.hash_slow(),
-        boundary_header.hash_slow(),
-    )
-    .wrap_err("failed determining syncers")?;
 
     let share = state::ShareState::Plaintext('verify_initial_share: {
         let Some(share) = share else {
@@ -1391,7 +1335,7 @@ where
         output: onchain_outcome.output.clone(),
         share,
         players: onchain_outcome.next_players,
-        syncers,
+        syncers: ordered::Set::default(),
         is_full_dkg: onchain_outcome.is_next_full_dkg,
     })
 }
@@ -1416,7 +1360,6 @@ struct Metrics {
     how_often_player: Counter,
 
     rounds_skipped: Counter,
-    attempts_to_read_validator_contract: Counter,
 }
 
 impl Metrics {
@@ -1520,13 +1463,6 @@ impl Metrics {
             rounds_skipped.clone(),
         );
 
-        let attempts_to_read_validator_contract = Counter::default();
-        context.register(
-            "attempts_to_read_validator_contract",
-            "the total number of attempts it took to read the validators from the smart contract",
-            attempts_to_read_validator_contract.clone(),
-        );
-
         Self {
             syncing_players,
             shares_distributed,
@@ -1542,7 +1478,6 @@ impl Metrics {
             failures,
             successes,
             rounds_skipped,
-            attempts_to_read_validator_contract,
         }
     }
 
@@ -1643,105 +1578,6 @@ fn read_dealer_log(
     Ok((dealer, log))
 }
 
-/// Reads syncing validators if the V2 contract is not yet initialized.
-async fn read_syncers_if_v2_not_initialized_with_retry(
-    context: &impl commonware_runtime::Clock,
-    node: &TempoFullNode,
-    boundary_block: &Block,
-    total_attempts: &Counter,
-) -> eyre::Result<ordered::Set<PublicKey>> {
-    let mut attempts = 0;
-    const MIN_RETRY: Duration = Duration::from_secs(1);
-    const MAX_RETRY: Duration = Duration::from_secs(30);
-
-    let parent_hash = boundary_block.parent_hash();
-    let block_hash = boundary_block.hash();
-    'read_contract: loop {
-        total_attempts.inc();
-        attempts += 1;
-
-        if let Ok(syncers) =
-            read_syncers_if_v2_not_initialized(attempts, node, parent_hash, block_hash)
-        {
-            break 'read_contract Ok(syncers);
-        }
-
-        let retry_after = MIN_RETRY.saturating_mul(attempts).min(MAX_RETRY);
-        let is_syncing = node.network.is_syncing();
-        let best_finalized_block = node.provider.finalized_block_number().ok().flatten();
-        let blocks_behind = best_finalized_block
-            .as_ref()
-            .map(|best| boundary_block.number().saturating_sub(*best));
-        tracing::warn_span!("read_validator_config_with_retry").in_scope(|| {
-            warn!(
-                attempts,
-                retry_after = %tempo_telemetry_util::display_duration(retry_after),
-                is_syncing,
-                best_finalized_block = %tempo_telemetry_util::display_option(&best_finalized_block),
-                height_if_v1 = boundary_block.number(),
-                blocks_behind = %tempo_telemetry_util::display_option(&blocks_behind),
-                "reading validator config from contract failed; will retry",
-            );
-        });
-        context.sleep(retry_after).await;
-    }
-}
-
-/// Reads the pre-t2 hardfork syncers from the v1 contract.
-///
-/// If the validator config v2 contract is already initialized, then this
-/// returns an empty set because after the hardfork syncers do not need to be
-/// tracked.
-///
-/// IMPORTANT: it is expected that this function is called on boundary blocks.
-/// Post-T2 hardfork, the next players are determined from the V2 smart contract
-/// on the boundary block's parent(!) block, not on the boundary block itself.
-///
-/// Therefore, this function checks if the hardfork already happened by the
-/// timestamp of the block identified by `parent_hash`, and likewise if the
-/// contract was initialized at the state of `parent_hash`.
-#[instrument(
-    skip_all,
-    fields(
-        attempt = _attempt,
-        parent_hash,
-        block_hash,
-    ),
-    err
-)]
-pub(crate) fn read_syncers_if_v2_not_initialized(
-    _attempt: u32,
-    node: &TempoFullNode,
-    parent_hash: B256,
-    block_hash: B256,
-) -> eyre::Result<ordered::Set<PublicKey>> {
-    // Use the finalized block hash for the v2 initialization check if available
-    // and at least as recent as the boundary block. The `is_initialized` and
-    // `initialization_height` contract values are immutable once set, so
-    // reading them from any later state is valid. This avoids failures when
-    // the boundary block's state has been pruned during sync catch-up.
-    let latest = node
-        .provider
-        .finalized_block_num_hash()
-        .ok()
-        .flatten()
-        .and_then(|finalized| {
-            let header = node.provider.header(block_hash).ok().flatten()?;
-            (finalized.number >= header.number()).then_some(finalized.hash)
-        })
-        .unwrap_or(block_hash);
-    if can_use_v2_at_block_hash(node, parent_hash, Some(latest))
-        .wrap_err("unable to determine if the validator config v2 can be used or not")?
-    {
-        return Ok(ordered::Set::default());
-    }
-    let peers =
-        read_active_and_known_peers_at_block_hash_v1(node, &ordered::Set::default(), block_hash)
-            .wrap_err("unable to read peers from validator config v1 contract")?;
-    info!(?peers, "read validators from validator config v1 contract");
-    Ok(peers.into_keys())
-}
-
 /// Determines the next players depending on the header timestamp identified by `digest`.
 ///
 /// This function should only be used when constructing or verifying a proposal.
@@ -1751,21 +1587,13 @@ pub(crate) fn read_syncers_if_v2_not_initialized(
 /// available then it cannot propose or verify a block.
 #[instrument(skip_all, fields(%hash), err(level = Level::WARN))]
 fn determine_next_players_at_hash(
-    state: &State,
     node: &TempoFullNode,
     hash: B256,
 ) -> eyre::Result<ordered::Set<PublicKey>> {
-    let next_players = if can_use_v2_at_block_hash(node, hash, None)
-        .wrap_err("failed determining if validator config v2 can be used")?
-    {
-        debug!("reading next players from validator config v2 contract");
-        read_active_and_known_peers_at_block_hash_v2(node, &ordered::Set::default(), hash)
+    let next_players =
+        read_active_and_known_peers_at_block_hash(node, &ordered::Set::default(), hash)
             .wrap_err("failed reading peers from  validator config v2")?
-            .into_keys()
-    } else {
-        debug!("using validator config v1 syncers from state");
-        state.syncers.clone()
-    };
+            .into_keys();
 
     debug!(?next_players, "determined next players");
     Ok(next_players)
@@ -1790,21 +1618,10 @@ fn determine_next_players_at_hash(
     ret,
 )]
 pub(crate) fn read_re_dkg_epoch(node: &TempoFullNode, digest: Digest) -> eyre::Result<u64> {
-    if can_use_v2_at_block_hash(node, digest.0, None)
-        .wrap_err("failed determining if validator config v2 can be used")?
-    {
-        read_validator_config_at_block_hash(node, digest.0, |config: &ValidatorConfigV2| {
-            config
-                .get_next_network_identity_rotation_epoch()
-                .map_err(eyre::Report::new)
-        })
-        .map(|(_, _, epoch)| epoch)
-    } else {
-        read_validator_config_at_block_hash(node, digest.0, |config: &ValidatorConfig| {
-            config
-                .get_next_full_dkg_ceremony()
-                .map_err(eyre::Report::new)
-        })
-        .map(|(_, _, epoch)| epoch)
-    }
+    read_validator_config_at_block_hash(node, digest.0, |config: &ValidatorConfigV2| {
+        config
+            .get_next_network_identity_rotation_epoch()
+            .map_err(eyre::Report::new)
+    })
+    .map(|(_, _, epoch)| epoch)
 }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -4,7 +4,7 @@
 //! execution layer and tracks the digest of the latest finalized block.
 //! It also advances the canonical chain by sending forkchoice-updates.
 
-use std::{collections::BTreeMap, pin::Pin, sync::Arc, time::Duration};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
@@ -31,7 +31,7 @@ use tracing::{
 
 use super::{
     Config,
-    ingress::{CanonicalizeHead, Command, Message, SubscribeFinalized},
+    ingress::{CanonicalizeHead, Command, Message},
 };
 use crate::{
     consensus::{Digest, block::Block},
@@ -118,10 +118,6 @@ pub(crate) struct Actor<TContext> {
 
     /// The timer for the next FCU heartbeat. Reset whenever an FCU is sent.
     fcu_heartbeat_timer: Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
-
-    /// A list of subscriptions waiting for the executor to finalize a block
-    /// at a given height.
-    pending_finalized_subscriptions: BTreeMap<Height, Vec<oneshot::Sender<()>>>,
 }
 
 impl<TContext> Actor<TContext>
@@ -170,7 +166,6 @@ where
             },
             fcu_heartbeat_interval,
             fcu_heartbeat_timer,
-            pending_finalized_subscriptions: BTreeMap::new(),
         })
     }
 
@@ -343,16 +338,6 @@ where
                     .await
                     .wrap_err("failed handling finalization")?;
             }
-            Command::SubscribeFinalized(SubscribeFinalized { height, response }) => {
-                if self.last_canonicalized.finalized_height >= height {
-                    let _ = response.send(());
-                } else {
-                    self.pending_finalized_subscriptions
-                        .entry(height)
-                        .or_default()
-                        .push(response);
-                }
-            }
         }
         Ok(())
     }
@@ -503,7 +488,6 @@ where
         block: Block,
         acknowledgment: Exact,
     ) -> eyre::Result<()> {
-        let height = block.height();
         let (response, rx) = oneshot::channel();
         self.canonicalize(
             Span::current(),
@@ -541,16 +525,6 @@ where
         );
 
         acknowledgment.acknowledge();
-
-        self.pending_finalized_subscriptions.retain(|&key, value| {
-            let retain = key > height;
-            if !retain {
-                value.drain(..).for_each(|tx| {
-                    let _ = tx.send(());
-                });
-            }
-            retain
-        });
 
         Ok(())
     }

--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -1,6 +1,6 @@
 use alloy_rpc_types_engine::PayloadId;
 use commonware_consensus::{Reporter, marshal::Update, types::Height};
-use eyre::{WrapErr as _, eyre};
+use eyre::WrapErr as _;
 use futures::{
     SinkExt as _,
     channel::{mpsc, oneshot},
@@ -57,19 +57,6 @@ impl Mailbox {
             .wrap_err("executor dropped response")
             .and_then(|res| res)
     }
-
-    pub(crate) async fn subscribe_finalized(&self, height: Height) -> eyre::Result<()> {
-        let (response, rx) = oneshot::channel();
-        self.inner
-            .unbounded_send(Message::in_current_span(SubscribeFinalized {
-                height,
-                response,
-            }))
-            .wrap_err(
-                "failed sending subscribe finalized request to agent, this means it exited",
-            )?;
-        rx.await.map_err(|_| eyre!("actor dropped response"))
-    }
 }
 
 #[derive(Debug)]
@@ -95,8 +82,6 @@ pub(super) enum Command {
     CanonicalizeAndBuild(CanonicalizeAndBuild),
     /// Requests the agent to forward a finalization event to the execution layer.
     Finalize(Box<Update<Block>>),
-    /// Returns once the executor actor has finalized the block at `height`.
-    SubscribeFinalized(SubscribeFinalized),
 }
 
 #[derive(Debug)]
@@ -114,12 +99,6 @@ pub(super) struct CanonicalizeAndBuild {
     pub(super) response: oneshot::Sender<eyre::Result<PayloadId>>,
 }
 
-#[derive(Debug)]
-pub(super) struct SubscribeFinalized {
-    pub(super) height: Height,
-    pub(super) response: oneshot::Sender<()>,
-}
-
 impl From<CanonicalizeHead> for Command {
     fn from(value: CanonicalizeHead) -> Self {
         Self::CanonicalizeHead(value)
@@ -135,12 +114,6 @@ impl From<CanonicalizeAndBuild> for Command {
 impl From<Update<Block>> for Command {
     fn from(value: Update<Block>) -> Self {
         Self::Finalize(value.into())
-    }
-}
-
-impl From<SubscribeFinalized> for Command {
-    fn from(value: SubscribeFinalized) -> Self {
-        Self::SubscribeFinalized(value)
     }
 }
 

--- a/crates/commonware-node/src/peer_manager/actor.rs
+++ b/crates/commonware-node/src/peer_manager/actor.rs
@@ -3,32 +3,23 @@ use std::{pin::Pin, time::Duration};
 use alloy_consensus::{BlockHeader as _, Sealable as _};
 use commonware_codec::ReadExt as _;
 use commonware_consensus::{
-    Heightable as _,
     marshal::Update,
     types::{Epocher, FixedEpocher, Height},
 };
 use commonware_cryptography::ed25519::PublicKey;
-use commonware_p2p::{Address, AddressableManager, Provider};
+use commonware_p2p::{AddressableManager, Provider};
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement, ordered};
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::{StreamExt as _, channel::mpsc};
 use prometheus_client::metrics::gauge::Gauge;
-use reth_ethereum::{chainspec::EthChainSpec, network::NetworkInfo};
 use reth_provider::{BlockIdReader as _, HeaderProvider as _};
-use tempo_chainspec::hardfork::TempoHardforks as _;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::TempoFullNode;
 use tempo_primitives::TempoHeader;
-use tempo_telemetry_util::{display_duration, display_option};
-use tracing::{Span, debug, error, info_span, instrument, warn};
+use tracing::{Span, debug, error, info_span, instrument};
 
-use crate::{
-    consensus::block::Block,
-    validators::{
-        read_active_and_known_peers_at_block_hash, read_active_and_known_peers_at_block_hash_v1,
-    },
-};
+use crate::validators::read_active_and_known_peers_at_block_hash;
 
 /// The interval on which the peer set is update during bootstrapping.
 /// Aggressive timing to get started.
@@ -48,7 +39,6 @@ where
 
     oracle: TPeerManager,
     execution_node: TempoFullNode,
-    executor: crate::executor::Mailbox,
     epoch_strategy: FixedEpocher,
     last_finalized_height: Height,
     mailbox: mpsc::UnboundedReceiver<MessageWithCause>,
@@ -70,7 +60,6 @@ where
         super::Config {
             oracle,
             execution_node,
-            executor,
             epoch_strategy,
             last_finalized_height,
         }: super::Config<TPeerManager>,
@@ -88,7 +77,6 @@ where
             context,
             oracle,
             execution_node,
-            executor,
             epoch_strategy,
             last_finalized_height,
             mailbox,
@@ -103,8 +91,6 @@ where
         let reason = 'event_loop: loop {
             tokio::select!(
                 biased;
-
-
                 msg = self.mailbox.next() => {
                     match msg {
                         None => break 'event_loop eyre::eyre!("mailbox closed unexpectedly"),
@@ -116,11 +102,10 @@ where
                         }
                     }
                 }
-
                 // Perform aggressive retries if no peer set is tracked yet.
                 // Otherwise just do it every minute.
                 _ = &mut self.peer_update_timer => {
-                    let _ = self.update_peer_set(None).await;
+                    let _ = self.refresh_peers().await;
                     self.reset_peer_update_timer();
                 }
             )
@@ -149,73 +134,13 @@ where
                 let _ = response.send(receiver);
             }
             Message::Finalized(update) => match *update {
-                Update::Block(block, ack) => {
-                    let _ = self.update_peer_set(Some(block)).await;
+                Update::Block(_, ack) => {
+                    let _ = self.refresh_peers().await;
                     ack.acknowledge();
                     self.reset_peer_update_timer();
                 }
                 Update::Tip { .. } => {}
             },
-        }
-        Ok(())
-    }
-
-    /// Updates the peer set.
-    #[instrument(
-        skip_all,
-        fields(
-            block.height = block.as_ref().map(|b| tracing::field::display(b.height())),
-        ),
-        err,
-    )]
-    async fn update_peer_set(&mut self, block: Option<Block>) -> eyre::Result<()> {
-        if let Some(block) = &block
-            && let Err(reason) = self.executor.subscribe_finalized(block.height()).await
-        {
-            warn!(
-                %reason,
-                "unable to clarify whether the finalized block was already \
-                forwarded to execution layer; will try to read validator \
-                config contract, but it will likely fail",
-            );
-        }
-
-        let maybe_latest_finalized_header = self.read_highest_finalized_header();
-        let reference_timestamp = match &block {
-            Some(block) => maybe_latest_finalized_header.ok().map_or_else(
-                || block.timestamp(),
-                |header| header.timestamp().max(block.timestamp()),
-            ),
-            None => maybe_latest_finalized_header
-                .wrap_err("could not determine a timestamp to determine peer behavior")?
-                .timestamp(),
-        };
-
-        // Post T2 behavior: do a best-effort update of the peerset, to whatever
-        // is available as long as it is newer than what we are already tracking.
-        //
-        // Also run this if we do not yet have any peer set available.
-        if self
-            .execution_node
-            .chain_spec()
-            .is_t2_active_at_timestamp(reference_timestamp)
-            || self.last_tracked_peer_set.is_none()
-        {
-            self.refresh_peers()
-                .await
-                .wrap_err("failed refreshing peer set")?;
-        } else if let Some(block) = block {
-            let height = block.number();
-            if let Some(peers) = read_peer_set_if_boundary(
-                &self.context,
-                &self.epoch_strategy,
-                &self.execution_node,
-                block,
-            )
-            .await
-            {
-                self.track_or_overwrite(height, peers).await;
-            }
         }
         Ok(())
     }
@@ -356,30 +281,6 @@ where
             ),
         );
     }
-    #[instrument(skip_all, fields(height), err)]
-    fn read_highest_finalized_header(&self) -> eyre::Result<TempoHeader> {
-        let highest_finalized = match self.execution_node.provider.finalized_block_hash() {
-            Ok(Some(highest_finalized)) => Ok(highest_finalized),
-            Ok(None) if self.last_finalized_height == Height::zero() => {
-                Ok(self.execution_node.chain_spec().genesis_hash())
-            }
-            Ok(None) => Err(eyre::eyre!(
-                "execution layer has no record of any finalization hashes"
-            )),
-            Err(err) => Err(eyre::Report::new(err)),
-        }
-        .wrap_err("failed reading latest finalizhed hash from execution layer")?;
-        self.execution_node
-            .provider
-            .header_by_hash_or_number(highest_finalized.into())
-            .map_err(eyre::Report::new)
-            .and_then(|h| {
-                h.ok_or_eyre(
-                    "execution layer did not have the header for the advertised finalized hash",
-                )
-            })
-            .wrap_err_with(|| format!("failed reading header for hash `{highest_finalized}`"))
-    }
 }
 
 #[derive(Debug)]
@@ -396,63 +297,4 @@ fn read_header_at_height(execution_node: &TempoFullNode, height: u64) -> eyre::R
         .map_err(eyre::Report::new)
         .and_then(|h| h.ok_or_eyre("execution layer did not have a header at the requested height"))
         .wrap_err_with(|| format!("failed reading header at height `{height}`"))
-}
-
-async fn read_peer_set_if_boundary(
-    context: &impl commonware_runtime::Clock,
-    epoch_strategy: &FixedEpocher,
-    node: &TempoFullNode,
-    block: Block,
-) -> Option<ordered::Map<PublicKey, Address>> {
-    let mut attempts = 0;
-    const MIN_RETRY: Duration = Duration::from_secs(1);
-    const MAX_RETRY: Duration = Duration::from_secs(30);
-
-    if epoch_strategy
-        .containing(block.height())
-        .expect("valid for all heights")
-        .last()
-        != block.height()
-    {
-        return None;
-    }
-
-    let onchain_outcome = OnchainDkgOutcome::read(&mut block.header().extra_data().as_ref())
-        .expect("invariant: boundary blocks must contain DKG outcome");
-
-    let peers_as_per_dkg = ordered::Set::from_iter_dedup(
-        onchain_outcome
-            .players()
-            .iter()
-            .cloned()
-            .chain(onchain_outcome.next_players().iter().cloned()),
-    );
-
-    loop {
-        attempts += 1;
-        if let Ok(peers) =
-            read_active_and_known_peers_at_block_hash_v1(node, &peers_as_per_dkg, block.hash())
-        {
-            return Some(peers);
-        }
-
-        let retry_after = MIN_RETRY.saturating_mul(attempts).min(MAX_RETRY);
-        let is_syncing = node.network.is_syncing();
-        let best_finalized = node.provider.finalized_block_number().ok().flatten();
-        let blocks_behind = best_finalized
-            .as_ref()
-            .map(|best| block.height().get().saturating_sub(*best));
-        tracing::warn_span!("read_peer_set_if_boundary").in_scope(|| {
-            warn!(
-                attempts,
-                retry_after = %display_duration(retry_after),
-                is_syncing,
-                best_finalized = %display_option(&best_finalized),
-                target_height = %block.height(),
-                blocks_behind = %display_option(&blocks_behind),
-                "reading validator config from contract failed; will retry",
-            );
-        });
-        context.sleep(retry_after).await;
-    }
 }

--- a/crates/commonware-node/src/peer_manager/mod.rs
+++ b/crates/commonware-node/src/peer_manager/mod.rs
@@ -39,8 +39,6 @@ mod ingress;
 pub(crate) use actor::Actor;
 pub(crate) use ingress::Mailbox;
 
-use crate::executor;
-
 /// Configuration of the peer manager actor.
 pub(crate) struct Config<TOracle> {
     /// The mailbox to the P2P network to register the peer sets.
@@ -48,9 +46,6 @@ pub(crate) struct Config<TOracle> {
     /// A handle to the full execution node to read block headers and look up
     /// the Validator Config contract
     pub(crate) execution_node: TempoFullNode,
-    /// The mailbox to the executor actor. Used to check if the executor has
-    /// already finalized a block at a given height.
-    pub(crate) executor: executor::Mailbox,
     /// The  epoch strategy used by the node.
     pub(crate) epoch_strategy: FixedEpocher,
     /// The last finalized height according to the consensus layer (marshal).

--- a/crates/commonware-node/src/validators.rs
+++ b/crates/commonware-node/src/validators.rs
@@ -13,11 +13,9 @@ use eyre::{OptionExt as _, WrapErr as _};
 use reth_ethereum::evm::revm::{State, database::StateProviderDatabase};
 use reth_node_builder::ConfigureEvm as _;
 use reth_provider::{HeaderProvider as _, StateProviderFactory as _};
-use tempo_chainspec::hardfork::TempoHardforks as _;
 use tempo_node::TempoFullNode;
 use tempo_precompiles::{
     storage::StorageCtx,
-    validator_config::{IValidatorConfig, ValidatorConfig},
     validator_config_v2::{IValidatorConfigV2, ValidatorConfigV2},
 };
 
@@ -25,76 +23,11 @@ use tracing::{Level, instrument, warn};
 
 use crate::utils::public_key_to_b256;
 
-/// Returns all active validators read from block state at block `hash`.
-///
-/// The returned validators are those that are marked active according to
-/// block state, and those that are `known`. This accounts for those validators
-/// that are actively participating in consensus (including DKG) but might
-/// be marked inactive on chain.
-///
-/// This function reads the `header` corresponding to `hash` from `node` and
-/// checks if the T2 hardfork is active at `header.timestamp` and if the
-/// Validator Config V2 is initialized.
-///
-/// If T2 is active and the contract is initialized, it will read the entries
-/// from the Validator Config V2 contract.
-///
-/// Otherwise, it will read the entries from the V1 contract.
-pub(crate) fn read_active_and_known_peers_at_block_hash(
-    node: &TempoFullNode,
-    known: &ordered::Set<PublicKey>,
-    hash: B256,
-) -> eyre::Result<ordered::Map<PublicKey, commonware_p2p::Address>> {
-    if can_use_v2_at_block_hash(node, hash, None)
-        .wrap_err("failed to determine validator config v2 status")?
-    {
-        read_active_and_known_peers_at_block_hash_v2(node, known, hash)
-            .wrap_err("failed reading peers from validator config v2")
-    } else {
-        read_active_and_known_peers_at_block_hash_v1(node, known, hash)
-            .wrap_err("failed reading peers from validator config v1")
-    }
-}
-
-/// Returns all validator config v1 entries at block `hash`.
-///
-/// Reads the validator config v1 contract at the block state identified by
-/// `hash` and retains all validators for which `$entry.active = true` or
-/// for which `$entry.publicKey` is in `known`.
-pub(crate) fn read_active_and_known_peers_at_block_hash_v1(
-    node: &TempoFullNode,
-    known: &ordered::Set<PublicKey>,
-    hash: B256,
-) -> eyre::Result<ordered::Map<PublicKey, commonware_p2p::Address>> {
-    read_validator_config_at_block_hash(node, hash, |config: &ValidatorConfig| {
-        let mut all = HashMap::new();
-        for raw in config
-            .get_validators()
-            .wrap_err("failed to query contract for validator config")?
-        {
-            if let Ok(decoded) = DecodedValidatorV1::decode_from_contract(raw)
-                && let Some(dupe) = all.insert(decoded.public_key.clone(), decoded)
-            {
-                warn!(
-                    duplicate = %dupe.public_key,
-                    "found duplicate public keys",
-                );
-            }
-        }
-        all.retain(|k, v| v.active || known.position(k).is_some());
-        Ok(
-            ordered::Map::try_from_iter(all.into_iter().map(|(k, v)| (k, v.to_address())))
-                .expect("hashmaps don't contain duplicates"),
-        )
-    })
-    .map(|(_height, _hash, value)| value)
-}
-
 /// Returns active validator config v2 entries at block `hash`.
 ///
 /// This returns both the validators that are `active` as per the contract, and
 /// those that are `known`.
-pub(crate) fn read_active_and_known_peers_at_block_hash_v2(
+pub(crate) fn read_active_and_known_peers_at_block_hash(
     node: &TempoFullNode,
     known: &ordered::Set<PublicKey>,
     hash: B256,
@@ -132,22 +65,6 @@ pub(crate) fn read_active_and_known_peers_at_block_hash_v2(
         Ok(ordered::Map::try_from_iter(all).expect("hashmaps don't contain duplicates"))
     })
     .map(|(_height, _hash, value)| value)
-}
-
-fn v2_initialization_height_at_block_hash(node: &TempoFullNode, hash: B256) -> eyre::Result<u64> {
-    read_validator_config_at_block_hash(node, hash, |config: &ValidatorConfigV2| {
-        config
-            .get_initialized_at_height()
-            .map_err(eyre::Report::new)
-    })
-    .map(|(_, _, activation_height)| activation_height)
-}
-
-fn is_v2_initialized_at_block_hash(node: &TempoFullNode, hash: B256) -> eyre::Result<bool> {
-    read_validator_config_at_block_hash(node, hash, |config: &ValidatorConfigV2| {
-        config.is_initialized().map_err(eyre::Report::new)
-    })
-    .map(|(_, _, activated)| activated)
 }
 
 /// Reads the validator state at the given block hash.
@@ -190,139 +107,6 @@ where
         || read_fn(&C::default()),
     )?;
     Ok((header.number(), block_hash, res))
-}
-
-/// Returns if the validator config v2 can be used exactly at `hash` and the
-/// timestamp of the corresponding `header`.
-///
-/// If `latest` is set, then the function will look at the timestamp of `hash`
-/// to determine hardfork activation, but `latest` to determine contract
-/// initialization. This is an optimization that makes use of the fact that
-/// the initialization height is stored in the contract.
-///
-/// Validators can be read from the V2 contract if the following conditions hold:
-///
-/// 1. `timestamp(hash) >= T2`.
-/// 2. `initialization_height(<state>) <= number(hash)`.
-/// 3. `is_init(<state>) == true`.
-///
-/// `<state>` is read at either `hash` or `latest` if set.
-///
-/// This makes use of the following assumption:
-///
-/// If `initialization_height > 0`, then `is_init == true` always (invariant of
-/// the smart contract).
-///
-/// If `initialization_height == 0`, then `is_init` is used to determine if
-/// the contract was initialized at genesis or not.
-pub(crate) fn can_use_v2_at_block_hash(
-    node: &TempoFullNode,
-    hash: B256,
-    latest: Option<B256>,
-) -> eyre::Result<bool> {
-    let header = node
-        .provider
-        .header(hash)
-        .map_err(eyre::Report::new)
-        .and_then(|maybe| maybe.ok_or_eyre("hash not known"))
-        .wrap_err_with(|| {
-            format!("failed reading header for block hash `{hash}` from execution layer")
-        })?;
-    let state_hash = latest.unwrap_or(hash);
-    Ok(node
-        .chain_spec()
-        .is_t2_active_at_timestamp(header.timestamp())
-        && is_v2_initialized_at_block_hash(node, state_hash)
-            .wrap_err("failed reading validator config v2 initialization flag")?
-        && v2_initialization_height_at_block_hash(node, state_hash)
-            .wrap_err("failed reading validator config v2 initialization height")?
-            <= header.number())
-}
-
-/// A ContractValidator is a peer read from the validator config smart const.
-///
-/// The inbound and outbound addresses stored herein are guaranteed to be of the
-/// form `<host>:<port>` for inbound, and `<ip>:<port>` for outbound. Here,
-/// `<host>` is either an IPv4 or IPV6 address, or a fully qualified domain name.
-/// `<ip>` is an IPv4 or IPv6 address.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct DecodedValidatorV1 {
-    pub(crate) active: bool,
-    /// The `publicKey` field of the contract. Used by other validators to
-    /// identify a peer by verifying the signatures of its p2p messages and
-    /// as a dealer/player/participant in DKG ceremonies and consensus for a
-    /// given epoch. Part of the set registered with the lookup p2p manager.
-    pub(crate) public_key: PublicKey,
-    /// The `inboundAddress` field of the contract. Used by other validators
-    /// to dial a peer and ensure that messages from that peer are coming from
-    /// this address. Part of the set registered with the lookup p2p manager.
-    pub(crate) inbound: SocketAddr,
-    /// The `outboundAddress` field of the contract. Currently ignored because
-    /// all p2p communication is symmetric (outbound and inbound) via the
-    /// `inboundAddress` field.
-    pub(crate) outbound: SocketAddr,
-    /// The `index` field of the contract. Not used by consensus and just here
-    /// for debugging purposes to identify the contract entry. Emitted in
-    /// tracing events.
-    pub(crate) index: u64,
-    /// The `address` field of the contract. Not used by consensus and just here
-    /// for debugging purposes to identify the contract entry. Emitted in
-    /// tracing events.
-    pub(crate) address: Address,
-}
-
-impl DecodedValidatorV1 {
-    /// Attempts to decode a single validator from the values read in the smart contract.
-    ///
-    /// This function does not perform hostname lookup on either of the addresses.
-    /// Instead, only the shape of the addresses are checked for whether they are
-    /// socket addresses (IP:PORT pairs), or fully qualified domain names.
-    #[instrument(ret(Display, level = Level::DEBUG), err(level = Level::WARN))]
-    fn decode_from_contract(
-        IValidatorConfig::Validator {
-            active,
-            publicKey,
-            index,
-            validatorAddress,
-            inboundAddress,
-            outboundAddress,
-        }: IValidatorConfig::Validator,
-    ) -> eyre::Result<Self> {
-        let public_key = PublicKey::decode(publicKey.as_ref())
-            .wrap_err("failed decoding publicKey field as ed25519 public key")?;
-        let inbound = inboundAddress
-            .parse()
-            .wrap_err("inboundAddress was not valid")?;
-        let outbound = outboundAddress
-            .parse()
-            .wrap_err("outboundAddress was not valid")?;
-        Ok(Self {
-            active,
-            public_key,
-            inbound,
-            outbound,
-            index,
-            address: validatorAddress,
-        })
-    }
-
-    fn to_address(&self) -> commonware_p2p::Address {
-        // NOTE: commonware takes egress as socket address but only uses the IP part.
-        // So setting port to 0 is ok.
-        commonware_p2p::Address::Asymmetric {
-            ingress: Ingress::Socket(self.inbound),
-            egress: self.outbound,
-        }
-    }
-}
-
-impl std::fmt::Display for DecodedValidatorV1 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "public key = `{}`, inbound = `{}`, outbound = `{}`, index = `{}`, address = `{}`",
-            self.public_key, self.inbound, self.outbound, self.index, self.address
-        ))
-    }
 }
 
 /// An entry in the validator config v2 contract with all its fields decoded


### PR DESCRIPTION
* v2 is initialized at genesis & mainnet is migrated
* v1 pathways in the peer and dkg manager will never be hit again. remove them
* subscribe_finalized is no longer needed in the v2 implementation