### PR TITLE
fix(precompile): charge gas for Ed25519 verification in ValidatorConfigV2

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -73,6 +73,9 @@ pub const INPUT_PER_WORD_COST: u64 = 6;
 /// Gas cost for `ecrecover` signature verification (used by KeyAuthorization and Permit).
 pub const ECRECOVER_GAS: u64 = 3_000;
 
+/// Gas cost for Ed25519 signature verification (used by ValidatorConfigV2).
+pub const ED25519_VERIFY_GAS: u64 = 3_000;
+
 /// Returns the gas cost for decoding calldata of the given length, rounded up to word boundaries.
 #[inline]
 pub fn input_cost(calldata_len: usize) -> u64 {

--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -456,7 +456,7 @@ impl ValidatorConfigV2 {
     /// Constructs the message according to the validator config v2 specification and verifies
     /// the Ed25519 signature using the appropriate namespace.
     fn verify_validator_signature(
-        &self,
+        &mut self,
         kind: SignatureKind,
         pubkey: &B256,
         signature: &[u8],
@@ -464,6 +464,10 @@ impl ValidatorConfigV2 {
         ingress: &str,
         egress: &str,
     ) -> Result<()> {
+        if self.storage.spec().is_t4() {
+            self.storage.deduct_gas(crate::ED25519_VERIFY_GAS)?;
+        }
+
         let sig = Signature::decode(signature)
             .map_err(|_| ValidatorConfigV2Error::invalid_signature_format())?;
 

--- a/tips/tip-1046.md
+++ b/tips/tip-1046.md
@@ -1,0 +1,43 @@
+---
+id: TIP-1046
+title: T4 Hardfork Meta TIP
+description: Meta TIP collecting all bug fixes and security hardening changes gated behind the T4 hardfork.
+authors: Federico Gimenez (@fgimenez)
+status: Draft
+related: TIP-1031, TIP-1038
+protocolVersion: T4
+---
+
+# TIP-1046: T4 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects bug fixes and security hardening changes that activate at T4. Each item is small in isolation, but together they define the complete in-scope T4 bug-fix bundle. Fixes already specified by other TIPs with their own standalone documents are intentionally excluded and only cross-referenced.
+
+## Motivation
+
+Ongoing internal review and audit follow-ups uncovered correctness and security issues that require hardfork gating. Because these fixes alter state-function behavior at activation boundaries, they are grouped here as one coordinated rollout under T4.
+
+---
+
+# Changes
+
+## 1. Gate precompile `state_gas_used` behind T4
+
+**PR**: [#3502](https://github.com/tempoxyz/tempo/pull/3502) · **Author**: @fgimenez
+
+With the EIP-8037 reservoir model, `PrecompileOutput.state_gas_used` feeds into `Gas.state_gas_spent`. On reverted precompile calls, `handle_reservoir_remaining_gas` propagates this into the parent frame's reservoir, which gets subtracted in `build_result_gas`, reducing `tx_gas_used()` and corrupting `cumulative_gas_used` in receipts. T4+ gates `state_gas_used` in `fill_precompile_output` so pre-T4 precompile calls leave it at 0.
+
+## 2. Check recipient authorization on payout token in `cancel_stale_order`
+
+**PR**: [#3181](https://github.com/tempoxyz/tempo/pull/3181) · **Author**: @fgimenez
+
+`cancel_stale_order` returns funds to the maker but did not verify that the maker is still authorized as a recipient on the payout token. Orders from makers blacklisted as recipients could not be cleaned up by third parties. T4+ adds a recipient authorization check on the payout token so these orders can be cancelled.
+
+---
+
+# Cross-Referenced TIPs
+
+The following standalone TIPs are also gated behind T4 and activate as part of this hardfork, but are specified in their own documents:
+
+- **[TIP-1031](./tip-1031.md)**: Consensus Context in the Block Header — encodes consensus metadata in Tempo block headers.


### PR DESCRIPTION
Closes QED-32

Adds `ED25519_VERIFY_GAS` (3,000) to `verify_validator_signature`, gated behind the T4 hard fork. Previously Ed25519 verification was unmetered, allowing DoS amplification via cheap calls that trigger expensive crypto.