### PR TITLE
ci(bench): hardcode 1T gas limit for benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -123,9 +123,9 @@ on:
         default: ""
         type: string
       gas-limit:
-        description: "Block gas limit for genesis (e.g. 500M, 1G, 2G). Default: 500M"
+        description: "Block gas limit for genesis (e.g. 500M, 1G, 2G)"
         required: false
-        default: ""
+        default: "1G"
         type: string
       no_slack:
         description: "Suppress Slack notifications for benchmark results"
@@ -253,7 +253,7 @@ jobs:
               const refArgs = new Set(['baseline', 'feature']);
               const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'gas-limit']);
               const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '' };
+              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '1G' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -122,11 +122,6 @@ on:
         required: false
         default: ""
         type: string
-      gas-limit:
-        description: "Block gas limit for genesis (e.g. 500M, 1G, 1T)"
-        required: false
-        default: "1T"
-        type: string
       no_slack:
         description: "Suppress Slack notifications for benchmark results"
         required: false
@@ -176,7 +171,6 @@ jobs:
       bench-env: ${{ steps.args.outputs.bench-env }}
       baseline-env: ${{ steps.args.outputs.baseline-env }}
       feature-env: ${{ steps.args.outputs.feature-env }}
-      gas-limit: ${{ steps.args.outputs.gas-limit }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
     steps:
       - name: Check org membership
@@ -204,7 +198,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, gasLimitInput;
+            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -229,7 +223,6 @@ jobs:
               benchEnv = '${{ github.event.inputs.bench-env }}' || '';
               baselineEnv = '${{ github.event.inputs.baseline-env }}' || '';
               featureEnv = '${{ github.event.inputs.feature-env }}' || '';
-              gasLimitInput = '${{ github.event.inputs.gas-limit }}' || '';
 
               // Find PR for the selected branch
               const branch = '${{ github.ref_name }}';
@@ -251,9 +244,9 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset']);
               const refArgs = new Set(['baseline', 'feature']);
-              const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'gas-limit']);
+              const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env']);
               const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '1T' };
+              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -304,7 +297,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"] [gas-limit=SIZE]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -335,10 +328,9 @@ jobs:
               benchEnv = defaults['bench-env'];
               baselineEnv = defaults['baseline-env'];
               featureEnv = defaults['feature-env'];
-              gasLimitInput = defaults['gas-limit'];
             }
 
-            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"] [gas-limit=SIZE]`';
+            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate tracy value
             if (!['off', 'on', 'full'].includes(tracy)) {
@@ -397,33 +389,6 @@ jobs:
               return;
             }
 
-            // Parse human-readable gas limit (e.g. "1T", "1G", "500M", "450000000")
-            let gasLimit = '';
-            if (gasLimitInput) {
-              const match = gasLimitInput.trim().match(/^(\d+)\s*([tTgGmM]?)$/);
-              if (!match) {
-                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` is not valid. Use an integer with optional M/G/T suffix (e.g. \`1T\`, \`500M\`, \`1G\`).\n\n${usageStr}`;
-                if (context.eventName === 'issue_comment') {
-                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: msg });
-                }
-                core.setFailed(msg);
-                return;
-              }
-              const base = BigInt(match[1]);
-              const suffix = match[2].toUpperCase();
-              const mult = suffix === 'T' ? 1_000_000_000_000n : suffix === 'G' ? 1_000_000_000n : suffix === 'M' ? 1_000_000n : 1n;
-              const value = base * mult;
-              if (value === 0n) {
-                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` must be greater than zero.\n\n${usageStr}`;
-                if (context.eventName === 'issue_comment') {
-                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: msg });
-                }
-                core.setFailed(msg);
-                return;
-              }
-              gasLimit = value.toString();
-            }
-
             // Resolve display names for baseline/feature
             let baselineName = baseline || 'main';
             let featureName = feature;
@@ -465,7 +430,6 @@ jobs:
             core.setOutput('bench-env', benchEnv || '');
             core.setOutput('baseline-env', baselineEnv || '');
             core.setOutput('feature-env', featureEnv || '');
-            core.setOutput('gas-limit', gasLimit);
 
       - name: Acknowledge request
         id: ack
