### PR TITLE
feat: `--tempo.bootnodes-endpoint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7638,7 +7638,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7730,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8208,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8342,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8370,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8385,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "clap",
  "eyre",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8563,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8579,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8592,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8646,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8740,7 +8740,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8802,7 +8802,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "bytes",
  "futures",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "bindgen",
  "cc",
@@ -8876,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "futures",
  "metrics",
@@ -8888,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9016,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9045,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9154,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9209,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "bytes",
  "eyre",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips 2.0.0",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10001,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10079,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10095,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10105,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "clap",
  "eyre",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "clap",
  "eyre",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10259,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
+source = "git+https://github.com/paradigmxyz/reth?rev=dbb8495#dbb8495be1f9ba41872ee39410056116ee01c7b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11718,6 +11718,7 @@ dependencies = [
  "pyroscope",
  "pyroscope_pprofrs",
  "rand 0.8.5",
+ "reqwest 0.13.2",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7638,7 +7638,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7730,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8208,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8296,6 +8296,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "futures",
+ "indexmap 2.14.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -8341,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8369,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8384,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8400,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8422,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8433,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8461,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8482,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8523,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "clap",
  "eyre",
@@ -8546,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8562,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8578,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8591,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8621,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8635,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8645,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8669,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8689,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8707,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8720,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8739,7 +8740,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8777,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8791,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "serde",
  "serde_json",
@@ -8801,7 +8802,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8829,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "bytes",
  "futures",
@@ -8849,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8866,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "bindgen",
  "cc",
@@ -8875,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "futures",
  "metrics",
@@ -8887,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8896,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8910,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8967,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8992,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9015,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9030,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9044,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9061,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9085,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9153,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9208,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9246,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9270,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9294,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "bytes",
  "eyre",
@@ -9323,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9335,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9359,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9371,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9395,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9438,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9484,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9513,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9529,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9544,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9622,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips 2.0.0",
@@ -9653,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9696,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9716,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9747,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9793,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9841,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9855,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9886,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9938,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9966,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9980,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10000,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10015,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10039,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10057,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10078,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10094,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10104,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "clap",
  "eyre",
@@ -10123,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "clap",
  "eyre",
@@ -10141,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10185,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10211,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10238,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10258,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10287,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=bfb7ab7#bfb7ab72f777666a33dddc9d8318591978db63b6"
+source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11726,6 +11726,7 @@ dependencies = [
  "reth-cli-runner",
  "reth-cli-util",
  "reth-db-api",
+ "reth-discv5",
  "reth-eth-wire-types",
  "reth-ethereum",
  "reth-ethereum-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7638,7 +7638,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7730,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7892,7 +7892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8043,7 +8043,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8208,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8342,7 +8342,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8370,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8385,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "clap",
  "eyre",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8563,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8579,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8592,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8646,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8740,7 +8740,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "serde",
  "serde_json",
@@ -8802,7 +8802,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "bytes",
  "futures",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "bindgen",
  "cc",
@@ -8876,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "futures",
  "metrics",
@@ -8888,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9016,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9045,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9154,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9209,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "bytes",
  "eyre",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9360,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9485,7 +9485,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips 2.0.0",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9856,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10001,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10079,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10095,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10105,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "clap",
  "eyre",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "clap",
  "eyre",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10259,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=13217d5#13217d55170a11cf106f4a749bc40ca2b59030d4"
+source = "git+https://github.com/paradigmxyz/reth?rev=e052f56#e052f564df3cc6c9be0bc0a00928011bee45bb30"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11731,6 +11731,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-etl",
+ "reth-network-api",
  "reth-network-peers",
  "reth-node-builder",
  "reth-primitives-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,57 +120,58 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
 reth-codecs = { version = "0.2.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
 reth-primitives-traits = { version = "0.2.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "dbb8495", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,56 +120,56 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-codecs = { version = "0.2.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-primitives-traits = { version = "0.2.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "bfb7ab7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ reth-codecs = { version = "0.2.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "13217d5" }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -82,6 +82,7 @@ reth-trie.workspace = true
 reth-trie-db.workspace = true
 clap.workspace = true
 eyre.workspace = true
+reqwest.workspace = true
 jiff.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -64,6 +64,7 @@ tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-dkg-onchain-artifacts.workspace = true
 reth-cli-commands.workspace = true
 reth-discv5.workspace = true
+reth-network-api.workspace = true
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
 reth-eth-wire-types.workspace = true

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -63,6 +63,7 @@ tempo-contracts.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-dkg-onchain-artifacts.workspace = true
 reth-cli-commands.workspace = true
+reth-discv5.workspace = true
 reth-cli-runner.workspace = true
 reth-cli-util.workspace = true
 reth-eth-wire-types.workspace = true

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -207,7 +207,7 @@ fn print_extensions_footer() {
 async fn fetch_bootnodes(
     endpoint: &str,
     chain_id: u64,
-) -> eyre::Result<Vec<reth_network_peers::TrustedPeer>> {
+) -> eyre::Result<Vec<reth_network_peers::NodeRecord>> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .build()
@@ -230,10 +230,7 @@ async fn fetch_bootnodes(
         None => return Ok(Vec::new()),
     };
 
-    Ok(reth_network_peers::parse_nodes(enodes)
-        .into_iter()
-        .map(Into::into)
-        .collect())
+    Ok(reth_network_peers::parse_nodes(enodes))
 }
 
 fn main() -> eyre::Result<()> {
@@ -518,30 +515,7 @@ fn main() -> eyre::Result<()> {
         } else {
             None
         };
-
-        // Fetch bootnodes from the endpoint before launching the node so they
-        // can be injected into the discovery config as boot nodes.
-        let endpoint_bootnodes = if let Some(endpoint) = &args.bootnodes_endpoint {
-            let chain_id = builder.config().chain.chain().id();
-            match fetch_bootnodes(endpoint, chain_id).await {
-                Ok(nodes) if nodes.is_empty() => Vec::new(),
-                Ok(nodes) => {
-                    info!(
-                        chain_id,
-                        count = nodes.len(),
-                        endpoint,
-                        "fetched bootnodes from endpoint"
-                    );
-                    nodes
-                }
-                Err(err) => {
-                    warn!(%err, endpoint, "failed to fetch bootnodes from endpoint");
-                    Vec::new()
-                }
-            }
-        } else {
-            Vec::new()
-        };
+        let chain_id = builder.config().chain.chain().id();
 
         let NodeHandle {
             node,
@@ -555,30 +529,6 @@ fn main() -> eyre::Result<()> {
                     .network
                     .discovery
                     .enable_discv5_discovery = true;
-
-                // Append bootnodes fetched from the endpoint to the discovery boot
-                // nodes. When `--bootnodes` was not explicitly provided we
-                // initialise from the chainspec defaults so we don't replace them.
-                if !endpoint_bootnodes.is_empty() {
-                    if builder.config().network.bootnodes.is_none() {
-                        let chainspec_bootnodes: Vec<reth_network_peers::TrustedPeer> = builder
-                            .config()
-                            .chain
-                            .bootnodes()
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(Into::into)
-                            .collect();
-                        builder.config_mut().network.bootnodes = Some(chainspec_bootnodes);
-                    }
-                    builder
-                        .config_mut()
-                        .network
-                        .bootnodes
-                        .as_mut()
-                        .expect("set above")
-                        .extend(endpoint_bootnodes);
-                }
 
                 // Resolve the follow URL:
                 // --follow or --follow=auto -> use chain-specific default
@@ -619,6 +569,39 @@ fn main() -> eyre::Result<()> {
             .launch_with_debug_capabilities()
             .await
             .wrap_err("failed launching execution node")?;
+
+        // Fetch bootnodes from the endpoint in a background task and inject
+        // them into the already-running discovery services.
+        if let Some(endpoint) = args.bootnodes_endpoint.clone() {
+            let network = node.network.clone();
+            node.tasks().spawn_task(async move {
+                match fetch_bootnodes(&endpoint, chain_id).await {
+                    Ok(nodes) if nodes.is_empty() => {}
+                    Ok(nodes) => {
+                        info!(
+                            chain_id,
+                            count = nodes.len(),
+                            endpoint,
+                            "fetched bootnodes from endpoint"
+                        );
+                        for node in &nodes {
+                            if let Some(discv4) = network.discv4() {
+                                discv4.add_node(*node);
+                            }
+                            if let Some(discv5) = network.discv5() {
+                                let enr = node.to_string();
+                                if let Err(err) = discv5.with_discv5(|d| d.request_enr(enr)).await {
+                                    warn!(%err, %node, "failed adding boot node to discv5");
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        warn!(%err, endpoint, "failed to fetch bootnodes from endpoint");
+                    }
+                }
+            });
+        }
 
         let _ = args_and_node_handle_tx.send((node, args));
 

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -69,7 +69,7 @@ use tempo_node::{
     telemetry::{PrometheusMetricsConfig, install_prometheus_metrics},
 };
 use tokio::sync::oneshot;
-use tracing::{info, info_span, warn};
+use tracing::{debug, info, info_span, warn};
 
 type TempoCli =
     Cli<TempoChainSpecParser, TempoArgs, DefaultRpcModuleValidator, tempo_cmd::TempoSubcommand>;
@@ -588,12 +588,27 @@ fn main() -> eyre::Result<()> {
                             if let Some(discv4) = network.discv4() {
                                 discv4.add_node(*node);
                             }
-                            if let Some(discv5) = network.discv5() {
-                                let enr = node.to_string();
-                                if let Err(err) = discv5.with_discv5(|d| d.request_enr(enr)).await {
-                                    warn!(%err, %node, "failed adding boot node to discv5");
+                        }
+                        if let Some(discv5) = network.discv5() {
+                            let enr_requests = nodes.iter().filter_map(|node| {
+                                match reth_discv5::BootNode::from_unsigned(*node) {
+                                    Ok(boot_node) => Some(async move {
+                                        if let Err(err) = discv5
+                                            .with_discv5(|d| {
+                                                d.request_enr(boot_node.to_string())
+                                            })
+                                            .await
+                                        {
+                                            debug!(%err, %node, "failed adding boot node to discv5");
+                                        }
+                                    }),
+                                    Err(err) => {
+                                        warn!(%err, %node, "failed converting boot node for discv5");
+                                        None
+                                    }
                                 }
-                            }
+                            });
+                            futures::future::join_all(enr_requests).await;
                         }
                     }
                     Err(err) => {

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -50,6 +50,7 @@ use eyre::WrapErr as _;
 use futures::{FutureExt as _, future::FusedFuture as _};
 use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands, evm::revm::primitives::B256};
 use reth_ethereum_cli::Cli;
+use reth_network_api::Peers;
 use reth_network_peers::pk2id;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
 use reth_rpc_server_types::DefaultRpcModuleValidator;
@@ -588,6 +589,12 @@ fn main() -> eyre::Result<()> {
                             if let Some(discv4) = network.discv4() {
                                 discv4.add_node(*node);
                             }
+                            network.add_peer_kind(
+                                node.id,
+                                None,
+                                node.tcp_addr(),
+                                Some(node.udp_addr()),
+                            );
                         }
                         if let Some(discv5) = network.discv5() {
                             let enr_requests = nodes.iter().filter_map(|node| {

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -53,7 +53,7 @@ use reth_ethereum_cli::Cli;
 use reth_network_peers::pk2id;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
 use reth_rpc_server_types::DefaultRpcModuleValidator;
-use std::{sync::Arc, thread};
+use std::{sync::Arc, thread, time::Duration};
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use tempo_commonware_node::{feed as consensus_feed, run_consensus_stack};
 use tempo_consensus::TempoConsensus;
@@ -81,6 +81,19 @@ struct TempoArgs {
     /// If provided without a value, defaults to the RPC URL for the selected chain.
     #[arg(long, value_name = "URL", default_missing_value = "auto", num_args(0..=1), env = "TEMPO_FOLLOW")]
     pub follow: Option<String>,
+
+    /// HTTP endpoint that returns a JSON object mapping chain IDs to bootnode lists.
+    ///
+    /// The endpoint must return JSON in the format:
+    /// `{ "<chain_id>": ["enode://...", ...] }`
+    ///
+    /// Bootnodes for the current chain are added as peer hints to the discovery service.
+    #[arg(
+        long = "tempo.bootnodes-endpoint",
+        value_name = "URL",
+        env = "TEMPO_BOOTNODES_ENDPOINT"
+    )]
+    pub bootnodes_endpoint: Option<String>,
 
     #[command(flatten)]
     pub telemetry: defaults::TelemetryArgs,
@@ -185,6 +198,42 @@ fn print_extensions_footer() {
             println!("  {b}{name:<22}{r} {desc}");
         }
     }
+}
+
+/// Fetches bootnodes from the given endpoint for the specified chain ID.
+///
+/// The endpoint must return JSON in the format:
+/// `{ "<chain_id>": ["enode://...", ...] }`
+async fn fetch_bootnodes(
+    endpoint: &str,
+    chain_id: u64,
+) -> eyre::Result<Vec<reth_network_peers::TrustedPeer>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .wrap_err("failed to build HTTP client")?;
+
+    let resp: std::collections::HashMap<String, Vec<String>> = client
+        .get(endpoint)
+        .send()
+        .await
+        .wrap_err("request failed")?
+        .error_for_status()
+        .wrap_err("endpoint returned error status")?
+        .json()
+        .await
+        .wrap_err("failed to parse response as JSON")?;
+
+    let key = chain_id.to_string();
+    let enodes = match resp.get(&key) {
+        Some(enodes) => enodes,
+        None => return Ok(Vec::new()),
+    };
+
+    Ok(reth_network_peers::parse_nodes(enodes)
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 fn main() -> eyre::Result<()> {
@@ -470,6 +519,32 @@ fn main() -> eyre::Result<()> {
             None
         };
 
+        // Fetch bootnodes from the endpoint before launching the node so they
+        // can be injected into the discovery config as boot nodes.
+        let endpoint_bootnodes = if let Some(endpoint) = &args.bootnodes_endpoint {
+            let chain_id = builder.config().chain.chain().id();
+            match fetch_bootnodes(endpoint, chain_id).await {
+                Ok(nodes) if nodes.is_empty() => {
+                    Vec::new()
+                }
+                Ok(nodes) => {
+                    info!(
+                        chain_id,
+                        count = nodes.len(),
+                        endpoint,
+                        "fetched bootnodes from endpoint"
+                    );
+                    nodes
+                }
+                Err(err) => {
+                    warn!(%err, endpoint, "failed to fetch bootnodes from endpoint");
+                    Vec::new()
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
         let NodeHandle {
             node,
             node_exit_future,
@@ -482,6 +557,30 @@ fn main() -> eyre::Result<()> {
                     .network
                     .discovery
                     .enable_discv5_discovery = true;
+
+                // Append bootnodes fetched from the endpoint to the discovery boot
+                // nodes. When `--bootnodes` was not explicitly provided we
+                // initialise from the chainspec defaults so we don't replace them.
+                if !endpoint_bootnodes.is_empty() {
+                    if builder.config().network.bootnodes.is_none() {
+                        let chainspec_bootnodes: Vec<reth_network_peers::TrustedPeer> = builder
+                            .config()
+                            .chain
+                            .bootnodes()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(Into::into)
+                            .collect();
+                        builder.config_mut().network.bootnodes = Some(chainspec_bootnodes);
+                    }
+                    builder
+                        .config_mut()
+                        .network
+                        .bootnodes
+                        .as_mut()
+                        .expect("set above")
+                        .extend(endpoint_bootnodes);
+                }
 
                 // Resolve the follow URL:
                 // --follow or --follow=auto -> use chain-specific default

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -524,9 +524,7 @@ fn main() -> eyre::Result<()> {
         let endpoint_bootnodes = if let Some(endpoint) = &args.bootnodes_endpoint {
             let chain_id = builder.config().chain.chain().id();
             match fetch_bootnodes(endpoint, chain_id).await {
-                Ok(nodes) if nodes.is_empty() => {
-                    Vec::new()
-                }
+                Ok(nodes) if nodes.is_empty() => Vec::new(),
                 Ok(nodes) => {
                     info!(
                         chain_id,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -798,7 +798,7 @@ where
             "Built payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests);
+        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -993,7 +993,7 @@ mod tests {
             },
         };
         let sealed = Arc::new(SealedBlock::seal_slow(block));
-        let eth = EthBuiltPayload::new(sealed, U256::ZERO, None);
+        let eth = EthBuiltPayload::new(sealed, U256::ZERO, None, None);
         TempoBuiltPayload::new(eth, None)
     }
 

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -171,6 +171,10 @@ impl PayloadAttributes for TempoPayloadAttributes {
     fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
         self.inner.withdrawals()
     }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number()
+    }
 }
 
 /// Constructs a [`PayloadId`] from the first 8 bytes of `block_hash`.

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -115,6 +115,10 @@ impl ExecutionPayload for TempoExecutionData {
         self.block.gas_used()
     }
 
+    fn slot_number(&self) -> Option<u64> {
+        self.block.slot_number()
+    }
+
     fn block_access_list(&self) -> Option<&alloy_primitives::Bytes> {
         None
     }


### PR DESCRIPTION
Adds a `--tempo.bootnodes-endpoint` CLI flag allowing to fetch bootnodes on startup from a predefined endpoint