### PR TITLE
docs(tip-1034): rename precompile to TIP20ChannelEscrow

### DIFF
--- a/tips/ref-impls/src/TIP20ChannelEscrow.sol
+++ b/tips/ref-impls/src/TIP20ChannelEscrow.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.20;
 
 import { ISignatureVerifier } from "./interfaces/ISignatureVerifier.sol";
 import { ITIP20 } from "./interfaces/ITIP20.sol";
-import { ITempoStreamChannel } from "./interfaces/ITempoStreamChannel.sol";
+import { ITIP20ChannelEscrow } from "./interfaces/ITIP20ChannelEscrow.sol";
 
-/// @title TempoStreamChannel
+/// @title TIP20ChannelEscrow
 /// @notice Reference contract for the TIP-1034 channel model.
-contract TempoStreamChannel is ITempoStreamChannel {
+contract TIP20ChannelEscrow is ITIP20ChannelEscrow {
 
-    address public constant MPP_CHANNEL_PRECOMPILE = 0x4d50500000000000000000000000000000000000;
+    address public constant TIP20_CHANNEL_ESCROW = 0x4d50500000000000000000000000000000000000;
     address public constant SIGNATURE_VERIFIER_PRECOMPILE =
         0x5165300000000000000000000000000000000000;
 
@@ -21,7 +21,7 @@ contract TempoStreamChannel is ITempoStreamChannel {
     bytes32 internal constant _EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
     );
-    bytes32 internal constant _NAME_HASH = keccak256("Tempo Stream Channel");
+    bytes32 internal constant _NAME_HASH = keccak256("TIP20 Channel Escrow");
     bytes32 internal constant _VERSION_HASH = keccak256("1");
 
     mapping(bytes32 => Channel) public channels;
@@ -250,7 +250,7 @@ contract TempoStreamChannel is ITempoStreamChannel {
     {
         return keccak256(
             abi.encode(
-                payer, payee, token, salt, authorizedSigner, MPP_CHANNEL_PRECOMPILE, block.chainid
+                payer, payee, token, salt, authorizedSigner, TIP20_CHANNEL_ESCROW, block.chainid
             )
         );
     }
@@ -309,7 +309,7 @@ contract TempoStreamChannel is ITempoStreamChannel {
                 _NAME_HASH,
                 _VERSION_HASH,
                 block.chainid,
-                MPP_CHANNEL_PRECOMPILE
+                TIP20_CHANNEL_ESCROW
             )
         );
     }

--- a/tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol
+++ b/tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
-/// @title ITempoStreamChannel
+/// @title ITIP20ChannelEscrow
 /// @notice Reference interface for the TIP-1034 channel model.
-interface ITempoStreamChannel {
+interface ITIP20ChannelEscrow {
 
     struct Channel {
         bool finalized;

--- a/tips/ref-impls/test/TIP20ChannelEscrow.t.sol
+++ b/tips/ref-impls/test/TIP20ChannelEscrow.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import { TIP20 } from "../src/TIP20.sol";
-import { TempoStreamChannel } from "../src/TempoStreamChannel.sol";
-import { ITempoStreamChannel } from "../src/interfaces/ITempoStreamChannel.sol";
+import { TIP20ChannelEscrow } from "../src/TIP20ChannelEscrow.sol";
+import { ITIP20ChannelEscrow } from "../src/interfaces/ITIP20ChannelEscrow.sol";
 import { BaseTest } from "./BaseTest.t.sol";
 
 contract MockSignatureVerifier {
@@ -60,9 +60,9 @@ contract MockSignatureVerifier {
 
 }
 
-contract TempoStreamChannelTest is BaseTest {
+contract TIP20ChannelEscrowTest is BaseTest {
 
-    TempoStreamChannel public channel;
+    TIP20ChannelEscrow public channel;
     TIP20 public token;
 
     address public payer;
@@ -75,7 +75,7 @@ contract TempoStreamChannelTest is BaseTest {
     function setUp() public override {
         super.setUp();
 
-        channel = new TempoStreamChannel();
+        channel = new TIP20ChannelEscrow();
         MockSignatureVerifier verifier = new MockSignatureVerifier();
         vm.etch(channel.SIGNATURE_VERIFIER_PRECOMPILE(), address(verifier).code);
         token = TIP20(
@@ -133,7 +133,7 @@ contract TempoStreamChannelTest is BaseTest {
         bytes32 channelId =
             channel.open(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
 
-        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
         assertFalse(ch.finalized);
         assertEq(ch.closeRequestedAt, 0);
         assertEq(ch.payer, payer);
@@ -147,25 +147,25 @@ contract TempoStreamChannelTest is BaseTest {
 
     function test_open_revert_zeroPayee() public {
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.InvalidPayee.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidPayee.selector);
         channel.open(address(0), address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
     }
 
     function test_open_revert_zeroToken() public {
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.InvalidToken.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidToken.selector);
         channel.open(payee, address(0), DEPOSIT, SALT, address(0), _defaultExpiry());
     }
 
     function test_open_revert_zeroDeposit() public {
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.ZeroDeposit.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.ZeroDeposit.selector);
         channel.open(payee, address(token), 0, SALT, address(0), _defaultExpiry());
     }
 
     function test_open_revert_invalidExpiry() public {
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.InvalidExpiry.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
         channel.open(payee, address(token), DEPOSIT, SALT, address(0), uint64(block.timestamp));
     }
 
@@ -173,7 +173,7 @@ contract TempoStreamChannelTest is BaseTest {
         _openChannel();
 
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.ChannelAlreadyExists.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelAlreadyExists.selector);
         channel.open(payee, address(token), DEPOSIT, SALT, address(0), _defaultExpiry());
     }
 
@@ -194,7 +194,7 @@ contract TempoStreamChannelTest is BaseTest {
 
         vm.warp(block.timestamp + 10);
         vm.prank(payee);
-        vm.expectRevert(ITempoStreamChannel.ChannelExpiredError.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.ChannelExpiredError.selector);
         channel.settle(channelId, 500_000, sig);
     }
 
@@ -204,7 +204,7 @@ contract TempoStreamChannelTest is BaseTest {
         bytes memory sig = _signVoucher(channelId, 500_000, wrongKey);
 
         vm.prank(payee);
-        vm.expectRevert(ITempoStreamChannel.InvalidSignature.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidSignature.selector);
         channel.settle(channelId, 500_000, sig);
     }
 
@@ -230,7 +230,7 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payer);
         channel.topUp(channelId, 250_000, nextExpiry);
 
-        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
         assertEq(ch.deposit, DEPOSIT + 250_000);
         assertEq(ch.expiresAt, nextExpiry);
     }
@@ -239,7 +239,7 @@ contract TempoStreamChannelTest is BaseTest {
         bytes32 channelId = _openChannel();
 
         vm.prank(payer);
-        vm.expectRevert(ITempoStreamChannel.InvalidExpiry.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.InvalidExpiry.selector);
         channel.topUp(channelId, 0, _defaultExpiry());
     }
 
@@ -265,7 +265,7 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payee);
         channel.close(channelId, 900_000, 600_000, sig);
 
-        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
         assertTrue(ch.finalized);
         assertEq(ch.settled, 600_000);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + 600_000);
@@ -298,7 +298,7 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payee);
         channel.close(channelId, DEPOSIT + 250_000, DEPOSIT, sig);
 
-        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        TIP20ChannelEscrow.Channel memory ch = channel.getChannel(channelId);
         assertTrue(ch.finalized);
         assertEq(ch.settled, DEPOSIT);
         assertEq(token.balanceOf(payee), payeeBalanceBefore + DEPOSIT);
@@ -312,7 +312,7 @@ contract TempoStreamChannelTest is BaseTest {
         channel.settle(channelId, 300_000, settleSig);
 
         vm.prank(payee);
-        vm.expectRevert(ITempoStreamChannel.CaptureAmountInvalid.selector);
+        vm.expectRevert(ITIP20ChannelEscrow.CaptureAmountInvalid.selector);
         channel.close(channelId, 300_000, 200_000, "");
     }
 
@@ -378,14 +378,14 @@ contract TempoStreamChannelTest is BaseTest {
         ids[0] = channelId1;
         ids[1] = channelId2;
 
-        TempoStreamChannel.Channel[] memory states = channel.getChannelsBatch(ids);
+        TIP20ChannelEscrow.Channel[] memory states = channel.getChannelsBatch(ids);
         assertEq(states.length, 2);
         assertEq(states[0].settled, 400_000);
         assertEq(states[1].settled, 0);
     }
 
     function test_computeChannelId_usesFixedPrecompileAddress() public {
-        TempoStreamChannel other = new TempoStreamChannel();
+        TIP20ChannelEscrow other = new TIP20ChannelEscrow();
 
         bytes32 id1 = channel.computeChannelId(payer, payee, address(token), SALT, address(0));
         bytes32 id2 = other.computeChannelId(payer, payee, address(token), SALT, address(0));

--- a/tips/tip-1034.md
+++ b/tips/tip-1034.md
@@ -1,24 +1,24 @@
 ---
 id: TIP-1034
-title: Enshrined MPP Channels Precompile
-description: Enshrines MPP payment channels as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
+title: TIP-20 Channel Escrow Precompile
+description: Enshrines TIP-20 channel escrow as a Tempo precompile with payment-lane admission and native escrow transfer semantics.
 authors: Tanishk Goyal
 status: Draft
 related: TIP-20, TIP-1000, TIP-1020, Tempo Session, Tempo Charge
 protocolVersion: TBD
 ---
 
-# TIP-1034: Enshrined MPP Channels Precompile
+# TIP-1034: TIP-20 Channel Escrow Precompile
 
 ## Abstract
 
-This TIP enshrines MPP payment channels in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
+This TIP enshrines TIP-20 channel escrow in Tempo as a native precompile. The implementation follows the existing reference channel model (`open`, `settle`, `topUp`, `requestClose`, `close`, `withdraw`) and keeps the same EIP-712 voucher flow, with expiry and explicit partial-capture updates defined in this spec.
 
 The precompile is introduced to reduce execution overhead, remove the separate `approve` UX via native escrow movement, and make channel operations first-class payment-lane traffic under congestion.
 
 ## Motivation
 
-MPP channels are currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
+TIP-20 channel escrow is currently specified as a Solidity contract reference implementation. Enshrining that behavior as a precompile is motivated by three protocol-level goals:
 
 1. **Efficiency**: Channel operations become native precompile execution instead of generic contract execution, reducing overhead and making gas behavior more predictable for high-frequency payment flows.
 2. **Payment-Lane Access**: Channel operations become payment-lane transactions, so they are not throttled by the non-payment `general_gas_limit` path during block contention.
@@ -35,17 +35,17 @@ This produces a simpler and more reliable path for session and auth/capture styl
 This TIP introduces a new system precompile at:
 
 ```solidity
-address constant MPP_CHANNEL_PRECOMPILE = 0x4D50500000000000000000000000000000000000;
+address constant TIP20_CHANNEL_ESCROW = 0x4D50500000000000000000000000000000000000;
 ```
 
-`MPP_CHANNEL_PRECOMPILE` MUST refer to this address throughout this specification.
+`TIP20_CHANNEL_ESCROW` MUST refer to this address throughout this specification.
 
 ## Implementation Details
 
 This TIP is normative. The current reference implementations are informative and live at:
 
-1. [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol)
-2. [`tips/ref-impls/src/TempoStreamChannel.sol`](ref-impls/src/TempoStreamChannel.sol)
+1. [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol)
+2. [`tips/ref-impls/src/TIP20ChannelEscrow.sol`](ref-impls/src/TIP20ChannelEscrow.sol)
 
 Implementations SHOULD keep those reference artifacts aligned with the normative interface and execution rules defined below.
 
@@ -79,7 +79,7 @@ channelId = keccak256(
         token,
         salt,
         authorizedSigner,
-        MPP_CHANNEL_PRECOMPILE,
+        TIP20_CHANNEL_ESCROW,
         block.chainid
     )
 );
@@ -87,7 +87,7 @@ channelId = keccak256(
 
 ### Interface
 
-The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITempoStreamChannel.sol`](ref-impls/src/interfaces/ITempoStreamChannel.sol).
+The canonical interface for this TIP is [`tips/ref-impls/src/interfaces/ITIP20ChannelEscrow.sol`](ref-impls/src/interfaces/ITIP20ChannelEscrow.sol).
 
 Implementations MUST expose an external interface that is semantically identical to that file, including the `Channel` state layout, events, errors, and function signatures.
 
@@ -143,13 +143,13 @@ Required behavior:
 
 ## Payment-Lane Integration (Mandatory)
 
-MPP channel operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.
+Channel escrow operations MUST be treated as payment-lane transactions in consensus classification, pool admission, and payload building.
 
 ### Classification Rules
 
-Implementations MUST define a strict classifier `is_mpp_channel_payment(to, input)` that returns true iff:
+Implementations MUST define a strict classifier `is_channel_escrow_payment(to, input)` that returns true iff:
 
-1. `to == MPP_CHANNEL_PRECOMPILE`.
+1. `to == TIP20_CHANNEL_ESCROW`.
 2. `input` selector is one of `{open, settle, topUp, close, requestClose, withdraw}`.
 3. Calldata length/encoding is valid for that selector.
 4. For `settle` and `close`, the trailing `signature` bytes use a valid TIP-1020 / Tempo transaction signature encoding.
@@ -163,16 +163,16 @@ For AA transactions, payment classification MUST satisfy all of:
 1. `calls.length > 0`.
 2. `tempo_authorization_list.length == 0`.
 3. `key_authorization` is absent.
-4. Every call satisfies either TIP-20 strict payment classification or `is_mpp_channel_payment`.
+4. Every call satisfies either TIP-20 strict payment classification or `is_channel_escrow_payment`.
 
 An AA transaction with an empty `calls` array MUST be classified as non-payment.
 
 ### Required Integration Points
 
-1. The consensus-level payment classifier (`is_payment`) MUST include MPP channel calls and MUST enforce the same authorization-side-effect exclusions above.
-2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_mpp_channel_payment` and MUST enforce the same authorization-side-effect exclusions above.
-3. The transaction pool payment flag MUST be computed from the strict classifier, so MPP channel calls are admitted in the payment lane path.
-4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat MPP channel calls as payment, so they are not rejected by the non-payment overflow path.
+1. The consensus-level payment classifier (`is_payment`) MUST include TIP-20 channel escrow calls and MUST enforce the same authorization-side-effect exclusions above.
+2. The strict builder/pool classifier (`is_payment_v2`) MUST include `is_channel_escrow_payment` and MUST enforce the same authorization-side-effect exclusions above.
+3. The transaction pool payment flag MUST be computed from the strict classifier, so channel escrow calls are admitted in the payment lane path.
+4. The payload builder non-payment gate (`general_gas_limit` enforcement) MUST treat channel escrow calls as payment, so they are not rejected by the non-payment overflow path.
 
 ### What This Means Operationally
 
@@ -189,7 +189,7 @@ With this integration, channel lifecycle calls consume payment-lane capacity rat
 5. Only payee can `settle` and `close`.
 6. Once finalized, all state-changing methods MUST revert for that channel.
 7. Fund conservation MUST hold at all terminal states.
-8. MPP channel calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
+8. Channel escrow calls MUST be classified as payment transactions in both consensus and strict builder/pool classifiers, AA payment classification MUST require `calls.length > 0`, and transactions with authorization side effects MUST be classified as non-payment.
 9. `open` and `topUp` MUST not require a prior user `approve` transaction.
 10. No capture-increasing operation may succeed past `expiresAt`.
 11. `topUp` MUST NOT reduce or preserve the channel expiry when `newExpiresAt` is provided.


### PR DESCRIPTION
Renames `TempoStreamChannel` / `MPP_CHANNEL_PRECOMPILE` to `TIP20ChannelEscrow` / `TIP20_CHANNEL_ESCROW` across the TIP spec, reference implementation, interface, and tests.

Prompted by: Tanishk