@@ -504,9 +468,7 @@ jobs:
             const bHf = '${{ steps.args.outputs.baseline-hardfork }}';
             const fHf = '${{ steps.args.outputs.feature-hardfork }}';
             const hfNote = bHf ? `, baseline-hardfork: \`${bHf}\`, feature-hardfork: \`${fHf}\`` : '';
-            const gasLim = '${{ steps.args.outputs.gas-limit }}';
-            const gasLimNote = gasLim ? `, gas-limit: \`${gasLim}\`` : '';
-            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}${gasLimNote}`;
+            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -543,7 +505,6 @@ jobs:
       BENCH_BENCH_ENV: ${{ needs.tempo-bench-ack.outputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ needs.tempo-bench-ack.outputs.baseline-env }}
       BENCH_FEATURE_ENV: ${{ needs.tempo-bench-ack.outputs.feature-env }}
-      BENCH_GAS_LIMIT: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
       BENCH_COMMENT_ID: ${{ needs.tempo-bench-ack.outputs.comment-id }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
@@ -630,9 +591,7 @@ jobs:
             const bHf2 = process.env.BENCH_BASELINE_HARDFORK || '';
             const fHf2 = process.env.BENCH_FEATURE_HARDFORK || '';
             const hfNote2 = bHf2 ? `, baseline-hardfork: \`${bHf2}\`, feature-hardfork: \`${fHf2}\`` : '';
-            const gasLim2 = process.env.BENCH_GAS_LIMIT || '';
-            const gasLimNote2 = gasLim2 ? `, gas-limit: \`${gasLim2}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote2}${gasLimNote2}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote2}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -763,6 +722,7 @@ jobs:
             --feature "$FEATURE_REF"
             --bench-datadir "/reth-bench/tempo_${BENCH_BLOAT}mb"
             --tune
+            --gas-limit 1000000000000
           )
           [ "$BENCH_SAMPLY" = "true" ] && cmd+=(--samply)
           [ "$BENCH_TRACY" != "off" ] && cmd+=(--tracy "$BENCH_TRACY" --tracy-seconds "$BENCH_TRACY_SECONDS" --tracy-offset "$BENCH_TRACY_OFFSET")
@@ -774,7 +734,6 @@ jobs:
           [ -n "$BENCH_BENCH_ENV" ] && cmd+=(--bench-env="$BENCH_BENCH_ENV")
           [ -n "$BENCH_BASELINE_ENV" ] && cmd+=(--baseline-env="$BENCH_BASELINE_ENV")
           [ -n "$BENCH_FEATURE_ENV" ] && cmd+=(--feature-env="$BENCH_FEATURE_ENV")
-          [ -n "$BENCH_GAS_LIMIT" ] && cmd+=(--gas-limit "$BENCH_GAS_LIMIT")
           "${cmd[@]}"
 
       - name: Find results directory

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -122,6 +122,11 @@ on:
         required: false
         default: ""
         type: string
+      gas-limit:
+        description: "Block gas limit for genesis (e.g. 500M, 1G, 2G). Default: 500M"
+        required: false
+        default: ""
+        type: string
       no_slack:
         description: "Suppress Slack notifications for benchmark results"
         required: false
@@ -171,6 +176,7 @@ jobs:
       bench-env: ${{ steps.args.outputs.bench-env }}
       baseline-env: ${{ steps.args.outputs.baseline-env }}
       feature-env: ${{ steps.args.outputs.feature-env }}
+      gas-limit: ${{ steps.args.outputs.gas-limit }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
     steps:
       - name: Check org membership
@@ -198,7 +204,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv;
+            let pr, actor, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, gasLimitInput;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -223,6 +229,7 @@ jobs:
               benchEnv = '${{ github.event.inputs.bench-env }}' || '';
               baselineEnv = '${{ github.event.inputs.baseline-env }}' || '';
               featureEnv = '${{ github.event.inputs.feature-env }}' || '';
+              gasLimitInput = '${{ github.event.inputs.gas-limit }}' || '';
 
               // Find PR for the selected branch
               const branch = '${{ github.ref_name }}';
@@ -244,9 +251,9 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset']);
               const refArgs = new Set(['baseline', 'feature']);
-              const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env']);
+              const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'gas-limit']);
               const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
+              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -297,7 +304,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"] [gas-limit=SIZE]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -328,9 +335,10 @@ jobs:
               benchEnv = defaults['bench-env'];
               baselineEnv = defaults['baseline-env'];
               featureEnv = defaults['feature-env'];
+              gasLimitInput = defaults['gas-limit'];
             }
 
-            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"] [gas-limit=SIZE]`';
 
             // Validate tracy value
             if (!['off', 'on', 'full'].includes(tracy)) {
@@ -389,6 +397,33 @@ jobs:
               return;
             }
 
