### PR TITLE
deps: update reth from main (2026-04-22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2126,12 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -5346,6 +5358,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8170,8 +8207,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8197,8 +8234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8229,8 +8266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8249,8 +8286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8262,8 +8299,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8345,8 +8382,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8355,8 +8392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8408,8 +8445,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8424,8 +8461,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8437,8 +8474,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8450,8 +8487,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8476,8 +8513,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8504,8 +8541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8530,8 +8567,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8560,8 +8597,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8575,8 +8612,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8600,8 +8637,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8624,8 +8661,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8648,8 +8685,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8683,8 +8720,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8740,8 +8777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8768,8 +8805,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8791,8 +8828,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8816,8 +8853,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8874,8 +8911,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8902,8 +8939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8917,8 +8954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8933,8 +8970,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8955,8 +8992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8966,8 +9003,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8994,8 +9031,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9016,8 +9053,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9057,8 +9094,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "clap",
  "eyre",
@@ -9080,8 +9117,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9096,8 +9133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9112,8 +9149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9125,8 +9162,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9155,8 +9192,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9169,8 +9206,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9179,8 +9216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9203,8 +9240,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9223,8 +9260,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9241,8 +9278,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9254,8 +9291,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9273,8 +9310,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9311,8 +9348,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9325,8 +9362,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "serde",
  "serde_json",
@@ -9335,8 +9372,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9363,8 +9400,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "bytes",
  "futures",
@@ -9383,8 +9420,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9400,8 +9437,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "bindgen",
  "cc",
@@ -9409,8 +9446,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "futures",
  "metrics",
@@ -9421,8 +9458,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9430,8 +9467,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9444,8 +9481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9501,8 +9538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9526,8 +9563,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9549,8 +9586,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9564,8 +9601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9578,8 +9615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9595,8 +9632,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9619,8 +9656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9687,8 +9724,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9742,8 +9779,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9780,8 +9817,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9804,8 +9841,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9828,8 +9865,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "bytes",
  "eyre",
@@ -9857,8 +9894,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9869,8 +9906,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9893,8 +9930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9905,8 +9942,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9929,8 +9966,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9972,8 +10009,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10018,8 +10055,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10047,8 +10084,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10063,8 +10100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10078,8 +10115,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10155,8 +10192,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10185,8 +10222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10228,8 +10265,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10248,8 +10285,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10279,8 +10316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10325,8 +10362,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10373,8 +10410,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10387,8 +10424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10418,8 +10455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10470,8 +10507,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10498,8 +10535,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10512,8 +10549,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10532,8 +10569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10547,8 +10584,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10571,8 +10608,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10589,8 +10626,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10610,8 +10647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10626,8 +10663,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10636,8 +10673,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "clap",
  "eyre",
@@ -10655,8 +10692,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "clap",
  "eyre",
@@ -10673,8 +10710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10684,6 +10721,7 @@ dependencies = [
  "auto_impl",
  "bitflags 2.11.0",
  "futures-util",
+ "imbl",
  "metrics",
  "parking_lot",
  "paste",
@@ -10717,8 +10755,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10743,8 +10781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10770,8 +10808,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10790,8 +10828,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10819,8 +10857,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11441,6 +11479,15 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "salsa20"
@@ -14189,6 +14236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8208,7 +8208,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8267,7 +8267,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8300,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8383,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8542,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8598,7 +8598,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8613,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8686,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8829,7 +8829,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8971,7 +8971,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9032,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "clap",
  "eyre",
@@ -9118,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9134,7 +9134,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9150,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9193,7 +9193,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9217,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "serde",
  "serde_json",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "bytes",
  "futures",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "futures",
  "metrics",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9564,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9587,7 +9587,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9780,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "bytes",
  "eyre",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9931,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10056,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10193,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10425,7 +10425,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10456,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10536,7 +10536,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10550,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10570,7 +10570,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10648,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10674,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "clap",
  "eyre",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "clap",
  "eyre",
@@ -10711,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10782,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10809,7 +10809,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10829,7 +10829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10858,12 +10858,11 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e92af36#e92af360aeb29d59b00f73d429139dd94714a658"
+source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "auto_impl",
  "metrics",
  "rayon",
  "reth-execution-errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.33.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc4b83cb672156663e6094d098beb509965b7fe684bb3d6e44bb9ca2e9ae714"
+checksum = "5f107d0e588e5d25fcf2db216390445d5804b875a22a419407ad0389b925bb4d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1848,12 +1848,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -1862,17 +1861,6 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2075,7 +2063,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2126,9 +2114,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -2206,7 +2194,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -2223,7 +2211,7 @@ checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -2315,7 +2303,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -2673,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2695,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3241,12 +3229,11 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
-version = "0.2.36"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
- "konst",
 ]
 
 [[package]]
@@ -3290,6 +3277,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cow-utils"
@@ -3481,7 +3477,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -4698,7 +4694,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -5141,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
  "hyper",
@@ -5154,7 +5150,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5448,7 +5444,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -5932,21 +5928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "konst"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,7 +6059,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -6130,7 +6111,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6549,11 +6530,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
- "no_std_io2",
+ "core2",
  "unsigned-varint",
 ]
 
