### PR TITLE
fix(builder): do not wait for interrupt in `--dev` mode

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -502,6 +502,7 @@ where
             pool,
             ctx.provider().clone(),
             evm_config,
+            ctx.is_dev(),
             self.state_provider_metrics,
             self.disable_state_cache,
         ))

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -92,6 +92,8 @@ pub struct TempoPayloadBuilder<Provider> {
     /// last height at which we've seen an invalid subblock, and not including any subblocks
     /// at this height for any payloads.
     highest_invalid_subblock: Arc<AtomicU64>,
+    /// Whether the node is configured in `--dev` miner mode.
+    is_dev: bool,
     /// Whether to enable state provider metrics.
     state_provider_metrics: bool,
     /// Whether to disable state cache.
@@ -103,6 +105,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         pool: TempoTransactionPool<Provider>,
         provider: Provider,
         evm_config: TempoEvmConfig,
+        is_dev: bool,
         state_provider_metrics: bool,
         disable_state_cache: bool,
     ) -> Self {
@@ -112,6 +115,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             evm_config,
             metrics: TempoPayloadBuilderMetrics::default(),
             highest_invalid_subblock: Default::default(),
+            is_dev,
             state_provider_metrics,
             disable_state_cache,
         }
@@ -182,13 +186,8 @@ where
 
     fn on_missing_payload(
         &self,
-        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+        _args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> MissingPayloadBehaviour<Self::BuiltPayload> {
-        // Interrupt the builder so it stops building and finalizes the block.
-        //
-        // This is needed only for dev mode where no consensus actor fires the interrupt.
-        // With actual CW consensus, the interrupt is already fired by the time `on_missing_payload` is called.
-        args.config.attributes.interrupt_handle().interrupt();
         MissingPayloadBehaviour::AwaitInProgress
     }
 
@@ -248,7 +247,11 @@ where
             attributes,
             payload_id,
         } = config;
-        let build_until_interrupt = trie_handle.is_some();
+        let build_until_interrupt =
+            // When trie handle is provided, we only build the payload once, until the interrupt is triggered
+            trie_handle.is_some()
+            // `--dev` mode doesn't have payload building interrupts
+            && !self.is_dev;
 
         macro_rules! check_cancel {
             () => {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -182,8 +182,13 @@ where
 
     fn on_missing_payload(
         &self,
-        _args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> MissingPayloadBehaviour<Self::BuiltPayload> {
+        // Interrupt the builder so it stops building and finalizes the block.
+        //
+        // This is needed only for dev mode where no consensus actor fires the interrupt.
+        // With actual CW consensus, the interrupt is already fired by the time `on_missing_payload` is called.
+        args.config.attributes.interrupt_handle().interrupt();
         MissingPayloadBehaviour::AwaitInProgress
     }
 

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -43,6 +43,9 @@ pub struct TempoPayloadAttributes {
     /// Interrupt handle.
     #[serde(skip)]
     interrupt: InterruptHandle,
+    /// Whether to interrupt the payload building process when no transactions left.
+    #[serde(skip)]
+    interrupt_on_exhaustion: bool,
     /// Milliseconds portion of the timestamp.
     timestamp_millis_part: u64,
     /// DKG ceremony data to include in the block's extra_data header field.
@@ -85,11 +88,19 @@ impl TempoPayloadAttributes {
                 parent_beacon_block_root: Some(B256::ZERO),
             },
             interrupt: InterruptHandle::default(),
+            interrupt_on_exhaustion: false,
             timestamp_millis_part: millis,
             extra_data,
             proposer_public_key,
             subblocks: Arc::new(subblocks),
         }
+    }
+
+    /// Sets the `interrupt_on_exhaustion` flag. If true, it marks that the payload building process
+    /// should be interrupted when no transactions are left.
+    pub fn with_interrupt_on_exhaustion(mut self, interrupt_on_exhaustion: bool) -> Self {
+        self.interrupt_on_exhaustion = interrupt_on_exhaustion;
+        self
     }
 
     /// Returns the extra data to be included in the block header.
@@ -140,6 +151,7 @@ impl From<EthPayloadAttributes> for TempoPayloadAttributes {
         Self {
             inner,
             interrupt: InterruptHandle::default(),
+            interrupt_on_exhaustion: false,
             timestamp_millis_part: 0,
             extra_data: Bytes::default(),
             proposer_public_key: None,

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -43,9 +43,6 @@ pub struct TempoPayloadAttributes {
     /// Interrupt handle.
     #[serde(skip)]
     interrupt: InterruptHandle,
-    /// Whether to interrupt the payload building process when no transactions left.
-    #[serde(skip)]
-    interrupt_on_exhaustion: bool,
     /// Milliseconds portion of the timestamp.
     timestamp_millis_part: u64,
     /// DKG ceremony data to include in the block's extra_data header field.
@@ -89,19 +86,11 @@ impl TempoPayloadAttributes {
                 slot_number: None,
             },
             interrupt: InterruptHandle::default(),
-            interrupt_on_exhaustion: false,
             timestamp_millis_part: millis,
             extra_data,
             proposer_public_key,
             subblocks: Arc::new(subblocks),
         }
-    }
-
-    /// Sets the `interrupt_on_exhaustion` flag. If true, it marks that the payload building process
-    /// should be interrupted when no transactions are left.
-    pub fn with_interrupt_on_exhaustion(mut self, interrupt_on_exhaustion: bool) -> Self {
-        self.interrupt_on_exhaustion = interrupt_on_exhaustion;
-        self
     }
 
     /// Returns the extra data to be included in the block header.
@@ -152,7 +141,6 @@ impl From<EthPayloadAttributes> for TempoPayloadAttributes {
         Self {
             inner,
             interrupt: InterruptHandle::default(),
-            interrupt_on_exhaustion: false,
             timestamp_millis_part: 0,
             extra_data: Bytes::default(),
             proposer_public_key: None,

--- a/tempo.nu
+++ b/tempo.nu
@@ -1193,7 +1193,6 @@ def build-dev-args [] {
         "--dev"
         "--dev.block-time" "1sec"
         "--builder.gaslimit" "3000000000"
-        "--builder.max-tasks" "8"
         "--builder.deadline" "3"
     ]
 }


### PR DESCRIPTION
Follow-up to https://github.com/tempoxyz/tempo/pull/3476

Tempo node running with `--dev --engine.share-sparse-trie-with-payload-builder` will never resolve a payload job in the builder, because this loop will spin forever as the payload job isn't interrupted in local miner mode https://github.com/tempoxyz/tempo/blob/e00f196ebb53812f4e5dca6e47a972d01c24f5ae/crates/payload/builder/src/lib.rs#L437-L440 https://github.com/tempoxyz/tempo/blob/e00f196ebb53812f4e5dca6e47a972d01c24f5ae/crates/payload/builder/src/lib.rs#L430-L432

This PR makes us to not wait for the interrupt in `--dev` mode, and instead drain the `best_txs` iterator and return the payload.