### PR TITLE
fix: only set v* tags as latest release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -58,7 +58,20 @@ jobs:
           PY
 
       - uses: tempoxyz/changelogs@master
+        id: changelogs
         with:
           conventional-commit: true
           post-version-command: cargo update -w
           github-token: ${{ secrets.TEMPO_GITHUB_PAT }}
+
+      - name: Demote non-v* releases from latest
+        if: steps.changelogs.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TEMPO_GITHUB_PAT }}
+        run: |
+          for tag in $(git tag --points-at HEAD); do
+            if [[ "$tag" != v* ]]; then
+              echo "Setting $tag as non-latest"
+              gh release edit "$tag" --latest=false || true
+            fi
+          done


### PR DESCRIPTION
After the changelogs action publishes crate releases, a new step
demotes any non-`v*` tags (e.g. `tempo-alloy@0.1.0`) with `--latest=false`
so the most recent `v*` release stays marked as latest on GitHub.

Prompted by: rusowsky