### PR TITLE
feat(consensus): log whether consensus datadir is empty on startup

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -389,8 +389,21 @@ fn main() -> eyre::Result<()> {
             });
 
             info_span!("prepare_consensus").in_scope(|| {
+                let is_empty = match consensus_storage.read_dir() {
+                    Ok(mut entries) => entries.next().is_none(),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+                    Err(err) => {
+                        warn!(
+                            path = %consensus_storage.display(),
+                            error = %err,
+                            "failed to inspect consensus data directory",
+                        );
+                        false
+                    }
+                };
                 info!(
                     path = %consensus_storage.display(),
+                    is_empty,
                     "determined directory for consensus data",
                 )
             });


### PR DESCRIPTION
Extends the existing `prepare_consensus` log line to also emit `is_empty`, reporting whether the consensus data directory contains any entries. Treats a missing directory as empty (`NotFound`); logs a warning for other `read_dir` errors.

Prompted by: janis