### PR TITLE
fix: add --private-key alias for --wallet-key

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -310,7 +310,7 @@ impl ValidatorSignatureArgs {
 #[group(required = true, multiple = false)]
 pub(crate) struct WalletArgs {
     /// Path to the file holding the validator's Ethereum private key.
-    #[arg(long, value_name = "FILE", help_heading = "Wallet options - raw")]
+    #[arg(long, alias = "private-key", value_name = "FILE", help_heading = "Wallet options - raw")]
     wallet_key: Option<PathBuf>,
 
     /// Use a Ledger hardware wallet.


### PR DESCRIPTION
PR #3611 renamed `--private-key` to `--wallet-key`. This adds a clap alias so existing scripts passing `--private-key` keep working.

Prompted by: Janis