### PR TITLE
chore(chainspec): isolate reth deps

### DIFF
--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "tempo-chainspec"
-description = "TODO:"
+description = "Tempo hardfork configuration and chain specification helpers"
 
-version.workspace = true
+version = "1.5.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-publish.workspace = true
+publish = true
 
 [lints]
 workspace = true
 
 [dependencies]
-tempo-primitives = { workspace = true, features = ["reth"] }
+tempo-primitives.workspace = true
 
 reth-cli = { workspace = true, optional = true }
-reth-chainspec.workspace = true
-reth-network-peers.workspace = true
+reth-chainspec = { workspace = true, optional = true }
+reth-network-peers = { workspace = true, optional = true }
 
 alloy-evm.workspace = true
 alloy-genesis.workspace = true
@@ -33,15 +33,13 @@ paste.workspace = true
 [dev-dependencies]
 
 [features]
-default = ["std", "serde", "cli"]
+default = ["std", "serde", "reth", "cli"]
 std = [
     "alloy-eips/std",
     "alloy-evm/std",
     "alloy-genesis/std",
     "alloy-primitives/std",
     "once_cell/std",
-    "reth-chainspec/std",
-    "reth-network-peers/std",
     "serde/std",
     "serde_json/std",
     "tempo-primitives/std",
@@ -52,4 +50,12 @@ serde = [
     "alloy-primitives/serde",
     "tempo-primitives/serde"
 ]
-cli = ["std", "dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]
+reth = [
+    "std",
+    "dep:reth-chainspec",
+    "dep:reth-network-peers",
+    "reth-chainspec/std",
+    "reth-network-peers/std",
+    "tempo-primitives/reth",
+]
+cli = ["reth", "dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -40,6 +40,8 @@ std = [
     "alloy-genesis/std",
     "alloy-primitives/std",
     "once_cell/std",
+    "reth-chainspec?/std",
+    "reth-network-peers?/std",
     "serde/std",
     "serde_json/std",
     "tempo-primitives/std",
@@ -54,8 +56,6 @@ reth = [
     "std",
     "dep:reth-chainspec",
     "dep:reth-network-peers",
-    "reth-chainspec/std",
-    "reth-network-peers/std",
     "tempo-primitives/reth",
 ]
 cli = ["reth", "dep:reth-cli", "dep:eyre", "tempo-primitives/reth-codec"]

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -1,6 +1,56 @@
-//! Tempo hardfork activation block numbers and timestamps for mainnet and moderato.
+//! Tempo constants shared by both the published surface and the reth-backed spec implementation.
 //!
-//! Block numbers are informational — Tempo hardforks activate by **timestamp**.
+//! Gas-accounting constants are grouped under [`gas`].
+//! Hardfork activation schedules live in [`mainnet`] and [`moderato`].
+
+pub mod gas {
+    //! Gas-accounting constants shared with `spec.rs`.
+
+    use alloy_evm::revm::interpreter::gas::{
+        COLD_SLOAD_COST as COLD_SLOAD, SSTORE_SET, WARM_SSTORE_RESET,
+        WARM_STORAGE_READ_COST as WARM_SLOAD,
+    };
+
+    /// T0 base fee: 10 billion attodollars (1×10^10).
+    ///
+    /// Attodollars are the atomic gas accounting units at 10^-18 USD precision.
+    /// Basefee is denominated in attodollars.
+    pub const TEMPO_T0_BASE_FEE: u64 = 10_000_000_000;
+
+    /// T1 base fee: 20 billion attodollars (2×10^10).
+    ///
+    /// Attodollars are the atomic gas accounting units at 10^-18 USD precision.
+    /// Basefee is denominated in attodollars.
+    ///
+    /// At this basefee, a standard TIP-20 transfer (~50,000 gas) costs:
+    /// - Gas: 50,000 × 20 billion attodollars/gas = 1 quadrillion attodollars
+    /// - Tokens: 1 quadrillion attodollars / 10^12 = 1,000 microdollars
+    /// - Economic: 1,000 microdollars = 0.001 USD = 0.1 cents
+    pub const TEMPO_T1_BASE_FEE: u64 = 20_000_000_000;
+
+    /// [TIP-1010] general (non-payment) gas limit: 30 million gas per block.
+    /// Cap for non-payment transactions.
+    ///
+    /// [TIP-1010]: <https://docs.tempo.xyz/protocol/tips/tip-1010>
+    pub const TEMPO_T1_GENERAL_GAS_LIMIT: u64 = 30_000_000;
+
+    /// TIP-1010 per-transaction gas limit cap: 30 million gas.
+    /// Allows maximum-sized contract deployments under [TIP-1000] state creation costs.
+    ///
+    /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
+    pub const TEMPO_T1_TX_GAS_LIMIT_CAP: u64 = 30_000_000;
+
+    /// Gas cost for using an existing 2D nonce key (cold SLOAD + warm SSTORE reset).
+    pub const TEMPO_T1_EXISTING_NONCE_KEY_GAS: u64 = COLD_SLOAD + WARM_SSTORE_RESET;
+    /// T2 adds 2 warm SLOADs for the extended nonce key lookup.
+    pub const TEMPO_T2_EXISTING_NONCE_KEY_GAS: u64 =
+        TEMPO_T1_EXISTING_NONCE_KEY_GAS + 2 * WARM_SLOAD;
+
+    /// Gas cost for using a new 2D nonce key (cold SLOAD + SSTORE set for 0 -> non-zero).
+    pub const TEMPO_T1_NEW_NONCE_KEY_GAS: u64 = COLD_SLOAD + SSTORE_SET;
+    /// T2 adds 2 warm SLOADs for the extended nonce key lookup.
+    pub const TEMPO_T2_NEW_NONCE_KEY_GAS: u64 = TEMPO_T1_NEW_NONCE_KEY_GAS + 2 * WARM_SLOAD;
+}
 
 pub mod mainnet {
     //! Tempo mainnet (Presto) hardfork activation constants.

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -23,10 +23,10 @@
 //! 6. Add `vivace_time: Option<u64>` arg to `xtask/src/genesis_args.rs`
 //! 7. Add insertion of `"vivaceTime"` to chain_config.extra_fields
 
+use crate::constants::gas;
 use alloy_eips::eip7825::MAX_TX_GAS_LIMIT_OSAKA;
 use alloy_evm::revm::primitives::hardfork::SpecId;
 use alloy_hardforks::hardfork;
-use reth_chainspec::{EthereumHardforks, ForkCondition};
 
 /// Single-source hardfork definition macro. Append a new variant and everything else is generated:
 ///
@@ -73,9 +73,10 @@ macro_rules! tempo_hardfork {
         }
 
         /// Trait for querying Tempo-specific hardfork activations.
-        pub trait TempoHardforks: EthereumHardforks {
+        #[cfg(feature = "reth")]
+        pub trait TempoHardforks: reth_chainspec::EthereumHardforks {
             /// Retrieves activation condition for a Tempo-specific hardfork.
-            fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition;
+            fn tempo_fork_activation(&self, fork: TempoHardfork) -> reth_chainspec::ForkCondition;
 
             /// Retrieves the Tempo hardfork active at a given timestamp.
             fn tempo_hardfork_at(&self, timestamp: u64) -> TempoHardfork {
@@ -107,7 +108,7 @@ macro_rules! tempo_hardfork {
             }
         }
 
-        #[cfg(test)]
+        #[cfg(all(test, feature = "reth"))]
         mod tests {
             use super::*;
             use TempoHardfork::*;
@@ -199,9 +200,9 @@ impl TempoHardfork {
     /// Economic conversion: ceil(basefee × gas_used / 10^12) = cost in microdollars (TIP-20 tokens)
     pub const fn base_fee(&self) -> u64 {
         if self.is_t1() {
-            return crate::spec::TEMPO_T1_BASE_FEE;
+            return gas::TEMPO_T1_BASE_FEE;
         }
-        crate::spec::TEMPO_T0_BASE_FEE
+        gas::TEMPO_T0_BASE_FEE
     }
 
     /// Returns the fixed general gas limit for T1+, or None for pre-T1.
@@ -209,7 +210,7 @@ impl TempoHardfork {
     /// - T1+: 30M gas (fixed)
     pub const fn general_gas_limit(&self) -> Option<u64> {
         if self.is_t1() {
-            return Some(crate::spec::TEMPO_T1_GENERAL_GAS_LIMIT);
+            return Some(gas::TEMPO_T1_GENERAL_GAS_LIMIT);
         }
         None
     }
@@ -221,7 +222,7 @@ impl TempoHardfork {
     /// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
     pub const fn tx_gas_limit_cap(&self) -> Option<u64> {
         if self.is_t1a() {
-            return Some(crate::spec::TEMPO_T1_TX_GAS_LIMIT_CAP);
+            return Some(gas::TEMPO_T1_TX_GAS_LIMIT_CAP);
         }
         Some(MAX_TX_GAS_LIMIT_OSAKA)
     }
@@ -229,17 +230,17 @@ impl TempoHardfork {
     /// Gas cost for using an existing 2D nonce key
     pub const fn gas_existing_nonce_key(&self) -> u64 {
         if self.is_t2() {
-            return crate::spec::TEMPO_T2_EXISTING_NONCE_KEY_GAS;
+            return gas::TEMPO_T2_EXISTING_NONCE_KEY_GAS;
         }
-        crate::spec::TEMPO_T1_EXISTING_NONCE_KEY_GAS
+        gas::TEMPO_T1_EXISTING_NONCE_KEY_GAS
     }
 
     /// Gas cost for using a new 2D nonce key
     pub const fn gas_new_nonce_key(&self) -> u64 {
         if self.is_t2() {
-            return crate::spec::TEMPO_T2_NEW_NONCE_KEY_GAS;
+            return gas::TEMPO_T2_NEW_NONCE_KEY_GAS;
         }
-        crate::spec::TEMPO_T1_NEW_NONCE_KEY_GAS
+        gas::TEMPO_T1_NEW_NONCE_KEY_GAS
     }
 
     /// Returns the active hardfork at the given timestamp for the specified chain.

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -1,13 +1,18 @@
 //! Tempo chainspec implementation.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(all(not(test), feature = "reth"), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "reth")]
 extern crate alloc;
 
+#[cfg(feature = "reth")]
 mod bootnodes;
+#[cfg(feature = "reth")]
+pub mod spec;
+#[cfg(feature = "reth")]
+pub use spec::TempoChainSpec;
+
 pub mod constants;
 pub mod hardfork;
-pub mod spec;
-pub use spec::TempoChainSpec;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1,16 +1,12 @@
+pub use crate::constants::gas::*;
+
 use crate::{
     bootnodes::{moderato_nodes, presto_nodes},
     hardfork::{TempoHardfork, TempoHardforks},
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_eips::eip7840::BlobParams;
-use alloy_evm::{
-    eth::spec::EthExecutorSpec,
-    revm::interpreter::gas::{
-        COLD_SLOAD_COST as COLD_SLOAD, SSTORE_SET, WARM_SSTORE_RESET,
-        WARM_STORAGE_READ_COST as WARM_SLOAD,
-    },
-};
+use alloy_evm::eth::spec::EthExecutorSpec;
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256, U256};
 use once_cell as _;
@@ -26,48 +22,9 @@ use reth_network_peers::NodeRecord;
 use std::sync::LazyLock;
 use tempo_primitives::TempoHeader;
 
-/// T0 base fee: 10 billion attodollars (1×10^10)
-///
-/// Attodollars are the atomic gas accounting units at 10^-18 USD precision.
-/// Basefee is denominated in attodollars.
-pub const TEMPO_T0_BASE_FEE: u64 = 10_000_000_000;
-
-/// T1 base fee: 20 billion attodollars (2×10^10)
-///
-/// Attodollars are the atomic gas accounting units at 10^-18 USD precision.
-/// Basefee is denominated in attodollars.
-///
-/// At this basefee, a standard TIP-20 transfer (~50,000 gas) costs:
-/// - Gas: 50,000 × 20 billion attodollars/gas = 1 quadrillion attodollars
-/// - Tokens: 1 quadrillion attodollars / 10^12 = 1,000 microdollars
-/// - Economic: 1,000 microdollars = 0.001 USD = 0.1 cents
-pub const TEMPO_T1_BASE_FEE: u64 = 20_000_000_000;
-
-/// [TIP-1010] general (non-payment) gas limit: 30 million gas per block.
-/// Cap for non-payment transactions.
-///
-/// [TIP-1010]: <https://docs.tempo.xyz/protocol/tips/tip-1010>
-pub const TEMPO_T1_GENERAL_GAS_LIMIT: u64 = 30_000_000;
-
-/// TIP-1010 per-transaction gas limit cap: 30 million gas.
-/// Allows maximum-sized contract deployments under [TIP-1000] state creation costs.
-///
-/// [TIP-1000]: <https://docs.tempo.xyz/protocol/tips/tip-1000>
-pub const TEMPO_T1_TX_GAS_LIMIT_CAP: u64 = 30_000_000;
-
 // End-of-block system transactions
 pub const SYSTEM_TX_COUNT: usize = 1;
 pub const SYSTEM_TX_ADDRESSES: [Address; SYSTEM_TX_COUNT] = [Address::ZERO];
-
-/// Gas cost for using an existing 2D nonce key (cold SLOAD + warm SSTORE reset)
-pub const TEMPO_T1_EXISTING_NONCE_KEY_GAS: u64 = COLD_SLOAD + WARM_SSTORE_RESET;
-/// T2 adds 2 warm SLOADs for the extended nonce key lookup
-pub const TEMPO_T2_EXISTING_NONCE_KEY_GAS: u64 = TEMPO_T1_EXISTING_NONCE_KEY_GAS + 2 * WARM_SLOAD;
-
-/// Gas cost for using a new 2D nonce key (cold SLOAD + SSTORE set for 0 -> non-zero)
-pub const TEMPO_T1_NEW_NONCE_KEY_GAS: u64 = COLD_SLOAD + SSTORE_SET;
-/// T2 adds 2 warm SLOADs for the extended nonce key lookup
-pub const TEMPO_T2_NEW_NONCE_KEY_GAS: u64 = TEMPO_T1_NEW_NONCE_KEY_GAS + 2 * WARM_SLOAD;
 
 /// Tempo genesis info extracted from genesis extra_fields
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/crates/commonware-node/Cargo.toml
+++ b/crates/commonware-node/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 tempo-alloy = { workspace = true, features = ["reth"] }
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-commonware-node-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-node.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-primitives = { workspace = true, features = ["reth"] }
 
 reth-chainspec.workspace = true

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -44,7 +44,7 @@ reth-node-core.workspace = true
 reth-node-metrics.workspace = true
 reth-rpc-builder.workspace = true
 
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-commonware-node.workspace = true
 tempo-node.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -12,7 +12,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-consensus.workspace = true
 tempo-contracts.workspace = true
 tempo-payload-types = { workspace = true, optional = true }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 tempo-alloy = { workspace = true, features = ["reth"] }
 tempo-evm = { workspace = true, features = ["rpc", "engine"] }
 tempo-transaction-pool.workspace = true
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-consensus.workspace = true
 tempo-payload-builder.workspace = true
 tempo-payload-types.workspace = true

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-consensus.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -12,7 +12,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-primitives = { workspace = true, features = ["serde", "reth-codec"] }


### PR DESCRIPTION
this PR prepares `tempo-chainspec` for sanitization (previous to publishing) to strip the code that deps on `reth`