### PR TITLE
refactor: properly propagate reservoir

### DIFF
--- a/crates/node/tests/it/eth_call.rs
+++ b/crates/node/tests/it/eth_call.rs
@@ -37,7 +37,7 @@ fn extract_revert_data(
 /// Expected revert bytes for `Panic(UnderOverflow)`.
 fn under_overflow_revert() -> Bytes {
     TempoPrecompileError::under_overflow()
-        .into_precompile_result(0)
+        .into_precompile_result(0, 0)
         .unwrap()
         .bytes
 }

--- a/crates/node/tests/it/pool.rs
+++ b/crates/node/tests/it/pool.rs
@@ -7,7 +7,7 @@ use alloy::{
     },
 };
 use alloy_eips::{Decodable2718, Encodable2718};
-use alloy_primitives::{Address, TxKind, U256};
+use alloy_primitives::{Address, TxKind, U64, U256};
 use reth_chainspec::EthChainSpec;
 use reth_ethereum::{
     evm::revm::primitives::hex,
@@ -104,7 +104,7 @@ async fn test_insufficient_funds() -> eyre::Result<()> {
 
     let tx = TempoTransaction {
         chain_id: chain_spec.chain_id(),
-        nonce: 1,
+        nonce: U64::random().to(),
         fee_token: Some(DEFAULT_FEE_TOKEN),
         max_priority_fee_per_gas: 74982851675,
         max_fee_per_gas: 74982851675,

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,10 +1,7 @@
 //! ABI dispatch for the [`AccountKeychain`] precompile.
 
 use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
-use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, error::TempoPrecompileError,
-    mutate_void, view,
-};
+use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate_void, view};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
@@ -40,12 +37,11 @@ impl Precompile for AccountKeychain {
             |call| match call {
                 IAccountKeychainCalls::authorizeKey_0(call) => {
                     if self.storage.spec().is_t3() {
-                        return TempoPrecompileError::AccountKeychainError(
+                        return self.storage.error_result(
                             AccountKeychainError::legacy_authorize_key_selector_changed(
                                 authorizeKeyCall::SELECTOR,
                             ),
-                        )
-                        .into_precompile_result(self.storage.gas_used());
+                        );
                     }
 
                     let call = authorizeKeyCall {

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -172,7 +172,7 @@ impl TempoPrecompileError {
     /// # Errors
     /// - `PrecompileOutput::halt(PrecompileHalt::OutOfGas, ..)` — if the variant is [`OutOfGas`](Self::OutOfGas)
     /// - `PrecompileError::Fatal` — if the variant is [`Fatal`](Self::Fatal)
-    pub fn into_precompile_result(self, gas: u64) -> PrecompileResult {
+    pub fn into_precompile_result(self, gas: u64, reservoir: u64) -> PrecompileResult {
         let bytes = match self {
             Self::StablecoinDEX(e) => e.abi_encode().into(),
             Self::TIP20(e) => e.abi_encode().into(),
@@ -195,7 +195,7 @@ impl TempoPrecompileError {
             Self::AccountKeychainError(e) => e.abi_encode().into(),
             Self::SignatureVerifierError(e) => e.abi_encode().into(),
             Self::OutOfGas => {
-                return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0));
+                return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir));
             }
             Self::UnknownFunctionSelector(selector) => UnknownFunctionSelector {
                 selector: selector.into(),
@@ -206,7 +206,7 @@ impl TempoPrecompileError {
                 return Err(PrecompileError::Fatal(msg));
             }
         };
-        Ok(PrecompileOutput::revert(gas, bytes, 0))
+        Ok(PrecompileOutput::revert(gas, bytes, reservoir))
     }
 }
 
@@ -289,6 +289,7 @@ pub trait IntoPrecompileResult<T> {
     fn into_precompile_result(
         self,
         gas: u64,
+        reservoir: u64,
         encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
     ) -> PrecompileResult;
 }
@@ -297,22 +298,13 @@ impl<T> IntoPrecompileResult<T> for Result<T> {
     fn into_precompile_result(
         self,
         gas: u64,
+        reservoir: u64,
         encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
     ) -> PrecompileResult {
         match self {
-            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), 0)),
-            Err(err) => err.into_precompile_result(gas),
+            Ok(res) => Ok(PrecompileOutput::new(gas, encode_ok(res), reservoir)),
+            Err(err) => err.into_precompile_result(gas, reservoir),
         }
-    }
-}
-
-impl<T> IntoPrecompileResult<T> for TempoPrecompileError {
-    fn into_precompile_result(
-        self,
-        gas: u64,
-        _encode_ok: impl FnOnce(T) -> alloy::primitives::Bytes,
-    ) -> PrecompileResult {
-        Self::into_precompile_result(self, gas)
     }
 }
 

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -163,12 +163,13 @@ macro_rules! tempo_precompile {
                 return Ok(PrecompileOutput::revert(
                     0,
                     DelegateCallNotAllowed {}.abi_encode().into(),
-                    0,
+                    $input.reservoir,
                 ));
             }
             let mut storage = crate::storage::evm::EvmPrecompileStorageProvider::new(
                 $input.internals,
                 $input.gas,
+                $input.reservoir,
                 spec,
                 $input.is_static,
                 gas_params.clone(),
@@ -262,13 +263,13 @@ impl SignatureVerifier {
 /// Dispatches a parameterless view call, encoding the return via `T`.
 #[inline]
 fn metadata<T: SolCall>(f: impl FnOnce() -> Result<T::Return>) -> PrecompileResult {
-    f().into_precompile_result(0, |ret| T::abi_encode_returns(&ret).into())
+    f().into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
 }
 
 /// Dispatches a read-only call with decoded arguments, encoding the return via `T`.
 #[inline]
 fn view<T: SolCall>(call: T, f: impl FnOnce(T) -> Result<T::Return>) -> PrecompileResult {
-    f(call).into_precompile_result(0, |ret| T::abi_encode_returns(&ret).into())
+    f(call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
 }
 
 /// Dispatches a state-mutating call that returns ABI-encoded data.
@@ -284,10 +285,10 @@ fn mutate<T: SolCall>(
         return Ok(PrecompileOutput::revert(
             0,
             StaticCallNotAllowed {}.abi_encode().into(),
-            0,
+            StorageCtx.reservoir(),
         ));
     }
-    f(sender, call).into_precompile_result(0, |ret| T::abi_encode_returns(&ret).into())
+    f(sender, call).into_precompile_result(0, 0, |ret| T::abi_encode_returns(&ret).into())
 }
 
 /// Dispatches a state-mutating call that returns no data (e.g. `approve`, `transfer`).
@@ -303,10 +304,10 @@ fn mutate_void<T: SolCall>(
         return Ok(PrecompileOutput::revert(
             0,
             StaticCallNotAllowed {}.abi_encode().into(),
-            0,
+            StorageCtx.reservoir(),
         ));
     }
-    f(sender, call).into_precompile_result(0, |()| Bytes::new())
+    f(sender, call).into_precompile_result(0, 0, |()| Bytes::new())
 }
 
 /// Deducts the calldata input cost, returning an OOG halt result if insufficient gas.
@@ -316,22 +317,9 @@ pub(crate) fn charge_input_cost(
     calldata: &[u8],
 ) -> Option<PrecompileResult> {
     if storage.deduct_gas(input_cost(calldata.len())).is_err() {
-        return Some(Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, 0)));
+        return Some(Ok(storage.halt_output(PrecompileHalt::OutOfGas)));
     }
     None
-}
-
-/// Fills gas accounting fields on a [`PrecompileOutput`] from the storage context.
-#[inline]
-fn fill_precompile_output(mut output: PrecompileOutput, storage: &StorageCtx) -> PrecompileOutput {
-    output.gas_used = storage.gas_used();
-    output
-}
-
-/// Returns an ABI-encoded `UnknownFunctionSelector` revert for the given 4-byte selector.
-#[inline]
-pub fn unknown_selector(selector: [u8; 4], gas: u64) -> PrecompileResult {
-    error::TempoPrecompileError::UnknownFunctionSelector(selector).into_precompile_result(gas)
 }
 
 /// A selector schedule at a given hardfork boundary.