@@ -6585,7 +6566,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
@@ -6596,19 +6577,10 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -6633,7 +6605,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -6651,7 +6623,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6815,7 +6787,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -7335,9 +7307,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -7487,7 +7459,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -7500,7 +7472,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "chrono",
  "hex",
 ]
@@ -7536,7 +7508,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -7913,7 +7885,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -7945,7 +7917,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -7964,7 +7936,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -8005,7 +7977,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -8014,7 +7986,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -8143,7 +8115,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -8199,7 +8171,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8226,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8258,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8278,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8291,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8374,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8384,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8437,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8453,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8466,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8479,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8505,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8533,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8559,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8589,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8604,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8629,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8653,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8677,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8712,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8769,7 +8741,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8797,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8820,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8845,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8903,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8931,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8946,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8962,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8984,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8995,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9023,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9045,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9086,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "clap",
  "eyre",
@@ -9109,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9125,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9141,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9154,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9184,7 +9156,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9198,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9208,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9232,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9252,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9270,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9283,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9302,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9340,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9354,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "serde",
  "serde_json",
@@ -9364,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9392,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "bytes",
  "futures",
@@ -9412,9 +9384,9 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "crossbeam-queue",
  "dashmap",
@@ -9429,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "bindgen",
  "cc",
@@ -9438,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "futures",
  "metrics",
@@ -9450,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9459,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9473,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9530,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9555,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9578,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9593,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9607,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9624,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9648,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9716,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9771,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9809,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9833,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9857,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "bytes",
  "eyre",
@@ -9886,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9898,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9922,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9934,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9958,7 +9930,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10001,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10047,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10076,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10092,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10107,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10184,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10214,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10257,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10277,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10308,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10354,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10402,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10416,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10447,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10499,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10527,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10541,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10561,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10576,7 +10548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10600,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10618,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10639,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10655,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10665,7 +10637,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "clap",
  "eyre",
@@ -10684,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "clap",
  "eyre",
@@ -10702,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10710,7 +10682,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "futures-util",
  "metrics",
  "parking_lot",
