### PR TITLE
docs(tip-1038): remove #3560 from T3 meta TIP

### DIFF
--- a/tips/tip-1038.md
+++ b/tips/tip-1038.md
@@ -67,13 +67,7 @@ The StablecoinDEX `swap_exact_amount_in` and `swap_exact_amount_out` paths opera
 
 `refund_spending_limit()` restored spending room with a saturating add, which could raise a T3 key's remaining allowance above the configured max during defensive refund paths. T3+ clamps refunded spending limits to the stored `max`, preserving the invariant that `remaining <= max` for T3 keys while leaving migrated pre-T3 rows on their legacy behavior because they do not persist a max bound.
 
-## 8. StablecoinDEX: fail early on order placement for paused tokens
-
-**PR**: [#3560](https://github.com/tempoxyz/tempo/pull/3560) · **Author**: @0xrusowsky
-
-The StablecoinDEX allowed limit orders to be placed for paused tokens, deferring the pause check to settlement time. This let users queue orders that would always revert on fill and could create misleading orderbook state. T3+ adds a pause check at order placement time for both the input and output tokens, rejecting orders immediately if either token is paused.
-
-## 9. TIP-20: propagate OOG from `is_initialized` instead of masking as uninitialized
+## 8. TIP-20: propagate OOG from `is_initialized` instead of masking as uninitialized
 
 **PR**: [#3535](https://github.com/tempoxyz/tempo/pull/3535) · **Author**: @0xrusowsky
 


### PR DESCRIPTION
Removes the paused-token order placement fix (#3560) from T3 scope — will be addressed in T4 instead.

Prompted by: Jennifer