### PR TITLE
perf(builder): use execution cache from build arguments

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -72,6 +72,10 @@ pub struct TempoNodeArgs {
     /// Enable prewarming for the payload builder.
     #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
+
+    /// Disable cached reads for the payload builder.
+    #[arg(long = "builder.disable-cached-reads", default_value_t = false)]
+    pub builder_disable_cached_reads: bool,
 }
 
 impl TempoNodeArgs {
@@ -89,6 +93,7 @@ impl TempoNodeArgs {
             state_provider_metrics: self.builder_state_provider_metrics,
             disable_state_cache: self.builder_disable_state_cache,
             enable_prewarming: self.builder_enable_prewarming,
+            disable_cached_reads: self.builder_disable_cached_reads,
         }
     }
 }
@@ -498,6 +503,9 @@ pub struct TempoPayloadBuilderBuilder {
     pub disable_state_cache: bool,
     /// Enable prewarming for the payload builder.
     pub enable_prewarming: bool,
+
+    /// Disable cached reads for the payload builder.
+    pub disable_cached_reads: bool,
 }
 
 impl<Node> PayloadBuilderBuilder<Node, TempoTransactionPool<Node::Provider>, TempoEvmConfig>
@@ -522,6 +530,7 @@ where
             self.state_provider_metrics,
             self.disable_state_cache,
             self.enable_prewarming,
+            self.disable_cached_reads,
         ))
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -65,17 +65,9 @@ pub struct TempoNodeArgs {
     #[arg(long = "builder.state-provider-metrics", default_value_t = false)]
     pub builder_state_provider_metrics: bool,
 
-    /// Disable state cache for the payload builder.
-    #[arg(long = "builder.disable-state-cache", default_value_t = false)]
-    pub builder_disable_state_cache: bool,
-
     /// Enable prewarming for the payload builder.
     #[arg(long = "builder.enable-prewarming", default_value_t = false)]
     pub builder_enable_prewarming: bool,
-
-    /// Disable cached reads for the payload builder.
-    #[arg(long = "builder.disable-cached-reads", default_value_t = false)]
-    pub builder_disable_cached_reads: bool,
 }
 
 impl TempoNodeArgs {
@@ -91,9 +83,7 @@ impl TempoNodeArgs {
     pub fn payload_builder_builder(&self) -> TempoPayloadBuilderBuilder {
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
-            disable_state_cache: self.builder_disable_state_cache,
             enable_prewarming: self.builder_enable_prewarming,
-            disable_cached_reads: self.builder_disable_cached_reads,
         }
     }
 }
@@ -499,13 +489,8 @@ where
 pub struct TempoPayloadBuilderBuilder {
     /// Enable state provider metrics for the payload builder.
     pub state_provider_metrics: bool,
-    /// Disable state cache for the payload builder.
-    pub disable_state_cache: bool,
     /// Enable prewarming for the payload builder.
     pub enable_prewarming: bool,
-
-    /// Disable cached reads for the payload builder.
-    pub disable_cached_reads: bool,
 }
 
 impl<Node> PayloadBuilderBuilder<Node, TempoTransactionPool<Node::Provider>, TempoEvmConfig>
@@ -528,9 +513,7 @@ where
             evm_config,
             ctx.is_dev(),
             self.state_provider_metrics,
-            self.disable_state_cache,
             self.enable_prewarming,
-            self.disable_cached_reads,
         ))
     }
 }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -100,7 +100,6 @@ pub struct TempoPayloadBuilder<Provider> {
 }
 
 impl<Provider> TempoPayloadBuilder<Provider> {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         pool: TempoTransactionPool<Provider>,
         provider: Provider,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -245,6 +245,7 @@ where
             + 'static,
     {
         let BuildArguments {
+            cached_reads,
             execution_cache,
             trie_handle,
             config,
@@ -636,7 +637,7 @@ where
             // can skip building the block
             return Ok(BuildOutcome::Aborted {
                 fees: total_fees,
-                cached_reads: Default::default(),
+                cached_reads,
             });
         }
 
@@ -896,7 +897,7 @@ where
         } else {
             Ok(BuildOutcome::Better {
                 payload,
-                cached_reads: Default::default(),
+                cached_reads,
             })
         }
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -19,7 +19,10 @@ use reth_basic_payload_builder::{
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
-use reth_engine_tree::tree::{CachedStateProvider, instrumented_state::InstrumentedStateProvider};
+use reth_engine_tree::tree::{
+    CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider,
+    instrumented_state::InstrumentedStateProvider,
+};
 use reth_errors::{ConsensusError, ProviderError};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
@@ -77,6 +80,7 @@ pub struct TempoPayloadBuilder<Provider> {
     executor: TaskExecutor,
     evm_config: TempoEvmConfig,
     metrics: TempoPayloadBuilderMetrics,
+    cache_metrics: CachedStateMetrics,
     /// Height at which we've seen an invalid subblock.
     ///
     /// We pre-validate all of the subblock transactions when collecting subblocks, so this
@@ -119,6 +123,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             executor,
             evm_config,
             metrics: TempoPayloadBuilderMetrics::default(),
+            cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder),
             highest_invalid_subblock: Default::default(),
             is_dev,
             state_provider_metrics,
@@ -294,14 +299,12 @@ where
             state_provider = Box::new(CachedStateProvider::new(
                 state_provider,
                 execution_cache.cache().clone(),
-                execution_cache.metrics().clone(),
+                self.cache_metrics.clone(),
             ));
         }
-        state_provider = if self.state_provider_metrics {
-            Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
-        } else {
-            state_provider
-        };
+        if self.state_provider_metrics {
+            state_provider = Box::new(InstrumentedStateProvider::new(state_provider, "builder"));
+        }
 
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -95,13 +95,8 @@ pub struct TempoPayloadBuilder<Provider> {
     is_dev: bool,
     /// Whether to enable state provider metrics.
     state_provider_metrics: bool,
-    /// Whether to disable state cache.
-    disable_state_cache: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
-
-    /// Whether to disable cached reads.
-    disable_cached_reads: bool,
 }
 
 impl<Provider> TempoPayloadBuilder<Provider> {
@@ -113,9 +108,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         evm_config: TempoEvmConfig,
         is_dev: bool,
         state_provider_metrics: bool,
-        disable_state_cache: bool,
         enable_prewarming: bool,
-        disable_cached_reads: bool,
     ) -> Self {
         Self {
             pool,
@@ -127,9 +120,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             highest_invalid_subblock: Default::default(),
             is_dev,
             state_provider_metrics,
-            disable_state_cache,
             enable_prewarming,
-            disable_cached_reads,
         }
     }
 }
