### PR TITLE
ci(specs): use foundry tempo branch for precompile tests

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -155,10 +155,10 @@ jobs:
           persist-credentials: false
 
       - name: Checkout foundry
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: tempo
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
Points the `foundry-test` job at `foundry-rs/foundry@tempo` instead of `@master`.

This pairs with [foundry-rs/foundry#14341](https://github.com/foundry-rs/foundry/pull/14341) which consolidates tempo branch maintenance (daily master→tempo sync + dep bumps) into a single workflow.

Prompted by: rusowsky