### PR TITLE
docs(tip-1047): revert code creation and set code at addresses with TIP-20 prefix

### DIFF
--- a/tips/tip-1047.md
+++ b/tips/tip-1047.md
@@ -1,0 +1,56 @@
+---
+id: TIP-1047
+title: Revert code creation and set code at addresses with TIP-20 prefix
+description: Reject contract creation and EIP-7702 delegations that produce addresses in the TIP-20 reserved prefix range
+authors: Howy (@howydev)
+status: Draft
+related: TIP-20
+protocolVersion: T5
+---
+
+# TIP-1047: Revert code creation and set code at addresses with TIP-20 prefix
+
+## Abstract
+
+Reject any CREATE, CREATE2, or EIP-7702 authorization that would produce or delegate to an address starting with the TIP-20 token prefix (`0x20C000000000000000000000`). Without this guard, anyone can could place arbitrary bytecode at an address that the rest of the system treats as a TIP-20 token.
+
+## Motivation
+
+Multiple system components use `is_tip20_prefix` to decide whether an address is a TIP-20 token: precompile routing, fee-token validation, stablecoin DEX, and transaction classification. Code or a delegation at a prefix-matching address would pass these checks despite not being a real token.
+
+CREATE and CREATE2 addresses are downstream of keccak; EIP-7702 authority addresses require secp256k1 point multiplication followed by keccak. Matching a 12-byte prefix requires ~2^96 work in all cases. This guard provides defense-in-depth by making such collisions fail-closed.
+
+---
+
+# Specification
+
+## CREATE and CREATE2
+
+Before setting up a create frame, compute the would-be contract address:
+
+- **CREATE**: `keccak256(rlp(caller, nonce))[12..]`
+- **CREATE2**: `keccak256(0xff ++ caller ++ salt ++ keccak256(init_code))[12..]`
+
+If `is_tip20_prefix(address)` is true, revert the opcode. The caller's nonce is not bumped, no value is transferred, and no init-code is executed. Base opcode gas is consumed; init-code gas is not.
+
+## EIP-7702 Authorizations
+
+When processing EIP-7702 authorization lists, if `is_tip20_prefix(authority)` is true for a recovered authority address, skip the entry. The delegation is not applied.
+
+---
+
+# Invariants
+
+1. **No new code at TIP-20 addresses**: No CREATE/CREATE2 produces a contract where `is_tip20_prefix` returns true. Applies to all depths (top-level and nested creates).
+
+2. **No delegations to TIP-20 addresses**: No EIP-7702 authorization sets a delegation for an address where `is_tip20_prefix` returns true.
+
+3. **Nonce preservation**: A rejected CREATE/CREATE2 does not bump the caller's nonce.
+
+### Test coverage
+
+- CREATE2 with a salt producing a TIP-20-prefixed address reverts without executing init-code.
+- CREATE where the computed address has a TIP-20 prefix reverts with nonce unchanged.
+- EIP-7702 authorization with a TIP-20-prefixed authority is skipped.
+- Normal CREATE/CREATE2 producing non-TIP-20 addresses is unaffected.
+

--- a/tips/tip-1047.md
+++ b/tips/tip-1047.md
@@ -12,7 +12,7 @@ protocolVersion: T5
 
 ## Abstract
 
-Reject any CREATE, CREATE2, or EIP-7702 authorization that would produce or delegate to an address starting with the TIP-20 token prefix (`0x20C000000000000000000000`). Without this guard, anyone can could place arbitrary bytecode at an address that the rest of the system treats as a TIP-20 token.
+Reject any CREATE, CREATE2, or EIP-7702 authorization that would produce or delegate to an address starting with the TIP-20 token prefix (`0x20C000000000000000000000`). Without this guard, anyone can place arbitrary bytecode at an address that the rest of the system treats as a TIP-20 token.
 
 ## Motivation
 


### PR DESCRIPTION
Closes CHAIN-418

Adds TIP-1047: a guard that rejects CREATE, CREATE2, and EIP-7702 operations that would produce or delegate to an address in the TIP-20 reserved prefix range (`0x20C000000000000000000000`).