+            // Parse human-readable gas limit (e.g. "1G", "500M", "450000000")
+            let gasLimit = '';
+            if (gasLimitInput) {
+              const match = gasLimitInput.trim().match(/^(\d+)\s*([gGmM]?)$/);
+              if (!match) {
+                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` is not valid. Use an integer with optional M/G suffix (e.g. \`500M\`, \`1G\`, \`1500000000\`).\n\n${usageStr}`;
+                if (context.eventName === 'issue_comment') {
+                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: msg });
+                }
+                core.setFailed(msg);
+                return;
+              }
+              const base = BigInt(match[1]);
+              const suffix = match[2].toUpperCase();
+              const mult = suffix === 'G' ? 1_000_000_000n : suffix === 'M' ? 1_000_000n : 1n;
+              const value = base * mult;
+              if (value === 0n) {
+                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` must be greater than zero.\n\n${usageStr}`;
+                if (context.eventName === 'issue_comment') {
+                  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: msg });
+                }
+                core.setFailed(msg);
+                return;
+              }
+              gasLimit = value.toString();
+            }
+
             // Resolve display names for baseline/feature
             let baselineName = baseline || 'main';
             let featureName = feature;
@@ -430,6 +465,7 @@ jobs:
             core.setOutput('bench-env', benchEnv || '');
             core.setOutput('baseline-env', baselineEnv || '');
             core.setOutput('feature-env', featureEnv || '');
+            core.setOutput('gas-limit', gasLimit);
 
       - name: Acknowledge request
         id: ack
@@ -468,7 +504,9 @@ jobs:
             const bHf = '${{ steps.args.outputs.baseline-hardfork }}';
             const fHf = '${{ steps.args.outputs.feature-hardfork }}';
             const hfNote = bHf ? `, baseline-hardfork: \`${bHf}\`, feature-hardfork: \`${fHf}\`` : '';
-            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}`;
+            const gasLim = '${{ steps.args.outputs.gas-limit }}';
+            const gasLimNote = gasLim ? `, gas-limit: \`${gasLim}\`` : '';
+            const config = `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}${gasLimNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -505,6 +543,7 @@ jobs:
       BENCH_BENCH_ENV: ${{ needs.tempo-bench-ack.outputs.bench-env }}
       BENCH_BASELINE_ENV: ${{ needs.tempo-bench-ack.outputs.baseline-env }}
       BENCH_FEATURE_ENV: ${{ needs.tempo-bench-ack.outputs.feature-env }}
+      BENCH_GAS_LIMIT: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
       BENCH_COMMENT_ID: ${{ needs.tempo-bench-ack.outputs.comment-id }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
@@ -591,7 +630,9 @@ jobs:
             const bHf2 = process.env.BENCH_BASELINE_HARDFORK || '';
             const fHf2 = process.env.BENCH_FEATURE_HARDFORK || '';
             const hfNote2 = bHf2 ? `, baseline-hardfork: \`${bHf2}\`, feature-hardfork: \`${fHf2}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote2}`);
