### PR TITLE
docs(xtask): update README with actual subcommands

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -2,6 +2,11 @@
 
 A polyfill to perform various operations on the codebase.
 
-Subcommands currently supported:
+Subcommands (see `cargo x --help`):
 
-+ `generate-config`: generates a set of validators to run a local network.
+- `generate-genesis`: write genesis JSON (and optional validator artifacts) for local testing.
+- `generate-localnet`: generate a multi-validator local layout (genesis, keys, suggested `tempo` commands).
+- `generate-devnet`: generate devnet-style configs (Docker image tag + genesis URL).
+- `generate-add-peer`: add a peer to an existing network (addresses + signing material).
+- `generate-state-bloat`: emit a TIP-20 state-bloat binary for genesis loading.
+- `get-dkg-outcome`: dump DKG outcome from a block's `extra_data` via RPC.


### PR DESCRIPTION
## What's changed
Updated `xtask/README.md` to reflect the current implementation.

## Why
The README only listed the obsolete `generate-config` subcommand, which no longer exists in the codebase.

## Changes
Replaced the outdated subcommands section with the actual list from `src/main.rs`:
- `generate-genesis` — write genesis JSON (and optional validator artifacts) for local testing
- `generate-localnet` — generate a multi-validator local layout (genesis, keys, suggested `tempo` commands)
- `generate-devnet` — generate devnet-style configs (Docker image tag + genesis URL)
- `generate-add-peer` — add a peer to an existing network (addresses + signing material)
- `generate-state-bloat` — emit a TIP-20 state-bloat binary for genesis loading
- `get-dkg-outcome` — dump DKG outcome from a block's `extra_data` via RPC