### PR TITLE
docs(tip-1022): address SIGP-228 and SIGP-229 audit findings

### DIFF
--- a/tips/tip-1022.md
+++ b/tips/tip-1022.md
@@ -449,6 +449,12 @@ This creates an edge case for protocols that mint LP shares, receipt tokens, or 
 
 In short, virtual-address forwarding is only defined for the TIP-20 paths enumerated by TIP-1022; other protocols remain literal-address systems unless they explicitly say otherwise.
 
+### Externally-Triggerable Revert on Unregistered Virtual Addresses
+
+TIP-1022 introduces a recipient-dependent revert: if the `to` address matches the virtual-address format but its `masterId` is not registered, the transfer reverts with `VirtualAddressUnregistered`. This is the first TIP-20 revert condition that an untrusted recipient address can induce — prior to TIP-1022, transfers could only revert due to sender-side conditions (insufficient balance, authorization failure).
+
+Contracts that perform batch transfers in a single transaction (e.g. payroll, airdrop, or distribution contracts) SHOULD validate recipient addresses before execution or wrap individual transfers in try/catch to prevent a single unregistered virtual address from reverting the entire batch.
+
 ### Contracts and EOAs at virtual addresses 
 
 It is theoretically possible to deploy a contract or control an EOA whose address matches `VIRTUAL_MAGIC`, including by grinding CREATE2 salts or private keys. Such addresses can still exist and originate ordinary EVM transactions, but we consider this unlikely in practice because targeting the 10-byte `VIRTUAL_MAGIC` requires roughly 2^80 work, with additional cost for targeted collisions against registered virtual namespaces.
@@ -465,7 +471,7 @@ It is theoretically possible to deploy a contract or control an EOA whose addres
 
 3. **Balance consistency**: After a successful virtual-forwarded transfer of amount `X`, `balanceOf(master)` MUST have increased by exactly `X`.
 
-4. **Zero-balance invariant**: For every virtual address, `balanceOf(virtualAddress)` MUST always equal 0.
+4. **Zero-balance invariant**: For every virtual address, `balanceOf(virtualAddress)` MUST equal 0 from T3 activation onwards. Pre-T3, the TIP-20 precompile does not perform virtual-address resolution, so a transfer targeting an address that matches the virtual format will credit the literal address. Such pre-T3 balances are stranded (no party can claim them) and do not violate this invariant, which applies only to the T3-and-later transfer path. The probability of anyone controlling a private key for such an address is negligible.
 
 5. **Event consistency**: For virtual-forwarded entrypoints, the precompile MUST emit two `Transfer` events: `Transfer(sender, virtualAddress, amount)` followed by `Transfer(virtualAddress, masterAddress, amount)`. `TransferWithMemo` events MUST immediately follow their matching `Transfer` and MUST use `virtualAddress` as the recipient to preserve deposit attribution. `Mint` events MUST use `virtualAddress`.
 


### PR DESCRIPTION
ref: `SIGP-228`, `SIGP-229`

Clarifies that the zero-balance invariant (invariant 4) applies from T3 activation onwards — pre-T3 transfers to virtual-format addresses credit the literal address since resolution isn't active yet, and those balances are permanently stranded.

Documents the externally-triggerable `VirtualAddressUnregistered` revert as a new recipient-dependent failure mode, with integrator guidance for batch transfer contracts.

Prompted by: rusowsky