@@ -401,18 +389,11 @@ pub(crate) fn dispatch_call<T>(
 
     if calldata.len() < 4 {
         if storage.spec().is_t1() {
-            return Ok(fill_precompile_output(
-                PrecompileOutput::revert(0, Bytes::new(), 0),
-                &storage,
-            ));
+            return Ok(storage.revert_output(Bytes::new()));
         } else {
-            return Ok(fill_precompile_output(
-                PrecompileOutput::halt(
-                    PrecompileHalt::Other("Invalid input: missing function selector".into()),
-                    0,
-                ),
-                &storage,
-            ));
+            return Ok(storage.halt_output(PrecompileHalt::Other(
+                "Invalid input: missing function selector".into(),
+            )));
         }
     }
 
@@ -421,22 +402,24 @@ pub(crate) fn dispatch_call<T>(
         .iter()
         .any(|schedule| schedule.rejects(selector, storage.spec()))
     {
-        return unknown_selector(selector, storage.gas_used())
-            .map(|res| fill_precompile_output(res, &storage));
+        return storage.error_result(error::TempoPrecompileError::UnknownFunctionSelector(
+            selector,
+        ));
     }
 
     let result = decode(calldata);
 
     match result {
-        Ok(call) => f(call).map(|res| fill_precompile_output(res, &storage)),
-        Err(alloy::sol_types::Error::UnknownSelector { selector, .. }) => {
-            unknown_selector(*selector, storage.gas_used())
-                .map(|res| fill_precompile_output(res, &storage))
-        }
-        Err(_) => Ok(fill_precompile_output(
-            PrecompileOutput::revert(0, Bytes::new(), 0),
-            &storage,
-        )),
+        Ok(call) => f(call).map(|mut res| {
+            // TODO: fix this, each precompile handler should either return output with proper gas values or don't return any gas values at all.
+            res.gas_used = storage.gas_used();
+            res.reservoir = storage.reservoir();
+            res
+        }),
+        Err(alloy::sol_types::Error::UnknownSelector { selector, .. }) => storage.error_result(
+            error::TempoPrecompileError::UnknownFunctionSelector(*selector),
+        ),
+        Err(_) => Ok(storage.revert_output(Bytes::new())),
     }
 }
 

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -93,7 +93,7 @@ pub trait Precompile {
     /// `dispatch_call` combined with the `view`, `mutate`, or `mutate_void` helpers.
     ///
     /// Business-logic errors are returned as reverted [`PrecompileOutput`]s with ABI-encoded
-    /// error data, while fatal failures (e.g. out-of-gas) are returned as [`PrecompileError`].
+    /// error data, while fatal failures (e.g. out-of-gas) are returned as [`revm::precompile::PrecompileError`].
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult;
 }
 
@@ -376,8 +376,6 @@ impl<'a> SelectorSchedule<'a> {
 /// Handles missing selectors (revert on T1+, error on earlier forks), hardfork-gated selectors,
 /// unknown selectors (ABI-encoded `UnknownFunctionSelector`), and malformed ABI data (empty
 /// revert).
-///
-/// Gas accounting is applied via [`fill_precompile_output`].
 #[inline]
 pub(crate) fn dispatch_call<T>(
     calldata: &[u8],

--- a/crates/precompiles/src/signature_verifier/dispatch.rs
+++ b/crates/precompiles/src/signature_verifier/dispatch.rs
@@ -1,7 +1,7 @@
 use super::SignatureVerifier;
 use crate::{Precompile, charge_input_cost, dispatch_call, view};
 use alloy::{primitives::Address, sol_types::SolInterface};
-use revm::precompile::{PrecompileOutput, PrecompileResult};
+use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::{
     ISignatureVerifier::ISignatureVerifierCalls as ISVCalls, SignatureVerifierError,
 };
@@ -20,11 +20,9 @@ impl Precompile for SignatureVerifier {
         }
 
         if calldata.len() > MAX_CALLDATA_LEN {
-            return Ok(PrecompileOutput::revert(
-                self.storage.gas_used(),
-                SignatureVerifierError::invalid_format().abi_encode().into(),
-                0,
-            ));
+            return Ok(self
+                .storage
+                .abi_revert(SignatureVerifierError::invalid_format()));
         }
 
         dispatch_call(calldata, &[], ISVCalls::abi_decode, |call| match call {

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -17,6 +17,7 @@ pub struct EvmPrecompileStorageProvider<'a> {
     gas_remaining: u64,
     gas_refunded: i64,
     gas_limit: u64,
+    reservoir: u64,
     spec: TempoHardfork,
     is_static: bool,
     gas_params: GasParams,
@@ -30,6 +31,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
     pub fn new(
         internals: EvmInternals<'a>,
         gas_limit: u64,
+        reservoir: u64,
         spec: TempoHardfork,
         is_static: bool,
         gas_params: GasParams,
@@ -39,6 +41,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             gas_remaining: gas_limit,
             gas_refunded: 0,
             gas_limit,
+            reservoir,
             spec,
             is_static,
             gas_params,
@@ -49,7 +52,14 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
 
     /// Creates a new storage provider with maximum gas limit and non-static context.
     pub fn new_max_gas(internals: EvmInternals<'a>, cfg: &CfgEnv<TempoHardfork>) -> Self {
-        Self::new(internals, u64::MAX, cfg.spec, false, cfg.gas_params.clone())
+        Self::new(
+            internals,
+            u64::MAX,
+            0,
+            cfg.spec,
+            false,
+            cfg.gas_params.clone(),
+        )
     }
 
     /// Creates a new storage provider with the given gas limit, deriving spec from `cfg`.
@@ -57,10 +67,12 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         internals: EvmInternals<'a>,
         cfg: &CfgEnv<TempoHardfork>,
         gas_limit: u64,
+        reservoir: u64,
     ) -> Self {
         Self::new(
             internals,
             gas_limit,
+            reservoir,
             cfg.spec,
             false,
             cfg.gas_params.clone(),
@@ -234,6 +246,11 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     #[inline]
     fn gas_refunded(&self) -> i64 {
         self.gas_refunded
+    }
+
+    #[inline]
+    fn reservoir(&self) -> u64 {
+        self.reservoir
     }
 
     #[inline]
@@ -621,7 +638,7 @@ mod tests {
         let evm_internals =
             EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
         let mut provider =
-            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 30);
+            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 30, 0);
         assert!(matches!(
             provider.keccak256(b"hello"),
             Err(TempoPrecompileError::OutOfGas)
@@ -665,7 +682,7 @@ mod tests {
         let evm_internals =
             EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
         let mut provider =
-            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 100);
+            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 100, 0);
         assert!(matches!(
             provider.recover_signer(digest, v, r, s),
             Err(TempoPrecompileError::OutOfGas)

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -171,6 +171,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         0
     }
 
+    fn reservoir(&self) -> u64 {
+        0
+    }
+
     fn spec(&self) -> TempoHardfork {
         self.spec
     }

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -88,6 +88,9 @@ pub trait PrecompileStorageProvider {
     /// Returns the gas refunded so far.
     fn gas_refunded(&self) -> i64;
 
+    /// Returns the state gas reservoir.
+    fn reservoir(&self) -> u64;
+
     /// Returns the currently active hardfork.
     fn spec(&self) -> TempoHardfork;
 

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -1,9 +1,13 @@
-use alloy::primitives::{Address, B256, LogData, U256};
+use alloy::{
+    primitives::{Address, B256, Bytes, LogData, U256},
+    sol_types::SolInterface,
+};
 use alloy_evm::{Database, EvmInternals};
 use revm::{
     context::{
         Block, CfgEnv, ContextTr, JournalTr, Transaction, journaled_state::JournalCheckpoint,
     },
+    precompile::{PrecompileHalt, PrecompileOutput, PrecompileResult},
     state::{AccountInfo, Bytecode},
 };
 use scoped_tls::scoped_thread_local;
@@ -178,6 +182,11 @@ impl StorageCtx {
         Self::with_storage(|s| s.gas_refunded())
     }
 
+    /// Returns the reservoir gas.
+    pub fn reservoir(&self) -> u64 {
+        Self::with_storage(|s| s.reservoir())
+    }
+
     /// Returns the currently active hardfork.
     pub fn spec(&self) -> TempoHardfork {
         Self::with_storage(|s| s.spec())
@@ -230,6 +239,38 @@ impl StorageCtx {
     /// [TIP-1004]: <https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md#signature-validation>
     pub fn recover_signer(&self, digest: B256, v: u8, r: B256, s: B256) -> Result<Option<Address>> {
         Self::try_with_storage(|storage| storage.recover_signer(digest, v, r, s))
+    }
+
+    /// Returns a [`PrecompileOutput`] with [`revm::precompile::PrecompileStatus::Success`] and the current gas values.
+    pub fn success_output(&self, output: Bytes) -> PrecompileOutput {
+        PrecompileOutput::new(self.gas_used(), output, self.reservoir())
+    }
+
+    /// Returns an ABI-encoded success output.
+    pub fn abi_success(&self, output: impl SolInterface) -> PrecompileOutput {
+        self.success_output(output.abi_encode().into())
+    }
+
+    /// Returns a [`PrecompileOutput`] with [`revm::precompile::PrecompileStatus::Revert`] and the current gas values.
+    pub fn revert_output(&self, output: Bytes) -> PrecompileOutput {
+        PrecompileOutput::revert(self.gas_used(), output, self.reservoir())
+    }
+
+    /// Reverts with an ABI-encoded error.
+    pub fn abi_revert(&self, error: impl SolInterface) -> PrecompileOutput {
+        self.revert_output(error.abi_encode().into())
+    }
+
+    /// Returns a [`PrecompileOutput`] with [`revm::precompile::PrecompileStatus::Halt`] and the current gas values.
+    pub fn halt_output(&self, halt: PrecompileHalt) -> PrecompileOutput {
+        PrecompileOutput::halt(halt, self.reservoir())
+    }
+
+    /// Returns a [`PrecompileResult`] constructed from the given [`TempoPrecompileError`].
+    pub fn error_result(&self, error: impl Into<TempoPrecompileError>) -> PrecompileResult {
+        error
+            .into()
+            .into_precompile_result(self.gas_used(), self.reservoir())
     }
 }
 
@@ -290,27 +331,6 @@ impl<'evm> StorageCtx {
         Self::enter(&mut provider, f)
     }
 
-    /// Like [`enter_evm`](Self::enter_evm), but meters storage access under `gas_limit`
-    /// and returns both the closure result and gas consumed.
-    pub fn enter_evm_with_gas_limit<J, R>(
-        journal: &'evm mut J,
-        block_env: &'evm dyn Block,
-        cfg: &CfgEnv<TempoHardfork>,
-        tx_env: &'evm impl Transaction,
-        gas_limit: u64,
-        f: impl FnOnce() -> R,
-    ) -> (R, u64)
-    where
-        J: JournalTr<Database: Database> + Debug,
-    {
-        let internals = EvmInternals::new(journal, block_env, cfg, tx_env);
-        let mut provider =
-            EvmPrecompileStorageProvider::new_with_gas_limit(internals, cfg, gas_limit);
-        let result = Self::enter(&mut provider, f);
-        let gas_used = provider.gas_used();
-        (result, gas_used)
-    }
-
     /// Like [`enter_evm`](Self::enter_evm), but takes a `&mut impl ContextTr`
     /// directly instead of requiring the caller to destructure the context.
     pub fn enter_ctx<C, R>(ctx: &mut C, f: impl FnOnce() -> R) -> R
@@ -326,13 +346,19 @@ impl<'evm> StorageCtx {
     pub fn enter_ctx_with_gas_limit<C, R>(
         ctx: &mut C,
         gas_limit: u64,
+        reservoir: u64,
         f: impl FnOnce() -> R,
     ) -> (R, u64)
     where
         C: ContextTr<Cfg = CfgEnv<TempoHardfork>, Journal: Debug, Db: Database>,
     {
         let (tx, block, cfg, journal) = ctx.tx_block_cfg_journal_mut();
-        Self::enter_evm_with_gas_limit(journal, block, cfg, tx, gas_limit, f)
+        let internals = EvmInternals::new(journal, block, cfg, tx);
+        let mut provider =
+            EvmPrecompileStorageProvider::new_with_gas_limit(internals, cfg, gas_limit, reservoir);
+        let result = Self::enter(&mut provider, f);
+        let gas_used = provider.gas_used();
+        (result, gas_used)
     }
 
     /// Entry point for a "canonical" precompile (with unique known address).

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -1,9 +1,7 @@
 //! ABI dispatch for the [`TIP20Token`] precompile.
 
 use crate::{
-    Precompile, SelectorSchedule, charge_input_cost, dispatch_call,
-    error::TempoPrecompileError,
-    metadata, mutate, mutate_void,
+    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, metadata, mutate, mutate_void,
     storage::ContractStorage,
     tip20::{ITIP20, TIP20Token},
     view,
@@ -51,11 +49,10 @@ impl Precompile for TIP20Token {
         let initialized = match self.is_initialized() {
             Ok(v) => v,
             Err(_) if !self.storage.spec().is_t4() => false,
-            Err(e) => return e.into_precompile_result(self.storage.gas_used()),
+            Err(e) => return self.storage.error_result(e),
         };
         if !initialized {
-            return TempoPrecompileError::TIP20(TIP20Error::uninitialized())
-                .into_precompile_result(self.storage.gas_used());
+            return self.storage.error_result(TIP20Error::uninitialized());
         }
 
         dispatch_call(

--- a/crates/precompiles/src/validator_config_v2/dispatch.rs
+++ b/crates/precompiles/src/validator_config_v2/dispatch.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::{Precompile, charge_input_cost, dispatch_call, mutate, mutate_void, view};
 use alloy::{primitives::Address, sol_types::SolInterface};
-use revm::precompile::{PrecompileOutput, PrecompileResult};
+use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::IValidatorConfigV2::IValidatorConfigV2Calls;
 
 impl Precompile for ValidatorConfigV2 {
@@ -14,11 +14,7 @@ impl Precompile for ValidatorConfigV2 {
 
         // Pre-T2: behave like an empty contract (call succeeds, no execution)
         if !self.storage.spec().is_t2() {
-            return Ok(PrecompileOutput::new(
-                self.storage.gas_used(),
-                Default::default(),
-                0,
-            ));
+            return Ok(self.storage.success_output(Default::default()));
         }
 
         dispatch_call(

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -405,6 +405,10 @@ where
         unreachable!("'gas_refunded' not implemented in read-only context yet")
     }
 
+    fn reservoir(&self) -> u64 {
+        unreachable!("'reservoir' not implemented in read-only context yet")
+    }
+
     // Write operations are not supported in read-only context
     fn sstore(&mut self, _: Address, _: U256, _: U256) -> TempoResult<()> {
         unreachable!("'sstore' not supported in read-only context")

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -383,8 +383,9 @@ where
             ));
         };
 
+        // It's fine to set reservoir to 0 because this won't create any state.
         let (validation, gas_used) =
-            StorageCtx::enter_ctx_with_gas_limit(evm.ctx_mut(), *remaining_gas, || {
+            StorageCtx::enter_ctx_with_gas_limit(evm.ctx_mut(), *remaining_gas, 0, || {
                 let keychain = AccountKeychain::default();
                 for call in calls {
                     keychain.validate_call_scope_for_transaction(
@@ -402,7 +403,7 @@ where
                 *remaining_gas = remaining_gas.saturating_sub(gas_used);
                 Ok(None)
             }
-            Err(err) => match err.into_precompile_result(gas_used) {
+            Err(err) => match err.into_precompile_result(gas_used, 0) {
                 Ok(output) if output.is_halt() => Ok(Some(oog_frame_result(kind, *remaining_gas))),
                 Ok(revert_output) => {
                     let mut gas = Gas::new(gas_used);
@@ -1127,8 +1128,9 @@ where
                 cfg.gas_params.clone()
             };
 
+            // It's ok to set reservoir to 0 because pre-T1B it doesn't matter and post-T1B we have unlimited gas anyway.
             let mut provider = EvmPrecompileStorageProvider::new(
-                internals, gas_limit, cfg.spec, false, gas_params,
+                internals, gas_limit, 0, cfg.spec, false, gas_params,
             );
 
             // The core logic of setting up thread-local storage is here.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1286,7 +1286,7 @@ mod tests {
         tip20::slots as tip20_slots,
         tip403_registry::{CompoundPolicyData, PolicyData, TIP403Registry},
     };
-    use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
+    use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoTxEnvelope};
 
     fn provider_with_spending_limit(
         account: Address,
@@ -1412,7 +1412,6 @@ mod tests {
 
         let inner =
             EthTransactionValidatorBuilder::new(provider.clone(), TempoEvmConfig::mainnet())
-                .with_custom_tx_type(TempoTxType::AA as u8)
                 .disable_balance_check()
                 .build(InMemoryBlobStore::default());
         let amm_cache =


### PR DESCRIPTION
Changes the logic to always propagate the `reservoir` we got as input to the call

Added serveral helpers to `StorageCtx` to construct `PrecompileOutput`