### PR TITLE
fix(tempoup): filter for binary release tags when resolving latest version

### DIFF
--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -285,13 +285,14 @@ get_latest_version() {
         error "curl not found. Please install curl."
     fi
 
-    # List recent releases and pick the first tag starting with "v" (binary releases).
-    # The /releases/latest endpoint can return crate-publish tags (e.g. tempo-primitives@1.6.0)
-    # which carry no binary assets.
-    local api_url="https://api.github.com/repos/$REPO/releases?per_page=20"
+    # List recent non-prerelease releases and pick the first tag starting with
+    # "v" (binary releases). The /releases/latest endpoint can return crate-publish
+    # tags (e.g. tempo-primitives@1.6.0) which carry no binary assets.
+    # We also match only strict "vN.N.N" to skip prerelease tags like v1.6.0-rc.1.
+    local api_url="https://api.github.com/repos/$REPO/releases?per_page=100"
     local version=$(curl -sSL "$api_url" 2>/dev/null | \
         grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' | \
-        grep '^v' | head -n 1)
+        grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | head -n 1)
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch latest version from GitHub"

--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -285,9 +285,13 @@ get_latest_version() {
         error "curl not found. Please install curl."
     fi
 
-    local api_url="https://api.github.com/repos/$REPO/releases/latest"
+    # List recent releases and pick the first tag starting with "v" (binary releases).
+    # The /releases/latest endpoint can return crate-publish tags (e.g. tempo-primitives@1.6.0)
+    # which carry no binary assets.
+    local api_url="https://api.github.com/repos/$REPO/releases?per_page=20"
     local version=$(curl -sSL "$api_url" 2>/dev/null | \
-        grep '"tag_name":' | head -n 1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+        grep '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' | \
+        grep '^v' | head -n 1)
 
     if [[ -z "$version" ]]; then
         error "Failed to fetch latest version from GitHub"


### PR DESCRIPTION
The `/releases/latest` endpoint returns whichever release was most recently
published, which can be a crate-publish tag (e.g. `tempo-primitives@1.6.0`)
with no binary assets. This causes a 404 during installation:

```
curl: (56) The requested URL returned error: 404
error: Failed to download tempo-tempo-primitives@1.6.0-aarch64-apple-darwin.tar.gz
```

Switch to querying `/releases?per_page=20` and filtering for tags starting
with `v`, which are the actual binary releases.

**Workaround** for anyone hitting this now: `tempoup -i v1.5.3`