### PR TITLE
fix(precompiles): address SIGP-239 findings

### DIFF
--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -148,6 +148,10 @@ impl SpendingLimitState {
     /// Computes the period end for the current rollover window, saturating on
     /// all intermediate operations to avoid overflow in extreme timestamps.
     fn compute_next_period_end(&self, current_timestamp: u64) -> u64 {
+        debug_assert!(
+            self.period != 0,
+            "period rollovers require a non-zero period"
+        );
         let elapsed = current_timestamp.saturating_sub(self.period_end);
         let periods_elapsed = (elapsed / self.period).saturating_add(1);
         let advance = self.period.saturating_mul(periods_elapsed);

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1137,7 +1137,7 @@ impl TIP20Token {
 
 /// Resolved transfer recipient for [TIP-1022] virtual address support.
 ///
-/// `to` is always the effective (resolved) address where the balance is credited. For virtual
+/// `target` is always the effective (resolved) address where the balance is credited. For virtual
 /// recipients, `virtual_addr` carries the original virtual address for event emission.
 ///
 /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>


### PR DESCRIPTION
Refs SIGP-239

Adds a debug assertion to document the non-zero period invariant before `compute_next_period_end()` divides by `self.period`, and fixes the `Recipient` docs to refer to `target` instead of a nonexistent `to` field.