### PR TITLE
fix(precompiles): remove redundant keychain recipient delete

### DIFF
--- a/crates/node/tests/it/tempo_transaction/snapshots/it__tempo_transaction__gas_estimation_snapshots.snap
+++ b/crates/node/tests/it/tempo_transaction/snapshots/it__tempo_transaction__gas_estimation_snapshots.snap
@@ -80,6 +80,6 @@ baseline: 274318
 "keychain_p256::batch_2_transfers": 832296
 "keychain_p256::batch_5_transfers": 852380
 "keychain_p256::batch_10_transfers": 885853
-"keychain_secp256k1_selector_any_recipient::transfer": 2598964
+"keychain_secp256k1_selector_any_recipient::transfer": 2600980
 "keychain_secp256k1_selector_recipient::transfer": 3360057
 "keychain_secp256k1_target_any_selector::transfer": 1835755

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -862,11 +862,7 @@ impl AccountKeychain {
                 .selectors
                 .insert(selector)?;
 
-            if rule.recipients.is_empty() {
-                self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
-                    .recipients
-                    .delete()?;
-            } else {
+            if !rule.recipients.is_empty() {
                 // `validate_selector_rules` already rejected duplicates.
                 self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
                     .recipients


### PR DESCRIPTION
SIGP-232

Removes the redundant `recipients.delete()` in `upsert_target_scope()`. `clear_target_selectors()` already clears nested recipient rows, so empty-recipient selector rules still encode the allow-all sentinel without re-clearing the same set.

Gas snapshot note: this slightly increases `keychain_secp256k1_selector_any_recipient::transfer` in the gas estimation snapshot. By no longer touching the empty recipient set during key authorization, the later same-transaction call-scope validation reads that slot cold instead of warm; semantics stay the same.
