### PR TITLE
fix(genesis): default t4_time to u64::MAX to prevent accidental activation

### DIFF
--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -27,7 +27,7 @@
     "t1cTime": 0,
     "t2Time": 0,
     "t3Time": 0,
-    "t4Time": 0,
+    "t4Time": 18446744073709551615,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -175,8 +175,9 @@ pub(crate) struct GenesisArgs {
     #[arg(long, default_value = "0")]
     t3_time: u64,
 
-    /// T4 hardfork activation time.
-    #[arg(long, default_value = "0")]
+    /// T4 hardfork activation time. Defaults to u64::MAX (disabled) to prevent
+    /// accidental activation on long-running devnets during rolling upgrades.
+    #[arg(long, default_value_t = u64::MAX)]
     t4_time: u64,
 
     /// Whether to skip initializing validator config v1


### PR DESCRIPTION
Changes the default `t4_time` in genesis args from `0` to `u64::MAX` so T4 is never accidentally activated on long-running devnets during rolling upgrades. This caused devnet-nightly and devnet-t4-long to stall when TIP-1031 was merged and validators ran mixed versions.

Regenerated `test-genesis.json` to match the new default.

Prompted by: Jen