### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11820,7 +11820,6 @@ dependencies = [
  "mimalloc",
  "rand 0.8.5",
  "rand 0.9.4",
- "rayon",
  "reth-tracing",
  "rlimit",
  "serde",
@@ -11957,7 +11956,6 @@ dependencies = [
  "commonware-cryptography",
  "commonware-math",
  "commonware-utils",
- "modular-bitfield",
  "rand 0.8.5",
 ]
 
@@ -12420,7 +12418,6 @@ dependencies = [
  "tempo-evm",
  "tempo-precompiles",
  "tempo-primitives",
- "tempo-revm",
  "tempo-validator-config",
  "tokio",
 ]

--- a/bin/tempo-bench/Cargo.toml
+++ b/bin/tempo-bench/Cargo.toml
@@ -42,7 +42,6 @@ tokio.workspace = true
 # Bespoke dependencies
 indicatif = { workspace = true, features = ["rayon", "futures"] }
 mimalloc = "0.1.48"
-rayon.workspace = true
 rlimit = "0.11.0"
 governor = "0.10.4"
 rand.workspace = true

--- a/crates/dkg-onchain-artifacts/Cargo.toml
+++ b/crates/dkg-onchain-artifacts/Cargo.toml
@@ -12,7 +12,6 @@ commonware-codec.workspace = true
 commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
 commonware-utils.workspace = true
-modular-bitfield = { version = "0.13.1", optional = true }
 
 [dev-dependencies]
 commonware-math.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,6 @@ tempo-validator-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
-tempo-revm.workspace = true
 
 alloy = { workspace = true, features = [
   "genesis",


### PR DESCRIPTION
Removes unused deps found by cargo-machete:

- `tempo-revm` from xtask (no imports)
- `modular-bitfield` from dkg-onchain-artifacts (optional dep, never activated)
- `rayon` from tempo-bench (only used as indicatif feature flag, not imported directly)

Skipped `alloy-contract` in contracts (used by `#[sol(rpc)]`) and `modular-bitfield` in primitives (needed by `reth_codecs::Compact` derive).

Prompted by: horsefacts