### PR TITLE
fix(e2e): box ExecutionNode::node to reduce stack size

### DIFF
--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -1074,7 +1074,7 @@ impl ExecutionRuntimeHandle {
 /// avoids the type parameters.
 pub struct ExecutionNode {
     /// All handles to interact with the launched node instances and services.
-    pub node: TempoFullNode,
+    pub node: Box<TempoFullNode>,
     /// The [`Runtime`] that drives the node's services.
     pub runtime: Runtime,
     /// The exist future that resolves when the node's engine future resolves.
@@ -1235,7 +1235,7 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
     })?;
 
     Ok(ExecutionNode {
-        node: node_handle.node,
+        node: Box::new(node_handle.node),
         runtime,
         exit_fut: node_handle.node_exit_future,
     })

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -252,7 +252,7 @@ where
         self.consensus_config = self
             .consensus_config
             .clone()
-            .with_execution_node(execution_node.node.clone());
+            .with_execution_node((*execution_node.node).clone());
         self.execution_node = Some(execution_node);
         debug!(%self.uid, "started execution node for testing node");
     }


### PR DESCRIPTION
Boxes `ExecutionNode::node` (`TempoFullNode`) to move it to the heap, reducing the stack frame size and fixing stack overflows in e2e tests.

Prompted by: mattsse