+            const gasLim2 = process.env.BENCH_GAS_LIMIT || '';
+            const gasLimNote2 = gasLim2 ? `, gas-limit: \`${gasLim2}\`` : '';
+            core.exportVariable('BENCH_CONFIG', `**Config:** preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote2}${gasLimNote2}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -733,6 +774,7 @@ jobs:
           [ -n "$BENCH_BENCH_ENV" ] && cmd+=(--bench-env="$BENCH_BENCH_ENV")
           [ -n "$BENCH_BASELINE_ENV" ] && cmd+=(--baseline-env="$BENCH_BASELINE_ENV")
           [ -n "$BENCH_FEATURE_ENV" ] && cmd+=(--feature-env="$BENCH_FEATURE_ENV")
+          [ -n "$BENCH_GAS_LIMIT" ] && cmd+=(--gas-limit "$BENCH_GAS_LIMIT")
           "${cmd[@]}"
 
       - name: Find results directory

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -123,9 +123,9 @@ on:
         default: ""
         type: string
       gas-limit:
-        description: "Block gas limit for genesis (e.g. 500M, 1G, 2G)"
+        description: "Block gas limit for genesis (e.g. 500M, 1G, 1T)"
         required: false
-        default: "1G"
+        default: "1T"
         type: string
       no_slack:
         description: "Suppress Slack notifications for benchmark results"
@@ -253,7 +253,7 @@ jobs:
               const refArgs = new Set(['baseline', 'feature']);
               const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'gas-limit']);
               const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '1G' };
+              const defaults = { preset: 'tip20', duration: '300', bloat: '1', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', 'gas-limit': '1T' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -397,12 +397,12 @@ jobs:
               return;
             }
 
-            // Parse human-readable gas limit (e.g. "1G", "500M", "450000000")
+            // Parse human-readable gas limit (e.g. "1T", "1G", "500M", "450000000")
             let gasLimit = '';
             if (gasLimitInput) {
-              const match = gasLimitInput.trim().match(/^(\d+)\s*([gGmM]?)$/);
+              const match = gasLimitInput.trim().match(/^(\d+)\s*([tTgGmM]?)$/);
               if (!match) {
-                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` is not valid. Use an integer with optional M/G suffix (e.g. \`500M\`, \`1G\`, \`1500000000\`).\n\n${usageStr}`;
+                const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` is not valid. Use an integer with optional M/G/T suffix (e.g. \`1T\`, \`500M\`, \`1G\`).\n\n${usageStr}`;
                 if (context.eventName === 'issue_comment') {
                   await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: msg });
                 }
@@ -411,7 +411,7 @@ jobs:
               }
               const base = BigInt(match[1]);
               const suffix = match[2].toUpperCase();
-              const mult = suffix === 'G' ? 1_000_000_000n : suffix === 'M' ? 1_000_000n : 1n;
+              const mult = suffix === 'T' ? 1_000_000_000_000n : suffix === 'G' ? 1_000_000_000n : suffix === 'M' ? 1_000_000n : 1n;
               const value = base * mult;
               if (value === 0n) {
                 const msg = `❌ **Invalid bench command**\n\n\`gas-limit=${gasLimitInput}\` must be greater than zero.\n\n${usageStr}`;

--- a/tempo.nu
+++ b/tempo.nu
@@ -2678,7 +2678,7 @@ def main [] {
     print "  --feature-args <ARGS>        Additional node arguments for feature runs only"
     print "  --bench-args <ARGS>      Additional tempo-bench arguments (space-separated)"
     print "  --bloat <N>              Generate TIP20 state bloat (size in MiB)"
-    print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 500000000)"
+    print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 1000000000)"
     print ""
     print "Localnet flags:"
     print "  --mode <dev|consensus>   Mode (default: dev)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -2678,7 +2678,7 @@ def main [] {
     print "  --feature-args <ARGS>        Additional node arguments for feature runs only"
     print "  --bench-args <ARGS>      Additional tempo-bench arguments (space-separated)"
     print "  --bloat <N>              Generate TIP20 state bloat (size in MiB)"
-    print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 1000000000)"
+    print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 1000000000000)"
     print ""
     print "Localnet flags:"
     print "  --mode <dev|consensus>   Mode (default: dev)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -1594,6 +1594,7 @@ def "main bench" [
     --tracing-otlp: string = ""                     # OTLP endpoint for tracing (auto-derived from TEMPO_TELEMETRY_URL if not set)
     --baseline-hardfork: string = ""                # Latest active hardfork for baseline (e.g. T1, T1C, T2)
     --feature-hardfork: string = ""                 # Latest active hardfork for feature (e.g. T1, T1C, T2)
