### PR TITLE
ci(changelog): make non-blocking when cargo metadata fails

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,5 +27,6 @@ jobs:
       - uses: wevm/changelogs/check@master
         with:
           ai: 'amp -x'
+          ecosystem: rust
         env:
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,6 +25,7 @@ jobs:
       - run: curl -fsSL https://ampcode.com/install.sh | bash
 
       - uses: wevm/changelogs/check@master
+        continue-on-error: true
         with:
           ai: 'amp -x'
           ecosystem: rust


### PR DESCRIPTION
The changelogs CLI still calls `cargo metadata` internally even with `--ecosystem rust`, failing on repos with unresolvable git deps. Mark the step as `continue-on-error` so it doesn't block PRs.

Prompted by: rusowsky