@@ -10746,7 +10718,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10772,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10799,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10819,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10848,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10878,9 +10850,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "38.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+checksum = "11353f234577a63048066df974d8a56e8c090d4de8b5f7d5f2a0d0c3a1ffaa2d"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10909,9 +10881,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+checksum = "c0e3d41127977e351ed795689147e6e59b0fa88e387840f921e46c440bb2fb44"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10926,9 +10898,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+checksum = "dd61f0f2f646ae74a75e12e7f1d57554868e2dc5c83fc9a761cb95735cb58309"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10942,9 +10914,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+checksum = "54f97178ab32358be770d09649d6fa86303923cab7afb95577353e7305a04193"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10956,9 +10928,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+checksum = "68e48ddde8f5ef2adaf1e920ccbf57fa6ef2c63c11e3e37d7d9137657873eecc"
 dependencies = [
  "auto_impl",
  "either",
@@ -10970,9 +10942,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+checksum = "f18b03319aee860ecc4631c9180abb0828480f5a4c39507fc735a417bd906984"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10989,9 +10961,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "19.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+checksum = "f33e8327376dff859eb18dea3623aa55ef5d580fe38fa0fd4bb92bd95ace60ad"
 dependencies = [
  "auto_impl",
  "either",
@@ -11007,9 +10979,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.39.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+checksum = "e41c7dc3d85c6186e57ec1438a426e7ddfac579d8255930cf8ed324a6c317e79"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11027,9 +10999,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.1"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+checksum = "8e5f438f47d40d9830c0498fa3ca16a447b3148ab7b78742cbb1b27a51a50963"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11040,9 +11012,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "34.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+checksum = "1c07bfcc9361f7b23970a68cbd17bfe255e70182cfb1a8896d06832217fc5439"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11077,12 +11049,12 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "11.0.1"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
+checksum = "0e480426a7d76b458789e4a1be3ffbce9df798f0145f0520c1cdf967755cfcbf"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -11335,7 +11307,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -11418,7 +11390,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.6",
  "windows-sys 0.61.2",
 ]
 
@@ -11430,9 +11402,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -11628,7 +11600,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -12798,7 +12770,6 @@ dependencies = [
  "tempo-evm",
  "tempo-precompiles-macros",
  "tempo-primitives",
- "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -13092,7 +13063,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
  "log",
@@ -13220,9 +13191,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -13388,7 +13359,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -13430,7 +13401,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -13910,9 +13881,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -14144,7 +14115,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver 1.0.28",
@@ -14190,14 +14161,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14208,14 +14179,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14780,7 +14751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -14920,7 +14891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467a4c054be41ff657a6823246b0194cd727fadc3c539b265d7bc125ac6d4884"
 dependencies = [
  "aes",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cbc",
  "cmac",
  "ecdsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,21 +121,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
+checksum = "a547705d5c1b42575a0542bae2ba45bc62a6154be86611afaef1c0ab5c38598e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
+checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -188,24 +188,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
+checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c16fa30b623e40a5b216da00f3b61870f5cbe863b59816ac1ecc2489515a40"
+checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -349,7 +349,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -370,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3e12b99b0c8f7298ffd3604c58310cba310203c5f6cd5e024f3b2bd9c3b09c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -385,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
+checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "borsh",
  "serde",
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
+checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -441,19 +441,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
+checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
+checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
@@ -511,13 +511,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ba5468f78c8893be2d68a7f2fda61753336e5653f006af19781001b5f99e6c"
+checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffcefb5d3391a320eadb95d398e4135f8cc35c7bf29a6bdb357eadcfc5ee5638"
+checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
+checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974df1e56405c27cb8242381f45d8b212ba9df5006046ccf704764a2a4634366"
+checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -638,15 +638,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1d057dcbacf8be8f689a7737e0d697fd40a2dc5b664c9035f182ff016649ea"
+checksum = "670b3a8e0d1b32e9886b7a419b8efe6754ea00b9fdd4c0ea3c7411b6c30431f4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -656,38 +656,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bc10b0dca4f5bfc3cd30ed46eab5d651b5bb2cd300d683bdcdf5d2bfe6e82c"
+checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
+checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8f7fa8ca056bb797a368aeed329e6ace6b62ee4271432ac36ab8ae87a5e60d"
+checksum = "caf5d68ddca890854fb78291cbde06115473ded00b2337d0f815e92c0c1f8003"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301249e3c9e43661cfd7ebbb4746a00af6ce1ef58b5c968451882cd60438417d"
+checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -716,15 +716,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59bc947935732cae5b072753e5e034c0b70a8b031c2839f45e2659ba07df9ae"
+checksum = "5f05338cfb4ee5508ff76f01c88142cab8a4579db74b7d9432936c26e4f11374"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -736,17 +736,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
+checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -758,28 +758,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286c40ce0d715217a5bfa9fb452779b11e6769e56680afa0de691ae8f3a848ac"
+checksum = "0df223478aec91d8fb0f8643234764042fa432e6111aca126774802b2618a3a5"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede0458c51bef23620aa6bd01a0b4f608be7bcb61d98e91b8530208ae545f3c2"
+checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -787,13 +787,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f4df183248b57f3e0b99054b1b6786769d3fdff6d01a702234068140c8ba76"
+checksum = "f7fbf71892d4df9cae8d35dc96f15d522384bb93806205465e2c8c012b7f0a34"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
+checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a57d1e72b1f9b11e5e71ebdab0569cb02277a462bbea6793fcaebfcd794ae9"
+checksum = "a19d1985804e9a46d3b1b4f0654a68210b44007ffdaddd0e0a35d2b8db6cc1f0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b27f20b5298b76a5a3b7cdbe6bdb184ab1ebd6e120e00dad748867673f5c90"
+checksum = "34ce972f2ade53477e8e9336773a417f731fc7c02f41b9cd3b8a2a273e06363e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c7acc40ffbfd37d4113eb619863099f3235d78d044006a1eecb94d8b0b2f1a"
+checksum = "943c0105e0294b34cd06417129fadc591aed464d06f0614a7e998e585d27fbb1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
+checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a09a865ae9e1f05478429ef0d935b16467f35c6e0b02cb10f23f66a3b33fc3"
+checksum = "efe910cd3f56f7e4b26b8b7330b11c11c81286eaa8aa9fa6157e767a95e0f310"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
+checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
+checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b27802653330740c88c28394cdaf1d55190b15b48ef9b99a946f37c9cdb19fa"
+checksum = "cfad7aa9206fcb831ae401b6a1c893a402b8eed74f9c8ffbb7a7323afb0d9a4c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b71dc951db66795cfb52eef835f64cf15163bc93b656e061b457ce5ebff370"
+checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
+checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3712,7 +3712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8208,10 +8208,10 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8235,10 +8235,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8267,11 +8267,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8300,11 +8300,11 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8383,7 +8383,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8393,9 +8393,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8418,7 +8418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8446,7 +8446,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8475,10 +8475,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8488,10 +8488,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8514,7 +8514,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8542,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8598,9 +8598,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8613,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8662,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8686,10 +8686,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8721,10 +8721,10 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8778,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8829,10 +8829,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8854,11 +8854,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8940,10 +8940,10 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8971,7 +8971,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8993,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9032,12 +9032,12 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -9118,10 +9118,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9134,9 +9134,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9150,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9163,10 +9163,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9193,10 +9193,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9217,10 +9217,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9241,10 +9241,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9292,10 +9292,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9311,10 +9311,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9349,9 +9349,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bytes",
  "futures",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9438,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "futures",
  "metrics",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9482,10 +9482,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9564,10 +9564,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9587,7 +9587,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9657,10 +9657,10 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9725,10 +9725,10 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9780,9 +9780,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9842,10 +9842,10 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bytes",
  "eyre",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9931,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9943,10 +9943,10 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9981,7 +9981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10010,10 +10010,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10056,10 +10056,10 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10116,11 +10116,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10136,7 +10136,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10193,9 +10193,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10209,7 +10209,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10286,9 +10286,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10317,12 +10317,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10330,7 +10330,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10363,10 +10363,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10425,9 +10425,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10456,10 +10456,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10508,9 +10508,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10536,7 +10536,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10550,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10570,7 +10570,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10585,10 +10585,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10609,9 +10609,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10648,10 +10648,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10674,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -10711,10 +10711,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10756,10 +10756,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10782,13 +10782,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -10809,7 +10809,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10829,7 +10829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10858,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b1ac264#b1ac2641079c89fa2010d732575cf76fb632836a"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12368,12 +12368,12 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12430,7 +12430,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.3"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12675,14 +12675,14 @@ name = "tempo-node"
 version = "1.6.0"
 dependencies = [
  "alloy",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -12776,7 +12776,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.6.0"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -12816,6 +12816,7 @@ dependencies = [
  "tempo-evm",
  "tempo-precompiles-macros",
  "tempo-primitives",
+ "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -12835,12 +12836,12 @@ name = "tempo-primitives"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12873,7 +12874,7 @@ name = "tempo-revm"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12941,7 +12942,7 @@ name = "tempo-transaction-pool"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.32.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f107d0e588e5d25fcf2db216390445d5804b875a22a419407ad0389b925bb4d"
+checksum = "bd3e12b99b0c8f7298ffd3604c58310cba310203c5f6cd5e024f3b2bd9c3b09c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8171,7 +8171,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8741,7 +8741,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8995,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9058,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "clap",
  "eyre",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9156,7 +9156,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9224,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "serde",
  "serde_json",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "bytes",
  "futures",
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "futures",
  "metrics",
@@ -9422,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "bytes",
  "eyre",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9906,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9930,7 +9930,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10064,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10079,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10280,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10419,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10499,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10548,7 +10548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10637,7 +10637,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "clap",
  "eyre",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "clap",
  "eyre",
@@ -10674,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10718,7 +10718,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10820,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
+source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10850,9 +10850,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11353f234577a63048066df974d8a56e8c090d4de8b5f7d5f2a0d0c3a1ffaa2d"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10881,9 +10881,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "16.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e3d41127977e351ed795689147e6e59b0fa88e387840f921e46c440bb2fb44"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10898,9 +10898,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd61f0f2f646ae74a75e12e7f1d57554868e2dc5c83fc9a761cb95735cb58309"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10914,9 +10914,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "13.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f97178ab32358be770d09649d6fa86303923cab7afb95577353e7305a04193"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10928,9 +10928,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e48ddde8f5ef2adaf1e920ccbf57fa6ef2c63c11e3e37d7d9137657873eecc"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -10942,9 +10942,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "18.0.0"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18b03319aee860ecc4631c9180abb0828480f5a4c39507fc735a417bd906984"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10961,9 +10961,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33e8327376dff859eb18dea3623aa55ef5d580fe38fa0fd4bb92bd95ace60ad"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
@@ -10979,9 +10979,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.38.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41c7dc3d85c6186e57ec1438a426e7ddfac579d8255930cf8ed324a6c317e79"
+checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10999,9 +10999,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5f438f47d40d9830c0498fa3ca16a447b3148ab7b78742cbb1b27a51a50963"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11012,9 +11012,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c07bfcc9361f7b23970a68cbd17bfe255e70182cfb1a8896d06832217fc5439"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11049,9 +11049,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e480426a7d76b458789e4a1be3ffbce9df798f0145f0520c1cdf967755cfcbf"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8171,7 +8171,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8741,7 +8741,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8995,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9058,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "clap",
  "eyre",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9156,7 +9156,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9224,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "serde",
  "serde_json",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "bytes",
  "futures",
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "bindgen",
  "cc",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "futures",
  "metrics",
@@ -9422,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "bytes",
  "eyre",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9906,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9930,7 +9930,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10064,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10079,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10280,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10419,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10499,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10548,7 +10548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10637,7 +10637,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "clap",
  "eyre",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "clap",
  "eyre",
@@ -10674,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10718,7 +10718,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10820,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ac3646#0ac36468c6e68092f7fd2ca6551cbdd11874fd4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8171,7 +8171,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8230,7 +8230,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8250,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8346,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8505,7 +8505,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8741,7 +8741,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8995,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9058,7 +9058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "clap",
  "eyre",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9126,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9156,7 +9156,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9224,7 +9224,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9312,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9326,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "serde",
  "serde_json",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "bytes",
  "futures",
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "bindgen",
  "cc",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "futures",
  "metrics",
@@ -9422,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "bytes",
  "eyre",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9906,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9930,7 +9930,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10019,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10064,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10079,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10280,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10374,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10419,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10499,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10548,7 +10548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10637,7 +10637,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "clap",
  "eyre",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "clap",
  "eyre",
@@ -10674,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10718,7 +10718,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10820,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=199b746#199b7460a91e31055a7e6eb73035e5fd7f50ee4b"
+source = "git+https://github.com/paradigmxyz/reth?rev=c2e649f#c2e649fc902374a39bc076cda87726f78adcf145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,14 +176,14 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "37.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.0", default-features = false }
 alloy-consensus = { version = "2.0.0", default-features = false }
 alloy-contract = { version = "2.0.0", default-features = false }
 alloy-eips = { version = "2.0.0", default-features = false }
-alloy-evm = { version = "0.32.0", default-features = false }
-revm-inspectors = "0.38.0"
+alloy-evm = { version = "0.33.0", default-features = false }
+revm-inspectors = "0.39.0"
 alloy-genesis = { version = "2.0.0", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.5.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,70 +120,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "199b746" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "199b746", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "37.0.0", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.0", default-features = false }
 alloy-consensus = { version = "2.0.0", default-features = false }
 alloy-contract = { version = "2.0.0", default-features = false }
 alloy-eips = { version = "2.0.0", default-features = false }
-alloy-evm = { version = "0.33.2", default-features = false }
-revm-inspectors = "0.39.0"
+alloy-evm = { version = "0.32.0", default-features = false }
+revm-inspectors = "0.38.0"
 alloy-genesis = { version = "2.0.0", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.5.7", default-features = false }
@@ -358,3 +358,15 @@ vergen-git2 = "9.1.0"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 # [patch.crates-io]
+# # Commonware at HEAD after PR #3594 was merged
+# commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }
+# commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "f4e49d2d8ce81b1ff594adb436e7f7560b23703c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,34 +178,34 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", feat
 ] }
 revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
-alloy = { version = "2.0.0", default-features = false }
-alloy-consensus = { version = "2.0.0", default-features = false }
-alloy-contract = { version = "2.0.0", default-features = false }
-alloy-eips = { version = "2.0.0", default-features = false }
+alloy = { version = "2.0.1", default-features = false }
+alloy-consensus = { version = "2.0.1", default-features = false }
+alloy-contract = { version = "2.0.1", default-features = false }
+alloy-eips = { version = "2.0.1", default-features = false }
 alloy-evm = { version = "0.33.0", default-features = false }
 revm-inspectors = "0.39.0"
-alloy-genesis = { version = "2.0.0", default-features = false }
+alloy-genesis = { version = "2.0.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.5.7", default-features = false }
-alloy-network = { version = "2.0.0", default-features = false }
+alloy-network = { version = "2.0.1", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "2.0.0", default-features = false }
+alloy-provider = { version = "2.0.1", default-features = false }
 alloy-rlp = { version = "0.3.15", default-features = false }
-alloy-rpc-types-admin = "2.0.0"
-alloy-rpc-types-engine = "2.0.0"
-alloy-rpc-types-eth = { version = "2.0.0" }
-alloy-serde = { version = "2.0.0", default-features = false }
-alloy-signer = "2.0.0"
-alloy-signer-aws = "2.0.0"
-alloy-signer-gcp = "2.0.0"
-alloy-signer-ledger = "2.0.0"
-alloy-signer-local = "2.0.0"
-alloy-signer-trezor = "2.0.0"
+alloy-rpc-types-admin = "2.0.1"
+alloy-rpc-types-engine = "2.0.1"
+alloy-rpc-types-eth = { version = "2.0.1" }
+alloy-serde = { version = "2.0.1", default-features = false }
+alloy-signer = "2.0.1"
+alloy-signer-aws = "2.0.1"
+alloy-signer-gcp = "2.0.1"
+alloy-signer-ledger = "2.0.1"
+alloy-signer-local = "2.0.1"
+alloy-signer-trezor = "2.0.1"
 
 coins-bip32 = "0.12"
 zeroize = "1"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "2.0.0"
+alloy-transport = "2.0.1"
 
 commonware-broadcast = "2026.4.0"
 commonware-codec = "2026.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b1ac264", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e92af36", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c2e649f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0ac3646", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -186,9 +186,7 @@ impl Consensus<Block> for TempoConsensus {
         // Validate that the sequence of end-of-block system txs is correct
         for (tx, expected_to) in end_of_block_system_txs.into_iter().zip(SYSTEM_TX_ADDRESSES) {
             if tx.to().unwrap_or_default() != expected_to {
-                return Err(ConsensusError::msg(
-                    "Invalid end-of-block system tx order",
-                ));
+                return Err(ConsensusError::msg("Invalid end-of-block system tx order"));
             }
         }
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -63,8 +63,8 @@ impl TempoConsensus {
 
         // Validate the timestamp milliseconds part
         if header.timestamp_millis_part >= 1000 {
-            return Err(ConsensusError::Other(
-                "Timestamp milliseconds part must be less than 1000".to_string(),
+            return Err(ConsensusError::msg(
+                "Timestamp milliseconds part must be less than 1000",
             ));
         }
 
@@ -76,8 +76,8 @@ impl TempoConsensus {
         }
 
         if header.shared_gas_limit != header.gas_limit() / TEMPO_SHARED_GAS_DIVISOR {
-            return Err(ConsensusError::Other(
-                "Shared gas limit does not match header gas limit".to_string(),
+            return Err(ConsensusError::msg(
+                "Shared gas limit does not match header gas limit",
             ));
         }
 
@@ -89,7 +89,7 @@ impl TempoConsensus {
         );
 
         if header.general_gas_limit != expected_general_gas_limit {
-            return Err(ConsensusError::Other(format!(
+            return Err(ConsensusError::msg(format!(
                 "General gas limit {} does not match expected {}",
                 header.general_gas_limit, expected_general_gas_limit
             )));
@@ -160,7 +160,7 @@ impl Consensus<Block> for TempoConsensus {
         if let Some(tx) = transactions.iter().find(|&tx| {
             tx.is_system_tx() && !tx.is_valid_system_tx(self.inner.chain_spec().chain().id())
         }) {
-            return Err(ConsensusError::Other(format!(
+            return Err(ConsensusError::msg(format!(
                 "Invalid system transaction: {}",
                 tx.tx_hash()
             )));
@@ -178,16 +178,16 @@ impl Consensus<Block> for TempoConsensus {
             .unwrap_or_default();
 
         if end_of_block_system_txs.len() != SYSTEM_TX_COUNT {
-            return Err(ConsensusError::Other(
-                "Block must contain end-of-block system txs".to_string(),
+            return Err(ConsensusError::msg(
+                "Block must contain end-of-block system txs",
             ));
         }
 
         // Validate that the sequence of end-of-block system txs is correct
         for (tx, expected_to) in end_of_block_system_txs.into_iter().zip(SYSTEM_TX_ADDRESSES) {
             if tx.to().unwrap_or_default() != expected_to {
-                return Err(ConsensusError::Other(
-                    "Invalid end-of-block system tx order".to_string(),
+                return Err(ConsensusError::msg(
+                    "Invalid end-of-block system tx order",
                 ));
             }
         }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -183,6 +183,10 @@ where
         self.cfg.chain_id
     }
 
+    fn cfg_env(&self) -> &alloy_evm::revm::context::CfgEnv<Self::Spec> {
+        &self.cfg
+    }
+
     fn transact_raw(
         &mut self,
         tx: Self::Tx,

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -183,10 +183,6 @@ where
         self.cfg.chain_id
     }
 
-    fn cfg_env(&self) -> &alloy_evm::revm::context::CfgEnv<Self::Spec> {
-        &self.cfg
-    }
-
     fn transact_raw(
         &mut self,
         tx: Self::Tx,

--- a/deny.toml
+++ b/deny.toml
@@ -65,7 +65,12 @@ allow = [
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [{ allow = ["MPL-2.0"], name = "option-ext" }]
+exceptions = [
+  { allow = ["MPL-2.0"], name = "option-ext" },
+  { allow = ["MPL-2.0"], name = "bitmaps" },
+  { allow = ["MPL-2.0"], name = "imbl" },
+  { allow = ["MPL-2.0"], name = "imbl-sized-chunks" },
+]
 
 [[licenses.clarify]]
 name = "rustls-webpki"


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`98ebc34...122c5b3`](https://github.com/paradigmxyz/reth/compare/98ebc34...122c5b3)

🔗 Amp thread: https://ampcode.com/threads/T-019db5d2-e59c-7008-b90d-de031cdaf2d6
**Engine**
- Suppress persistence during payload building ([#23618](https://github.com/paradigmxyz/reth/pull/23618))
- Revert [#23541](https://github.com/paradigmxyz/reth/pull/23541) and [#23578](https://github.com/paradigmxyz/reth/pull/23578) ([#23646](https://github.com/paradigmxyz/reth/pull/23646))
- Align Amsterdam endpoint validation ([#23625](https://github.com/paradigmxyz/reth/pull/23625))
- Let consensus impls control which errors are transient ([#23668](https://github.com/paradigmxyz/reth/pull/23668))

**BAL (Block Access List)**
- Scaffold BAL store abstraction ([#23596](https://github.com/paradigmxyz/reth/pull/23596)), enable BAL building in ethereum payload ([#23597](https://github.com/paradigmxyz/reth/pull/23597)), add parallelization and batch IO flags ([#23663](https://github.com/paradigmxyz/reth/pull/23663))

**Perf**
- Relax re-execute executor reset thresholds ([#23617](https://github.com/paradigmxyz/reth/pull/23617)); disable read tx timeout ([#23680](https://github.com/paradigmxyz/reth/pull/23680))
- Replace `BTreeMap` with `imbl::OrdMap` in `BestTransactions` ([#23621](https://github.com/paradigmxyz/reth/pull/23621))

**P2P / Net**
- Optionally fetch BAL with full blocks ([#23629](https://github.com/paradigmxyz/reth/pull/23629))
- Add snap/2 wire helpers and messages ([#23611](https://github.com/paradigmxyz/reth/pull/23611))

**DB / CLI**
- Add `reth db migrate-v2` for v1→v2 storage migration ([#23422](https://github.com/paradigmxyz/reth/pull/23422))
- Add gas limit and slot number to `BlockOrPayload` ([#23624](https://github.com/paradigmxyz/reth/pull/23624), [#23626](https://github.com/paradigmxyz/reth/pull/23626))

**Refactor**
- Make `WorkerPool` lazy by default ([#23627](https://github.com/paradigmxyz/reth/pull/23627))
- Encapsulate state fetching in db provider ([#23656](https://github.com/paradigmxyz/reth/pull/23656))
- Remove `TrieNodeProvider` ([#23658](https://github.com/paradigmxyz/reth/pull/23658))
- Unify opaque consensus error helpers ([#23669](https://github.com/paradigmxyz/reth/pull/23669))

**Bench**
- Add CLI flag to fetch balances by default; require local benchmark data ([#23655](https://github.com/paradigmxyz/reth/pull/23655), [#23679](https://github.com/paradigmxyz/reth/pull/23679))

**Testing**
- Remove unsafe `env::set_var(RUST_LOG)` from tests ([#23672](https://github.com/paradigmxyz/reth/pull/23672))

**Deps**
- Bump alloy crates to 2.0.1 ([#23677](https://github.com/paradigmxyz/reth/pull/23677)), bump rustls-webpki ([#23681](https://github.com/paradigmxyz/reth/pull/23681)), weekly cargo update ([#23628](https://github.com/paradigmxyz/reth/pull/23628))
- Fix nightly clippy warnings ([#23630](https://github.com/paradigmxyz/reth/pull/23630))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019db5d3-160e-77d2-b3be-02317a2384c9
- **Reth dependency bump**: All `reth-*` git dependencies updated from rev `98ebc34` to `122c5b3`
- **Alloy version bump**: `alloy-*` crates updated from `2.0.0` to `2.0.1`; `alloy-evm` changed from `0.33.2` to `0.33.0`
- **`ConsensusError::Other` → `ConsensusError::msg`**: All `ConsensusError::Other(...)` calls replaced with `ConsensusError::msg(...)`, which accepts `&str`/`impl Display` directly — removing unnecessary `.to_string()` conversions on static string literals
- **`deny.toml` license exceptions**: Added MPL-2.0 exceptions for `bitmaps`, `imbl`, and `imbl-sized-chunks` (new transitive dependencies)
- **Commented-out commonware patch block**: Added commented-out `[patch.crates-io]` entries for pinning all `commonware-*` crates to a specific git rev (for local development/testing)

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/24786948996)
