### PR TITLE
feat(bench): per-node custom args and arg dedup for baseline/feature runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -222,7 +222,12 @@ jobs:
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
-              for (const part of args.split(/\s+/).filter(Boolean)) {
+              // Parse args, handling quoted values like key="value with spaces"
+              const parts = [];
+              const argRegex = /(\S+?="[^"]*"|\S+?='[^']*'|\S+)/g;
+              let m;
+              while ((m = argRegex.exec(args)) !== null) parts.push(m[1]);
+              for (const part of parts) {
                 const eq = part.indexOf('=');
                 if (eq === -1) {
                   if (boolArgs.has(part)) {
@@ -233,7 +238,11 @@ jobs:
                   continue;
                 }
                 const key = part.slice(0, eq);
-                const value = part.slice(eq + 1);
+                let value = part.slice(eq + 1);
+                // Strip surrounding quotes
+                if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+                  value = value.slice(1, -1);
+                }
                 if (intArgs.has(key)) {
                   if (!/^\d+$/.test(value)) {
                     invalid.push(`\`${key}=${value}\` (must be a positive integer)`);

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -670,23 +670,26 @@ jobs:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          nu tempo.nu bench \
-            --preset "$BENCH_PRESET" \
-            --mode dev \
-            --bloat "$BENCH_BLOAT" \
-            --duration "$BENCH_DURATION" \
-            --tps "$BENCH_TPS" \
-            --no-infra \
-            --baseline "$BASELINE_REF" \
-            --feature "$FEATURE_REF" \
-            --bench-datadir "/reth-bench/tempo_${BENCH_BLOAT}mb" \
-            --tune \
-            $([ "$BENCH_SAMPLY" = "true" ] && echo "--samply" || true) \
-            $([ "$BENCH_TRACY" != "off" ] && echo "--tracy $BENCH_TRACY --tracy-seconds $BENCH_TRACY_SECONDS --tracy-offset $BENCH_TRACY_OFFSET" || true) \
-            $([ -n "$BENCH_BASELINE_NODE_ARGS" ] && echo "--baseline-node-args \"$BENCH_BASELINE_NODE_ARGS\"" || true) \
-            $([ -n "$BENCH_FEATURE_NODE_ARGS" ] && echo "--feature-node-args \"$BENCH_FEATURE_NODE_ARGS\"" || true) \
-            $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true) \
-            $([ "$BENCH_FORCE_BLOAT" = "true" ] && echo "--force" || true)
+          cmd=(
+            nu tempo.nu bench
+            --preset "$BENCH_PRESET"
+            --mode dev
+            --bloat "$BENCH_BLOAT"
+            --duration "$BENCH_DURATION"
+            --tps "$BENCH_TPS"
+            --no-infra
+            --baseline "$BASELINE_REF"
+            --feature "$FEATURE_REF"
+            --bench-datadir "/reth-bench/tempo_${BENCH_BLOAT}mb"
+            --tune
+          )
+          [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
+          [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
+          [ -n "$BENCH_BASELINE_NODE_ARGS" ] && cmd+=(--baseline-node-args="$BENCH_BASELINE_NODE_ARGS")
+          [ -n "$BENCH_FEATURE_NODE_ARGS" ] && cmd+=(--feature-node-args="$BENCH_FEATURE_NODE_ARGS")
+          [ -n "$BENCH_BASELINE_HARDFORK" ] && cmd+=(--baseline-hardfork "$BENCH_BASELINE_HARDFORK" --feature-hardfork "$BENCH_FEATURE_HARDFORK")
+          [ "$BENCH_FORCE_BLOAT" = "true" ] && cmd+=(--force)
+          "${cmd[@]}"
 
       - name: Find results directory
         id: results-dir

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,6 +74,16 @@ on:
         required: false
         default: "120"
         type: string
+      baseline-node-args:
+        description: "Additional node arguments for baseline runs only (space-separated)"
+        required: false
+        default: ""
+        type: string
+      feature-node-args:
+        description: "Additional node arguments for feature runs only (space-separated)"
+        required: false
+        default: ""
+        type: string
       baseline-hardfork:
         description: "Latest active hardfork for baseline (e.g. T1, T1C, T2). Empty = all forks active"
         required: false
@@ -130,6 +140,8 @@ jobs:
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
+      baseline-node-args: ${{ steps.args.outputs.baseline-node-args }}
+      feature-node-args: ${{ steps.args.outputs.feature-node-args }}
       baseline-hardfork: ${{ steps.args.outputs.baseline-hardfork }}
       feature-hardfork: ${{ steps.args.outputs.feature-hardfork }}
       run-type: ${{ steps.args.outputs.run-type }}
@@ -162,7 +174,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineHardfork, featureHardfork, runType, forceBloat, noSlack;
+            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineNodeArgs, featureNodeArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -176,6 +188,8 @@ jobs:
               tracy = '${{ github.event.inputs.tracy }}' || 'off';
               tracySeconds = '${{ github.event.inputs.tracy-seconds }}' || '30';
               tracyOffset = '${{ github.event.inputs.tracy-offset }}' || '120';
+              baselineNodeArgs = '${{ github.event.inputs.baseline-node-args }}' || '';
+              featureNodeArgs = '${{ github.event.inputs.feature-node-args }}' || '';
               baselineHardfork = '${{ github.event.inputs.baseline-hardfork }}' || '';
               featureHardfork = '${{ github.event.inputs.feature-hardfork }}' || '';
               runType = '${{ github.event.inputs.run-type }}' || 'manual';
@@ -202,9 +216,9 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset']);
               const refArgs = new Set(['baseline', 'feature']);
-              const stringArgs = new Set(['preset', 'tracy', 'baseline-hardfork', 'feature-hardfork']);
+              const stringArgs = new Set(['preset', 'tracy', 'baseline-hardfork', 'feature-hardfork', 'baseline-node-args', 'feature-node-args']);
               const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '1024', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false' };
+              const defaults = { preset: 'tip20', duration: '300', bloat: '1024', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-node-args': '', 'feature-node-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -246,7 +260,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-hardfork=FORK] [feature-hardfork=FORK]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-node-args=ARGS] [feature-node-args=ARGS] [baseline-hardfork=FORK] [feature-hardfork=FORK]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -266,6 +280,8 @@ jobs:
               tracy = defaults.tracy;
               tracySeconds = defaults['tracy-seconds'];
               tracyOffset = defaults['tracy-offset'];
+              baselineNodeArgs = defaults['baseline-node-args'];
+              featureNodeArgs = defaults['feature-node-args'];
               baselineHardfork = defaults['baseline-hardfork'];
               featureHardfork = defaults['feature-hardfork'];
               runType = 'manual';
@@ -273,7 +289,7 @@ jobs:
               noSlack = defaults['no-slack'];
             }
 
-            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-hardfork=FORK] [feature-hardfork=FORK]`';
+            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-node-args=ARGS] [feature-node-args=ARGS] [baseline-hardfork=FORK] [feature-hardfork=FORK]`';
 
             // Validate tracy value
             if (!['off', 'on', 'full'].includes(tracy)) {
@@ -362,6 +378,8 @@ jobs:
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
+            core.setOutput('baseline-node-args', baselineNodeArgs || '');
+            core.setOutput('feature-node-args', featureNodeArgs || '');
             core.setOutput('baseline-hardfork', baselineHardfork || '');
             core.setOutput('feature-hardfork', featureHardfork || '');
             core.setOutput('run-type', runType);
@@ -399,10 +417,13 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = '${{ steps.args.outputs.tracy }}';
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const bNa = '${{ steps.args.outputs.baseline-node-args }}';
+            const fNa = '${{ steps.args.outputs.feature-node-args }}';
+            const naNote = (bNa || fNa) ? `${bNa ? `, baseline-node-args: \`${bNa}\`` : ''}${fNa ? `, feature-node-args: \`${fNa}\`` : ''}` : '';
             const bHf = '${{ steps.args.outputs.baseline-hardfork }}';
             const fHf = '${{ steps.args.outputs.feature-hardfork }}';
             const hfNote = bHf ? `, baseline-hardfork: \`${bHf}\`, feature-hardfork: \`${fHf}\`` : '';
-            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote}`;
+            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -428,6 +449,8 @@ jobs:
       BENCH_TRACY: ${{ needs.tempo-bench-ack.outputs.tracy }}
       BENCH_TRACY_SECONDS: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       BENCH_TRACY_OFFSET: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
+      BENCH_BASELINE_NODE_ARGS: ${{ needs.tempo-bench-ack.outputs.baseline-node-args }}
+      BENCH_FEATURE_NODE_ARGS: ${{ needs.tempo-bench-ack.outputs.feature-node-args }}
       BENCH_BASELINE_HARDFORK: ${{ needs.tempo-bench-ack.outputs.baseline-hardfork }}
       BENCH_FEATURE_HARDFORK: ${{ needs.tempo-bench-ack.outputs.feature-hardfork }}
       BENCH_RUN_TYPE: ${{ needs.tempo-bench-ack.outputs.run-type }}
@@ -651,6 +674,8 @@ jobs:
             --tune \
             $([ "$BENCH_SAMPLY" = "true" ] && echo "--samply" || true) \
             $([ "$BENCH_TRACY" != "off" ] && echo "--tracy $BENCH_TRACY --tracy-seconds $BENCH_TRACY_SECONDS --tracy-offset $BENCH_TRACY_OFFSET" || true) \
+            $([ -n "$BENCH_BASELINE_NODE_ARGS" ] && echo "--baseline-node-args \"$BENCH_BASELINE_NODE_ARGS\"" || true) \
+            $([ -n "$BENCH_FEATURE_NODE_ARGS" ] && echo "--feature-node-args \"$BENCH_FEATURE_NODE_ARGS\"" || true) \
             $([ -n "$BENCH_BASELINE_HARDFORK" ] && echo "--baseline-hardfork $BENCH_BASELINE_HARDFORK --feature-hardfork $BENCH_FEATURE_HARDFORK" || true) \
             $([ "$BENCH_FORCE_BLOAT" = "true" ] && echo "--force" || true)
 

--- a/tempo.nu
+++ b/tempo.nu
@@ -424,7 +424,7 @@ def worktree-bin [worktree_dir: string, profile: string, bin_name: string] {
 # Dedup CLI args: if extra_args provides a flag already present in base_args,
 # the default (in base_args) is dropped so clap doesn't see it twice.
 # Handles both `--flag value` and `--flag=value` forms.
-def dedup-args [base_args: list<string>, extra_args: list<string>] -> list<string> {
+def dedup-args [base_args: list<string>, extra_args: list<string>] {
     if ($extra_args | is-empty) { return $base_args }
 
     # Collect flag keys the user wants to override

--- a/tempo.nu
+++ b/tempo.nu
@@ -1536,7 +1536,9 @@ def "main bench" [
     --loud                                          # Show node logs (silent by default)
     --profile: string = $DEFAULT_PROFILE            # Cargo build profile
     --features: string = $DEFAULT_FEATURES          # Cargo features
-    --node-args: string = ""                        # Additional node arguments (space-separated)
+    --node-args: string = ""                        # Additional node arguments (space-separated, applied to all runs)
+    --baseline-node-args: string = ""               # Additional node arguments for baseline runs only (space-separated)
+    --feature-node-args: string = ""                # Additional node arguments for feature runs only (space-separated)
     --bench-args: string = ""                       # Additional tempo-bench arguments (space-separated)
     --bloat: int = 0                                # Generate state bloat (size in MiB) for TIP20 tokens
     --no-infra                                      # Skip starting observability stack (Grafana + Prometheus)
@@ -1974,6 +1976,12 @@ def "main bench" [
             # virgin state. In dual-hardfork mode this resets both baseline-db
             # and feature-db subdirs at once.
             bench-recover $datadir
+
+            # Merge common node-args with per-side args (baseline-node-args / feature-node-args)
+            let run_type = if ($run.label | str starts-with "baseline") { "baseline" } else { "feature" }
+            let side_args = if $run_type == "baseline" { $baseline_node_args } else { $feature_node_args }
+            let effective_node_args = ([$node_args $side_args] | where { |a| $a != "" } | str join " ")
+
             (run-bench-single
                 --tempo-bin $run.tempo --bench-bin $baseline_bench_bin
                 --genesis-path $run.genesis --datadir $run.datadir
@@ -1981,7 +1989,7 @@ def "main bench" [
                 --tps $tps --duration $duration --accounts $accounts
                 --max-concurrent-requests $max_concurrent_requests
                 --weights $weights --preset $preset --bench-args $bench_args
-                --loud=$loud --node-args $node_args --bloat $bloat
+                --loud=$loud --node-args $effective_node_args --bloat $bloat
                 --git-ref $run.git_ref --build-profile $profile --benchmark-mode $mode
                 --benchmark-id $benchmark_id --reference-epoch $reference_epoch
                 --samply=$samply --samply-args $samply_args_list
@@ -2618,7 +2626,9 @@ def main [] {
     print "  --loud                   Show all node logs (WARN/ERROR shown by default)"
     print $"  --profile <P>            Cargo profile \(default: ($DEFAULT_PROFILE)\)"
     print $"  --features <F>           Cargo features \(default: ($DEFAULT_FEATURES)\)"
-    print "  --node-args <ARGS>       Additional node arguments (space-separated)"
+    print "  --node-args <ARGS>       Additional node arguments (space-separated, all runs)"
+    print "  --baseline-node-args <ARGS>  Additional node arguments for baseline runs only"
+    print "  --feature-node-args <ARGS>   Additional node arguments for feature runs only"
     print "  --bench-args <ARGS>      Additional tempo-bench arguments (space-separated)"
     print "  --bloat <N>              Generate TIP20 state bloat (size in MiB)"
     print ""

--- a/tempo.nu
+++ b/tempo.nu
@@ -421,6 +421,39 @@ def worktree-bin [worktree_dir: string, profile: string, bin_name: string] {
     }
 }
 
+# Dedup CLI args: if extra_args provides a flag already present in base_args,
+# the default (in base_args) is dropped so clap doesn't see it twice.
+# Handles both `--flag value` and `--flag=value` forms.
+def dedup-args [base_args: list<string>, extra_args: list<string>] -> list<string> {
+    if ($extra_args | is-empty) { return $base_args }
+
+    # Collect flag keys the user wants to override
+    let override_keys = ($extra_args | where { |a| $a starts-with "--" }
+        | each { |a| $a | split row "=" | first })
+
+    # Walk base_args, skip any flag (and its value) whose key is overridden
+    mut result = []
+    mut skip_next = false
+    for arg in $base_args {
+        if $skip_next {
+            $skip_next = false
+            continue
+        }
+        if ($arg starts-with "--") {
+            let key = ($arg | split row "=" | first)
+            if ($key in $override_keys) {
+                # Skip this flag; if it's `--flag value` form (no =), skip next token too
+                if not ($arg | str contains "=") {
+                    $skip_next = true
+                }
+                continue
+            }
+        }
+        $result = ($result | append $arg)
+    }
+    $result | append $extra_args
+}
+
 # Run a single benchmark run (start node, run bench, stop node, collect report)
 def run-bench-single [
     --tempo-bin: string
@@ -483,13 +516,13 @@ def run-bench-single [
     # Parse extra node args
     let extra_args = if $node_args == "" { [] } else { $node_args | split row " " }
 
-    # Build node arguments
-    let args = (build-base-args $genesis_path $datadir $log_dir "0.0.0.0" 8545 9001)
+    # Build node arguments, then dedup so user-provided args override defaults
+    let base_args = (build-base-args $genesis_path $datadir $log_dir "0.0.0.0" 8545 9001)
         | append (build-dev-args)
         | append (log-filter-args $loud)
-        | append $extra_args
         | append (if $tracy != "off" { ["--log.tracy" "--log.tracy.filter" $tracy_filter] } else { [] })
         | append (if $tracing_otlp != "" { [$"--tracing-otlp=($tracing_otlp)"] } else { [] })
+    let args = (dedup-args $base_args $extra_args)
 
     # Tracy environment variables
     let tracy_env_prefix = if $tracy == "on" {


### PR DESCRIPTION
Adds `--baseline-node-args` and `--feature-node-args` to `tempo.nu bench`
and the `bench.yml` workflow, so you can pass different `tempo node` arguments
to baseline vs feature runs.

Per-side args are merged with `--node-args` (which still applies to all runs).
When a user-provided flag conflicts with a default from `build-dev-args`
(e.g. `--builder.max-tasks`), the default is dropped via `dedup-args`.

Also ports the quoted-value parser from reth so multi-word args work in PR
comments: `@decofe bench feature-node-args="--flag-a --flag-b=1"`, and
switches the bench invocation to a bash array for correct quoting.

Prompted by: Alexey