+    --gas-limit: string = ""                        # Block gas limit for genesis (raw number, e.g. 1000000000)
 ] {
     validate-mode $mode
 
@@ -1617,6 +1618,7 @@ def "main bench" [
     }
 
     let weights = if $preset != "" { $PRESETS | get $preset } else { [0.0, 0.0, 0.0, 0.0] }
+    let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
 
     # Auto-derive tracing OTLP URL: prefer GRAFANA_TEMPO, fall back to TEMPO_TELEMETRY_URL
     let tracing_otlp = if $tracing_otlp == "" and ($env.GRAFANA_TEMPO? | default "" | str length) > 0 {
@@ -1831,6 +1833,7 @@ def "main bench" [
                 and ($marker.accounts | into int) == $genesis_accounts
                 and ($marker | get -o baseline_hardfork | default "") == ($baseline_hardfork | str upcase)
                 and ($marker | get -o feature_hardfork | default "") == ($feature_hardfork | str upcase)
+                and ($marker | get -o gas_limit | default "") == $gas_limit
                 and ($"($baseline_datadir)/db" | path exists)
                 and ($"($feature_datadir)/db" | path exists)
                 and ($"($meta_dir)/genesis-baseline.json" | path exists)
@@ -1848,11 +1851,11 @@ def "main bench" [
                 if ($baseline_genesis_dir | path exists) { rm -rf $baseline_genesis_dir }
                 mkdir $baseline_genesis_dir
                 if $baseline == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
                 } else {
                     do {
                         cd $baseline_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
                     }
                 }
                 cp $"($baseline_genesis_dir)/genesis.json" $baseline_genesis_path
@@ -1863,13 +1866,13 @@ def "main bench" [
                 if ($feature_genesis_dir | path exists) { rm -rf $feature_genesis_dir }
                 mkdir $feature_genesis_dir
                 if $feature == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
                 } else {
                     # Use feature worktree for feature genesis so it picks up any
                     # new hardfork-related genesis changes from the feature branch
                     do {
                         cd $feature_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
                     }
                 }
                 cp $"($feature_genesis_dir)/genesis.json" $feature_genesis_path
@@ -1905,6 +1908,7 @@ def "main bench" [
                     bench_datadir: $datadir
                     baseline_hardfork: ($baseline_hardfork | str upcase)
                     feature_hardfork: ($feature_hardfork | str upcase)
+                    gas_limit: $gas_limit
                 } [[$baseline_genesis_path "genesis-baseline.json"] [$feature_genesis_path "genesis-feature.json"]] $bloat $bloat_file
 
                 print "Dual-hardfork databases initialized and promoted."
@@ -1921,6 +1925,7 @@ def "main bench" [
                 and $marker != null
                 and ($marker.bloat_mib | into int) == $bloat
                 and ($marker.accounts | into int) == $genesis_accounts
+                and ($marker | get -o gas_limit | default "") == $gas_limit
                 and ($"($datadir)/db" | path exists)
                 and ($"($meta_dir)/genesis.json" | path exists)
             )
@@ -1935,11 +1940,11 @@ def "main bench" [
                     if not ($abs_localnet | path exists) { mkdir $abs_localnet }
                     print $"Generating genesis with ($genesis_accounts) accounts from baseline..."
                     if $baseline == "local" {
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis ...$gas_limit_args
                     } else {
                         do {
                             cd $baseline_wt
-                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis
+                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis ...$gas_limit_args
                         }
                     }
                 }
@@ -1963,7 +1968,8 @@ def "main bench" [
                 bench-save-and-promote $datadir $meta_dir {
                     bloat_mib: $bloat,
                     accounts: $genesis_accounts,
-                    bench_datadir: $datadir
+                    bench_datadir: $datadir,
+                    gas_limit: $gas_limit
                 } [[$genesis_path_std "genesis.json"]] $bloat $bloat_file
 
                 print "Database initialized and promoted to virgin baseline."
@@ -2672,6 +2678,7 @@ def main [] {
     print "  --feature-args <ARGS>        Additional node arguments for feature runs only"
     print "  --bench-args <ARGS>      Additional tempo-bench arguments (space-separated)"
     print "  --bloat <N>              Generate TIP20 state bloat (size in MiB)"
+    print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 500000000)"
     print ""
     print "Localnet flags:"
     print "  --mode <dev|consensus>   Mode (default: dev)"


### PR DESCRIPTION
Adds `--gas-limit` to `tempo.nu bench` and hardcodes 1T (1,000,000,000,000)
in `bench.yml`. Previous runs were gas-limited at 500M, leaving ~540ms idle
per block. With 1T the builder fills blocks until it runs out of time, measuring
true execution throughput.

Prompted by: alexey