### PR TITLE
chore: remove unused BENCH_RUNNERS env var from bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -130,7 +130,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  BENCH_RUNNERS: 1
 
 name: bench
 


### PR DESCRIPTION
BENCH_RUNNERS is set but never read by tempo.nu or any script in the workflow. Dead code from when the var was copied from reth's bench.yml.

Prompted by: alexey