### PR TITLE
chore: ignore rustls-webpki advisories in cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,10 @@ ignore = [
   "RUSTSEC-2025-0141",
   # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
   "RUSTSEC-2026-0097",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0098 rustls-webpki upgrade is pending
+  "RUSTSEC-2026-0098",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0099 rustls-webpki upgrade is pending
+  "RUSTSEC-2026-0099",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Allows `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099` in `deny.toml` so `cargo deny check all` passes on `main`.

`origin/main` currently resolves `rustls-webpki 0.103.11`. This keeps the advisory gate green until that dependency can be upgraded to a fixed release.