### PR TITLE
ci(changelog): set ecosystem to skip cargo metadata

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,5 +27,6 @@ jobs:
       - uses: wevm/changelogs/check@master
         with:
           ai: 'amp -x'
+          ecosystem: rust
         env:
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}


### PR DESCRIPTION
The changelogs action auto-detects the ecosystem via `cargo metadata`, which fails because it tries to resolve git deps (reth) without a full cargo environment. Pass `ecosystem: rust` explicitly to skip detection.

Prompted by: rusowsky