### PR TITLE
fix(dex): check paused state on internal balance debit paths

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -5511,6 +5511,133 @@ mod tests {
     }
 
     #[test]
+    fn test_place_orders_on_paused_token_respects_internal_balance_path() -> eyre::Result<()> {
+        fn assert_paused_token_order_path<F>(
+            internal_balance_amount: u128,
+            is_bid: bool,
+            mut place_order: F,
+        ) -> eyre::Result<()>
+        where
+            F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
+        {
+            for spec in [TempoHardfork::T2, TempoHardfork::T3] {
+                let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+                StorageCtx::enter(&mut storage, || {
+                    let mut exchange = StablecoinDEX::new();
+                    exchange.initialize()?;
+
+                    let (alice, admin) = (Address::random(), Address::random());
+                    let amount = MIN_ORDER_AMOUNT;
+
+                    let (base_token, quote_token) =
+                        setup_test_tokens(admin, alice, exchange.address, 500_000_000u128)?;
+                    exchange.create_pair(base_token)?;
+                    let escrow_token = if is_bid { quote_token } else { base_token };
+                    exchange.set_balance(alice, escrow_token, internal_balance_amount)?;
+
+                    let mut escrow_tip20 = TIP20Token::from_address(escrow_token)?;
+                    escrow_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                    escrow_tip20.pause(admin, ITIP20::pauseCall {})?;
+
+                    let next_order_id_before = exchange.next_order_id()?;
+                    let res = place_order(&mut exchange, alice, base_token, amount);
+
+                    if internal_balance_amount >= amount && !spec.is_t3() {
+                        let order_id = res?;
+                        assert_eq!(order_id, next_order_id_before);
+                        assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
+                        assert_eq!(
+                            exchange.balance_of(alice, escrow_token)?,
+                            internal_balance_amount - amount
+                        );
+                    } else {
+                        assert_eq!(res.unwrap_err(), TIP20Error::contract_paused().into());
+                        assert_eq!(exchange.next_order_id()?, next_order_id_before);
+                        assert_eq!(
+                            exchange.balance_of(alice, escrow_token)?,
+                            internal_balance_amount
+                        );
+                    }
+
+                    Ok::<_, eyre::Report>(())
+                })?;
+            }
+            Ok(())
+        }
+
+        let partial_internal_balance = MIN_ORDER_AMOUNT - 1;
+
+        // Full internal balance uses the internal-only path pre-T3, but T3 still rejects
+        // paused-token orders.
+        assert_paused_token_order_path(
+            MIN_ORDER_AMOUNT,
+            false,
+            |exchange, alice, base_token, amount| {
+                exchange.place(alice, base_token, amount, false, 0)
+            },
+        )?;
+        assert_paused_token_order_path(
+            MIN_ORDER_AMOUNT,
+            true,
+            |exchange, alice, base_token, amount| {
+                exchange.place(alice, base_token, amount, true, 0)
+            },
+        )?;
+        assert_paused_token_order_path(
+            MIN_ORDER_AMOUNT,
+            false,
+            |exchange, alice, base_token, amount| {
+                exchange.place_flip(alice, base_token, amount, false, 100, 0, true)
+            },
+        )?;
+        assert_paused_token_order_path(
+            MIN_ORDER_AMOUNT,
+            true,
+            |exchange, alice, base_token, amount| {
+                exchange.place_flip(alice, base_token, amount, true, 0, 100, true)
+            },
+        )?;
+
+        // Regular ask order: fallback transferFrom should fail without consuming partial base
+        // balance.
+        assert_paused_token_order_path(
+            partial_internal_balance,
+            false,
+            |exchange, alice, base_token, amount| {
+                exchange.place(alice, base_token, amount, false, 0)
+            },
+        )?;
+
+        // Regular bid order: fallback transferFrom should fail without consuming partial quote
+        // balance.
+        assert_paused_token_order_path(
+            partial_internal_balance,
+            true,
+            |exchange, alice, base_token, amount| {
+                exchange.place(alice, base_token, amount, true, 0)
+            },
+        )?;
+
+        // Flip ask order on the shared debit-or-transfer path.
+        assert_paused_token_order_path(
+            partial_internal_balance,
+            false,
+            |exchange, alice, base_token, amount| {
+                exchange.place_flip(alice, base_token, amount, false, 100, 0, false)
+            },
+        )?;
+
+        // Flip bid order on the shared debit-or-transfer path.
+        assert_paused_token_order_path(
+            partial_internal_balance,
+            true,
+            |exchange, alice, base_token, amount| {
+                exchange.place_flip(alice, base_token, amount, true, 0, 100, false)
+            },
+        )
+    }
+
+    #[test]
     fn test_swap_paused_intermediate_token_allowed_pre_t3_blocked_on_t3() -> eyre::Result<()> {
         for spec in [TempoHardfork::T2, TempoHardfork::T3] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -509,8 +509,15 @@ impl StablecoinDEX {
 
         // Check policy on non-escrow token (escrow token is checked in decrement_balance_or_transfer_from)
         // Direction: DEX → sender (order placer receives non-escrow token when filled)
-        TIP20Token::from_address(non_escrow_token)?
-            .ensure_transfer_authorized(self.address, sender)?;
+        let non_escrow_tip20 = TIP20Token::from_address(non_escrow_token)?;
+        non_escrow_tip20.ensure_transfer_authorized(self.address, sender)?;
+
+        // On T4+, reject if the non-escrow token is paused. When this order fills, the
+        // non-escrow token may be moved via internal-balance updates that bypass TIP-20's
+        // pause check, so we enforce it at placement.
+        if self.storage.spec().is_t4() {
+            non_escrow_tip20.check_not_paused()?;
+        }
 
         // Debit from user's balance or transfer from wallet
         self.decrement_balance_or_transfer_from(sender, escrow_token, escrow_amount, true)?;
@@ -678,8 +685,15 @@ impl StablecoinDEX {
 
         // Check policy on non-escrow token (escrow token is checked in decrement_balance_or_transfer_from or below)
         // Direction: DEX → sender (order placer receives non-escrow token when filled)
-        TIP20Token::from_address(non_escrow_token)?
-            .ensure_transfer_authorized(self.address, sender)?;
+        let non_escrow_tip20 = TIP20Token::from_address(non_escrow_token)?;
+        non_escrow_tip20.ensure_transfer_authorized(self.address, sender)?;
+
+        // On T4+, reject if the non-escrow token is paused. When this order fills, the
+        // non-escrow token may be moved via internal-balance updates that bypass TIP-20's
+        // pause check, so we enforce it at placement.
+        if self.storage.spec().is_t4() {
+            non_escrow_tip20.check_not_paused()?;
+        }
 
         // Debit from user's balance only. This is set to true after a flip order is filled and the
         // subsequent flip order is being placed.
@@ -5633,6 +5647,98 @@ mod tests {
             true,
             |exchange, alice, base_token, amount| {
                 exchange.place_flip(alice, base_token, amount, true, 0, 100, false)
+            },
+        )
+    }
+
+    #[test]
+    fn test_place_orders_on_paused_non_escrow_token_blocked_on_t4() -> eyre::Result<()> {
+        fn assert_paused_non_escrow_token_order<F>(
+            is_bid: bool,
+            internal_balance_amount: u128,
+            mut place_order: F,
+        ) -> eyre::Result<()>
+        where
+            F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
+        {
+            for spec in [TempoHardfork::T3, TempoHardfork::T4] {
+                let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+                StorageCtx::enter(&mut storage, || {
+                    let mut exchange = StablecoinDEX::new();
+                    exchange.initialize()?;
+
+                    let (alice, admin) = (Address::random(), Address::random());
+                    let amount = MIN_ORDER_AMOUNT;
+
+                    let (base_token, quote_token) =
+                        setup_test_tokens(admin, alice, exchange.address, 500_000_000u128)?;
+                    exchange.create_pair(base_token)?;
+
+                    // Pre-fund alice's internal escrow balance so we exercise both the
+                    // internal-only and transferFrom paths cleanly.
+                    let escrow_token = if is_bid { quote_token } else { base_token };
+                    if internal_balance_amount > 0 {
+                        exchange.set_balance(alice, escrow_token, internal_balance_amount)?;
+                    }
+
+                    // Pause the non-escrow side of the pair (escrow stays unpaused).
+                    let non_escrow_token = if is_bid { base_token } else { quote_token };
+                    let mut non_escrow_tip20 = TIP20Token::from_address(non_escrow_token)?;
+                    non_escrow_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                    non_escrow_tip20.pause(admin, ITIP20::pauseCall {})?;
+
+                    let next_order_id_before = exchange.next_order_id()?;
+                    let escrow_balance_before = exchange.balance_of(alice, escrow_token)?;
+                    let res = place_order(&mut exchange, alice, base_token, amount);
+
+                    if spec.is_t4() {
+                        assert_eq!(res.unwrap_err(), TIP20Error::contract_paused().into());
+                        assert_eq!(exchange.next_order_id()?, next_order_id_before);
+                        assert_eq!(
+                            exchange.balance_of(alice, escrow_token)?,
+                            escrow_balance_before
+                        );
+                    } else {
+                        let order_id = res?;
+                        assert_eq!(order_id, next_order_id_before);
+                        assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
+                    }
+
+                    Ok::<_, eyre::Report>(())
+                })?;
+            }
+            Ok(())
+        }
+
+        // place: ask + bid (transferFrom path covers both internal and external escrow)
+        assert_paused_non_escrow_token_order(false, 0, |exchange, alice, base, amount| {
+            exchange.place(alice, base, amount, false, 0)
+        })?;
+        assert_paused_non_escrow_token_order(true, 0, |exchange, alice, base, amount| {
+            exchange.place(alice, base, amount, true, 0)
+        })?;
+
+        // place_flip non-internal-only: ask + bid
+        assert_paused_non_escrow_token_order(false, 0, |exchange, alice, base, amount| {
+            exchange.place_flip(alice, base, amount, false, 100, 0, false)
+        })?;
+        assert_paused_non_escrow_token_order(true, 0, |exchange, alice, base, amount| {
+            exchange.place_flip(alice, base, amount, true, 0, 100, false)
+        })?;
+
+        // place_flip internal-only: ask + bid (requires escrow internal balance)
+        assert_paused_non_escrow_token_order(
+            false,
+            MIN_ORDER_AMOUNT,
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, false, 100, 0, true)
+            },
+        )?;
+        assert_paused_non_escrow_token_order(
+            true,
+            MIN_ORDER_AMOUNT,
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, true, 0, 100, true)
             },
         )
     }

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -194,7 +194,7 @@ impl StablecoinDEX {
     /// Decrement user's internal balance or transfer from external wallet.
     ///
     /// When `check_pause` is true and the full amount is covered by internal balance,
-    /// verifies the token is not paused (T3+). Callers that already check pause state
+    /// verifies the token is not paused (T4+). Callers that already check pause state
     /// (e.g. swaps via `validate_and_build_route`) should pass `false` to avoid a
     /// redundant SLOAD.
     fn decrement_balance_or_transfer_from(
@@ -211,7 +211,7 @@ impl StablecoinDEX {
         let user_balance = self.balance_of(user, token)?;
         if user_balance >= amount {
             // When fully covered by internal balance, TIP-20 transferFrom won't run,
-            // so we must check the pause state ourselves (spec: T3+).
+            // so we must check the pause state ourselves (spec: T4+).
             if check_pause && self.storage.spec().is_t4() {
                 tip20.check_not_paused()?;
             }
@@ -5567,7 +5567,7 @@ mod tests {
 
         let partial_internal_balance = MIN_ORDER_AMOUNT - 1;
 
-        // Full internal balance uses the internal-only path pre-T3, but T3 still rejects
+        // Full internal balance uses the internal-only path pre-T4, but T4 still rejects
         // paused-token orders.
         assert_paused_token_order_path(
             MIN_ORDER_AMOUNT,

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1459,9 +1459,9 @@ impl StablecoinDEX {
             let (base, quote) = {
                 let token_in_tip20 = TIP20Token::from_address(token_in)?;
 
-                // Ensure that the token is not paused (spec: T4+)
+                // Ensure that the token is not paused (spec: T3+)
                 // Necessary because TIP20 transfer checks don't cover internal DEX balance updates
-                if self.storage.spec().is_t4() {
+                if self.storage.spec().is_t3() {
                     token_in_tip20.check_not_paused()?;
                 }
 
@@ -5474,8 +5474,8 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_paused_token_allowed_pre_t4_blocked_on_t4() -> eyre::Result<()> {
-        for spec in [TempoHardfork::T3, TempoHardfork::T4] {
+    fn test_swap_paused_token_allowed_pre_t3_blocked_on_t3() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T2, TempoHardfork::T3] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let mut exchange = StablecoinDEX::new();
@@ -5510,7 +5510,7 @@ mod tests {
                     u128::MAX,
                 );
 
-                if spec.is_t4() {
+                if spec.is_t3() {
                     assert_eq!(res_in, res_out);
                     assert_eq!(res_in.unwrap_err(), TIP20Error::contract_paused().into());
                 } else {
@@ -5744,8 +5744,8 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_paused_intermediate_token_allowed_pre_t4_blocked_on_t4() -> eyre::Result<()> {
-        for spec in [TempoHardfork::T3, TempoHardfork::T4] {
+    fn test_swap_paused_intermediate_token_allowed_pre_t3_blocked_on_t3() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T2, TempoHardfork::T3] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let mut exchange = StablecoinDEX::new();
@@ -5804,7 +5804,7 @@ mod tests {
                     u128::MAX,
                 );
 
-                if spec.is_t4() {
+                if spec.is_t3() {
                     assert_eq!(res_in, res_out);
                     assert_eq!(res_in.unwrap_err(), TIP20Error::contract_paused().into());
                 } else {

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -191,12 +191,18 @@ impl StablecoinDEX {
         Ok(())
     }
 
-    /// Decrement user's internal balance or transfer from external wallet
+    /// Decrement user's internal balance or transfer from external wallet.
+    ///
+    /// When `check_pause` is true and the full amount is covered by internal balance,
+    /// verifies the token is not paused (T3+). Callers that already check pause state
+    /// (e.g. swaps via `validate_and_build_route`) should pass `false` to avoid a
+    /// redundant SLOAD.
     fn decrement_balance_or_transfer_from(
         &mut self,
         user: Address,
         token: Address,
         amount: u128,
+        check_pause: bool,
     ) -> Result<()> {
         // Ensure that the token can be transferred
         let tip20 = TIP20Token::from_address(token)?;
@@ -206,7 +212,7 @@ impl StablecoinDEX {
         if user_balance >= amount {
             // When fully covered by internal balance, TIP-20 transferFrom won't run,
             // so we must check the pause state ourselves (spec: T3+).
-            if self.storage.spec().is_t3() {
+            if check_pause && self.storage.spec().is_t3() {
                 tip20.check_not_paused()?;
             }
             self.sub_balance(user, token, amount)
@@ -293,7 +299,8 @@ impl StablecoinDEX {
         let route = self.find_trade_path(token_in, token_out)?;
 
         // Deduct input tokens from sender (only once, at the start)
-        self.decrement_balance_or_transfer_from(sender, token_in, amount_in)?;
+        // Pause already checked in validate_and_build_route
+        self.decrement_balance_or_transfer_from(sender, token_in, amount_in, false)?;
 
         // Execute swaps for each hop - intermediate balances are transitory
         let mut amount = amount_in;
@@ -343,7 +350,8 @@ impl StablecoinDEX {
         }
 
         // Deduct input tokens ONCE at end
-        self.decrement_balance_or_transfer_from(sender, token_in, amount)?;
+        // Pause already checked in validate_and_build_route
+        self.decrement_balance_or_transfer_from(sender, token_in, amount, false)?;
 
         // Transfer only final output ONCE at end
         self.transfer(token_out, sender, amount_out)?;
@@ -505,7 +513,7 @@ impl StablecoinDEX {
             .ensure_transfer_authorized(self.address, sender)?;
 
         // Debit from user's balance or transfer from wallet
-        self.decrement_balance_or_transfer_from(sender, escrow_token, escrow_amount)?;
+        self.decrement_balance_or_transfer_from(sender, escrow_token, escrow_amount, true)?;
 
         // Create the order
         let order_id = self.next_order_id()?;
@@ -689,7 +697,7 @@ impl StablecoinDEX {
             }
             self.sub_balance(sender, escrow_token, escrow_amount)?;
         } else {
-            self.decrement_balance_or_transfer_from(sender, escrow_token, escrow_amount)?;
+            self.decrement_balance_or_transfer_from(sender, escrow_token, escrow_amount, true)?;
         }
 
         // Create the flip order

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -199,10 +199,16 @@ impl StablecoinDEX {
         amount: u128,
     ) -> Result<()> {
         // Ensure that the token can be transferred
-        TIP20Token::from_address(token)?.ensure_transfer_authorized(user, self.address)?;
+        let tip20 = TIP20Token::from_address(token)?;
+        tip20.ensure_transfer_authorized(user, self.address)?;
 
         let user_balance = self.balance_of(user, token)?;
         if user_balance >= amount {
+            // When fully covered by internal balance, TIP-20 transferFrom won't run,
+            // so we must check the pause state ourselves (spec: T3+).
+            if self.storage.spec().is_t3() {
+                tip20.check_not_paused()?;
+            }
             self.sub_balance(user, token, amount)
         } else {
             let remaining = amount
@@ -670,8 +676,13 @@ impl StablecoinDEX {
         // Debit from user's balance only. This is set to true after a flip order is filled and the
         // subsequent flip order is being placed.
         if internal_balance_only {
-            TIP20Token::from_address(escrow_token)?
-                .ensure_transfer_authorized(sender, self.address)?;
+            let tip20 = TIP20Token::from_address(escrow_token)?;
+            tip20.ensure_transfer_authorized(sender, self.address)?;
+            // Internal-balance-only path bypasses TIP-20 transferFrom,
+            // so we must check the pause state ourselves (spec: T3+).
+            if self.storage.spec().is_t3() {
+                tip20.check_not_paused()?;
+            }
             let user_balance = self.balance_of(sender, escrow_token)?;
             if user_balance < escrow_amount {
                 return Err(StablecoinDEXError::insufficient_balance().into());

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -212,7 +212,7 @@ impl StablecoinDEX {
         if user_balance >= amount {
             // When fully covered by internal balance, TIP-20 transferFrom won't run,
             // so we must check the pause state ourselves (spec: T3+).
-            if check_pause && self.storage.spec().is_t3() {
+            if check_pause && self.storage.spec().is_t4() {
                 tip20.check_not_paused()?;
             }
             self.sub_balance(user, token, amount)
@@ -687,8 +687,8 @@ impl StablecoinDEX {
             let tip20 = TIP20Token::from_address(escrow_token)?;
             tip20.ensure_transfer_authorized(sender, self.address)?;
             // Internal-balance-only path bypasses TIP-20 transferFrom,
-            // so we must check the pause state ourselves (spec: T3+).
-            if self.storage.spec().is_t3() {
+            // so we must check the pause state ourselves (spec: T4+).
+            if self.storage.spec().is_t4() {
                 tip20.check_not_paused()?;
             }
             let user_balance = self.balance_of(sender, escrow_token)?;
@@ -1445,9 +1445,9 @@ impl StablecoinDEX {
             let (base, quote) = {
                 let token_in_tip20 = TIP20Token::from_address(token_in)?;
 
-                // Ensure that the token is not paused (spec: T3+)
+                // Ensure that the token is not paused (spec: T4+)
                 // Necessary because TIP20 transfer checks don't cover internal DEX balance updates
-                if self.storage.spec().is_t3() {
+                if self.storage.spec().is_t4() {
                     token_in_tip20.check_not_paused()?;
                 }
 
@@ -5460,8 +5460,8 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_paused_token_allowed_pre_t3_blocked_on_t3() -> eyre::Result<()> {
-        for spec in [TempoHardfork::T2, TempoHardfork::T3] {
+    fn test_swap_paused_token_allowed_pre_t4_blocked_on_t4() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T3, TempoHardfork::T4] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let mut exchange = StablecoinDEX::new();
@@ -5496,7 +5496,7 @@ mod tests {
                     u128::MAX,
                 );
 
-                if spec.is_t3() {
+                if spec.is_t4() {
                     assert_eq!(res_in, res_out);
                     assert_eq!(res_in.unwrap_err(), TIP20Error::contract_paused().into());
                 } else {
@@ -5520,7 +5520,7 @@ mod tests {
         where
             F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
         {
-            for spec in [TempoHardfork::T2, TempoHardfork::T3] {
+            for spec in [TempoHardfork::T3, TempoHardfork::T4] {
                 let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
                 StorageCtx::enter(&mut storage, || {
                     let mut exchange = StablecoinDEX::new();
@@ -5542,7 +5542,7 @@ mod tests {
                     let next_order_id_before = exchange.next_order_id()?;
                     let res = place_order(&mut exchange, alice, base_token, amount);
 
-                    if internal_balance_amount >= amount && !spec.is_t3() {
+                    if internal_balance_amount >= amount && !spec.is_t4() {
                         let order_id = res?;
                         assert_eq!(order_id, next_order_id_before);
                         assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
@@ -5638,8 +5638,8 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_paused_intermediate_token_allowed_pre_t3_blocked_on_t3() -> eyre::Result<()> {
-        for spec in [TempoHardfork::T2, TempoHardfork::T3] {
+    fn test_swap_paused_intermediate_token_allowed_pre_t4_blocked_on_t4() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T3, TempoHardfork::T4] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
             StorageCtx::enter(&mut storage, || {
                 let mut exchange = StablecoinDEX::new();
@@ -5698,7 +5698,7 @@ mod tests {
                     u128::MAX,
                 );
 
-                if spec.is_t3() {
+                if spec.is_t4() {
                     assert_eq!(res_in, res_out);
                     assert_eq!(res_in.unwrap_err(), TIP20Error::contract_paused().into());
                 } else {

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -5524,219 +5524,177 @@ mod tests {
         Ok(())
     }
 
+    /// Shared helper for paused-token order placement tests across T3 (no enforcement) and T4
+    /// (rejection). Pauses either the escrow or non-escrow side of the pair and asserts whether
+    /// `place_order` succeeds based on the pause side, internal balance, and active hardfork.
+    fn assert_paused_token_order<F>(
+        pause_escrow_side: bool,
+        internal_balance_amount: u128,
+        is_bid: bool,
+        mut place_order: F,
+    ) -> eyre::Result<()>
+    where
+        F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
+    {
+        for spec in [TempoHardfork::T3, TempoHardfork::T4] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            StorageCtx::enter(&mut storage, || {
+                let mut exchange = StablecoinDEX::new();
+                exchange.initialize()?;
+
+                let (alice, admin) = (Address::random(), Address::random());
+                let amount = MIN_ORDER_AMOUNT;
+
+                let (base_token, quote_token) =
+                    setup_test_tokens(admin, alice, exchange.address, 500_000_000u128)?;
+                exchange.create_pair(base_token)?;
+
+                let escrow_token = if is_bid { quote_token } else { base_token };
+                let non_escrow_token = if is_bid { base_token } else { quote_token };
+                exchange.set_balance(alice, escrow_token, internal_balance_amount)?;
+
+                let token_to_pause = if pause_escrow_side {
+                    escrow_token
+                } else {
+                    non_escrow_token
+                };
+                let mut tip20 = TIP20Token::from_address(token_to_pause)?;
+                tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                tip20.pause(admin, ITIP20::pauseCall {})?;
+
+                let next_order_id_before = exchange.next_order_id()?;
+                let escrow_balance_before = exchange.balance_of(alice, escrow_token)?;
+                let res = place_order(&mut exchange, alice, base_token, amount);
+
+                // Pre-T4: succeeds iff there's a debit path that doesn't touch the paused token.
+                // - escrow paused: only the internal-only fast path avoids it (requires
+                //   balance >= amount)
+                // - non-escrow paused: escrow itself is unpaused, so any debit path works
+                // T4: rejected regardless.
+                let should_succeed =
+                    !spec.is_t4() && (!pause_escrow_side || internal_balance_amount >= amount);
+
+                if should_succeed {
+                    let order_id = res?;
+                    assert_eq!(order_id, next_order_id_before);
+                    assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
+                    assert_eq!(
+                        exchange.balance_of(alice, escrow_token)?,
+                        escrow_balance_before.saturating_sub(amount)
+                    );
+                } else {
+                    assert_eq!(res.unwrap_err(), TIP20Error::contract_paused().into());
+                    assert_eq!(exchange.next_order_id()?, next_order_id_before);
+                    assert_eq!(
+                        exchange.balance_of(alice, escrow_token)?,
+                        escrow_balance_before
+                    );
+                }
+
+                Ok::<_, eyre::Report>(())
+            })?;
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_place_orders_on_paused_token_respects_internal_balance_path() -> eyre::Result<()> {
-        fn assert_paused_token_order_path<F>(
-            internal_balance_amount: u128,
-            is_bid: bool,
-            mut place_order: F,
-        ) -> eyre::Result<()>
-        where
-            F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
-        {
-            for spec in [TempoHardfork::T3, TempoHardfork::T4] {
-                let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
-                StorageCtx::enter(&mut storage, || {
-                    let mut exchange = StablecoinDEX::new();
-                    exchange.initialize()?;
-
-                    let (alice, admin) = (Address::random(), Address::random());
-                    let amount = MIN_ORDER_AMOUNT;
-
-                    let (base_token, quote_token) =
-                        setup_test_tokens(admin, alice, exchange.address, 500_000_000u128)?;
-                    exchange.create_pair(base_token)?;
-                    let escrow_token = if is_bid { quote_token } else { base_token };
-                    exchange.set_balance(alice, escrow_token, internal_balance_amount)?;
-
-                    let mut escrow_tip20 = TIP20Token::from_address(escrow_token)?;
-                    escrow_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
-                    escrow_tip20.pause(admin, ITIP20::pauseCall {})?;
-
-                    let next_order_id_before = exchange.next_order_id()?;
-                    let res = place_order(&mut exchange, alice, base_token, amount);
-
-                    if internal_balance_amount >= amount && !spec.is_t4() {
-                        let order_id = res?;
-                        assert_eq!(order_id, next_order_id_before);
-                        assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
-                        assert_eq!(
-                            exchange.balance_of(alice, escrow_token)?,
-                            internal_balance_amount - amount
-                        );
-                    } else {
-                        assert_eq!(res.unwrap_err(), TIP20Error::contract_paused().into());
-                        assert_eq!(exchange.next_order_id()?, next_order_id_before);
-                        assert_eq!(
-                            exchange.balance_of(alice, escrow_token)?,
-                            internal_balance_amount
-                        );
-                    }
-
-                    Ok::<_, eyre::Report>(())
-                })?;
-            }
-            Ok(())
-        }
-
         let partial_internal_balance = MIN_ORDER_AMOUNT - 1;
 
         // Full internal balance uses the internal-only path pre-T4, but T4 still rejects
         // paused-token orders.
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             MIN_ORDER_AMOUNT,
             false,
-            |exchange, alice, base_token, amount| {
-                exchange.place(alice, base_token, amount, false, 0)
-            },
+            |exchange, alice, base, amount| exchange.place(alice, base, amount, false, 0),
         )?;
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             MIN_ORDER_AMOUNT,
             true,
-            |exchange, alice, base_token, amount| {
-                exchange.place(alice, base_token, amount, true, 0)
-            },
+            |exchange, alice, base, amount| exchange.place(alice, base, amount, true, 0),
         )?;
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             MIN_ORDER_AMOUNT,
             false,
-            |exchange, alice, base_token, amount| {
-                exchange.place_flip(alice, base_token, amount, false, 100, 0, true)
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, false, 100, 0, true)
             },
         )?;
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             MIN_ORDER_AMOUNT,
             true,
-            |exchange, alice, base_token, amount| {
-                exchange.place_flip(alice, base_token, amount, true, 0, 100, true)
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, true, 0, 100, true)
             },
         )?;
 
-        // Regular ask order: fallback transferFrom should fail without consuming partial base
-        // balance.
-        assert_paused_token_order_path(
+        // Partial internal balance: the fallback transferFrom hits the paused escrow token and
+        // fails on both T3 and T4 without consuming the partial balance.
+        assert_paused_token_order(
+            true,
             partial_internal_balance,
             false,
-            |exchange, alice, base_token, amount| {
-                exchange.place(alice, base_token, amount, false, 0)
-            },
+            |exchange, alice, base, amount| exchange.place(alice, base, amount, false, 0),
         )?;
-
-        // Regular bid order: fallback transferFrom should fail without consuming partial quote
-        // balance.
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             partial_internal_balance,
             true,
-            |exchange, alice, base_token, amount| {
-                exchange.place(alice, base_token, amount, true, 0)
-            },
+            |exchange, alice, base, amount| exchange.place(alice, base, amount, true, 0),
         )?;
-
-        // Flip ask order on the shared debit-or-transfer path.
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             partial_internal_balance,
             false,
-            |exchange, alice, base_token, amount| {
-                exchange.place_flip(alice, base_token, amount, false, 100, 0, false)
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, false, 100, 0, false)
             },
         )?;
-
-        // Flip bid order on the shared debit-or-transfer path.
-        assert_paused_token_order_path(
+        assert_paused_token_order(
+            true,
             partial_internal_balance,
             true,
-            |exchange, alice, base_token, amount| {
-                exchange.place_flip(alice, base_token, amount, true, 0, 100, false)
+            |exchange, alice, base, amount| {
+                exchange.place_flip(alice, base, amount, true, 0, 100, false)
             },
         )
     }
 
     #[test]
     fn test_place_orders_on_paused_non_escrow_token_blocked_on_t4() -> eyre::Result<()> {
-        fn assert_paused_non_escrow_token_order<F>(
-            is_bid: bool,
-            internal_balance_amount: u128,
-            mut place_order: F,
-        ) -> eyre::Result<()>
-        where
-            F: FnMut(&mut StablecoinDEX, Address, Address, u128) -> Result<u128>,
-        {
-            for spec in [TempoHardfork::T3, TempoHardfork::T4] {
-                let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
-                StorageCtx::enter(&mut storage, || {
-                    let mut exchange = StablecoinDEX::new();
-                    exchange.initialize()?;
-
-                    let (alice, admin) = (Address::random(), Address::random());
-                    let amount = MIN_ORDER_AMOUNT;
-
-                    let (base_token, quote_token) =
-                        setup_test_tokens(admin, alice, exchange.address, 500_000_000u128)?;
-                    exchange.create_pair(base_token)?;
-
-                    // Pre-fund alice's internal escrow balance so we exercise both the
-                    // internal-only and transferFrom paths cleanly.
-                    let escrow_token = if is_bid { quote_token } else { base_token };
-                    if internal_balance_amount > 0 {
-                        exchange.set_balance(alice, escrow_token, internal_balance_amount)?;
-                    }
-
-                    // Pause the non-escrow side of the pair (escrow stays unpaused).
-                    let non_escrow_token = if is_bid { base_token } else { quote_token };
-                    let mut non_escrow_tip20 = TIP20Token::from_address(non_escrow_token)?;
-                    non_escrow_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
-                    non_escrow_tip20.pause(admin, ITIP20::pauseCall {})?;
-
-                    let next_order_id_before = exchange.next_order_id()?;
-                    let escrow_balance_before = exchange.balance_of(alice, escrow_token)?;
-                    let res = place_order(&mut exchange, alice, base_token, amount);
-
-                    if spec.is_t4() {
-                        assert_eq!(res.unwrap_err(), TIP20Error::contract_paused().into());
-                        assert_eq!(exchange.next_order_id()?, next_order_id_before);
-                        assert_eq!(
-                            exchange.balance_of(alice, escrow_token)?,
-                            escrow_balance_before
-                        );
-                    } else {
-                        let order_id = res?;
-                        assert_eq!(order_id, next_order_id_before);
-                        assert_eq!(exchange.next_order_id()?, next_order_id_before + 1);
-                    }
-
-                    Ok::<_, eyre::Report>(())
-                })?;
-            }
-            Ok(())
-        }
-
-        // place: ask + bid (transferFrom path covers both internal and external escrow)
-        assert_paused_non_escrow_token_order(false, 0, |exchange, alice, base, amount| {
+        // place: ask + bid (transferFrom path, escrow is unpaused so this succeeds pre-T4)
+        assert_paused_token_order(false, 0, false, |exchange, alice, base, amount| {
             exchange.place(alice, base, amount, false, 0)
         })?;
-        assert_paused_non_escrow_token_order(true, 0, |exchange, alice, base, amount| {
+        assert_paused_token_order(false, 0, true, |exchange, alice, base, amount| {
             exchange.place(alice, base, amount, true, 0)
         })?;
 
         // place_flip non-internal-only: ask + bid
-        assert_paused_non_escrow_token_order(false, 0, |exchange, alice, base, amount| {
+        assert_paused_token_order(false, 0, false, |exchange, alice, base, amount| {
             exchange.place_flip(alice, base, amount, false, 100, 0, false)
         })?;
-        assert_paused_non_escrow_token_order(true, 0, |exchange, alice, base, amount| {
+        assert_paused_token_order(false, 0, true, |exchange, alice, base, amount| {
             exchange.place_flip(alice, base, amount, true, 0, 100, false)
         })?;
 
         // place_flip internal-only: ask + bid (requires escrow internal balance)
-        assert_paused_non_escrow_token_order(
+        assert_paused_token_order(
             false,
             MIN_ORDER_AMOUNT,
+            false,
             |exchange, alice, base, amount| {
                 exchange.place_flip(alice, base, amount, false, 100, 0, true)
             },
         )?;
-        assert_paused_non_escrow_token_order(
-            true,
+        assert_paused_token_order(
+            false,
             MIN_ORDER_AMOUNT,
+            true,
             |exchange, alice, base, amount| {
                 exchange.place_flip(alice, base, amount, true, 0, 100, true)
             },


### PR DESCRIPTION
Adds `check_not_paused()` in `decrement_balance_or_transfer_from` and `place_flip`'s internal-balance-only path when `user_balance >= amount` on T4+, since TIP-20 `transferFrom` won't run in that case. A `check_pause` bool avoids redundant SLOADs on the swap path (already covered by `validate_and_build_route`).

Prompted by: daniel