@@ -254,7 +245,6 @@ where
             + 'static,
     {
         let BuildArguments {
-            mut cached_reads,
             execution_cache,
             trie_handle,
             config,
@@ -293,9 +283,7 @@ where
         let state_setup_start = Instant::now();
         let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();
         let mut state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
-        if !self.disable_state_cache
-            && let Some(execution_cache) = execution_cache
-        {
+        if let Some(execution_cache) = execution_cache {
             state_provider = Box::new(CachedStateProvider::new(
                 state_provider,
                 execution_cache.cache().clone(),
@@ -308,11 +296,7 @@ where
 
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
-            .with_database(if self.disable_cached_reads {
-                Box::new(state) as Box<dyn Database<Error = ProviderError>>
-            } else {
-                Box::new(cached_reads.as_db_mut(state))
-            })
+            .with_database(Box::new(state) as Box<dyn Database<Error = ProviderError>>)
             .with_bundle_update()
             .build();
         drop(_state_setup_span);
@@ -652,7 +636,7 @@ where
             // can skip building the block
             return Ok(BuildOutcome::Aborted {
                 fees: total_fees,
-                cached_reads,
+                cached_reads: Default::default(),
             });
         }
 
@@ -912,7 +896,7 @@ where
         } else {
             Ok(BuildOutcome::Better {
                 payload,
-                cached_reads,
+                cached_reads: Default::default(),
             })
         }
     }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -19,7 +19,7 @@ use reth_basic_payload_builder::{
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
-use reth_engine_tree::tree::instrumented_state::InstrumentedStateProvider;
+use reth_engine_tree::tree::{CachedStateProvider, instrumented_state::InstrumentedStateProvider};
 use reth_errors::{ConsensusError, ProviderError};
 use reth_evm::{
     ConfigureEvm, Database, Evm, NextBlockEnvAttributes,
@@ -31,7 +31,7 @@ use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
 use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
 use reth_revm::{State, context::Block, database::StateProviderDatabase};
-use reth_storage_api::{StateProvider, StateProviderFactory};
+use reth_storage_api::StateProviderFactory;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
@@ -95,6 +95,9 @@ pub struct TempoPayloadBuilder<Provider> {
     disable_state_cache: bool,
     /// Whether to enable prewarming of best transactions.
     enable_prewarming: bool,
+
+    /// Whether to disable cached reads.
+    disable_cached_reads: bool,
 }
 
 impl<Provider> TempoPayloadBuilder<Provider> {
@@ -108,6 +111,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         state_provider_metrics: bool,
         disable_state_cache: bool,
         enable_prewarming: bool,
+        disable_cached_reads: bool,
     ) -> Self {
         Self {
             pool,
@@ -120,6 +124,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
             state_provider_metrics,
             disable_state_cache,
             enable_prewarming,
+            disable_cached_reads,
         }
     }
 }
@@ -245,6 +250,7 @@ where
     {
         let BuildArguments {
             mut cached_reads,
+            execution_cache,
             trie_handle,
             config,
             cancel,
@@ -281,15 +287,25 @@ where
 
         let state_setup_start = Instant::now();
         let _state_setup_span = debug_span!(target: "payload_builder", "state_setup").entered();
-        let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
-        let state_provider: Box<dyn StateProvider> = if self.state_provider_metrics {
+        let mut state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
+        if !self.disable_state_cache
+            && let Some(execution_cache) = execution_cache
+        {
+            state_provider = Box::new(CachedStateProvider::new(
+                state_provider,
+                execution_cache.cache().clone(),
+                execution_cache.metrics().clone(),
+            ));
+        }
+        state_provider = if self.state_provider_metrics {
             Box::new(InstrumentedStateProvider::new(state_provider, "builder"))
         } else {
             state_provider
         };
+
         let state = StateProviderDatabase::new(&state_provider);
         let mut db = State::builder()
-            .with_database(if self.disable_state_cache {
+            .with_database(if self.disable_cached_reads {
                 Box::new(state) as Box<dyn Database<Error = ProviderError>>
             } else {
                 Box::new(cached_reads.as_db_mut(state))


### PR DESCRIPTION
Uses execution cache shared with validation, if provided. This behaviour is gated behind `--engine.share-execution-cache-with-payload-builder` flag, which is disabled by default.

10% gas throughput improvement in builder: https://github.com/tempoxyz/tempo/pull/3602#issuecomment-4497693462