### PR TITLE
feat(ci): use upstream foundry

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -134,9 +134,9 @@ jobs:
 
           # Build object flags
           OBJECT_FLAGS=""
-          if [[ -f forge-coverage/tempo-foundry/target/release/forge ]]; then
-            chmod +x forge-coverage/tempo-foundry/target/release/forge
-            OBJECT_FLAGS="$OBJECT_FLAGS --object=forge-coverage/tempo-foundry/target/release/forge"
+          if [[ -f forge-coverage/foundry/target/release/forge ]]; then
+            chmod +x forge-coverage/foundry/target/release/forge
+            OBJECT_FLAGS="$OBJECT_FLAGS --object=forge-coverage/foundry/target/release/forge"
           fi
           if [[ -d cargo-coverage/precompiles-bin ]]; then
             for bin in cargo-coverage/precompiles-bin/*; do
@@ -159,7 +159,7 @@ jobs:
             --ignore-filename-regex='/rustc/' \
             --ignore-filename-regex='\.cargo/' \
             --ignore-filename-regex='\.rustup/' \
-            --ignore-filename-regex='tempo-foundry/' \
+            --ignore-filename-regex='foundry/' \
             --ignore-filename-regex='library/' \
             2>/dev/null > coverage-report/full-summary.txt || true
 
@@ -183,7 +183,7 @@ jobs:
             --ignore-filename-regex='/rustc/' \
             --ignore-filename-regex='\.cargo/' \
             --ignore-filename-regex='\.rustup/' \
-            --ignore-filename-regex='tempo-foundry/' \
+            --ignore-filename-regex='foundry/' \
             --ignore-filename-regex='library/' \
             > coverage-report/full.lcov 2>/dev/null || true
 

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -28,13 +28,16 @@ jobs:
     name: rpc-tests (${{ matrix.network }})
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
-    continue-on-error: true
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        network: [testnet, devnet]
+        include:
+          - network: testnet
+            allow_failure: false
+          - network: devnet
+            allow_failure: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,6 +49,14 @@ jobs:
         with:
           tool: nextest@0.9.124
       - name: Build RPC tests
+        id: build
+        continue-on-error: ${{ matrix.allow_failure }}
         run: cargo nextest run --profile ci-rpc -E 'package(tempo-node) & binary(it) & test(/test_matrices_${{ matrix.network }}/)' --no-run
       - name: Run RPC tests
+        id: run
+        if: steps.build.outcome == 'success'
+        continue-on-error: ${{ matrix.allow_failure }}
         run: cargo nextest run --profile ci-rpc -E 'package(tempo-node) & binary(it) & test(/test_matrices_${{ matrix.network }}/)'
+      - name: Report allowed devnet failure
+        if: matrix.allow_failure && (steps.build.outcome == 'failure' || steps.run.outcome == 'failure')
+        run: echo '::warning::Devnet RPC tests failed, but this check is allowed to fail so merge queue processing can continue.'

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -175,28 +175,48 @@ jobs:
         if: needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
-      - name: Update foundry to use current commit
+      - name: Patch foundry to use checked-out tempo crates
         working-directory: foundry
         run: |
-          if ! grep -q 'https://github.com/tempoxyz/tempo' Cargo.toml; then
-            echo "No Tempo git dependencies to rewrite in $(pwd)/Cargo.toml"
-            exit 0
+          if ! grep -q '^\[patch\."https://github.com/tempoxyz/tempo"\]' Cargo.toml; then
+            PATCHES="$({
+              awk '
+                /^\[workspace.dependencies\]/ { in_section = 1; next }
+                in_section && /^\[/ { exit }
+                in_section && $1 ~ /^tempo-/ && index($0, "path = \"") {
+                  split($0, path_parts, /path = "/)
+                  split(path_parts[2], rest, /"/)
+                  print $1 "\t" rest[1]
+                }
+              ' ../tempo/Cargo.toml | sort
+            })"
+
+            if [[ -z "$PATCHES" ]]; then
+              echo "No path-based tempo-* workspace dependencies found in ../tempo/Cargo.toml"
+              exit 1
+            fi
+
+            {
+              printf '\n[patch."https://github.com/tempoxyz/tempo"]\n'
+              while IFS=$'\t' read -r crate path; do
+                [[ -n "$crate" ]] || continue
+                printf '%s = { path = "../tempo/%s" }\n' "$crate" "$path"
+              done <<< "$PATCHES"
+            } >> Cargo.toml
           fi
 
-          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          echo "Updating tempo dependencies to commit: $COMMIT_SHA"
-
-          # Update all tempo dependencies to point to the current commit
-          # Using # as delimiter since URLs contain /
-          sed -i -E \
-            "s#(tempo-[a-z-]+) = \{ git = \"https://github.com/tempoxyz/tempo\", rev = \"[^\"]+\"([^}]*)\}#\1 = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$COMMIT_SHA\"\2}#g" \
-            Cargo.toml
-
-          echo "Updated Cargo.toml:"
-          grep "tempo-" Cargo.toml | head -20
+          echo "Updated Cargo.toml patch section:"
+          sed -n '/^\[patch\."https:\/\/github.com\/tempoxyz\/tempo"\]/,$p' Cargo.toml
 
           # Update Cargo.lock to resolve version conflicts
           cargo update
+
+          if grep -q '^source = "git+https://github.com/tempoxyz/tempo?rev=' Cargo.lock; then
+            echo "Tempo git sources still present in Cargo.lock after patching:"
+            grep '^source = "git+https://github.com/tempoxyz/tempo?rev=' Cargo.lock
+            echo "Expected all Tempo crates to resolve from ../tempo after patching"
+            exit 1
+          fi
 
       # Build and run WITH coverage (only on PR when precompiles changed)
       - name: Build foundry forge with coverage instrumentation

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -13,7 +13,6 @@ on:
   pull_request:
 
 env:
-  FOUNDRY_PROFILE: ci
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
 
@@ -137,7 +136,7 @@ jobs:
         working-directory: tips/ref-impls
         run: forge test -vvv --no-match-contract TempoTransactionInvariantTest
 
-  tempo-foundry-test:
+  foundry-test:
     name: Forge Test (Rust Precompiles)
     needs: [check-specs-changes, check-precompiles]
     # Skip for forked repos
@@ -154,12 +153,12 @@ jobs:
           path: tempo
           persist-credentials: false
 
-      - name: Checkout tempo-foundry
+      - name: Checkout foundry
         uses: actions/checkout@v6
         with:
-          repository: tempoxyz/tempo-foundry
-          ref: tempo
-          path: tempo-foundry
+          repository: foundry-rs/foundry
+          ref: master
+          path: foundry
           persist-credentials: false
 
       - name: Setup Rust
@@ -169,15 +168,20 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
         with:
-          workspaces: tempo-foundry
+          workspaces: foundry
 
       - name: Install llvm-tools
         if: needs.check-precompiles.outputs.coverage == 'true'
         run: rustup component add llvm-tools-preview
 
-      - name: Update tempo-foundry to use current commit
-        working-directory: tempo-foundry
+      - name: Update foundry to use current commit
+        working-directory: foundry
         run: |
+          if ! grep -q 'https://github.com/tempoxyz/tempo' Cargo.toml; then
+            echo "No Tempo git dependencies to rewrite in $(pwd)/Cargo.toml"
+            exit 0
+          fi
+
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           echo "Updating tempo dependencies to commit: $COMMIT_SHA"
 
@@ -194,30 +198,30 @@ jobs:
           cargo update
 
       # Build and run WITH coverage (only on PR when precompiles changed)
-      - name: Build tempo-foundry forge with coverage instrumentation
+      - name: Build foundry forge with coverage instrumentation
         if: needs.check-precompiles.outputs.coverage == 'true'
-        working-directory: tempo-foundry
+        working-directory: foundry
         run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release
 
       - name: Run Forge tests with Rust precompiles (with coverage)
         if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: tempo/tips/ref-impls
         run: |
-          echo "Running forge test with tempo-foundry (isTempo=true)"
-          LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../tempo-foundry/target/release/forge test -vvv
+          echo "Running forge test with Rust precompiles (isTempo=true)"
+          FOUNDRY_PROFILE=tempo LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
       # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
-      - name: Build tempo-foundry forge
+      - name: Build foundry forge
         if: needs.check-precompiles.outputs.coverage != 'true'
-        working-directory: tempo-foundry
+        working-directory: foundry
         run: cargo build -p forge --profile release
 
       - name: Run Forge tests with Rust precompiles
         if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: tempo/tips/ref-impls
         run: |
-          echo "Running forge test with tempo-foundry (isTempo=true)"
-          ../../../tempo-foundry/target/release/forge test -vvv
+          echo "Running forge test with Rust precompiles (isTempo=true)"
+          FOUNDRY_PROFILE=tempo ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage profdata
         if: needs.check-precompiles.outputs.coverage == 'true'
@@ -233,7 +237,7 @@ jobs:
           name: forge-test-coverage
           path: |
             coverage/forge-test.profdata
-            tempo-foundry/target/release/forge
+            foundry/target/release/forge
           retention-days: 1
 
   specs-success:
@@ -247,14 +251,14 @@ jobs:
       - build
       - lint
       - test
-      - tempo-foundry-test
+      - foundry-test
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
-          allowed-failures: tempo-foundry-test
-          allowed-skips: check-precompiles,build,lint,test,tempo-foundry-test
+          allowed-failures: foundry-test
+          allowed-skips: check-precompiles,build,lint,test,foundry-test
           jobs: ${{ toJSON(needs) }}
 
   precompiles-coverage:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -229,7 +229,7 @@ jobs:
         working-directory: tempo/tips/ref-impls
         run: |
           echo "Running forge test with Rust precompiles (isTempo=true)"
-          FOUNDRY_PROFILE=tempo-ci LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
+          FOUNDRY_PROFILE=tempo_ci LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
       # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
       - name: Build foundry forge
@@ -242,7 +242,7 @@ jobs:
         working-directory: tempo/tips/ref-impls
         run: |
           echo "Running forge test with Rust precompiles (isTempo=true)"
-          FOUNDRY_PROFILE=tempo-ci ../../../foundry/target/release/forge test -vvv
+          FOUNDRY_PROFILE=tempo_ci ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage profdata
         if: needs.check-precompiles.outputs.coverage == 'true'

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
 
 env:
+  FOUNDRY_PROFILE: ci
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
 
@@ -208,7 +209,7 @@ jobs:
         working-directory: tempo/tips/ref-impls
         run: |
           echo "Running forge test with Rust precompiles (isTempo=true)"
-          FOUNDRY_PROFILE=tempo LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
+          FOUNDRY_PROFILE=tempo-ci LLVM_PROFILE_FILE="$(pwd)/forge-coverage-%p.profraw" ../../../foundry/target/release/forge test -vvv
 
       # Build and run WITHOUT coverage (main/merge_group or no precompiles changes)
       - name: Build foundry forge
@@ -221,7 +222,7 @@ jobs:
         working-directory: tempo/tips/ref-impls
         run: |
           echo "Running forge test with Rust precompiles (isTempo=true)"
-          FOUNDRY_PROFILE=tempo ../../../foundry/target/release/forge test -vvv
+          FOUNDRY_PROFILE=tempo-ci ../../../foundry/target/release/forge test -vvv
 
       - name: Generate coverage profdata
         if: needs.check-precompiles.outputs.coverage == 'true'

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can connect to Tempo's public testnet using the following details:
 
 Next, grab some stablecoins to test with from Tempo's [Faucet](https://docs.tempo.xyz/quickstart/faucet#faucet).
 
-Alternatively, use [`cast`](https://github.com/tempoxyz/tempo-foundry):
+Alternatively, use [`cast`](https://github.com/foundry-rs/foundry):
 
 ```bash
 cast rpc tempo_fundAddress <ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz

--- a/tips/ref-impls/README.md
+++ b/tips/ref-impls/README.md
@@ -17,7 +17,7 @@ This allows the same test suite to verify both implementations are in sync.
 The checked-in `foundry.toml` keeps these two modes separate with profiles:
 
 - `default` / `ci`: Solidity reference implementations (`isTempo = false`)
-- `tempo` / `tempo-ci`: Native Rust precompiles (`isTempo = true`)
+- `tempo` / `tempo_ci`: Native Rust precompiles (`isTempo = true`)
 
 ## Running Tests
 
@@ -101,6 +101,6 @@ forge test
 The CI runs both test modes:
 
 1. `forge test` - Validates Solidity implementations
-2. `FOUNDRY_PROFILE=tempo-ci forge test` - Validates Rust precompiles match Solidity specs
+2. `FOUNDRY_PROFILE=tempo_ci forge test` - Validates Rust precompiles match Solidity specs
 
 This ensures the Rust and Solidity implementations stay in sync.

--- a/tips/ref-impls/README.md
+++ b/tips/ref-impls/README.md
@@ -3,30 +3,36 @@
 This directory contains Solidity specifications and fuzz tests for Tempo's precompile contracts. The tests are designed to run against both:
 
 1. **Solidity reference implementations** - Using standard Foundry
-2. **Rust precompile implementations** - Using tempo-foundry's custom forge
+2. **Rust precompile implementations** - Using Foundry with the Tempo profile
 
 ## How Tests Work
 
 The tests use an `isTempo` flag (defined in `BaseTest.t.sol`) to detect which implementation is being tested:
 
-- **`isTempo = false`**: Tests run against Solidity implementations deployed via `deployCodeTo()`. This is the default when using standard `forge`.
-- **`isTempo = true`**: Tests run against Rust precompiles built into tempo-foundry's EVM. The flag is automatically true when native precompile code exists at addresses like `0x20Fc...` (TIP20Factory).
+- **`isTempo = false`**: Tests run against Solidity implementations deployed via `deployCodeTo()`. This is the default `forge` path.
+- **`isTempo = true`**: Tests run against Rust precompiles built into upstream Foundry's Tempo EVM. This is the Tempo profile path.
 
 This allows the same test suite to verify both implementations are in sync.
 
-This means running tests with normal foundry, will run them against the solidity implementation.
-Using tempo-foundry, will run tests against the rust precompiles.
+The checked-in `foundry.toml` keeps these two modes separate with profiles:
+
+- `default`: Solidity reference implementations (`isTempo = false`)
+- `tempo`: Native Rust precompiles (`isTempo = true`)
 
 ## Running Tests
 
-**Prerequisite:** Clone the `tempo-foundry` github repo, and update the tempo deps to your branch before running the tests.
+**Prerequisite:** Use an upstream Foundry nightly build.
 
-### Option 1: Solidity Only (Standard Foundry)
+```bash
+foundryup -i nightly
+```
+
+### Option 1: Solidity-Only Reference Implementations (Standard Foundry)
 
 Run tests against the Solidity reference implementations:
 
 ```bash
-cd docs/specs
+cd tips/ref-impls
 forge test
 ```
 
@@ -42,16 +48,30 @@ Run a specific test:
 forge test --match-test test_mint
 ```
 
-### Option 2: Rust Precompiles (tempo-foundry)
+This path is what CI uses for the Solidity-only `forge test` job.
+
+### Option 2: Rust Precompiles (Tempo Profile)
 
 Run tests against the actual Rust precompile implementations:
 
 ```bash
-cd docs/specs
+cd tips/ref-impls
+FOUNDRY_PROFILE=tempo forge test
+```
+
+Equivalent wrapper command:
+
+```bash
 ./tempo-forge test
 ```
 
 With verbose output:
+
+```bash
+FOUNDRY_PROFILE=tempo forge test -vvv
+```
+
+Equivalent wrapper command:
 
 ```bash
 ./tempo-forge test -vvv
@@ -60,67 +80,20 @@ With verbose output:
 Run a specific test:
 
 ```bash
+FOUNDRY_PROFILE=tempo forge test --match-test test_mint
+```
+
+Equivalent wrapper command:
+
+```bash
 ./tempo-forge test --match-test test_mint
 ```
 
-## Setting Up tempo-foundry
-
-The `tempo-forge` and `tempo-cast` scripts require the [tempo-foundry](https://github.com/tempoxyz/tempo-foundry) repository.
-
-### Option 1: Clone as Sibling Directory (Recommended)
-
-Clone tempo-foundry as a sibling to the tempo repository:
-
-```
-Tempo/
-├── tempo/              # This repository
-└── tempo-foundry/      # tempo-foundry repository
-```
+Foundry selects profiles via `FOUNDRY_PROFILE`, so if you run Tempo-mode commands frequently you can also set it in your shell:
 
 ```bash
-cd ..  # From tempo repo root
-git clone git@github.com:tempoxyz/tempo-foundry.git
-```
-
-### Option 2: Set Environment Variable
-
-If tempo-foundry is in a different location, set the `TEMPO_FOUNDRY_PATH` environment variable:
-
-```bash
-export TEMPO_FOUNDRY_PATH=/path/to/tempo-foundry
-./tempo-forge test
-```
-
-### Building tempo-foundry
-
-The scripts will automatically build the forge/cast binaries on first run. To build manually:
-
-```bash
-cd /path/to/tempo-foundry
-cargo build -p forge --profile dev
-cargo build -p cast --profile dev
-```
-
-If you encounter build errors, try cleaning and rebuilding:
-
-```bash
-cargo clean
-cargo build -p forge --profile dev
-```
-
-## tempo-cast
-
-The `tempo-cast` script runs cast commands using tempo-foundry's custom cast binary:
-
-```bash
-# Get function signature
-./tempo-cast sig "transfer(address,uint256)"
-
-# Decode function selector
-./tempo-cast 4byte 0xa9059cbb
-
-# ABI encode
-./tempo-cast abi-encode "transfer(address,uint256)" 0x1234...5678 1000000
+export FOUNDRY_PROFILE=tempo
+forge test
 ```
 
 ## CI Integration
@@ -128,7 +101,6 @@ The `tempo-cast` script runs cast commands using tempo-foundry's custom cast bin
 The CI runs both test modes:
 
 1. `forge test` - Validates Solidity implementations
-2. `tempo-forge test` - Validates Rust precompiles match Solidity specs
+2. `FOUNDRY_PROFILE=tempo forge test` - Validates Rust precompiles match Solidity specs
 
 This ensures the Rust and Solidity implementations stay in sync.
-

--- a/tips/ref-impls/README.md
+++ b/tips/ref-impls/README.md
@@ -16,8 +16,8 @@ This allows the same test suite to verify both implementations are in sync.
 
 The checked-in `foundry.toml` keeps these two modes separate with profiles:
 
-- `default`: Solidity reference implementations (`isTempo = false`)
-- `tempo`: Native Rust precompiles (`isTempo = true`)
+- `default` / `ci`: Solidity reference implementations (`isTempo = false`)
+- `tempo` / `tempo-ci`: Native Rust precompiles (`isTempo = true`)
 
 ## Running Tests
 
@@ -101,6 +101,6 @@ forge test
 The CI runs both test modes:
 
 1. `forge test` - Validates Solidity implementations
-2. `FOUNDRY_PROFILE=tempo forge test` - Validates Rust precompiles match Solidity specs
+2. `FOUNDRY_PROFILE=tempo-ci forge test` - Validates Rust precompiles match Solidity specs
 
 This ensures the Rust and Solidity implementations stay in sync.

--- a/tips/ref-impls/foundry.toml
+++ b/tips/ref-impls/foundry.toml
@@ -17,6 +17,17 @@ remappings = [
 [profile.tempo]
 hardfork = "tempo:T3"
 
+[profile.ci]
+optimizer = true
+optimizer_runs = 1
+invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true }
+
+[profile.tempo-ci]
+hardfork = "tempo:T3"
+optimizer = true
+optimizer_runs = 1
+invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true }
+
 [profile.fuzz500]
 optimizer = true
 optimizer_runs = 200

--- a/tips/ref-impls/foundry.toml
+++ b/tips/ref-impls/foundry.toml
@@ -22,7 +22,7 @@ optimizer = true
 optimizer_runs = 1
 invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true }
 
-[profile.tempo-ci]
+[profile.tempo_ci]
 hardfork = "tempo:T3"
 optimizer = true
 optimizer_runs = 1

--- a/tips/ref-impls/foundry.toml
+++ b/tips/ref-impls/foundry.toml
@@ -4,7 +4,6 @@ out = "out"
 libs = ["lib"]
 optimizer = true
 optimizer_runs = 200
-hardfork = "tempo:T3"
 extra_output = ["storageLayout"]
 invariant = { fail_on_revert = true, show_solidity = true }
 fs_permissions = [{ access = "read-write", path = "./"}]
@@ -15,10 +14,8 @@ remappings = [
     "solady/=lib/solady/src/"
 ]
 
-[profile.ci]
-optimizer = true
-optimizer_runs = 1
-invariant = { runs = 10, depth = 50, fail_on_revert = true, show_solidity = true }
+[profile.tempo]
+hardfork = "tempo:T3"
 
 [profile.fuzz500]
 optimizer = true

--- a/tips/ref-impls/tempo-cast
+++ b/tips/ref-impls/tempo-cast
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run cast commands using tempo-foundry's custom cast binary.
+# Convenience wrapper for running cast in Tempo mode.
 #
 # Usage:
 #   ./tempo-cast [cast-args...]
@@ -12,61 +12,48 @@
 #
 # Prerequisites:
 #   - Rust toolchain installed
-#   - tempo-foundry repo cloned as a sibling to tempo repo:
-#       Tempo/
-#         tempo/          <- this repo
-#         tempo-foundry/  <- tempo-foundry repo
+#   - Either an installed `cast` binary (for example via `foundryup -b master`)
+#     or a local foundry-rs/foundry checkout.
 #
 # The script will:
-#   1. Locate or build the tempo-foundry cast binary
-#   2. Run cast with the Rust precompiles enabled
+#   1. Use `cast` from PATH, or fall back to a local Foundry checkout
+#   2. Run cast with `FOUNDRY_PROFILE=tempo` unless already set
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Try to find tempo-foundry in common locations
-TEMPO_FOUNDRY_PATHS=(
-    "$TEMPO_ROOT/../tempo-foundry"           # Sibling directory
-    "$TEMPO_ROOT/../../tempo-foundry"        # Parent's sibling
-    "${TEMPO_FOUNDRY_PATH:-}"                # Environment variable override
-)
+CAST_BIN="$(command -v cast || true)"
 
-TEMPO_FOUNDRY_DIR=""
-for path in "${TEMPO_FOUNDRY_PATHS[@]}"; do
-    if [[ -n "$path" && -d "$path" && -f "$path/Cargo.toml" ]]; then
-        TEMPO_FOUNDRY_DIR="$path"
-        break
+if [[ -z "$CAST_BIN" ]]; then
+    # Fall back to a local Foundry checkout when cast is not installed.
+    FOUNDRY_PATHS=(
+        "${FOUNDRY_PATH:-}"
+        "$TEMPO_ROOT/../foundry"
+        "$TEMPO_ROOT/../../foundry"
+    )
+
+    FOUNDRY_DIR=""
+    for path in "${FOUNDRY_PATHS[@]}"; do
+        if [[ -n "$path" && -d "$path" && -f "$path/Cargo.toml" ]]; then
+            FOUNDRY_DIR="$path"
+            break
+        fi
+    done
+
+    if [[ -z "$FOUNDRY_DIR" ]]; then
+        echo "Error: Could not find an installed cast binary or a local Foundry checkout."
+        echo "Install upstream Foundry with: foundryup -b master"
+        exit 1
     fi
-done
 
-if [[ -z "$TEMPO_FOUNDRY_DIR" ]]; then
-    echo "Error: Could not find tempo-foundry repository."
-    echo ""
-    echo "Please either:"
-    echo "  1. Clone tempo-foundry as a sibling to the tempo repo:"
-    echo "     git clone git@github.com:tempoxyz/tempo-foundry.git ../tempo-foundry"
-    echo ""
-    echo "  2. Set TEMPO_FOUNDRY_PATH environment variable:"
-    echo "     export TEMPO_FOUNDRY_PATH=/path/to/tempo-foundry"
-    exit 1
+    CAST_BIN="$FOUNDRY_DIR/target/debug/cast"
+    # Check if cast binary exists, build if not
+    if [[ ! -x "$CAST_BIN" ]]; then
+        echo "Building cast binary..."
+        (cd "$FOUNDRY_DIR" && cargo build -p cast --profile dev)
+    fi
 fi
 
-CAST_BIN="$TEMPO_FOUNDRY_DIR/target/debug/cast"
-
-# Check if cast binary exists, build if not
-if [[ ! -x "$CAST_BIN" ]]; then
-    echo "Building tempo-foundry cast binary..."
-    echo "(This may take a few minutes on first run)"
-    echo ""
-    (cd "$TEMPO_FOUNDRY_DIR" && cargo build -p cast --profile dev)
-fi
-
-if [[ ! -x "$CAST_BIN" ]]; then
-    echo "Error: Failed to build cast binary at $CAST_BIN"
-    exit 1
-fi
-
-# Run cast
-exec "$CAST_BIN" "$@"
+FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-tempo}" exec "$CAST_BIN" "$@"

--- a/tips/ref-impls/tempo-forge
+++ b/tips/ref-impls/tempo-forge
@@ -1,80 +1,61 @@
 #!/usr/bin/env bash
 #
-# Run forge commands using tempo-foundry's custom forge binary.
-# This tests the Solidity specs against the actual Rust precompile implementations.
+# Convenience wrapper for running forge in Tempo mode.
 #
 # Usage:
 #   ./tempo-forge [forge-args...]
 #
 # Examples:
-#   ./tempo-forge test                         # Run all tests
+#   ./tempo-forge test                         # Run all tests in Tempo mode
 #   ./tempo-forge test -vvv                    # Run with verbose output
-#   ./tempo-forge test --match-test test_mint  # Run specific test
-#   ./tempo-forge build                        # Build contracts
+#   ./tempo-forge test --match-test test_mint  # Run a specific test
+#   ./tempo-forge build                        # Build contracts in Tempo mode
 #
 # Prerequisites:
 #   - Rust toolchain installed
-#   - tempo-foundry repo cloned as a sibling to tempo repo:
-#       Tempo/
-#         tempo/          <- this repo
-#         tempo-foundry/  <- tempo-foundry repo
+#   - Either an installed `forge` binary (for example via `foundryup -b master`)
+#     or a local foundry-rs/foundry checkout.
 #
 # The script will:
-#   1. Locate or build the tempo-foundry forge binary
-#   2. Run forge with the Rust precompiles enabled (isTempo=true)
+#   1. Use `forge` from PATH, or fall back to a local Foundry checkout
+#   2. Run forge with `FOUNDRY_PROFILE=tempo` unless already set
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Try to find tempo-foundry in common locations
-TEMPO_FOUNDRY_PATHS=(
-    "$TEMPO_ROOT/../tempo-foundry"           # Sibling directory
-    "$TEMPO_ROOT/../../tempo-foundry"        # Parent's sibling
-    "${TEMPO_FOUNDRY_PATH:-}"                # Environment variable override
-)
+FORGE_BIN="$(command -v forge || true)"
 
-TEMPO_FOUNDRY_DIR=""
-for path in "${TEMPO_FOUNDRY_PATHS[@]}"; do
-    if [[ -n "$path" && -d "$path" && -f "$path/Cargo.toml" ]]; then
-        TEMPO_FOUNDRY_DIR="$path"
-        break
+if [[ -z "$FORGE_BIN" ]]; then
+    # Fall back to a local Foundry checkout when forge is not installed.
+    FOUNDRY_PATHS=(
+        "${FOUNDRY_PATH:-}"
+        "$TEMPO_ROOT/../foundry"
+        "$TEMPO_ROOT/../../foundry"
+    )
+
+    FOUNDRY_DIR=""
+    for path in "${FOUNDRY_PATHS[@]}"; do
+        if [[ -n "$path" && -d "$path" && -f "$path/Cargo.toml" ]]; then
+            FOUNDRY_DIR="$path"
+            break
+        fi
+    done
+
+    if [[ -z "$FOUNDRY_DIR" ]]; then
+        echo "Error: Could not find an installed forge binary or a local Foundry checkout."
+        echo "Install upstream Foundry with: foundryup -b master"
+        exit 1
     fi
-done
 
-if [[ -z "$TEMPO_FOUNDRY_DIR" ]]; then
-    echo "Error: Could not find tempo-foundry repository."
-    echo ""
-    echo "Please either:"
-    echo "  1. Clone tempo-foundry as a sibling to the tempo repo:"
-    echo "     git clone git@github.com:tempoxyz/tempo-foundry.git ../tempo-foundry"
-    echo ""
-    echo "  2. Set TEMPO_FOUNDRY_PATH environment variable:"
-    echo "     export TEMPO_FOUNDRY_PATH=/path/to/tempo-foundry"
-    exit 1
+    FORGE_BIN="$FOUNDRY_DIR/target/debug/forge"
+    # Check if forge binary exists, build if not
+    if [[ ! -x "$FORGE_BIN" ]]; then
+        echo "Building forge binary..."
+        (cd "$FOUNDRY_DIR" && cargo build -p forge --profile dev)
+    fi
 fi
 
-FORGE_BIN="$TEMPO_FOUNDRY_DIR/target/debug/forge"
-
-echo "Using tempo-foundry at: $TEMPO_FOUNDRY_DIR"
-
-# Check if forge binary exists, build if not
-if [[ ! -x "$FORGE_BIN" ]]; then
-    echo "Building tempo-foundry forge binary..."
-    echo "(This may take a few minutes on first run)"
-    echo ""
-    (cd "$TEMPO_FOUNDRY_DIR" && cargo build -p forge --profile dev)
-fi
-
-if [[ ! -x "$FORGE_BIN" ]]; then
-    echo "Error: Failed to build forge binary at $FORGE_BIN"
-    exit 1
-fi
-
-echo "Using forge binary: $FORGE_BIN"
-echo ""
-
-# Run forge from the specs directory
 cd "$SCRIPT_DIR"
-exec "$FORGE_BIN" "$@"
+FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-tempo}" exec "$FORGE_BIN" "$@"

--- a/tips/ref-impls/test/invariants/SignatureVerifier.t.sol
+++ b/tips/ref-impls/test/invariants/SignatureVerifier.t.sol
@@ -10,6 +10,7 @@ import { BaseTest } from "../BaseTest.t.sol";
 ///      stateless, so each handler tests a specific property via direct calls.
 ///      SV5 (gas schedule) requires dedicated low-level gas tests and is NOT covered here.
 /// forge-config: ci.invariant.depth = 300
+/// forge-config: tempo_ci.invariant.depth = 300
 contract SignatureVerifierInvariantTest is BaseTest {
 
     address internal constant SIG_VERIFIER = 0x5165300000000000000000000000000000000000;


### PR DESCRIPTION
this PR updates CI to use upstream `foundry` rather than the `tempo-foundry` fork.

NOTES:
- i had to patch foundry’s tempo deps in CI (rather than manually rewriting the pinned revs) so the build graph resolves to a single local tempo source.
- i've updated the readme to already mention `foundryup -i nightly` although technically, until the next nightly is realeased, it will only work with `foundryup -b master`