### PR TITLE
tip: temporary storage precompile spec

### DIFF
--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -4,7 +4,7 @@ pub use IAccountKeychain::{
     IAccountKeychainErrors as AccountKeychainError, IAccountKeychainEvents as AccountKeychainEvent,
     authorizeKey_0Call as legacyAuthorizeKeyCall, authorizeKey_1Call as authorizeKeyCall,
     getAllowedCallsReturn, getRemainingLimitWithPeriodCall,
-    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn, pruneExpiredKeyCall,
+    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn, pruneExpiryCall,
 };
 
 crate::sol! {
@@ -139,7 +139,7 @@ crate::sol! {
         function removeAllowedCalls(address keyId, address target) external;
 
         /// Permissionlessly prune an expired temporary key and its temporary restriction rows.
-        function pruneExpiredKey(address account, address keyId) external returns (bool pruned);
+        function pruneExpiry(address account, address keyId) external returns (bool pruned);
 
         /// Get key information
         /// @param account The account address

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -4,7 +4,7 @@ pub use IAccountKeychain::{
     IAccountKeychainErrors as AccountKeychainError, IAccountKeychainEvents as AccountKeychainEvent,
     authorizeKey_0Call as legacyAuthorizeKeyCall, authorizeKey_1Call as authorizeKeyCall,
     getAllowedCallsReturn, getRemainingLimitWithPeriodCall,
-    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn,
+    getRemainingLimitWithPeriodReturn as getRemainingLimitReturn, pruneExpiredKeyCall,
 };
 
 crate::sol! {
@@ -137,6 +137,9 @@ crate::sol! {
 
         /// Remove any configured call scope for a key+target pair.
         function removeAllowedCalls(address keyId, address target) external;
+
+        /// Permissionlessly prune an expired temporary key and its temporary restriction rows.
+        function pruneExpiredKey(address account, address keyId) external returns (bool pruned);
 
         /// Get key information
         /// @param account The account address

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -19,7 +19,7 @@ const T3_ADDED: &[[u8; 4]] = &[
     authorizeKeyCall::SELECTOR,
     IAccountKeychain::setAllowedCallsCall::SELECTOR,
     IAccountKeychain::removeAllowedCallsCall::SELECTOR,
-    IAccountKeychain::pruneExpiredKeyCall::SELECTOR,
+    IAccountKeychain::pruneExpiryCall::SELECTOR,
     IAccountKeychain::getRemainingLimitWithPeriodCall::SELECTOR,
     IAccountKeychain::getAllowedCallsCall::SELECTOR,
 ];
@@ -90,10 +90,8 @@ impl Precompile for AccountKeychain {
                         self.remove_allowed_calls(sender, c)
                     })
                 }
-                IAccountKeychainCalls::pruneExpiredKey(call) => {
-                    mutate(call, msg_sender, |sender, c| {
-                        self.prune_expired_key(sender, c)
-                    })
+                IAccountKeychainCalls::pruneExpiry(call) => {
+                    mutate(call, msg_sender, |sender, c| self.prune_expiry(sender, c))
                 }
                 IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),
                 IAccountKeychainCalls::getRemainingLimit(call) => {

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -1,7 +1,9 @@
 //! ABI dispatch for the [`AccountKeychain`] precompile.
 
 use super::{AccountKeychain, KeyRestrictions, TokenLimit, authorizeKeyCall};
-use crate::{Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate_void, view};
+use crate::{
+    Precompile, SelectorSchedule, charge_input_cost, dispatch_call, mutate, mutate_void, view,
+};
 use alloy::{
     primitives::Address,
     sol_types::{SolCall, SolInterface},
@@ -17,6 +19,7 @@ const T3_ADDED: &[[u8; 4]] = &[
     authorizeKeyCall::SELECTOR,
     IAccountKeychain::setAllowedCallsCall::SELECTOR,
     IAccountKeychain::removeAllowedCallsCall::SELECTOR,
+    IAccountKeychain::pruneExpiredKeyCall::SELECTOR,
     IAccountKeychain::getRemainingLimitWithPeriodCall::SELECTOR,
     IAccountKeychain::getAllowedCallsCall::SELECTOR,
 ];
@@ -85,6 +88,11 @@ impl Precompile for AccountKeychain {
                 IAccountKeychainCalls::removeAllowedCalls(call) => {
                     mutate_void(call, msg_sender, |sender, c| {
                         self.remove_allowed_calls(sender, c)
+                    })
+                }
+                IAccountKeychainCalls::pruneExpiredKey(call) => {
+                    mutate(call, msg_sender, |sender, c| {
+                        self.prune_expired_key(sender, c)
                     })
                 }
                 IAccountKeychainCalls::getKey(call) => view(call, |c| self.get_key(c)),

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -17,8 +17,8 @@ pub use tempo_contracts::precompiles::{
     IAccountKeychain::{
         CallScope, KeyInfo, KeyRestrictions, SelectorRule, SignatureType, TokenLimit,
         getAllowedCallsCall, getKeyCall, getRemainingLimitCall, getRemainingLimitWithPeriodCall,
-        getTransactionKeyCall, removeAllowedCallsCall, revokeKeyCall, setAllowedCallsCall,
-        updateSpendingLimitCall,
+        getTransactionKeyCall, pruneExpiredKeyCall, removeAllowedCallsCall, revokeKeyCall,
+        setAllowedCallsCall, updateSpendingLimitCall,
     },
     authorizeKeyCall, getAllowedCallsReturn, getRemainingLimitReturn,
 };
@@ -36,6 +36,7 @@ use tempo_precompiles_macros::{Storable, contract};
 const TIP20_TRANSFER_SELECTOR: [u8; 4] = ITIP20::transferCall::SELECTOR;
 const TIP20_APPROVE_SELECTOR: [u8; 4] = ITIP20::approveCall::SELECTOR;
 const TIP20_TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = ITIP20::transferWithMemoCall::SELECTOR;
+const MAX_TEMPORARY_TTL_SECS: u64 = 30 * 24 * 60 * 60;
 
 #[inline]
 pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
@@ -52,6 +53,7 @@ pub fn is_constrained_tip20_selector(selector: [u8; 4]) -> bool {
 /// - bytes 1-8: expiry (u64, little-endian)
 /// - byte 9: enforce_limits (bool)
 /// - byte 10: is_revoked (bool)
+/// - byte 11: is_temporary (bool)
 #[derive(Debug, Clone, Default, PartialEq, Eq, Storable)]
 pub struct AuthorizedKey {
     /// Signature type: 0 = secp256k1, 1 = P256, 2 = WebAuthn
@@ -63,6 +65,8 @@ pub struct AuthorizedKey {
     /// Whether this key has been revoked. Once revoked, a key cannot be re-authorized
     /// with the same key_id. This prevents replay attacks.
     pub is_revoked: bool,
+    /// Whether this key prepaid temporary cleanup and may be pruned after expiry.
+    pub is_temporary: bool,
 }
 
 /// Account Keychain contract for managing authorized keys (session keys, spending limits).
@@ -79,6 +83,9 @@ pub struct AccountKeychain {
 
     // key_scopes[(account, keyId)] -> call scoping configuration.
     key_scopes: Mapping<B256, KeyScope>,
+
+    // spending_limit_tokens[(account, keyId)] -> tokens with temporary spending-limit rows.
+    spending_limit_tokens: Mapping<B256, Set<Address>>,
 
     // WARNING(rusowsky): transient storage slots must always be placed at the very end until the `contract`
     // macro is refactored and has 2 independent layouts (persistent and transient).
@@ -201,6 +208,7 @@ impl AccountKeychain {
 
         self.ensure_admin_caller(msg_sender)?;
         let is_t3 = self.storage.spec().is_t3();
+        let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
 
         // Validate inputs
         if call.keyId == Address::ZERO {
@@ -208,11 +216,8 @@ impl AccountKeychain {
         }
 
         // T0+: Expiry must be in the future (also catches expiry == 0 which means "key doesn't exist")
-        if self.storage.spec().is_t0() {
-            let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
-            if config.expiry <= current_timestamp {
-                return Err(AccountKeychainError::expiry_in_past().into());
-            }
+        if self.storage.spec().is_t0() && config.expiry <= current_timestamp {
+            return Err(AccountKeychainError::expiry_in_past().into());
         }
 
         // Check if key already exists (key exists if expiry > 0)
@@ -263,11 +268,13 @@ impl AccountKeychain {
         };
 
         // Create and store the new key
+        let is_temporary = is_t3 && Self::is_temporary_expiry(config.expiry, current_timestamp);
         let new_key = AuthorizedKey {
             signature_type,
             expiry: config.expiry,
             enforce_limits: config.enforceLimits,
             is_revoked: false,
+            is_temporary,
         };
 
         self.keys[msg_sender][call.keyId].write(new_key)?;
@@ -283,6 +290,7 @@ impl AccountKeychain {
             call.keyId,
             limits,
             allowed_call_configs,
+            is_temporary,
         )?;
 
         // Emit event
@@ -313,6 +321,12 @@ impl AccountKeychain {
             return Err(AccountKeychainError::key_not_found().into());
         }
 
+        if key.is_temporary {
+            let account_key = Self::spending_limit_key(msg_sender, call.keyId);
+            self.clear_spending_limit_rows(account_key)?;
+            self.clear_key_scope(account_key)?;
+        }
+
         // Mark the key as revoked - this prevents replay attacks by ensuring
         // the same key_id can never be re-authorized for this account.
         // We keep is_revoked=true but clear other fields.
@@ -321,8 +335,6 @@ impl AccountKeychain {
             ..Default::default()
         };
         self.keys[msg_sender][call.keyId].write(revoked_key)?;
-
-        // Note: We don't clear spending limits here - they become inaccessible
 
         // Emit event
         self.emit_event(AccountKeychainEvent::KeyRevoked(
@@ -351,6 +363,7 @@ impl AccountKeychain {
 
         let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
         let mut key = self.load_active_key(msg_sender, call.keyId, current_timestamp)?;
+        let is_temporary = key.is_temporary;
 
         // If this key had unlimited spending (enforce_limits=false), enable limits now
         if !key.enforce_limits {
@@ -361,6 +374,10 @@ impl AccountKeychain {
         // Update the spending limit
         let limit_key = Self::spending_limit_key(msg_sender, call.keyId);
         if self.storage.spec().is_t3() {
+            if is_temporary {
+                self.spending_limit_tokens[limit_key].insert(call.token)?;
+            }
+
             // T3: newLimit updates both the configured cap and current remaining amount,
             // while preserving period + period_end.
             let mut limit_state = self.spending_limits[limit_key][call.token].read()?;
@@ -382,6 +399,39 @@ impl AccountKeychain {
                 newLimit: call.newLimit,
             },
         ))
+    }
+
+    /// Permissionlessly prune an expired temporary key and its temporary restriction rows.
+    ///
+    /// Returns `false` without changing state when the key is missing, revoked, permanent,
+    /// or not yet expired. Permanent finite-expiry keys are intentionally not pruned because they
+    /// did not prepay temporary cleanup and must keep the existing replay behavior.
+    pub fn prune_expired_key(
+        &mut self,
+        _msg_sender: Address,
+        call: pruneExpiredKeyCall,
+    ) -> Result<bool> {
+        if call.keyId.is_zero() {
+            return Ok(false);
+        }
+
+        let key = self.keys[call.account][call.keyId].read()?;
+        if key.expiry == 0 || key.is_revoked || !key.is_temporary {
+            return Ok(false);
+        }
+
+        let current_timestamp = self.storage.timestamp().saturating_to::<u64>();
+        if current_timestamp < key.expiry {
+            return Ok(false);
+        }
+
+        let account_key = Self::spending_limit_key(call.account, call.keyId);
+
+        self.keys[call.account][call.keyId].delete()?;
+        self.clear_spending_limit_rows(account_key)?;
+        self.clear_key_scope(account_key)?;
+
+        Ok(true)
     }
 
     /// Returns key info for the given account-key pair, or a blank entry if inexistent or revoked.
@@ -628,6 +678,7 @@ impl AccountKeychain {
         key_id: Address,
         limits: impl IntoIterator<Item = &'a TokenLimit>,
         allowed_calls: Option<&[CallScope]>,
+        is_temporary: bool,
     ) -> Result<()> {
         let limit_key = Self::spending_limit_key(account, key_id);
 
@@ -653,6 +704,10 @@ impl AccountKeychain {
                 self.spending_limits[limit_key][limit.token]
                     .remaining
                     .write(limit.amount)?;
+            }
+
+            if is_temporary {
+                self.spending_limit_tokens[limit_key].insert(limit.token)?;
             }
         }
 
@@ -800,6 +855,10 @@ impl AccountKeychain {
     /// Deletes every persisted target scope under an account key.
     fn clear_all_target_scopes(&mut self, account_key: B256) -> Result<()> {
         let targets = self.key_scopes[account_key].targets.read()?;
+        if targets.is_empty() {
+            return Ok(());
+        }
+
         for target in targets {
             self.clear_target_selectors(account_key, target)?;
         }
@@ -821,15 +880,47 @@ impl AccountKeychain {
         let selectors = self.key_scopes[account_key].target_scopes[target]
             .selectors
             .read()?;
+        if selectors.is_empty() {
+            return Ok(());
+        }
+
         for selector in selectors {
-            self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
-                .recipients
-                .delete()?;
+            let recipients = &mut self.key_scopes[account_key].target_scopes[target]
+                .selector_scopes[selector]
+                .recipients;
+            if !recipients.is_empty()? {
+                recipients.delete()?;
+            }
         }
 
         self.key_scopes[account_key].target_scopes[target]
             .selectors
             .delete()
+    }
+
+    /// Deletes all temporary spending-limit rows and the token index for an account key.
+    fn clear_spending_limit_rows(&mut self, account_key: B256) -> Result<()> {
+        let tokens: Vec<Address> = self.spending_limit_tokens[account_key].read()?.into();
+        if tokens.is_empty() {
+            return Ok(());
+        }
+
+        for token in &tokens {
+            self.spending_limits[account_key][*token].delete()?;
+        }
+
+        self.spending_limit_tokens[account_key].delete()
+    }
+
+    /// Deletes the key-level call scope flag and all nested target/selector/recipient rows.
+    fn clear_key_scope(&mut self, account_key: B256) -> Result<()> {
+        self.clear_all_target_scopes(account_key)?;
+
+        if self.key_scopes[account_key].is_scoped.read()? {
+            self.key_scopes[account_key].is_scoped.delete()?;
+        }
+
+        Ok(())
     }
 
     /// Creates or replaces one target scope, including all nested selector rules.
@@ -910,6 +1001,13 @@ impl AccountKeychain {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    fn is_temporary_expiry(expiry: u64, current_timestamp: u64) -> bool {
+        expiry != u64::MAX
+            && expiry > current_timestamp
+            && expiry <= current_timestamp.saturating_add(MAX_TEMPORARY_TTL_SECS)
     }
 
     /// Ensures admin operations are authorized for this caller.
@@ -3269,6 +3367,7 @@ mod tests {
                 expiry: u64::MAX,
                 enforce_limits: true,
                 is_revoked: false,
+                is_temporary: false,
             })?;
             keychain.spending_limits[limit_key][token].write(SpendingLimitState {
                 remaining: U256::from(90),
@@ -3523,6 +3622,346 @@ mod tests {
     }
 
     #[test]
+    fn test_t3_prune_expired_key_clears_bare_temporary_key_and_allows_reuse() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let expiry = 1_060u64;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let stored = keychain.keys[account][key_id].read()?;
+            assert!(stored.is_temporary);
+
+            let pruned = keychain.prune_expired_key(
+                Address::random(),
+                pruneExpiredKeyCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(!pruned, "unexpired temporary keys must not prune");
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+
+            let pruned = keychain.prune_expired_key(
+                Address::random(),
+                pruneExpiredKeyCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(pruned);
+            assert_eq!(
+                keychain.keys[account][key_id].read()?,
+                AuthorizedKey::default()
+            );
+
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::P256,
+                    config: KeyRestrictions {
+                        expiry: expiry + 60,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            let reused = keychain.keys[account][key_id].read()?;
+            assert_eq!(reused.signature_type, SignatureType::P256 as u8);
+            assert!(reused.is_temporary);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_prune_expired_key_clears_spending_limits_and_token_index() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token_a = Address::repeat_byte(0x11);
+        let token_b = Address::repeat_byte(0x22);
+        let token_c = Address::repeat_byte(0x33);
+        let expiry = 1_060u64;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: true,
+                        limits: vec![
+                            TokenLimit {
+                                token: token_a,
+                                amount: U256::from(100),
+                                period: 0,
+                            },
+                            TokenLimit {
+                                token: token_b,
+                                amount: U256::from(200),
+                                period: 30,
+                            },
+                        ],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )?;
+
+            keychain.update_spending_limit(
+                account,
+                updateSpendingLimitCall {
+                    keyId: key_id,
+                    token: token_c,
+                    newLimit: U256::from(300),
+                },
+            )?;
+
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+            let indexed_tokens: Vec<Address> =
+                keychain.spending_limit_tokens[account_key].read()?.into();
+            assert_eq!(indexed_tokens.len(), 3);
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+
+            assert!(keychain.prune_expired_key(
+                Address::random(),
+                pruneExpiredKeyCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?);
+
+            assert_eq!(
+                keychain.keys[account][key_id].read()?,
+                AuthorizedKey::default()
+            );
+            assert_eq!(
+                keychain.spending_limits[account_key][token_a].read()?,
+                SpendingLimitState::default()
+            );
+            assert_eq!(
+                keychain.spending_limits[account_key][token_b].read()?,
+                SpendingLimitState::default()
+            );
+            assert_eq!(
+                keychain.spending_limits[account_key][token_c].read()?,
+                SpendingLimitState::default()
+            );
+            assert!(
+                keychain.spending_limit_tokens[account_key]
+                    .read()?
+                    .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_prune_expired_key_clears_call_scopes() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let recipient = Address::repeat_byte(0x44);
+        let expiry = 1_060u64;
+        let target = DEFAULT_FEE_TOKEN;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )?;
+
+            let scopes = keychain.get_allowed_calls(getAllowedCallsCall {
+                account,
+                keyId: key_id,
+            })?;
+            assert!(scopes.isScoped);
+            assert_eq!(scopes.scopes.len(), 1);
+
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+
+            assert!(keychain.prune_expired_key(
+                Address::random(),
+                pruneExpiredKeyCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?);
+
+            assert!(!keychain.key_scopes[account_key].is_scoped.read()?);
+            assert!(keychain.key_scopes[account_key].targets.read()?.is_empty());
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target]
+                    .selectors
+                    .read()?
+                    .is_empty()
+            );
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target].selector_scopes
+                    [TIP20_TRANSFER_SELECTOR.into()]
+                .recipients
+                .read()?
+                .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t3_revoke_temporary_key_clears_temporary_restriction_rows() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+
+        let account = Address::random();
+        let key_id = Address::random();
+        let token = Address::repeat_byte(0x55);
+        let recipient = Address::repeat_byte(0x66);
+        let target = DEFAULT_FEE_TOKEN;
+
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry: 1_060,
+                        enforceLimits: true,
+                        limits: vec![TokenLimit {
+                            token,
+                            amount: U256::from(100),
+                            period: 30,
+                        }],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )?;
+
+            keychain.revoke_key(account, revokeKeyCall { keyId: key_id })?;
+
+            let account_key = AccountKeychain::spending_limit_key(account, key_id);
+            let revoked = keychain.keys[account][key_id].read()?;
+            assert!(revoked.is_revoked);
+            assert!(!revoked.is_temporary);
+            assert_eq!(
+                keychain.spending_limits[account_key][token].read()?,
+                SpendingLimitState::default()
+            );
+            assert!(
+                keychain.spending_limit_tokens[account_key]
+                    .read()?
+                    .is_empty()
+            );
+            assert!(!keychain.key_scopes[account_key].is_scoped.read()?);
+            assert!(keychain.key_scopes[account_key].targets.read()?.is_empty());
+            assert!(
+                keychain.key_scopes[account_key].target_scopes[target]
+                    .selectors
+                    .read()?
+                    .is_empty()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_t3_rejects_recipient_constrained_scope_for_undeployed_tip20() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         let account = Address::random();
@@ -3567,6 +4006,7 @@ mod tests {
                             recipients: vec![recipient],
                         }],
                     }]),
+                    false,
                 )
                 .expect_err("unexpected success for undeployed TIP-20 target");
 
@@ -3625,6 +4065,7 @@ mod tests {
                     period: 60,
                 }],
                 None,
+                false,
             )?;
 
             keychain.set_transaction_key(key_id)?;
@@ -3692,7 +4133,13 @@ mod tests {
             assert!(!scopes.isScoped);
             assert!(scopes.scopes.is_empty());
 
-            keychain.apply_key_authorization_restrictions(account, key_id, &[], Some(&[]))?;
+            keychain.apply_key_authorization_restrictions(
+                account,
+                key_id,
+                &[],
+                Some(&[]),
+                false,
+            )?;
 
             let deny_all = keychain.get_allowed_calls(getAllowedCallsCall {
                 account,
@@ -4246,6 +4693,7 @@ mod tests {
                         recipients: vec![allowed_recipient],
                     }],
                 }]),
+                false,
             )?;
 
             let make_calldata = |selector: [u8; 4], recipient: Address| {

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -17,7 +17,7 @@ pub use tempo_contracts::precompiles::{
     IAccountKeychain::{
         CallScope, KeyInfo, KeyRestrictions, SelectorRule, SignatureType, TokenLimit,
         getAllowedCallsCall, getKeyCall, getRemainingLimitCall, getRemainingLimitWithPeriodCall,
-        getTransactionKeyCall, pruneExpiredKeyCall, removeAllowedCallsCall, revokeKeyCall,
+        getTransactionKeyCall, pruneExpiryCall, removeAllowedCallsCall, revokeKeyCall,
         setAllowedCallsCall, updateSpendingLimitCall,
     },
     authorizeKeyCall, getAllowedCallsReturn, getRemainingLimitReturn,
@@ -406,11 +406,7 @@ impl AccountKeychain {
     /// Returns `false` without changing state when the key is missing, revoked, permanent,
     /// or not yet expired. Permanent finite-expiry keys are intentionally not pruned because they
     /// did not prepay temporary cleanup and must keep the existing replay behavior.
-    pub fn prune_expired_key(
-        &mut self,
-        _msg_sender: Address,
-        call: pruneExpiredKeyCall,
-    ) -> Result<bool> {
+    pub fn prune_expiry(&mut self, _msg_sender: Address, call: pruneExpiryCall) -> Result<bool> {
         if call.keyId.is_zero() {
             return Ok(false);
         }
@@ -653,7 +649,7 @@ impl AccountKeychain {
     /// - If key_id is Address::ZERO (main key), this should store Address::ZERO
     /// - If key_id is a specific key address, this should store that key
     ///
-    /// This creates a secure channel between validation and the precompile to ensure
+    /// This creates a secure link between validation and the precompile to ensure
     /// only the main key can authorize/revoke other keys.
     /// Uses transient storage, so the key is automatically cleared after the transaction.
     pub fn set_transaction_key(&mut self, key_id: Address) -> Result<()> {
@@ -1406,6 +1402,12 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, IAccountKeychain::SignatureType};
 
+    const COLD_SLOAD_GAS: u64 = 2_100;
+    const WARM_STORAGE_READ_GAS: u64 = 100;
+    const COLD_SSTORE_CLEAR_GAS: u64 = 7_100;
+    const WARM_SSTORE_CLEAR_GAS: u64 = 5_000;
+    const ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS: u64 = 15_000;
+
     // Helper function to assert unauthorized error
     fn assert_unauthorized_error(error: TempoPrecompileError) {
         match error {
@@ -1441,6 +1443,32 @@ mod tests {
             }
             _ => panic!("Expected AccountKeychainError, got: {error:?}"),
         }
+    }
+
+    fn assert_prune_expiry_cleanup_refund_covers_storage(
+        label: &str,
+        storage: &HashMapStorageProvider,
+    ) -> u64 {
+        let estimated_storage_gas = storage.counter_cold_sload() * COLD_SLOAD_GAS
+            + storage.counter_warm_sload() * WARM_STORAGE_READ_GAS
+            + storage.counter_cold_sstore() * COLD_SSTORE_CLEAR_GAS
+            + storage.counter_warm_sstore() * WARM_SSTORE_CLEAR_GAS;
+        let cleanup_refund = storage.counter_sstore() * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS;
+
+        eprintln!(
+            "{label}: {} cold SLOAD, {} warm SLOAD, {} cold SSTORE, {} warm SSTORE; estimated storage gas = {estimated_storage_gas}; cleanup refund = {cleanup_refund}",
+            storage.counter_cold_sload(),
+            storage.counter_warm_sload(),
+            storage.counter_cold_sstore(),
+            storage.counter_warm_sstore(),
+        );
+
+        assert!(
+            cleanup_refund > estimated_storage_gas,
+            "{label}: cleanup refund {cleanup_refund} must exceed estimated storage gas {estimated_storage_gas}"
+        );
+
+        cleanup_refund
     }
 
     #[test]
@@ -3622,7 +3650,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t3_prune_expired_key_clears_bare_temporary_key_and_allows_reuse() -> eyre::Result<()> {
+    fn test_t3_prune_expiry_clears_bare_temporary_key_and_allows_reuse() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         storage.set_timestamp(U256::from(1_000u64));
 
@@ -3654,9 +3682,9 @@ mod tests {
             let stored = keychain.keys[account][key_id].read()?;
             assert!(stored.is_temporary);
 
-            let pruned = keychain.prune_expired_key(
+            let pruned = keychain.prune_expiry(
                 Address::random(),
-                pruneExpiredKeyCall {
+                pruneExpiryCall {
                     account,
                     keyId: key_id,
                 },
@@ -3670,9 +3698,9 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut keychain = AccountKeychain::new();
 
-            let pruned = keychain.prune_expired_key(
+            let pruned = keychain.prune_expiry(
                 Address::random(),
-                pruneExpiredKeyCall {
+                pruneExpiryCall {
                     account,
                     keyId: key_id,
                 },
@@ -3709,7 +3737,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t3_prune_expired_key_clears_spending_limits_and_token_index() -> eyre::Result<()> {
+    fn test_t3_prune_expiry_clears_spending_limits_and_token_index() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         storage.set_timestamp(U256::from(1_000u64));
 
@@ -3774,9 +3802,9 @@ mod tests {
             let mut keychain = AccountKeychain::new();
             let account_key = AccountKeychain::spending_limit_key(account, key_id);
 
-            assert!(keychain.prune_expired_key(
+            assert!(keychain.prune_expiry(
                 Address::random(),
-                pruneExpiredKeyCall {
+                pruneExpiryCall {
                     account,
                     keyId: key_id,
                 },
@@ -3809,7 +3837,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t3_prune_expired_key_clears_call_scopes() -> eyre::Result<()> {
+    fn test_t3_prune_expiry_clears_call_scopes() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
         storage.set_timestamp(U256::from(1_000u64));
 
@@ -3862,9 +3890,9 @@ mod tests {
             let mut keychain = AccountKeychain::new();
             let account_key = AccountKeychain::spending_limit_key(account, key_id);
 
-            assert!(keychain.prune_expired_key(
+            assert!(keychain.prune_expiry(
                 Address::random(),
-                pruneExpiredKeyCall {
+                pruneExpiryCall {
                     account,
                     keyId: key_id,
                 },
@@ -3888,6 +3916,167 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_t3_prune_expiry_storage_accounting_benchmark() -> eyre::Result<()> {
+        let account = Address::random();
+        let key_id = Address::random();
+        let expiry = 1_060u64;
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            AccountKeychain::new().prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )
+        })?;
+        assert_eq!(storage.counter_sload(), 4);
+        assert_eq!(storage.counter_sstore(), 1);
+        assert_eq!(
+            assert_prune_expiry_cleanup_refund_covers_storage("bare temporary key", &storage),
+            15_000
+        );
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+        let key_id = Address::random();
+        let tokens = [
+            Address::repeat_byte(0x11),
+            Address::repeat_byte(0x22),
+            Address::repeat_byte(0x33),
+        ];
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: true,
+                        limits: tokens
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, token)| TokenLimit {
+                                token,
+                                amount: U256::from(100 + index),
+                                period: index as u64 * 30,
+                            })
+                            .collect(),
+                        allowAnyCalls: true,
+                        allowedCalls: vec![],
+                    },
+                },
+            )
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            AccountKeychain::new().prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )
+        })?;
+        assert_eq!(storage.counter_sload(), 12);
+        assert_eq!(storage.counter_sstore(), 14);
+        assert_eq!(
+            assert_prune_expiry_cleanup_refund_covers_storage(
+                "temporary key with three spending limits",
+                &storage,
+            ),
+            210_000
+        );
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(1_000u64));
+        let key_id = Address::random();
+        let recipient = Address::repeat_byte(0x44);
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            TIP20Setup::path_usd(account).apply()?;
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: KeyRestrictions {
+                        expiry,
+                        enforceLimits: false,
+                        limits: vec![],
+                        allowAnyCalls: false,
+                        allowedCalls: vec![CallScope {
+                            target: DEFAULT_FEE_TOKEN,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![recipient],
+                            }],
+                        }],
+                    },
+                },
+            )
+        })?;
+
+        storage.set_timestamp(U256::from(expiry));
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            AccountKeychain::new().prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )
+        })?;
+        assert_eq!(storage.counter_sload(), 17);
+        assert_eq!(storage.counter_sstore(), 11);
+        assert_eq!(
+            assert_prune_expiry_cleanup_refund_covers_storage(
+                "temporary key with one target/selector/recipient scope",
+                &storage,
+            ),
+            165_000
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -1406,7 +1406,23 @@ mod tests {
     const WARM_STORAGE_READ_GAS: u64 = 100;
     const COLD_SSTORE_CLEAR_GAS: u64 = 7_100;
     const WARM_SSTORE_CLEAR_GAS: u64 = 5_000;
+    const TIP1000_STORAGE_CREATE_GAS: u64 = 250_000;
     const ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS: u64 = 15_000;
+    const ACCESS_KEY_CREATION_BUFFER_GAS: u64 = 20_000;
+    const ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS: u64 = 1_000;
+    const BENCHMARK_TIMESTAMP: u64 = 1_000;
+    const BENCHMARK_TTL_DAYS: u64 = 7;
+    const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Tip1048BenchmarkRow {
+        label: &'static str,
+        temporary_slots: u64,
+        create_without_tip_gas: u64,
+        create_with_tip_gas: u64,
+        prune_execution_gas: u64,
+        prune_refund_gas: u64,
+    }
 
     // Helper function to assert unauthorized error
     fn assert_unauthorized_error(error: TempoPrecompileError) {
@@ -1445,30 +1461,88 @@ mod tests {
         }
     }
 
-    fn assert_prune_expiry_cleanup_refund_covers_storage(
-        label: &str,
-        storage: &HashMapStorageProvider,
-    ) -> u64 {
-        let estimated_storage_gas = storage.counter_cold_sload() * COLD_SLOAD_GAS
+    fn estimated_storage_gas(storage: &HashMapStorageProvider) -> u64 {
+        storage.counter_cold_sload() * COLD_SLOAD_GAS
             + storage.counter_warm_sload() * WARM_STORAGE_READ_GAS
             + storage.counter_cold_sstore() * COLD_SSTORE_CLEAR_GAS
-            + storage.counter_warm_sstore() * WARM_SSTORE_CLEAR_GAS;
-        let cleanup_refund = storage.counter_sstore() * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS;
+            + storage.counter_warm_sstore() * WARM_SSTORE_CLEAR_GAS
+    }
 
-        eprintln!(
-            "{label}: {} cold SLOAD, {} warm SLOAD, {} cold SSTORE, {} warm SSTORE; estimated storage gas = {estimated_storage_gas}; cleanup refund = {cleanup_refund}",
-            storage.counter_cold_sload(),
-            storage.counter_warm_sload(),
-            storage.counter_cold_sstore(),
-            storage.counter_warm_sstore(),
+    fn tip1048_create_cost(temporary_slots: u64, ttl_days: u64) -> u64 {
+        temporary_slots * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS
+            + ACCESS_KEY_CREATION_BUFFER_GAS
+            + temporary_slots * ttl_days * ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
+    }
+
+    fn run_tip1048_access_key_benchmark(
+        label: &'static str,
+        config: impl FnOnce(u64) -> KeyRestrictions,
+    ) -> eyre::Result<Tip1048BenchmarkRow> {
+        let account = Address::random();
+        let key_id = Address::random();
+        let expiry = BENCHMARK_TIMESTAMP + BENCHMARK_TTL_DAYS * SECONDS_PER_DAY;
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        storage.set_timestamp(U256::from(BENCHMARK_TIMESTAMP));
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.initialize()?;
+            TIP20Setup::path_usd(account).apply()?;
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            keychain.set_transaction_key(Address::ZERO)?;
+            keychain.set_tx_origin(account)?;
+            keychain.authorize_key(
+                account,
+                authorizeKeyCall {
+                    keyId: key_id,
+                    signatureType: SignatureType::Secp256k1,
+                    config: config(expiry),
+                },
+            )
+        })?;
+        let temporary_slots = storage.counter_zero_to_nonzero_sstore();
+        assert_ne!(temporary_slots, 0, "{label} must create temporary slots");
+
+        storage.set_timestamp(U256::from(expiry));
+        storage.reset_counters();
+        StorageCtx::enter(&mut storage, || {
+            let pruned = AccountKeychain::new().prune_expiry(
+                Address::random(),
+                pruneExpiryCall {
+                    account,
+                    keyId: key_id,
+                },
+            )?;
+            assert!(pruned, "{label} must prune after expiry");
+            Ok::<_, eyre::Report>(())
+        })?;
+
+        let prune_execution_gas = estimated_storage_gas(&storage);
+        let prune_refund_gas =
+            storage.counter_nonzero_to_zero_sstore() * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS;
+        assert_eq!(
+            prune_refund_gas,
+            temporary_slots * ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS,
+            "{label} must refund exactly the measured temporary slots"
         );
-
         assert!(
-            cleanup_refund > estimated_storage_gas,
-            "{label}: cleanup refund {cleanup_refund} must exceed estimated storage gas {estimated_storage_gas}"
+            prune_refund_gas > prune_execution_gas,
+            "{label}: refund {prune_refund_gas} must exceed prune cost {prune_execution_gas}"
         );
 
-        cleanup_refund
+        Ok(Tip1048BenchmarkRow {
+            label,
+            temporary_slots,
+            create_without_tip_gas: temporary_slots * TIP1000_STORAGE_CREATE_GAS,
+            create_with_tip_gas: tip1048_create_cost(temporary_slots, BENCHMARK_TTL_DAYS),
+            prune_execution_gas,
+            prune_refund_gas,
+        })
     }
 
     #[test]
@@ -3919,161 +3993,145 @@ mod tests {
     }
 
     #[test]
-    fn test_t3_prune_expiry_storage_accounting_benchmark() -> eyre::Result<()> {
-        let account = Address::random();
-        let key_id = Address::random();
-        let expiry = 1_060u64;
+    fn test_t3_access_key_tip_1048_benchmark_table() -> eyre::Result<()> {
+        let scoped_recipient = Address::repeat_byte(0x44);
 
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        storage.set_timestamp(U256::from(1_000u64));
-        StorageCtx::enter(&mut storage, || {
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_transaction_key(Address::ZERO)?;
-            keychain.set_tx_origin(account)?;
-            keychain.authorize_key(
-                account,
-                authorizeKeyCall {
-                    keyId: key_id,
-                    signatureType: SignatureType::Secp256k1,
-                    config: KeyRestrictions {
-                        expiry,
-                        enforceLimits: false,
-                        limits: vec![],
-                        allowAnyCalls: true,
-                        allowedCalls: vec![],
+        let rows = vec![
+            run_tip1048_access_key_benchmark("bare key", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: false,
+                limits: vec![],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1048_access_key_benchmark("one spending limit", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: true,
+                limits: vec![TokenLimit {
+                    token: Address::repeat_byte(0x11),
+                    amount: U256::from(100),
+                    period: 0,
+                }],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1048_access_key_benchmark("three spending limits", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: true,
+                limits: vec![
+                    TokenLimit {
+                        token: Address::repeat_byte(0x11),
+                        amount: U256::from(100),
+                        period: 0,
                     },
-                },
-            )
-        })?;
-
-        storage.set_timestamp(U256::from(expiry));
-        storage.reset_counters();
-        StorageCtx::enter(&mut storage, || {
-            AccountKeychain::new().prune_expiry(
-                Address::random(),
-                pruneExpiryCall {
-                    account,
-                    keyId: key_id,
-                },
-            )
-        })?;
-        assert_eq!(storage.counter_sload(), 4);
-        assert_eq!(storage.counter_sstore(), 1);
-        assert_eq!(
-            assert_prune_expiry_cleanup_refund_covers_storage("bare temporary key", &storage),
-            15_000
-        );
-
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        storage.set_timestamp(U256::from(1_000u64));
-        let key_id = Address::random();
-        let tokens = [
-            Address::repeat_byte(0x11),
-            Address::repeat_byte(0x22),
-            Address::repeat_byte(0x33),
-        ];
-        StorageCtx::enter(&mut storage, || {
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_transaction_key(Address::ZERO)?;
-            keychain.set_tx_origin(account)?;
-            keychain.authorize_key(
-                account,
-                authorizeKeyCall {
-                    keyId: key_id,
-                    signatureType: SignatureType::Secp256k1,
-                    config: KeyRestrictions {
-                        expiry,
-                        enforceLimits: true,
-                        limits: tokens
-                            .into_iter()
-                            .enumerate()
-                            .map(|(index, token)| TokenLimit {
-                                token,
-                                amount: U256::from(100 + index),
-                                period: index as u64 * 30,
-                            })
-                            .collect(),
-                        allowAnyCalls: true,
-                        allowedCalls: vec![],
+                    TokenLimit {
+                        token: Address::repeat_byte(0x22),
+                        amount: U256::from(200),
+                        period: 30,
                     },
-                },
-            )
-        })?;
-
-        storage.set_timestamp(U256::from(expiry));
-        storage.reset_counters();
-        StorageCtx::enter(&mut storage, || {
-            AccountKeychain::new().prune_expiry(
-                Address::random(),
-                pruneExpiryCall {
-                    account,
-                    keyId: key_id,
-                },
-            )
-        })?;
-        assert_eq!(storage.counter_sload(), 12);
-        assert_eq!(storage.counter_sstore(), 14);
-        assert_eq!(
-            assert_prune_expiry_cleanup_refund_covers_storage(
-                "temporary key with three spending limits",
-                &storage,
-            ),
-            210_000
-        );
-
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        storage.set_timestamp(U256::from(1_000u64));
-        let key_id = Address::random();
-        let recipient = Address::repeat_byte(0x44);
-        StorageCtx::enter(&mut storage, || {
-            let mut keychain = AccountKeychain::new();
-            keychain.initialize()?;
-            keychain.set_transaction_key(Address::ZERO)?;
-            keychain.set_tx_origin(account)?;
-            TIP20Setup::path_usd(account).apply()?;
-            keychain.authorize_key(
-                account,
-                authorizeKeyCall {
-                    keyId: key_id,
-                    signatureType: SignatureType::Secp256k1,
-                    config: KeyRestrictions {
-                        expiry,
-                        enforceLimits: false,
-                        limits: vec![],
-                        allowAnyCalls: false,
-                        allowedCalls: vec![CallScope {
-                            target: DEFAULT_FEE_TOKEN,
-                            selectorRules: vec![SelectorRule {
-                                selector: TIP20_TRANSFER_SELECTOR.into(),
-                                recipients: vec![recipient],
-                            }],
+                    TokenLimit {
+                        token: Address::repeat_byte(0x33),
+                        amount: U256::from(300),
+                        period: 60,
+                    },
+                ],
+                allowAnyCalls: true,
+                allowedCalls: vec![],
+            })?,
+            run_tip1048_access_key_benchmark("one scoped call", |expiry| KeyRestrictions {
+                expiry,
+                enforceLimits: false,
+                limits: vec![],
+                allowAnyCalls: false,
+                allowedCalls: vec![CallScope {
+                    target: DEFAULT_FEE_TOKEN,
+                    selectorRules: vec![SelectorRule {
+                        selector: TIP20_TRANSFER_SELECTOR.into(),
+                        recipients: vec![scoped_recipient],
+                    }],
+                }],
+            })?,
+            run_tip1048_access_key_benchmark("one limit and one scoped call", |expiry| {
+                KeyRestrictions {
+                    expiry,
+                    enforceLimits: true,
+                    limits: vec![TokenLimit {
+                        token: Address::repeat_byte(0x11),
+                        amount: U256::from(100),
+                        period: 0,
+                    }],
+                    allowAnyCalls: false,
+                    allowedCalls: vec![CallScope {
+                        target: DEFAULT_FEE_TOKEN,
+                        selectorRules: vec![SelectorRule {
+                            selector: TIP20_TRANSFER_SELECTOR.into(),
+                            recipients: vec![scoped_recipient],
                         }],
-                    },
-                },
-            )
-        })?;
+                    }],
+                }
+            })?,
+        ];
 
-        storage.set_timestamp(U256::from(expiry));
-        storage.reset_counters();
-        StorageCtx::enter(&mut storage, || {
-            AccountKeychain::new().prune_expiry(
-                Address::random(),
-                pruneExpiryCall {
-                    account,
-                    keyId: key_id,
-                },
-            )
-        })?;
-        assert_eq!(storage.counter_sload(), 17);
-        assert_eq!(storage.counter_sstore(), 11);
+        eprintln!(
+            "| config | slots | create without TIP | create after TIP | prune execution | prune refund |"
+        );
+        eprintln!("| --- | ---: | ---: | ---: | ---: | ---: |");
+        for row in &rows {
+            eprintln!(
+                "| {} | {} | {} | {} | {} | {} |",
+                row.label,
+                row.temporary_slots,
+                row.create_without_tip_gas,
+                row.create_with_tip_gas,
+                row.prune_execution_gas,
+                row.prune_refund_gas
+            );
+        }
+
         assert_eq!(
-            assert_prune_expiry_cleanup_refund_covers_storage(
-                "temporary key with one target/selector/recipient scope",
-                &storage,
-            ),
-            165_000
+            rows,
+            vec![
+                Tip1048BenchmarkRow {
+                    label: "bare key",
+                    temporary_slots: 1,
+                    create_without_tip_gas: 250_000,
+                    create_with_tip_gas: 42_000,
+                    prune_execution_gas: 13_400,
+                    prune_refund_gas: 15_000,
+                },
+                Tip1048BenchmarkRow {
+                    label: "one spending limit",
+                    temporary_slots: 6,
+                    create_without_tip_gas: 1_500_000,
+                    create_with_tip_gas: 152_000,
+                    prune_execution_gas: 47_100,
+                    prune_refund_gas: 90_000,
+                },
+                Tip1048BenchmarkRow {
+                    label: "three spending limits",
+                    temporary_slots: 14,
+                    create_without_tip_gas: 3_500_000,
+                    create_with_tip_gas: 328_000,
+                    prune_execution_gas: 104_100,
+                    prune_refund_gas: 210_000,
+                },
+                Tip1048BenchmarkRow {
+                    label: "one scoped call",
+                    temporary_slots: 11,
+                    create_without_tip_gas: 2_750_000,
+                    create_with_tip_gas: 262_000,
+                    prune_execution_gas: 81_000,
+                    prune_refund_gas: 165_000,
+                },
+                Tip1048BenchmarkRow {
+                    label: "one limit and one scoped call",
+                    temporary_slots: 16,
+                    create_without_tip_gas: 4_000_000,
+                    create_with_tip_gas: 372_000,
+                    prune_execution_gas: 114_700,
+                    prune_refund_gas: 240_000,
+                },
+            ]
         );
 
         Ok(())

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -3,7 +3,7 @@ use revm::{
     context::journaled_state::JournalCheckpoint,
     state::{AccountInfo, Bytecode},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tempo_chainspec::hardfork::TempoHardfork;
 
 use crate::{error::TempoPrecompileError, storage::PrecompileStorageProvider};
@@ -22,7 +22,13 @@ pub struct HashMapStorageProvider {
     block_number: u64,
     spec: TempoHardfork,
     is_static: bool,
+    accessed_storage: HashSet<(Address, U256)>,
     counter_sload: u64,
+    counter_cold_sload: u64,
+    counter_warm_sload: u64,
+    counter_sstore: u64,
+    counter_cold_sstore: u64,
+    counter_warm_sstore: u64,
     snapshots: Vec<Snapshot>,
 
     /// Emitted events keyed by contract address.
@@ -64,7 +70,13 @@ impl HashMapStorageProvider {
             block_number: 0,
             spec,
             is_static: false,
+            accessed_storage: HashSet::new(),
             counter_sload: 0,
+            counter_cold_sload: 0,
+            counter_warm_sload: 0,
+            counter_sstore: 0,
+            counter_cold_sstore: 0,
+            counter_warm_sstore: 0,
         }
     }
 
@@ -115,6 +127,13 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        if self.accessed_storage.insert((address, key)) {
+            self.counter_cold_sstore += 1;
+        } else {
+            self.counter_warm_sstore += 1;
+        }
+
+        self.counter_sstore += 1;
         self.internals.insert((address, key), value);
         Ok(())
     }
@@ -140,6 +159,12 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         self.counter_sload += 1;
+        if self.accessed_storage.insert((address, key)) {
+            self.counter_cold_sload += 1;
+        } else {
+            self.counter_warm_sload += 1;
+        }
+
         Ok(self
             .internals
             .get(&(address, key))
@@ -277,6 +302,36 @@ impl HashMapStorageProvider {
 
     pub fn counter_sload(&self) -> u64 {
         self.counter_sload
+    }
+
+    pub fn counter_cold_sload(&self) -> u64 {
+        self.counter_cold_sload
+    }
+
+    pub fn counter_warm_sload(&self) -> u64 {
+        self.counter_warm_sload
+    }
+
+    pub fn counter_sstore(&self) -> u64 {
+        self.counter_sstore
+    }
+
+    pub fn counter_cold_sstore(&self) -> u64 {
+        self.counter_cold_sstore
+    }
+
+    pub fn counter_warm_sstore(&self) -> u64 {
+        self.counter_warm_sstore
+    }
+
+    pub fn reset_counters(&mut self) {
+        self.accessed_storage.clear();
+        self.counter_sload = 0;
+        self.counter_cold_sload = 0;
+        self.counter_warm_sload = 0;
+        self.counter_sstore = 0;
+        self.counter_cold_sstore = 0;
+        self.counter_warm_sstore = 0;
     }
 
     /// Returns all storage entries as `(address, slot, value)`.

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -29,6 +29,8 @@ pub struct HashMapStorageProvider {
     counter_sstore: u64,
     counter_cold_sstore: u64,
     counter_warm_sstore: u64,
+    counter_zero_to_nonzero_sstore: u64,
+    counter_nonzero_to_zero_sstore: u64,
     snapshots: Vec<Snapshot>,
 
     /// Emitted events keyed by contract address.
@@ -77,6 +79,8 @@ impl HashMapStorageProvider {
             counter_sstore: 0,
             counter_cold_sstore: 0,
             counter_warm_sstore: 0,
+            counter_zero_to_nonzero_sstore: 0,
+            counter_nonzero_to_zero_sstore: 0,
         }
     }
 
@@ -131,6 +135,17 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
             self.counter_cold_sstore += 1;
         } else {
             self.counter_warm_sstore += 1;
+        }
+
+        let previous = self
+            .internals
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO);
+        if previous.is_zero() && !value.is_zero() {
+            self.counter_zero_to_nonzero_sstore += 1;
+        } else if !previous.is_zero() && value.is_zero() {
+            self.counter_nonzero_to_zero_sstore += 1;
         }
 
         self.counter_sstore += 1;
@@ -324,6 +339,14 @@ impl HashMapStorageProvider {
         self.counter_warm_sstore
     }
 
+    pub fn counter_zero_to_nonzero_sstore(&self) -> u64 {
+        self.counter_zero_to_nonzero_sstore
+    }
+
+    pub fn counter_nonzero_to_zero_sstore(&self) -> u64 {
+        self.counter_nonzero_to_zero_sstore
+    }
+
     pub fn reset_counters(&mut self) {
         self.accessed_storage.clear();
         self.counter_sload = 0;
@@ -332,6 +355,8 @@ impl HashMapStorageProvider {
         self.counter_sstore = 0;
         self.counter_cold_sstore = 0;
         self.counter_warm_sstore = 0;
+        self.counter_zero_to_nonzero_sstore = 0;
+        self.counter_nonzero_to_zero_sstore = 0;
     }
 
     /// Returns all storage entries as `(address, slot, value)`.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1326,6 +1326,7 @@ mod tests {
                     expiry: u64::MAX,
                     enforce_limits: true,
                     is_revoked: false,
+                    is_temporary: false,
                 })?;
                 let limit_key = AccountKeychain::spending_limit_key(account, key_id);
                 keychain.spending_limits[limit_key][fee_token].write(limit_state)?;
@@ -1815,6 +1816,7 @@ mod tests {
                     expiry: u64::MAX,
                     enforce_limits: true,
                     is_revoked: false,
+                    is_temporary: false,
                 })
             })
             .unwrap();
@@ -1850,6 +1852,7 @@ mod tests {
                     expiry: u64::MAX,
                     enforce_limits: false,
                     is_revoked: false,
+                    is_temporary: false,
                 })
             })
             .unwrap();

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -372,6 +372,7 @@ pub(crate) fn create_mock_provider() -> MockEthProvider<TempoPrimitives, TempoCh
 ///         expiry: u64::MAX,
 ///         enforce_limits: false,
 ///         is_revoked: false,
+///         is_temporary: false,
 ///     })
 /// });
 /// ```

--- a/tips/ref-impls/src/TempoStreamChannel.sol
+++ b/tips/ref-impls/src/TempoStreamChannel.sol
@@ -21,8 +21,11 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
 
     bytes32 public constant VOUCHER_TYPEHASH =
         keccak256("Voucher(bytes32 channelId,uint128 cumulativeAmount)");
+    bytes32 public constant EXPIRING_CHANNEL_DOMAIN =
+        keccak256("TempoStreamChannel.expiringChannel.v1");
 
     uint64 public constant CLOSE_GRACE_PERIOD = 15 minutes;
+    uint64 public constant MAX_TEMPORARY_TTL = 30 days;
 
     // --- State ---
 
@@ -86,6 +89,7 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
             deposit: deposit,
             settled: 0,
             closeRequestedAt: 0,
+            expiresAt: 0,
             finalized: false
         });
 
@@ -95,6 +99,70 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
         }
 
         emit ChannelOpened(channelId, msg.sender, payee, token, authorizedSigner, salt, deposit);
+    }
+
+    /**
+     * @notice Open a bounded-lifetime payment channel with escrowed funds.
+     * @param payee Address authorized to close with a voucher
+     * @param token TIP-20 token address
+     * @param deposit Amount to deposit
+     * @param salt Random salt for channel ID generation
+     * @param authorizedSigner Address authorized to sign vouchers (0 = use msg.sender)
+     * @param expiresAt Timestamp when the channel starts its expiry grace window
+     * @return channelId The unique expiring channel identifier
+     */
+    function openExpiring(
+        address payee,
+        address token,
+        uint128 deposit,
+        bytes32 salt,
+        address authorizedSigner,
+        uint64 expiresAt
+    )
+        external
+        override
+        returns (bytes32 channelId)
+    {
+        if (payee == address(0)) {
+            revert InvalidPayee();
+        }
+        if (!TempoUtilities.isTIP20(token)) {
+            revert InvalidToken();
+        }
+        if (deposit == 0) {
+            revert ZeroDeposit();
+        }
+        if (expiresAt <= block.timestamp || expiresAt > block.timestamp + MAX_TEMPORARY_TTL) {
+            revert InvalidExpiry();
+        }
+
+        channelId =
+            computeExpiringChannelId(msg.sender, payee, token, salt, authorizedSigner, expiresAt);
+
+        if (channels[channelId].payer != address(0) || channels[channelId].finalized) {
+            revert ChannelAlreadyExists();
+        }
+
+        channels[channelId] = Channel({
+            payer: msg.sender,
+            payee: payee,
+            token: token,
+            authorizedSigner: authorizedSigner,
+            deposit: deposit,
+            settled: 0,
+            closeRequestedAt: 0,
+            expiresAt: expiresAt,
+            finalized: false
+        });
+
+        bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
+        if (!success) {
+            revert TransferFailed();
+        }
+
+        emit ExpiringChannelOpened(
+            channelId, msg.sender, payee, token, authorizedSigner, salt, deposit, expiresAt
+        );
     }
 
     /**
@@ -345,6 +413,46 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
         emit ChannelClosed(channelId, payer, payee, settledAmount, refund);
     }
 
+    /**
+     * @notice Finalize an expired channel and refund unsettled funds to the payer.
+     * @dev Callable by anyone after expiresAt + CLOSE_GRACE_PERIOD.
+     * @param channelId The expired channel to finalize
+     */
+    function finalizeChannel(bytes32 channelId) external override {
+        Channel storage channel = channels[channelId];
+
+        if (channel.finalized) {
+            revert ChannelFinalized();
+        }
+        if (channel.payer == address(0)) {
+            revert ChannelNotFound();
+        }
+        if (channel.expiresAt == 0) {
+            revert ChannelNotExpired();
+        }
+        if (block.timestamp < channel.expiresAt + CLOSE_GRACE_PERIOD) {
+            revert ChannelNotExpired();
+        }
+
+        address token = channel.token;
+        address payer = channel.payer;
+        address payee = channel.payee;
+        uint128 settledAmount = channel.settled;
+        uint128 refund = channel.deposit - settledAmount;
+
+        delete channels[channelId];
+
+        if (refund > 0) {
+            bool success = ITIP20(token).transfer(payer, refund);
+            if (!success) {
+                revert TransferFailed();
+            }
+        }
+
+        emit ChannelExpired(channelId, payer, payee);
+        emit ChannelClosed(channelId, payer, payee, settledAmount, refund);
+    }
+
     // --- View Functions ---
 
     /**
@@ -376,6 +484,38 @@ contract TempoStreamChannel is ITempoStreamChannel, EIP712 {
     {
         return keccak256(
             abi.encode(payer, payee, token, salt, authorizedSigner, address(this), block.chainid)
+        );
+    }
+
+    /**
+     * @notice Compute the channel ID for an expiring channel.
+     * @dev Includes a domain separator and expiresAt to avoid legacy channel ID collisions.
+     */
+    function computeExpiringChannelId(
+        address payer,
+        address payee,
+        address token,
+        bytes32 salt,
+        address authorizedSigner,
+        uint64 expiresAt
+    )
+        public
+        view
+        override
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                EXPIRING_CHANNEL_DOMAIN,
+                payer,
+                payee,
+                token,
+                salt,
+                authorizedSigner,
+                expiresAt,
+                address(this),
+                block.chainid
+            )
         );
     }
 

--- a/tips/ref-impls/src/interfaces/ITempoStreamChannel.sol
+++ b/tips/ref-impls/src/interfaces/ITempoStreamChannel.sol
@@ -10,6 +10,7 @@ interface ITempoStreamChannel {
     struct Channel {
         bool finalized;
         uint64 closeRequestedAt;
+        uint64 expiresAt;
         address payer;
         address payee;
         address token;
@@ -19,6 +20,7 @@ interface ITempoStreamChannel {
     }
 
     function CLOSE_GRACE_PERIOD() external view returns (uint64);
+    function MAX_TEMPORARY_TTL() external view returns (uint64);
     function VOUCHER_TYPEHASH() external view returns (bytes32);
 
     function open(
@@ -27,6 +29,17 @@ interface ITempoStreamChannel {
         uint128 deposit,
         bytes32 salt,
         address authorizedSigner
+    )
+        external
+        returns (bytes32 channelId);
+
+    function openExpiring(
+        address payee,
+        address token,
+        uint128 deposit,
+        bytes32 salt,
+        address authorizedSigner,
+        uint64 expiresAt
     )
         external
         returns (bytes32 channelId);
@@ -41,6 +54,8 @@ interface ITempoStreamChannel {
 
     function withdraw(bytes32 channelId) external;
 
+    function finalizeChannel(bytes32 channelId) external;
+
     function getChannel(bytes32 channelId) external view returns (Channel memory);
 
     function getChannelsBatch(bytes32[] calldata channelIds)
@@ -54,6 +69,18 @@ interface ITempoStreamChannel {
         address token,
         bytes32 salt,
         address authorizedSigner
+    )
+        external
+        view
+        returns (bytes32);
+
+    function computeExpiringChannelId(
+        address payer,
+        address payee,
+        address token,
+        bytes32 salt,
+        address authorizedSigner,
+        uint64 expiresAt
     )
         external
         view
@@ -77,6 +104,17 @@ interface ITempoStreamChannel {
         address authorizedSigner,
         bytes32 salt,
         uint256 deposit
+    );
+
+    event ExpiringChannelOpened(
+        bytes32 indexed channelId,
+        address indexed payer,
+        address indexed payee,
+        address token,
+        address authorizedSigner,
+        bytes32 salt,
+        uint256 deposit,
+        uint64 expiresAt
     );
 
     event Settled(
@@ -131,5 +169,7 @@ interface ITempoStreamChannel {
     error InvalidToken();
     error ZeroDeposit();
     error DepositOverflow();
+    error InvalidExpiry();
+    error ChannelNotExpired();
 
 }

--- a/tips/ref-impls/test/TempoStreamChannel.t.sol
+++ b/tips/ref-impls/test/TempoStreamChannel.t.sol
@@ -44,6 +44,11 @@ contract TempoStreamChannelTest is BaseTest {
         return channel.open(payee, address(token), DEPOSIT, SALT, address(0));
     }
 
+    function _openExpiringChannel(uint64 expiresAt) internal returns (bytes32) {
+        vm.prank(payer);
+        return channel.openExpiring(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
+    }
+
     function _signVoucher(bytes32 channelId, uint128 amount) internal view returns (bytes memory) {
         bytes32 digest = channel.getVoucherDigest(channelId, amount);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(payerKey, digest);
@@ -73,6 +78,35 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payer);
         vm.expectRevert(ITempoStreamChannel.ChannelAlreadyExists.selector);
         channel.open(payee, address(token), DEPOSIT, SALT, address(0));
+    }
+
+    function test_openExpiring_success() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        assertEq(ch.payer, payer);
+        assertEq(ch.payee, payee);
+        assertEq(ch.token, address(token));
+        assertEq(ch.deposit, DEPOSIT);
+        assertEq(ch.expiresAt, expiresAt);
+        assertFalse(ch.finalized);
+    }
+
+    function test_openExpiring_revert_pastExpiry() public {
+        vm.prank(payer);
+        vm.expectRevert(ITempoStreamChannel.InvalidExpiry.selector);
+        channel.openExpiring(
+            payee, address(token), DEPOSIT, SALT, address(0), uint64(block.timestamp)
+        );
+    }
+
+    function test_openExpiring_revert_tooLong() public {
+        uint64 expiresAt = uint64(block.timestamp + channel.MAX_TEMPORARY_TTL() + 1);
+
+        vm.prank(payer);
+        vm.expectRevert(ITempoStreamChannel.InvalidExpiry.selector);
+        channel.openExpiring(payee, address(token), DEPOSIT, SALT, address(0), expiresAt);
     }
 
     // --- Settle Tests ---
@@ -270,6 +304,142 @@ contract TempoStreamChannelTest is BaseTest {
         vm.prank(payer);
         vm.expectRevert(ITempoStreamChannel.ChannelFinalized.selector);
         channel.withdraw(channelId);
+    }
+
+    // --- Finalize Expired Channel Tests ---
+
+    function test_finalizeChannel_fullRefund() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        address finalizer = makeAddr("finalizer");
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        uint256 finalizerBalanceBefore = token.balanceOf(finalizer);
+
+        vm.prank(finalizer);
+        channel.finalizeChannel(channelId);
+
+        TempoStreamChannel.Channel memory ch = channel.getChannel(channelId);
+        assertEq(ch.payer, address(0));
+        assertEq(ch.deposit, 0);
+        assertEq(ch.settled, 0);
+        assertEq(ch.expiresAt, 0);
+        assertEq(token.balanceOf(payer), payerBalanceBefore + DEPOSIT);
+        assertEq(token.balanceOf(finalizer), finalizerBalanceBefore);
+    }
+
+    function test_finalizeChannel_partialSettleRefundsRemainder() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        bytes memory sig = _signVoucher(channelId, 300_000);
+        vm.prank(payee);
+        channel.settle(channelId, 300_000, sig);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+        uint256 payeeBalanceBefore = token.balanceOf(payee);
+
+        vm.prank(makeAddr("finalizer"));
+        channel.finalizeChannel(channelId);
+
+        assertEq(token.balanceOf(payer), payerBalanceBefore + (DEPOSIT - 300_000));
+        assertEq(token.balanceOf(payee), payeeBalanceBefore);
+        assertEq(channel.getChannel(channelId).payer, address(0));
+    }
+
+    function test_finalizeChannel_noRefundWhenFullySettled() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        bytes memory sig = _signVoucher(channelId, DEPOSIT);
+        vm.prank(payee);
+        channel.settle(channelId, DEPOSIT, sig);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        uint256 payerBalanceBefore = token.balanceOf(payer);
+
+        vm.prank(makeAddr("finalizer"));
+        channel.finalizeChannel(channelId);
+
+        assertEq(token.balanceOf(payer), payerBalanceBefore);
+        assertEq(token.balanceOf(address(channel)), 0);
+        assertEq(channel.getChannel(channelId).payer, address(0));
+    }
+
+    function test_finalizeChannel_revert_beforeExpiryGrace() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD() - 1);
+
+        vm.expectRevert(ITempoStreamChannel.ChannelNotExpired.selector);
+        channel.finalizeChannel(channelId);
+    }
+
+    function test_finalizeChannel_revert_permanentChannel() public {
+        bytes32 channelId = _openChannel();
+
+        vm.warp(block.timestamp + channel.MAX_TEMPORARY_TTL() + channel.CLOSE_GRACE_PERIOD());
+
+        vm.expectRevert(ITempoStreamChannel.ChannelNotExpired.selector);
+        channel.finalizeChannel(channelId);
+    }
+
+    function test_gas_finalizeChannel_fullRefund() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        vm.prank(makeAddr("finalizer"));
+        uint256 gasBefore = gasleft();
+        channel.finalizeChannel(channelId);
+        uint256 gasUsed = gasBefore - gasleft();
+
+        emit log_named_uint("finalizeChannel_fullRefund", gasUsed);
+        assertEq(channel.getChannel(channelId).payer, address(0));
+    }
+
+    function test_gas_finalizeChannel_partialSettle() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        bytes memory sig = _signVoucher(channelId, 300_000);
+        vm.prank(payee);
+        channel.settle(channelId, 300_000, sig);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        vm.prank(makeAddr("finalizer"));
+        uint256 gasBefore = gasleft();
+        channel.finalizeChannel(channelId);
+        uint256 gasUsed = gasBefore - gasleft();
+
+        emit log_named_uint("finalizeChannel_partialSettle", gasUsed);
+        assertEq(channel.getChannel(channelId).payer, address(0));
+    }
+
+    function test_gas_finalizeChannel_noRefund() public {
+        uint64 expiresAt = uint64(block.timestamp + 1 hours);
+        bytes32 channelId = _openExpiringChannel(expiresAt);
+
+        bytes memory sig = _signVoucher(channelId, DEPOSIT);
+        vm.prank(payee);
+        channel.settle(channelId, DEPOSIT, sig);
+
+        vm.warp(expiresAt + channel.CLOSE_GRACE_PERIOD());
+
+        vm.prank(makeAddr("finalizer"));
+        uint256 gasBefore = gasleft();
+        channel.finalizeChannel(channelId);
+        uint256 gasUsed = gasBefore - gasleft();
+
+        emit log_named_uint("finalizeChannel_noRefund", gasUsed);
+        assertEq(channel.getChannel(channelId).payer, address(0));
     }
 
     // --- Batch Read Test ---
@@ -881,6 +1051,7 @@ contract TempoStreamChannelTest is BaseTest {
         (
             bool rawFinalized,
             uint64 rawCloseRequestedAt,
+            uint64 rawExpiresAt,
             address rawPayer,
             address rawPayee,
             address rawToken,
@@ -896,6 +1067,7 @@ contract TempoStreamChannelTest is BaseTest {
         assertEq(rawDeposit, 0);
         assertEq(rawSettled, 0);
         assertEq(rawCloseRequestedAt, 0);
+        assertEq(rawExpiresAt, 0);
         assertTrue(rawFinalized);
 
         assertTrue(channel.getChannel(channelId).finalized);

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -215,6 +215,14 @@ Expiring nonces are intentionally left out of this TIP.
 
 Once this precompile is live, we expect to propose a separate TIP that migrates expiring nonces away from the current ring buffer design and onto this precompile. That migration is straightforward because expiring nonces already have a very short maximum lifetime of 30 seconds, so we can just abandon the ring buffer when required
 
+## Future Compatibility
+
+This design intentionally separates the user-facing storage semantics from the cleanup mechanism.
+
+`XSTORE` and `XLOAD` define the core interface and semantics: write a value with an expiry, and read it while it is still live. A future TIP could keep those interfaces the same while changing how expired state is physically managed underneath, for example with separate temporary storage tries, system transactions, or other more sophisticated cleanup mechanisms.
+
+In this version, cleanup is exposed through `XCLEAR`. A future design may keep `XCLEAR` as a compatibility hook, or make it unnecessary if cleanup becomes fully protocol-driven.
+
 ## XCLEAR Incentives
 
 This TIP keeps the incentive model simple: successful `XCLEAR` calls receive the existing `15,000` gas storage-clearing refund, and no additional incentive is introduced.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -184,10 +184,10 @@ Let `ttl = expiry - block.timestamp` as measured at execution time.
 
 | Lifetime | Gas |
 |----------|-----|
-| `ttl <= 1 hour` | 500 |
-| `1 hour < ttl <= 1 day` | 1,500 |
-| `1 day < ttl <= 1 week` | 10,000 |
-| `1 week < ttl <= 30 days` | 40,000 |
+| `ttl <= 1 hour` | 20,000 |
+| `1 hour < ttl <= 1 day` | 40,000 |
+| `1 day < ttl <= 1 week` | 80,000 |
+| `1 week < ttl <= 30 days` | 120,000 |
 | `30 days < ttl <= 365 days` | 200,000 |
 | `365 days < ttl` | 250,000 |
 
@@ -195,7 +195,9 @@ These are the full `XSTORE` gas charges defined by this TIP. `XSTORE` does not a
 
 The pricing follows one simple principle: the longer state is allowed to stay around, the closer it should get to ordinary persistent-state pricing.
 
-Short-lived entries are deliberately cheap. A one-year entry is still cheaper than permanent storage at `200,000` gas. Anything beyond one year is charged `250,000` gas, matching the [TIP-1000](./tip-1000.md) benchmark for permanent state growth.
+Short-lived entries are still cheaper than persistent storage, but they do not start below ordinary storage-write costs. The minimum `20,000` gas tier ensures that `XSTORE` plus a later successful `XCLEAR` can never create net-positive refund farming against the `15,000` gas cleanup refund.
+
+A one-year entry is still cheaper than permanent storage at `200,000` gas. Anything beyond one year is charged `250,000` gas, matching the [TIP-1000](./tip-1000.md) benchmark for permanent state growth.
 
 This keeps temporary storage useful for real application flows, while making sure that very long-lived entries do not underprice effectively persistent state.
 

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -1,0 +1,255 @@
+---
+id: TIP-1048
+title: X Storage Precompile
+description: Adds an expiring per-address storage precompile with XSTORE, XLOAD, and XCLEAR.
+authors: TBD
+status: Draft
+related: TIP-1000
+protocolVersion: TBD
+---
+
+# TIP-1048: X Storage Precompile
+
+## Abstract
+
+This TIP introduces a new precompile that stores expiring key-value slots for an address. The precompile exposes three entrypoints: `XSTORE(slot, value, expiry)`, `XLOAD(slot)`, and `XCLEAR(addr, slot)`.
+
+`XSTORE` and `XLOAD` are scoped to `msg.sender`, so each caller gets an isolated slot namespace. `XCLEAR` is permissionless, but it may only succeed once an entry has expired.
+
+This allows us effectively introduce an out-of-protocol solution for clearing expired state, without having to make involved changes to the state trie or introducing new system transactions.
+
+> **Note:** The precompile logic can be built completely out-of-protocol, but we propose this as TIP so that we can also introduce a discounted gas schedule, which encourages the use of temporary storage.
+
+## Motivation
+
+1. **Short-lived state management:**
+   Many applications need short-lived state that persists longer than a single call frame or transaction, but still have an expiry associated with them.
+   Some examples are permit nonces with expiry, keychain state after the key has expired, DEX orders after expiry etc.
+   
+   Persistent contract storage is a poor fit for this pattern because it requires the owner to manage cleanup manually, and every expired entry becomes long-lived state unless someone explicitly removes it. 
+
+2. **Reducing upfront user costs:** 
+   The 250,000 gas introduced in TIP 1000, is necessary to control state growth, but also introduces higher costs for user onboarding. Introducing cheaper temporary storage primitives, would encourage app devs to use state efficient onboarding patterns which is a win-win for all parties.
+
+This TIP introduces a small precompile dedicated to expiring slot storage, with a built-in cleanup path that any actor can trigger once an entry has expired.
+
+
+
+## Assumptions
+
+- Expiry is measured against `block.timestamp`.
+- A slot is live while `block.timestamp <= expiry`.
+- A slot is expired once `block.timestamp > expiry`.
+- `XSTORE` rejects expiries that are not strictly greater than the current `block.timestamp`.
+- `XSTORE` and `XLOAD` key storage by the immediate `msg.sender`, not `tx.origin`.
+- `XCLEAR` can be called by any address, but it only succeeds for an expired, not-yet-cleared slot.
+- Clearing a slot sets both its stored value and its expiry to zero.
+
+---
+
+# Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Precompile Address
+
+The X storage precompile is deployed at the ASCII `X` address:
+
+```text
+0x5800000000000000000000000000000000000000
+```
+
+## Interface
+
+```solidity
+interface IXStorage {
+    /// @notice The requested slot is not currently live.
+    error Expired();
+
+    /// @notice The supplied expiry is not strictly in the future.
+    error InvalidExpiry();
+
+    /// @notice The requested slot cannot currently be cleared.
+    error NotClearable();
+
+    /// @notice Stores or overwrites a slot owned by msg.sender.
+    /// @param slot Caller-defined slot key.
+    /// @param value Value to store.
+    /// @param expiry Inclusive unix timestamp after which the slot becomes expired.
+    /// @dev Reverts with InvalidExpiry if expiry <= block.timestamp.
+    function XSTORE(bytes32 slot, bytes32 value, uint64 expiry) external;
+
+    /// @notice Loads a slot owned by msg.sender.
+    /// @param slot Caller-defined slot key.
+    /// @return value Stored value.
+    /// @return expiry Stored inclusive unix expiry.
+    /// @dev Reverts with Expired if the slot is expired or has been cleared.
+    function XLOAD(bytes32 slot) external view returns (bytes32 value, uint64 expiry);
+
+    /// @notice Clears an expired slot for any address.
+    /// @param addr Owner of the slot.
+    /// @param slot Caller-defined slot key.
+    /// @dev Reverts with NotClearable unless the slot exists, is expired, and has not already been cleared.
+    function XCLEAR(address addr, bytes32 slot) external;
+}
+```
+
+## Storage Model
+
+The precompile maintains the following logical mapping:
+
+```solidity
+struct XEntry {
+    bytes32 value;
+    bytes32 metadata;
+}
+
+mapping(address => mapping(bytes32 => XEntry)) entries;
+```
+
+Each address has its own independent slot namespace. Two different callers using the same `slot` key MUST read and write different records.
+
+This mapping is a logical model. The implementation MAY use any internal layout so long as the externally visible behavior and gas accounting defined by this TIP are preserved.
+
+## Metadata Encoding
+
+The second storage slot of each entry uses the full 256-bit word with the following layout:
+
+| Bits | Meaning |
+|------|---------|
+| `255` | Version bit |
+| `254:64` | Reserved for future use |
+| `63:0` | expiry |
+
+In this TIP, the current version is `0`, so the version bit is `0`.
+
+For version `0`:
+
+- bit `255` MUST be `0`
+- bits `254:64` MUST be `0`
+- bits `63:0` contain the inclusive unix timestamp used for expiry checks
+
+The reserved middle bits are intentionally left empty for future use. The current API only exposes the `uint64 expiry` timestamp; callers do not provide or observe the other metadata bits in this version.
+
+Under this model, `value` and `expiry` are distinct storage fields. A fresh entry therefore behaves like creation of two state elements for economic analysis.
+
+## Function Semantics
+
+### `XSTORE(slot, value, expiry)`
+
+`XSTORE` uses `msg.sender` as the slot owner. It MUST write `value` and `expiry` into `entries[msg.sender][slot]`, replacing any previous record for that slot.
+
+`XSTORE` MUST revert with `InvalidExpiry()` unless `expiry > block.timestamp`.
+
+If the call succeeds, the precompile MUST store the expiry in the low 64 bits of the metadata slot, and MUST set the version bit and all reserved middle bits to `0`.
+
+### `XLOAD(slot)`
+
+`XLOAD` uses `msg.sender` as the slot owner and reads `entries[msg.sender][slot]`.
+
+If `block.timestamp > expiry`, the call MUST revert with `Expired()` and MUST NOT return the stored value. This includes slots that were previously cleared, since clearing sets `expiry = 0`.
+
+If `block.timestamp <= expiry`, the call MUST return the stored `value` and `expiry`.
+
+## Gas Accounting For `XLOAD`
+
+`XLOAD` MUST charge gas equal to two `SLOAD`s: one for reading the expiry field and one for reading the value field.
+
+Each read MUST be charged according to the warm or cold access state of the corresponding storage slot.
+
+### `XCLEAR(addr, slot)`
+
+`XCLEAR` reads `entries[addr][slot]`.
+
+If `expiry == 0`, the call MUST revert with `NotClearable()`.
+
+If `block.timestamp <= expiry`, the call MUST revert with `NotClearable()`.
+
+If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` and `expiry = 0`.
+
+`XCLEAR` MAY be called by any address for any `addr`; there is no ownership check.
+
+## Gas Accounting For `XCLEAR`
+
+`XCLEAR` MUST first read the target entry's expiry to determine whether the entry is clearable.
+
+If `XCLEAR` reverts, the call MUST cost exactly as much gas as an `SLOAD` of the expiry slot in the corresponding warm or cold access state. A reverting `XCLEAR` MUST NOT add any gas refund.
+
+If `XCLEAR` succeeds, the call MUST be free to execute and MUST add 15,000 gas to the transaction's refund counter. This 15,000 gas refund is the only explicit cleanup incentive introduced by this TIP.
+
+## XSTORE Pricing
+
+Let `ttl = expiry - block.timestamp` as measured at execution time.
+
+`XSTORE` MUST charge gas according to the following lifetime buckets:
+
+| Lifetime | Gas |
+|----------|-----|
+| `ttl <= 1 hour` | 500 |
+| `1 hour < ttl <= 1 day` | 1,500 |
+| `1 day < ttl <= 1 week` | 10,000 |
+| `1 week < ttl <= 30 days` | 40,000 |
+| `30 days < ttl <= 365 days` | 200,000 |
+| `365 days < ttl` | 250,000 |
+
+These are the full `XSTORE` gas charges defined by this TIP. `XSTORE` does not additionally inherit ordinary `SSTORE` creation pricing on top of this table.
+
+The pricing follows one simple principle: the longer state is allowed to stay around, the closer it should get to ordinary persistent-state pricing.
+
+Short-lived entries are deliberately cheap. A one-year entry is still cheaper than permanent storage at `200,000` gas. Anything beyond one year is charged `250,000` gas, matching the [TIP-1000](./tip-1000.md) benchmark for permanent state growth.
+
+This keeps temporary storage useful for real application flows, while making sure that very long-lived entries do not underprice effectively persistent state.
+
+## Empty And Cleared Slots
+
+An entry with `expiry = 0` is treated as not live. As a result:
+
+- `XLOAD` on a never-written slot MUST revert with `Expired()`.
+- `XLOAD` on a cleared slot MUST revert with `Expired()`.
+- `XCLEAR` on a never-written or already-cleared slot MUST revert with `NotClearable()`.
+
+## Expiring Nonces
+
+Expiring nonces are intentionally left out of this TIP.
+
+Once this precompile is live, we expect to propose a separate TIP that migrates expiring nonces away from the current ring buffer design and onto this precompile. That migration is straightforward because expiring nonces already have a very short maximum lifetime of 30 seconds, so we can just abandon the ring buffer when required
+
+## XCLEAR Incentives
+
+This TIP keeps the incentive model simple: successful `XCLEAR` calls receive the existing `15,000` gas storage-clearing refund, and no additional incentive is introduced.
+
+We believe this is sufficient for two reasons - 
+1. Validators are naturally incentivized to keep the state they serve smaller, so many validators can justify running expiry cleanup as a protocol service even when the direct economic return is modest. 
+2. Searchers and arbitrage bots can bundle `XCLEAR` calls into transactions they already intend to send, using the refund to reduce the effective cost of those transactions.
+
+Because of these existing incentives, this TIP does not add any larger or special-purpose cleanup reward.
+
+## Events
+This TIP does not introduce any events.
+
+## Errors
+
+This TIP introduces the following custom errors:
+
+- `Expired()`: returned by `XLOAD` when the requested slot is not currently live.
+- `InvalidExpiry()`: returned by `XSTORE` when `expiry <= block.timestamp`.
+- `NotClearable()`: returned by `XCLEAR` when the target slot is still live, was never written, or has already been cleared.
+
+## Race Conditions
+
+# Invariants
+
+- **Sender isolation**: `XSTORE` and `XLOAD` MUST only access the namespace keyed by `msg.sender`.
+- **Versioned metadata slot**: the metadata slot MUST use the packed layout above, with version bit `0` in this TIP.
+- **Reserved bits zero**: the reserved middle bits in the metadata slot MUST be zero in this version.
+- **Future expiry only**: `XSTORE` MUST only accept expiries strictly greater than the current `block.timestamp`.
+- **Live-read only**: `XLOAD` MUST only return data when `block.timestamp <= expiry`.
+- **Expired-read rejection**: `XLOAD` MUST revert once `block.timestamp > expiry`.
+- **XLOAD price**: `XLOAD` MUST charge gas equal to two `SLOAD`s.
+- **Permissionless cleanup**: Any caller MUST be able to clear an expired slot for any owner.
+- **No premature deletion**: `XCLEAR` MUST revert and MUST NOT modify a slot whose expiry has not yet passed.
+- **No repeated cleanup reward**: `XCLEAR` MUST revert for never-written and already-cleared slots.
+- **XCLEAR revert cost**: A reverting `XCLEAR` MUST cost only the corresponding expiry-slot `SLOAD`.
+- **XCLEAR success incentive**: A successful `XCLEAR` MUST add exactly 15,000 gas to the transaction refund counter.
+- **Tiered XSTORE price**: `XSTORE` MUST charge according to the lifetime bucket table above.
+- **Overwrite behavior**: A later `XSTORE` for the same `(msg.sender, slot)` pair MUST fully replace the previous `value` and `expiry`.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -42,7 +42,7 @@ This TIP introduces a small precompile dedicated to expiring slot storage, with 
 - A slot is expired once `block.timestamp > expiry`.
 - `XSTORE` rejects expiries that are not strictly greater than the current `block.timestamp`.
 - `XSTORE` and `XLOAD` key storage by the immediate `msg.sender`, not `tx.origin`.
-- `XCLEAR` can be called by any address, but it only succeeds for an expired, not-yet-cleared slot.
+- `XCLEAR` can be called by any address and returns `true` only for an expired, not-yet-cleared slot.
 - Clearing a slot sets both its stored value and its expiry to zero.
 
 ---
@@ -69,9 +69,6 @@ interface IXStorage {
     /// @notice The supplied expiry is not strictly in the future.
     error InvalidExpiry();
 
-    /// @notice The requested slot cannot currently be cleared.
-    error NotClearable();
-
     /// @notice Stores or overwrites a slot owned by msg.sender.
     /// @param slot Caller-defined slot key.
     /// @param value Value to store.
@@ -89,8 +86,10 @@ interface IXStorage {
     /// @notice Clears an expired slot for any address.
     /// @param addr Owner of the slot.
     /// @param slot Caller-defined slot key.
-    /// @dev Reverts with NotClearable unless the slot exists, is expired, and has not already been cleared.
-    function XCLEAR(address addr, bytes32 slot) external;
+    /// @return cleared True if the slot was cleared, false otherwise.
+    /// @dev  Returns false when the slot is still live,
+    /// was never written, or has already been cleared.
+    function XCLEAR(address addr, bytes32 slot) external returns (bool cleared);
 }
 ```
 
@@ -161,11 +160,11 @@ Each read MUST be charged according to the warm or cold access state of the corr
 
 `XCLEAR` reads `entries[addr][slot]`.
 
-If `expiry == 0`, the call MUST revert with `NotClearable()`.
+If `expiry == 0`, the call MUST return `false`.
 
-If `block.timestamp <= expiry`, the call MUST revert with `NotClearable()`.
+If `block.timestamp <= expiry`, the call MUST return `false`.
 
-If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` and `expiry = 0`.
+If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` and `expiry = 0`, and MUST return `true`.
 
 `XCLEAR` MAY be called by any address for any `addr`; there is no ownership check.
 
@@ -173,9 +172,9 @@ If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` an
 
 `XCLEAR` MUST first read the target entry's expiry to determine whether the entry is clearable.
 
-If `XCLEAR` reverts, the call MUST cost exactly as much gas as an `SLOAD` of the expiry slot in the corresponding warm or cold access state. A reverting `XCLEAR` MUST NOT add any gas refund.
+If `XCLEAR` does not clear the slot, the call MUST cost exactly as much gas as an `SLOAD` of the expiry slot in the corresponding warm or cold access state. An unsuccessful `XCLEAR` MUST return `false` and MUST NOT add any gas refund.
 
-If `XCLEAR` succeeds, the call MUST be free to execute and MUST add 15,000 gas to the transaction's refund counter. This 15,000 gas refund is the only explicit cleanup incentive introduced by this TIP.
+If `XCLEAR` succeeds, the call MUST be free to execute, MUST return `true`, and MUST add 15,000 gas to the transaction's refund counter. This 15,000 gas refund is the only explicit cleanup incentive introduced by this TIP.
 
 ## XSTORE Pricing
 
@@ -206,7 +205,7 @@ An entry with `expiry = 0` is treated as not live. As a result:
 
 - `XLOAD` on a never-written slot MUST revert with `Expired()`.
 - `XLOAD` on a cleared slot MUST revert with `Expired()`.
-- `XCLEAR` on a never-written or already-cleared slot MUST revert with `NotClearable()`.
+- `XCLEAR` on a never-written or already-cleared slot MUST return `false`.
 
 ## Expiring Nonces
 
@@ -224,6 +223,21 @@ We believe this is sufficient for two reasons -
 
 Because of these existing incentives, this TIP does not add any larger or special-purpose cleanup reward.
 
+## Race Conditions
+
+`XCLEAR` has ordering races, not correctness races.
+
+Execution is serialized, so the precompile always checks the current slot state at execution time. This means a stale `XCLEAR` cannot clear a slot that has already been reused with a fresh future expiry: in that case it will see the new live expiry and return `false`.
+
+The main remaining question is economic. There are two cases:
+
+1. **Unsuccessful `XCLEAR`**: costs one `SLOAD` of the expiry/metadata slot and returns `false`.
+2. **Successful `XCLEAR`**: clears the slot, returns `true`, and receives the `15,000` gas refund.
+
+If two actors race to clear the same expired slot, the loser only pays the cost of a single `SLOAD` instead of risking a full transaction revert. This makes `XCLEAR` safe to include inside larger flows and bundles.
+
+This design does not remove ordering races, but it reduces their downside to a small, bounded gas cost while preserving correct state transitions.
+
 ## Events
 This TIP does not introduce any events.
 
@@ -233,9 +247,6 @@ This TIP introduces the following custom errors:
 
 - `Expired()`: returned by `XLOAD` when the requested slot is not currently live.
 - `InvalidExpiry()`: returned by `XSTORE` when `expiry <= block.timestamp`.
-- `NotClearable()`: returned by `XCLEAR` when the target slot is still live, was never written, or has already been cleared.
-
-## Race Conditions
 
 # Invariants
 
@@ -247,9 +258,9 @@ This TIP introduces the following custom errors:
 - **Expired-read rejection**: `XLOAD` MUST revert once `block.timestamp > expiry`.
 - **XLOAD price**: `XLOAD` MUST charge gas equal to two `SLOAD`s.
 - **Permissionless cleanup**: Any caller MUST be able to clear an expired slot for any owner.
-- **No premature deletion**: `XCLEAR` MUST revert and MUST NOT modify a slot whose expiry has not yet passed.
-- **No repeated cleanup reward**: `XCLEAR` MUST revert for never-written and already-cleared slots.
-- **XCLEAR revert cost**: A reverting `XCLEAR` MUST cost only the corresponding expiry-slot `SLOAD`.
-- **XCLEAR success incentive**: A successful `XCLEAR` MUST add exactly 15,000 gas to the transaction refund counter.
+- **No premature deletion**: `XCLEAR` MUST return `false` and MUST NOT modify a slot whose expiry has not yet passed.
+- **No repeated cleanup reward**: `XCLEAR` MUST return `false` for never-written and already-cleared slots.
+- **XCLEAR unsuccessful cost**: An unsuccessful `XCLEAR` MUST cost only the corresponding expiry-slot `SLOAD`.
+- **XCLEAR success incentive**: A successful `XCLEAR` MUST return `true` and MUST add exactly 15,000 gas to the transaction refund counter.
 - **Tiered XSTORE price**: `XSTORE` MUST charge according to the lifetime bucket table above.
 - **Overwrite behavior**: A later `XSTORE` for the same `(msg.sender, slot)` pair MUST fully replace the previous `value` and `expiry`.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -1,260 +1,177 @@
 ---
 id: TIP-1048
-title: Temporary Channel and Access Key State
-description: Reduces upfront state-creation cost for bounded-lifetime MPP channel rows and AccountKeychain access-key rows, with prepaid generic gas refunds for semantic cleanup.
+title: Temporary Access Key State
+description: Reduces upfront state-creation cost for bounded-lifetime AccountKeychain access-key rows, with prepaid generic gas refunds for semantic cleanup.
 authors: TBD
 status: Draft
-related: TIP-1000, TIP-1034, TIP-1053, TIP-1060
+related: TIP-1000, TIP-1011, TIP-1060
 protocolVersion: TBD
 ---
 
-# TIP-1048: Temporary Channel and Access Key State
+# TIP-1048: Temporary Access Key State
 
 ## Abstract
 
 This TIP replaces the previous general-purpose X storage precompile proposal with a scoped
-temporary-state mechanism for two existing precompiles:
+temporary-state mechanism for the AccountKeychain precompile.
 
-- the MPP / TIP-20 Channel Reserve precompile
-- the AccountKeychain precompile
+The goal is to make bounded-lifetime access-key authorizations cheaper upfront without creating a
+general temporary storage primitive. A temporary access key prepays a cleanup refund `X(config)`,
+where `X` is a function of the physical temporary slots needed for the key, plus a nonrefundable
+`20,000` gas buffer and a nonrefundable expiry premium based on the key lifetime.
 
-The goal is to make bounded-lifetime channel opens and access-key authorizations cheaper upfront
-without creating a general temporary storage primitive. Expiring channels prepay a benchmarked
-`85,000` gas cleanup refund for semantic finalization, plus a `20,000` gas nonrefundable residual
-cost. Temporary access-key rows pay `35,000` gas each: `20,000` gas residual cost and a `15,000` gas
-one-shot generic cleanup refund.
-
-Temporary rows MUST NOT mint TIP-1060 storage credits when deleted. The cleanup refund is generic
-gas accounting, not a token bounty and not a transferable credit.
+Temporary access-key rows MUST NOT mint TIP-1060 storage credits when deleted. The cleanup refund is
+generic gas accounting, not a token bounty and not a transferable credit.
 
 ## Motivation
 
 TIP-1000 prices net-new state creation at `250,000` gas to protect the chain from unbounded state
-growth. That cost is appropriate for permanent state, but it makes two bounded-lifetime flows too
-expensive:
+growth. That cost is appropriate for permanent state, but it makes session-style wallet UX
+expensive. Wallets commonly authorize short-lived access keys, and those keys can include spending
+limits and call scopes that are useful only until the key expires.
 
-1. **MPP channel opens.** A payer often opens a short-lived payment channel, funds it, lets a payee
-   settle cumulative vouchers, then closes or lets the channel expire. The channel row is not meant
-   to be permanent, but the opener currently pays permanent-state economics.
-2. **Access keys.** Wallets commonly authorize short-lived access keys for session-style UX. These
-   keys expire by construction, but their key rows, spending limits, and call scopes can remain in
-   state unless they are explicitly cleaned up.
-
-The cleanup for these flows is domain-specific. A channel cannot be safely removed by blindly
-clearing storage because any unsettled funds must be returned to the payer. Access-key cleanup must
-respect key expiry, revocation semantics, spending limits, and call scopes. This TIP therefore
-scopes temporary state to the precompiles that understand those semantics.
+Expiry alone is not enough. Expired keys, spending limits, and call-scope rows still occupy state
+unless the AccountKeychain precompile removes them. Cleanup also cannot be a blind storage delete:
+the precompile must respect key expiry, revocation semantics, spending-limit indexes, and call-scope
+indexes. This TIP therefore scopes temporary state to the access-key precompile that understands
+those semantics.
 
 ## Constants
 
 This TIP defines the following gas constants:
 
 ```text
-CHANNEL_CLEANUP_REFUND_GAS     = 85_000
-PER_ROW_CLEANUP_REFUND_GAS     = 15_000
-TEMP_ROW_RESIDUAL_GAS          = 20_000
-EXPIRING_CHANNEL_CREATION_GAS  = 105_000
-TEMP_ROW_CREATION_GAS          = 35_000
-MAX_TEMPORARY_TTL              = 30 days
+ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS       = 15_000
+ACCESS_KEY_CREATION_BUFFER_GAS           = 20_000
+ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS = 1_000
+MAX_TEMPORARY_TTL                        = 30 days
 ```
 
-`EXPIRING_CHANNEL_CREATION_GAS` is the minimum cost to create one expiring channel row:
+For a temporary access-key authorization:
 
 ```text
-EXPIRING_CHANNEL_CREATION_GAS = CHANNEL_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
+temporary_slot_count(config) =
+    number of physical nonzero temporary storage slots the key cleanup path can delete
+
+ACCESS_KEY_CLEANUP_REFUND_GAS(config) =
+    ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS * temporary_slot_count(config)
+
+ACCESS_KEY_EXPIRY_PREMIUM_GAS(config, expiry) =
+    ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
+    * temporary_slot_count(config)
+    * ceil((expiry - block.timestamp) / 1 day)
+
+TEMP_ACCESS_KEY_CREATION_GAS(config, expiry) =
+    ACCESS_KEY_CLEANUP_REFUND_GAS(config)
+    + ACCESS_KEY_CREATION_BUFFER_GAS
+    + ACCESS_KEY_EXPIRY_PREMIUM_GAS(config, expiry)
 ```
 
-`TEMP_ROW_CREATION_GAS` is the minimum cost to create one temporary access-key storage row:
+`ACCESS_KEY_CLEANUP_REFUND_GAS(config)` is the `X` value prepaid by the creator and later refunded
+to the transaction that prunes the expired key. The `20,000` gas buffer and the expiry premium are
+not refunded.
+
+## Slot Counting
+
+`temporary_slot_count(config)` is counted over physical storage slots, not logical objects. Every
+slot that receives temporary pricing MUST be reachable by `pruneExpiry`, and every slot that
+`pruneExpiry` refunds MUST have prepaid the refund during creation.
+
+For the current Rust AccountKeychain layout:
 
 ```text
-TEMP_ROW_CREATION_GAS = PER_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
+primary key row:
+  1 slot
+
+L spending-limit tokens:
+  if L == 0: 0 slots
+  if L > 0: 1 + 4L slots
+    - 2L spending-limit state slots
+    - 1 + 2L enumerable token-index slots
+
+call scopes:
+  allowAnyCalls = true:
+    0 slots
+
+  scoped deny-all with no targets:
+    1 slot
+    - key-level is_scoped flag
+
+  scoped key with T targets:
+    1 + (1 + 2T)
+    + per-target selector/recipient slots
+    - 1 key-level is_scoped flag
+    - 1 + 2T enumerable target-index slots
+
+  for target i with S_i selector rules:
+    if S_i == 0: 0 slots
+    if S_i > 0: 1 + ceil(S_i / 8) + S_i slots
+      - selector set length
+      - packed selector value slots
+      - selector position slots
+
+  for selector j with R_ij recipient restrictions:
+    if R_ij == 0: 0 slots
+    if R_ij > 0: 1 + 2R_ij slots
+      - recipient set length
+      - recipient value slots
+      - recipient position slots
 ```
 
-The `85,000` gas channel cleanup refund is based on the reference implementation's
-`finalizeChannel` benchmark:
+Examples:
 
 ```text
-forge test --match-contract TempoStreamChannelTest --match-test test_gas_finalizeChannel --gas-report -vv
+bare temporary key:
+  temporary_slot_count = 1
+  X = 15_000
 
-finalizeChannel_fullRefund    = 81_002 gas
-finalizeChannel_partialSettle = 81_002 gas
-finalizeChannel_noRefund      = 48_539 gas
+temporary key with one spending-limit token and no call scope:
+  temporary_slot_count = 6
+  X = 90_000
+
+temporary key with three spending-limit tokens and no call scope:
+  temporary_slot_count = 14
+  X = 210_000
+
+temporary key with one target, one selector, and one recipient:
+  temporary_slot_count = 11
+  X = 165_000
 ```
 
-The constant rounds the worst direct measurement up to `85,000` gas. The `15,000` gas per-row cleanup
-refund is intentionally equal to the pre-TIP storage-clearing refund for non-channel temporary rows.
-The `20,000` gas residual ensures that even a perfectly cleaned temporary row has a positive net cost
-and cannot be used for refund farming.
+## Cleanup Benchmark
 
-The access-key cleanup refund is based on physical temporary storage rows, not logical key objects.
-The Rust AccountKeychain implementation uses a packed primary key slot, two physical slots per T3
-spending-limit state, and enumerable `Set` storage for spending-limit tokens and call scopes.
-Successful `pruneExpiredKey` cleanup therefore has these storage-operation counts:
+`ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS = 15,000` is based on the Rust AccountKeychain
+`pruneExpiry` implementation using the test storage provider's warm/cold SLOAD and SSTORE counters:
 
 ```text
-bare temporary key, no limits, no call scopes:
-  4 SLOAD, 1 SSTORE
+cargo test -p tempo-precompiles test_t3_prune_expiry_storage_accounting_benchmark -- --nocapture
 
-temporary key with N indexed spending-limit tokens, no call scopes:
-  (6 + 2N) SLOAD, (2 + 4N) SSTORE
+bare temporary key:
+  4 cold SLOAD, 0 warm SLOAD, 0 cold SSTORE, 1 warm SSTORE
+  estimated storage gas = 13_400
+  cleanup refund = 15_000
 
-temporary key with one target, one selector, one recipient, no spending limits:
-  18 SLOAD, 11 SSTORE
+temporary key with three spending limits:
+  7 cold SLOAD, 5 warm SLOAD, 9 cold SSTORE, 5 warm SSTORE
+  estimated storage gas = 104_100
+  cleanup refund = 210_000
+
+temporary key with one target/selector/recipient scope:
+  9 cold SLOAD, 8 warm SLOAD, 3 cold SSTORE, 8 warm SSTORE
+  estimated storage gas = 81_000
+  cleanup refund = 165_000
 ```
 
-Using cold-read and storage-reset pricing, the common one-token-limit cleanup is approximately
-`8 * 2,100 + 6 * 5,000 = 46,800` gas before event/call overhead. It deletes six physical temporary
-rows, which credits `6 * 15,000 = 90,000` gas and was prepaid by `6 * 35,000 = 210,000` gas at
-creation. The same per-row accounting covers call-scope cleanup: the one-target/one-selector/
-one-recipient example deletes eleven physical temporary rows and credits `165,000` gas. Therefore
-access keys do not need a separate key-level cleanup refund; `PER_ROW_CLEANUP_REFUND_GAS = 15,000`
-and `TEMP_ROW_CREATION_GAS = 35,000` remain per physical temporary storage slot.
+The estimate uses `2,100` gas for cold `SLOAD`, `100` gas for warm storage reads, `7,100` gas for
+cold storage clears, and `5,000` gas for warm storage clears. The bare-key case is the tightest
+case because it has fixed read overhead and only one slot to refund; `15,000` still exceeds the
+measured `13,400` storage cleanup cost. Larger keys have more slots to clear, so the slot-scaled
+refund provides a wider margin.
 
-## Temporary Row Accounting
+If the AccountKeychain storage layout changes, `temporary_slot_count(config)` and the benchmarked
+cleanup paths MUST be updated before the new layout can use this TIP's temporary pricing.
 
-A **temporary row** is a persistent storage row created by an eligible precompile operation and
-associated with an expiry no later than `MAX_TEMPORARY_TTL` from the creation timestamp.
-
-Unless the MPP channel section specifies the channel-specific cleanup refund, temporary rows use the
-per-row access-key accounting below.
-
-When an eligible access-key operation creates a temporary row from zero to nonzero:
-
-1. The operation MUST charge `TEMP_ROW_CREATION_GAS` for that row instead of the TIP-1000
-   `250,000` gas storage-creation charge.
-2. The row MUST be marked as temporary or otherwise associated with a prepaid cleanup refund budget
-   of exactly `PER_ROW_CLEANUP_REFUND_GAS`.
-3. The operation MUST still charge ordinary read, write, log, transfer, and execution gas not
-   replaced by this TIP.
-
-When a temporary access-key row is removed by a valid semantic cleanup path:
-
-1. The row MUST be set to zero or otherwise made absent.
-2. The transaction MUST receive exactly `PER_ROW_CLEANUP_REFUND_GAS` in generic gas refund for that
-   row.
-3. The row's cleanup refund budget MUST be consumed.
-4. The row MUST NOT mint a TIP-1060 storage credit.
-
-The cleanup refund is one-shot. A row that was never temporary, has already been cleaned, or has no
-remaining prepaid cleanup budget MUST NOT produce a TIP-1048 cleanup refund.
-
-## Generic Refund Semantics
-
-TIP-1048 cleanup refunds are generic transaction gas refunds. They can offset gas spent by the same
-transaction, including unrelated execution in the same transaction, but they MUST NOT produce a
-negative gas charge or any token payout.
-
-Implementations MUST enforce:
-
-- The total TIP-1048 cleanup refund credited for one transaction MUST NOT exceed the sum of prepaid
-  cleanup refund budgets consumed by that transaction.
-- A temporary row deletion MUST NOT also receive the ordinary storage-clearing refund for the same
-  row.
-- A temporary row deletion MUST NOT mint or consume TIP-1060 storage credits.
-- If an operation reverts, its temporary-row creations, cleanup-budget changes, and cleanup refunds
-  MUST revert with the same EVM execution scope.
-
-The standard refund cap MUST NOT apply to TIP-1048 cleanup refunds. The refund is prepaid at
-creation time and bounded by consumed cleanup budgets, so the cap is not needed to prevent
-net-positive gas accounting.
-
-## MPP Expiring Channels
-
-This TIP extends the TIP-20 Channel Reserve precompile with expiring channels. Existing permanent
-channels continue to use the existing TIP-1034 economics and behavior.
-
-### Channel Expiry
-
-An expiring channel has an `expiresAt` timestamp. The precompile MUST reject expiring channel opens
-unless:
-
-```text
-block.timestamp < expiresAt <= block.timestamp + MAX_TEMPORARY_TTL
-```
-
-The channel id for an expiring channel MUST include `expiresAt` and a domain separator that prevents
-collisions with legacy non-expiring channel ids.
-
-The precompile MUST expose an expiring channel open path that includes `expiresAt` and a
-permissionless finalization path:
-
-```solidity
-function openExpiring(
-    address payee,
-    address token,
-    uint128 deposit,
-    bytes32 salt,
-    address authorizedSigner,
-    uint64 expiresAt
-) external returns (bytes32 channelId);
-
-function finalizeChannel(bytes32 channelId) external;
-```
-
-### Channel Creation Cost
-
-The packed channel state row created by an expiring channel open is a temporary row.
-
-Opening an expiring channel therefore charges:
-
-```text
-EXPIRING_CHANNEL_CREATION_GAS = 105_000
-```
-
-for the channel state row and its prepaid finalization refund budget, plus the ordinary gas required
-for validation, TIP-20 transfer, event emission, and any other execution work.
-
-Top-ups and settlements modify an existing channel row and MUST NOT create a new temporary-row
-cleanup budget for that row. Extending `expiresAt` is out of scope for this TIP; a channel that needs
-a later expiry should be closed or finalized and replaced with a new channel.
-
-### Expiry and Finalization
-
-When `block.timestamp < expiresAt`, the expiring channel behaves like a normal channel.
-
-When `block.timestamp >= expiresAt`, the channel is expired. Expiry starts the close window; it does
-not blindly delete the row. Until the existing channel close grace period has elapsed, the payee or
-operator MAY still close the channel with a valid voucher under the usual channel close rules.
-
-After:
-
-```text
-block.timestamp >= expiresAt + CLOSE_GRACE_PERIOD
-```
-
-any caller MAY finalize the expired channel. Finalization MUST:
-
-1. load the channel state,
-2. compute `refund = deposit - settled`,
-3. delete the temporary channel state row,
-4. transfer `refund` to the channel payer when `refund > 0`,
-5. emit the normal channel close event or a new expired-channel event,
-6. credit `CHANNEL_CLEANUP_REFUND_GAS` as a generic gas refund for the finalized channel.
-
-Finalization MUST NOT transfer any channel funds to the finalizing caller.
-
-Any valid channel close path that deletes an expiring channel state row MUST consume the row's
-cleanup refund budget and credit `CHANNEL_CLEANUP_REFUND_GAS`. This includes payee/operator close,
-payer withdraw after an explicit close request, and permissionless expired finalization. If a close
-path reverts, the deleted row, fund transfers, and cleanup refund MUST all revert together.
-
-### Replacement Flow
-
-The precompile MAY expose a helper that finalizes an expired channel and opens a replacement channel
-in one call. The helper MUST be equivalent to executing finalization followed by a new expiring
-channel open in the same transaction.
-
-Because TIP-1048 cleanup refunds are generic gas refunds, a transaction that finalizes one account's
-expired channel can use that prepaid refund to offset any other gas in the same transaction. This is
-intentional: the refund was prepaid by the temporary row's creator and remains capped by that prepaid
-budget.
-
-## Expiring Access Keys
-
-This TIP makes short-lived, non-admin AccountKeychain access-key rows temporary. Admin keys and
-non-expiring keys remain permanent.
-
-### Eligibility
+## Eligibility
 
 An access-key authorization is eligible for temporary pricing only when all of the following are
 true:
@@ -267,7 +184,7 @@ true:
 Access-key authorizations that do not meet these requirements continue to use ordinary TIP-1000 and
 TIP-1060 storage economics.
 
-### Temporary Access-Key Rows
+## Temporary Access-Key Rows
 
 Every persistent storage row created by an eligible access-key authorization is a temporary row. This
 includes:
@@ -277,39 +194,41 @@ includes:
 - each stored call-scope row created for the key,
 - any enumerable index row needed to later find and delete temporary spending limits or scopes.
 
-The precompile MUST charge `TEMP_ROW_CREATION_GAS` for each such row. If the implementation uses
-multiple physical storage slots for one logical restriction, each physical zero-to-nonzero storage
-slot is one temporary row and MUST be charged separately.
+The precompile MUST charge `TEMP_ACCESS_KEY_CREATION_GAS(config, expiry)` for the key. If rows are
+added later to an already-temporary access key, such as through `updateSpendingLimit` or call-scope
+updates before expiry, the operation MUST charge:
 
-Temporary access keys MUST maintain enough internal indexing to prune all temporary rows associated
-with the key after expiry. A row that cannot be found by the expiry cleanup path MUST NOT receive
-temporary pricing.
+```text
+ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS * added_temporary_slots
++ ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
+   * added_temporary_slots
+   * ceil((key.expiry - block.timestamp) / 1 day)
+```
 
-Rows created later for an already-temporary access key, such as spending-limit or call-scope rows
-added by an update before the key expires, are temporary rows tied to the same key expiry and MUST be
-charged `TEMP_ROW_CREATION_GAS` per row.
+Those later-added rows share the key's original expiry. A row that cannot be found by the expiry
+cleanup path MUST NOT receive temporary pricing.
 
-### Access-Key Pruning
+## Access-Key Pruning
 
 The AccountKeychain precompile MUST expose a permissionless cleanup path:
 
 ```solidity
-function pruneExpiredKey(address account, address keyId) external returns (bool pruned);
+function pruneExpiry(address account, address keyId) external returns (bool pruned);
 ```
 
-`pruneExpiredKey` MUST return `false` and MUST NOT modify state when:
+`pruneExpiry` MUST return `false` and MUST NOT modify state when:
 
 - the key does not exist,
 - the key is revoked,
 - the key is not temporary,
 - the key has not expired.
 
-When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneExpiredKey` MUST:
+When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneExpiry` MUST:
 
 1. delete the primary key row,
 2. delete all temporary spending-limit rows associated with the key,
 3. delete all temporary call-scope rows associated with the key,
-4. credit `PER_ROW_CLEANUP_REFUND_GAS` for each temporary row actually deleted,
+4. credit `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS` for each temporary slot actually deleted,
 5. return `true`.
 
 After an expired key is pruned, a new authorization for the same `keyId` MAY succeed if it carries a
@@ -322,21 +241,35 @@ keys intentionally revoked before expiry.
 If a temporary key is revoked before expiry and the implementation keeps a permanent revoked-key
 tombstone, the revocation MUST convert the primary key row from temporary to permanent. The caller
 MUST be charged enough additional gas that the primary key row has paid at least the ordinary
-TIP-1000 permanent storage-creation cost in total. With the constants in this TIP, that additional
-charge is:
+TIP-1000 permanent storage-creation cost in total. The primary key row's temporary cleanup refund
+budget MUST be cancelled during this conversion and MUST NOT be refunded. Temporary restriction rows
+that are deleted during revocation MAY receive their ordinary TIP-1048 cleanup refunds, because
+those rows do not become permanent tombstones.
 
-```text
-250_000 - TEMP_ROW_CREATION_GAS = 215_000
-```
+## Generic Refund Semantics
 
-The primary key row's temporary cleanup refund budget MUST be cancelled during this conversion and
-MUST NOT be refunded. Temporary restriction rows that are deleted during revocation MAY receive their
-ordinary TIP-1048 cleanup refunds, because those rows do not become permanent tombstones.
+TIP-1048 cleanup refunds are generic transaction gas refunds. They can offset gas spent by the same
+transaction, including unrelated execution in the same transaction, but they MUST NOT produce a
+negative gas charge or any token payout.
 
-### Lazy Replacement
+Implementations MUST enforce:
+
+- The total TIP-1048 cleanup refund credited for one transaction MUST NOT exceed the sum of prepaid
+  cleanup refund budgets consumed by that transaction.
+- A temporary slot deletion MUST NOT also receive the ordinary storage-clearing refund for the same
+  slot.
+- A temporary slot deletion MUST NOT mint or consume TIP-1060 storage credits.
+- If an operation reverts, its temporary-slot creations, cleanup-budget changes, and cleanup refunds
+  MUST revert with the same EVM execution scope.
+
+The standard refund cap MUST NOT apply to TIP-1048 cleanup refunds. The refund is prepaid at
+creation time and bounded by consumed cleanup budgets, so the cap is not needed to prevent
+net-positive gas accounting.
+
+## Lazy Replacement
 
 The AccountKeychain precompile MAY expose a helper that prunes one expired key and authorizes a new
-key for the same account in one call. The helper MUST be equivalent to `pruneExpiredKey(account,
+key for the same account in one call. The helper MUST be equivalent to `pruneExpiry(account,
 oldKeyId)` followed by the ordinary authorization path for the new key in the same transaction.
 
 The helper MUST only authorize the new key for the same account whose expired key was pruned.
@@ -350,18 +283,18 @@ temporary rows are separate:
 
 - Creating a temporary row does not consume a TIP-1060 storage credit.
 - Deleting a temporary row does not mint a TIP-1060 storage credit.
-- The `20,000` residual and `15,000` cleanup refund are TIP-1048 accounting only.
-- Permanent channel rows, non-expiring access keys, admin keys, revoked-key tombstones, and other
-  non-temporary rows continue to use TIP-1000 and TIP-1060 economics.
+- The cleanup refund, `20,000` buffer, and expiry premium are TIP-1048 accounting only.
+- Non-expiring access keys, admin keys, revoked-key tombstones, and other non-temporary rows
+  continue to use TIP-1000 and TIP-1060 economics.
 
 This separation prevents a caller from creating cheap temporary rows and later converting them into
 full `230,000` gas TIP-1060 storage credits.
 
 ## Backward Compatibility
 
-Existing non-expiring channels and existing AccountKeychain behavior remain available. This TIP adds
-temporary pricing and cleanup paths for bounded-lifetime rows; it does not require users to migrate
-existing permanent rows.
+Existing AccountKeychain behavior remains available. This TIP adds temporary pricing and cleanup
+paths for bounded-lifetime access-key rows; it does not require users to migrate existing permanent
+rows.
 
 The main semantic change is that expired temporary access keys can be fully pruned and their key id
 can later be reused with a new authorization. This does not allow replay of the old authorization
@@ -369,25 +302,21 @@ because the old authorization's signed expiry is in the past by the time pruning
 
 ## Invariants
 
-1. **Scoped use only.** TIP-1048 temporary pricing MUST apply only to MPP channel rows and
-   AccountKeychain access-key rows described in this TIP.
-2. **Minimum creation cost.** Every temporary access-key row creation MUST charge at least
-   `PER_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`, and every expiring channel row creation MUST
-   charge at least `CHANNEL_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`.
-3. **Fixed cleanup refund.** Each temporary access-key row MAY produce at most one
-   `PER_ROW_CLEANUP_REFUND_GAS` cleanup refund. Each expiring channel MAY produce at most one
-   `CHANNEL_CLEANUP_REFUND_GAS` cleanup refund.
-4. **Prepaid refund bound.** Total cleanup refund credited MUST NOT exceed prepaid cleanup budgets
+1. **Scoped use only.** TIP-1048 temporary pricing MUST apply only to AccountKeychain access-key
+   rows described in this TIP.
+2. **Minimum creation cost.** Every temporary access-key creation MUST charge at least
+   `ACCESS_KEY_CLEANUP_REFUND_GAS(config) + ACCESS_KEY_CREATION_BUFFER_GAS`.
+3. **Expiry premium.** Every temporary access-key creation MUST charge the expiry premium for the
+   key's configured lifetime and temporary slot count.
+4. **Fixed cleanup refund.** Each temporary access-key slot MAY produce at most one
+   `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS` cleanup refund.
+5. **Prepaid refund bound.** Total cleanup refund credited MUST NOT exceed prepaid cleanup budgets
    consumed by the transaction.
-5. **No TIP-1060 conversion.** Temporary row deletion MUST NOT mint TIP-1060 storage credits.
-6. **No double refund.** Temporary row deletion MUST NOT also receive an ordinary storage-clearing
-   refund for the same row.
-7. **Semantic channel cleanup.** An expired channel MUST NOT be deleted without returning
-   `deposit - settled` to the payer.
-8. **No finalizer bounty.** Channel finalization MUST NOT transfer channel funds to the finalizing
-   caller.
-9. **Access-key expiry gate.** `pruneExpiredKey` MUST NOT delete an unexpired key.
-10. **Revocation preservation.** Revoked keys MUST retain their revocation semantics and MUST NOT be
-    pruned as expired temporary keys.
-11. **Revert safety.** Temporary-row creation, cleanup-budget consumption, cleanup refunds, channel
-    fund transfers, and access-key pruning MUST revert with their EVM execution scope.
+6. **No TIP-1060 conversion.** Temporary slot deletion MUST NOT mint TIP-1060 storage credits.
+7. **No double refund.** Temporary slot deletion MUST NOT also receive an ordinary storage-clearing
+   refund for the same slot.
+8. **Access-key expiry gate.** `pruneExpiry` MUST NOT delete an unexpired key.
+9. **Revocation preservation.** Revoked keys MUST retain their revocation semantics and MUST NOT be
+   pruned as expired temporary keys.
+10. **Revert safety.** Temporary-slot creation, cleanup-budget consumption, cleanup refunds, and
+    access-key pruning MUST revert with their EVM execution scope.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -19,10 +19,10 @@ temporary-state mechanism for two existing precompiles:
 - the AccountKeychain precompile
 
 The goal is to make bounded-lifetime channel opens and access-key authorizations cheaper upfront
-without creating a general temporary storage primitive. A temporary row pays a fixed creation
-charge of `35,000` gas: `20,000` gas is nonrefundable residual cost, and `15,000` gas prepays a
-one-shot generic cleanup refund. When the temporary row is later removed by a valid semantic cleanup
-path, the transaction receives a `15,000` gas refund for that row.
+without creating a general temporary storage primitive. Expiring channels prepay a benchmarked
+`85,000` gas cleanup refund for semantic finalization, plus a `20,000` gas nonrefundable residual
+cost. Temporary access-key rows pay `35,000` gas each: `20,000` gas residual cost and a `15,000` gas
+one-shot generic cleanup refund.
 
 Temporary rows MUST NOT mint TIP-1060 storage credits when deleted. The cleanup refund is generic
 gas accounting, not a token bounty and not a transferable credit.
@@ -50,40 +50,63 @@ scopes temporary state to the precompiles that understand those semantics.
 This TIP defines the following gas constants:
 
 ```text
-TEMP_ROW_CLEANUP_REFUND_GAS = 15_000
-TEMP_ROW_RESIDUAL_GAS       = 20_000
-TEMP_ROW_CREATION_GAS       = 35_000
-MAX_TEMPORARY_TTL           = 30 days
+CHANNEL_CLEANUP_REFUND_GAS     = 85_000
+PER_ROW_CLEANUP_REFUND_GAS     = 15_000
+TEMP_ROW_RESIDUAL_GAS          = 20_000
+EXPIRING_CHANNEL_CREATION_GAS  = 105_000
+TEMP_ROW_CREATION_GAS          = 35_000
+MAX_TEMPORARY_TTL              = 30 days
 ```
 
-`TEMP_ROW_CREATION_GAS` is the minimum cost to create one temporary persistent storage row:
+`EXPIRING_CHANNEL_CREATION_GAS` is the minimum cost to create one expiring channel row:
 
 ```text
-TEMP_ROW_CREATION_GAS = TEMP_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
+EXPIRING_CHANNEL_CREATION_GAS = CHANNEL_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
 ```
 
-The `15,000` gas cleanup refund is intentionally equal to the pre-TIP storage-clearing refund. The
-`20,000` gas residual ensures that even a perfectly cleaned temporary row has a positive net cost and
-cannot be used for refund farming.
+`TEMP_ROW_CREATION_GAS` is the minimum cost to create one temporary access-key storage row:
+
+```text
+TEMP_ROW_CREATION_GAS = PER_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
+```
+
+The `85,000` gas channel cleanup refund is based on the reference implementation's
+`finalizeChannel` benchmark:
+
+```text
+forge test --match-contract TempoStreamChannelTest --match-test test_gas_finalizeChannel --gas-report -vv
+
+finalizeChannel_fullRefund    = 81_002 gas
+finalizeChannel_partialSettle = 81_002 gas
+finalizeChannel_noRefund      = 48_539 gas
+```
+
+The constant rounds the worst direct measurement up to `85,000` gas. The `15,000` gas per-row cleanup
+refund is intentionally equal to the pre-TIP storage-clearing refund for non-channel temporary rows.
+The `20,000` gas residual ensures that even a perfectly cleaned temporary row has a positive net cost
+and cannot be used for refund farming.
 
 ## Temporary Row Accounting
 
 A **temporary row** is a persistent storage row created by an eligible precompile operation and
 associated with an expiry no later than `MAX_TEMPORARY_TTL` from the creation timestamp.
 
-When an eligible operation creates a temporary row from zero to nonzero:
+Unless the MPP channel section specifies the channel-specific cleanup refund, temporary rows use the
+per-row access-key accounting below.
+
+When an eligible access-key operation creates a temporary row from zero to nonzero:
 
 1. The operation MUST charge `TEMP_ROW_CREATION_GAS` for that row instead of the TIP-1000
    `250,000` gas storage-creation charge.
 2. The row MUST be marked as temporary or otherwise associated with a prepaid cleanup refund budget
-   of exactly `TEMP_ROW_CLEANUP_REFUND_GAS`.
+   of exactly `PER_ROW_CLEANUP_REFUND_GAS`.
 3. The operation MUST still charge ordinary read, write, log, transfer, and execution gas not
    replaced by this TIP.
 
-When a temporary row is removed by a valid semantic cleanup path:
+When a temporary access-key row is removed by a valid semantic cleanup path:
 
 1. The row MUST be set to zero or otherwise made absent.
-2. The transaction MUST receive exactly `TEMP_ROW_CLEANUP_REFUND_GAS` in generic gas refund for that
+2. The transaction MUST receive exactly `PER_ROW_CLEANUP_REFUND_GAS` in generic gas refund for that
    row.
 3. The row's cleanup refund budget MUST be consumed.
 4. The row MUST NOT mint a TIP-1060 storage credit.
@@ -128,6 +151,22 @@ block.timestamp < expiresAt <= block.timestamp + MAX_TEMPORARY_TTL
 The channel id for an expiring channel MUST include `expiresAt` and a domain separator that prevents
 collisions with legacy non-expiring channel ids.
 
+The precompile MUST expose an expiring channel open path that includes `expiresAt` and a
+permissionless finalization path:
+
+```solidity
+function openExpiring(
+    address payee,
+    address token,
+    uint128 deposit,
+    bytes32 salt,
+    address authorizedSigner,
+    uint64 expiresAt
+) external returns (bytes32 channelId);
+
+function finalizeChannel(bytes32 channelId) external;
+```
+
 ### Channel Creation Cost
 
 The packed channel state row created by an expiring channel open is a temporary row.
@@ -135,11 +174,11 @@ The packed channel state row created by an expiring channel open is a temporary 
 Opening an expiring channel therefore charges:
 
 ```text
-TEMP_ROW_CREATION_GAS = 35_000
+EXPIRING_CHANNEL_CREATION_GAS = 105_000
 ```
 
-for the channel state row, plus the ordinary gas required for validation, TIP-20 transfer, event
-emission, and any other execution work.
+for the channel state row and its prepaid finalization refund budget, plus the ordinary gas required
+for validation, TIP-20 transfer, event emission, and any other execution work.
 
 Top-ups and settlements modify an existing channel row and MUST NOT create a new temporary-row
 cleanup budget for that row. Extending `expiresAt` is out of scope for this TIP; a channel that needs
@@ -166,12 +205,12 @@ any caller MAY finalize the expired channel. Finalization MUST:
 3. delete the temporary channel state row,
 4. transfer `refund` to the channel payer when `refund > 0`,
 5. emit the normal channel close event or a new expired-channel event,
-6. credit `TEMP_ROW_CLEANUP_REFUND_GAS` as a generic gas refund for the deleted temporary row.
+6. credit `CHANNEL_CLEANUP_REFUND_GAS` as a generic gas refund for the finalized channel.
 
 Finalization MUST NOT transfer any channel funds to the finalizing caller.
 
 Any valid channel close path that deletes an expiring channel state row MUST consume the row's
-cleanup refund budget and credit `TEMP_ROW_CLEANUP_REFUND_GAS`. This includes payee/operator close,
+cleanup refund budget and credit `CHANNEL_CLEANUP_REFUND_GAS`. This includes payee/operator close,
 payer withdraw after an explicit close request, and permissionless expired finalization. If a close
 path reverts, the deleted row, fund transfers, and cleanup refund MUST all revert together.
 
@@ -246,7 +285,7 @@ When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneEx
 1. delete the primary key row,
 2. delete all temporary spending-limit rows associated with the key,
 3. delete all temporary call-scope rows associated with the key,
-4. credit `TEMP_ROW_CLEANUP_REFUND_GAS` for each temporary row actually deleted,
+4. credit `PER_ROW_CLEANUP_REFUND_GAS` for each temporary row actually deleted,
 5. return `true`.
 
 After an expired key is pruned, a new authorization for the same `keyId` MAY succeed if it carries a
@@ -308,10 +347,12 @@ because the old authorization's signed expiry is in the past by the time pruning
 
 1. **Scoped use only.** TIP-1048 temporary pricing MUST apply only to MPP channel rows and
    AccountKeychain access-key rows described in this TIP.
-2. **Minimum creation cost.** Every temporary row creation MUST charge at least
-   `TEMP_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`.
-3. **Fixed cleanup refund.** Each temporary row MAY produce at most one
-   `TEMP_ROW_CLEANUP_REFUND_GAS` cleanup refund.
+2. **Minimum creation cost.** Every temporary access-key row creation MUST charge at least
+   `PER_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`, and every expiring channel row creation MUST
+   charge at least `CHANNEL_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`.
+3. **Fixed cleanup refund.** Each temporary access-key row MAY produce at most one
+   `PER_ROW_CLEANUP_REFUND_GAS` cleanup refund. Each expiring channel MAY produce at most one
+   `CHANNEL_CLEANUP_REFUND_GAS` cleanup refund.
 4. **Prepaid refund bound.** Total cleanup refund credited MUST NOT exceed prepaid cleanup budgets
    consumed by the transaction.
 5. **No TIP-1060 conversion.** Temporary row deletion MUST NOT mint TIP-1060 storage credits.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -86,6 +86,30 @@ refund is intentionally equal to the pre-TIP storage-clearing refund for non-cha
 The `20,000` gas residual ensures that even a perfectly cleaned temporary row has a positive net cost
 and cannot be used for refund farming.
 
+The access-key cleanup refund is based on physical temporary storage rows, not logical key objects.
+The Rust AccountKeychain implementation uses a packed primary key slot, two physical slots per T3
+spending-limit state, and enumerable `Set` storage for spending-limit tokens and call scopes.
+Successful `pruneExpiredKey` cleanup therefore has these storage-operation counts:
+
+```text
+bare temporary key, no limits, no call scopes:
+  4 SLOAD, 1 SSTORE
+
+temporary key with N indexed spending-limit tokens, no call scopes:
+  (6 + 2N) SLOAD, (2 + 4N) SSTORE
+
+temporary key with one target, one selector, one recipient, no spending limits:
+  18 SLOAD, 11 SSTORE
+```
+
+Using cold-read and storage-reset pricing, the common one-token-limit cleanup is approximately
+`8 * 2,100 + 6 * 5,000 = 46,800` gas before event/call overhead. It deletes six physical temporary
+rows, which credits `6 * 15,000 = 90,000` gas and was prepaid by `6 * 35,000 = 210,000` gas at
+creation. The same per-row accounting covers call-scope cleanup: the one-target/one-selector/
+one-recipient example deletes eleven physical temporary rows and credits `165,000` gas. Therefore
+access keys do not need a separate key-level cleanup refund; `PER_ROW_CLEANUP_REFUND_GAS = 15,000`
+and `TEMP_ROW_CREATION_GAS = 35,000` remain per physical temporary storage slot.
+
 ## Temporary Row Accounting
 
 A **temporary row** is a persistent storage row created by an eligible precompile operation and

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -1,276 +1,328 @@
 ---
 id: TIP-1048
-title: X Storage Precompile
-description: Adds an expiring per-address storage precompile with XSTORE, XLOAD, and XCLEAR.
+title: Temporary Channel and Access Key State
+description: Reduces upfront state-creation cost for bounded-lifetime MPP channel rows and AccountKeychain access-key rows, with prepaid generic gas refunds for semantic cleanup.
 authors: TBD
 status: Draft
-related: TIP-1000
+related: TIP-1000, TIP-1034, TIP-1053, TIP-1060
 protocolVersion: TBD
 ---
 
-# TIP-1048: X Storage Precompile
+# TIP-1048: Temporary Channel and Access Key State
 
 ## Abstract
 
-This TIP introduces a new precompile that stores expiring key-value slots for an address. The precompile exposes three entrypoints: `XSTORE(slot, value, expiry)`, `XLOAD(slot)`, and `XCLEAR(addr, slot)`.
+This TIP replaces the previous general-purpose X storage precompile proposal with a scoped
+temporary-state mechanism for two existing precompiles:
 
-`XSTORE` and `XLOAD` are scoped to `msg.sender`, so each caller gets an isolated slot namespace. `XCLEAR` is permissionless, but it may only succeed once an entry has expired.
+- the MPP / TIP-20 Channel Reserve precompile
+- the AccountKeychain precompile
 
-This allows us effectively introduce an out-of-protocol solution for clearing expired state, without having to make involved changes to the state trie or introducing new system transactions.
+The goal is to make bounded-lifetime channel opens and access-key authorizations cheaper upfront
+without creating a general temporary storage primitive. A temporary row pays a fixed creation
+charge of `35,000` gas: `20,000` gas is nonrefundable residual cost, and `15,000` gas prepays a
+one-shot generic cleanup refund. When the temporary row is later removed by a valid semantic cleanup
+path, the transaction receives a `15,000` gas refund for that row.
 
-> **Note:** The precompile logic can be built completely out-of-protocol, but we propose this as TIP so that we can also introduce a discounted gas schedule, which encourages the use of temporary storage.
+Temporary rows MUST NOT mint TIP-1060 storage credits when deleted. The cleanup refund is generic
+gas accounting, not a token bounty and not a transferable credit.
 
 ## Motivation
 
-1. **Short-lived state management:**
-   Many applications need short-lived state that persists longer than a single call frame or transaction, but still have an expiry associated with them.
-   Some examples are permit nonces with expiry, keychain state after the key has expired, DEX orders after expiry etc.
-   
-   Persistent contract storage is a poor fit for this pattern because it requires the owner to manage cleanup manually, and every expired entry becomes long-lived state unless someone explicitly removes it. 
+TIP-1000 prices net-new state creation at `250,000` gas to protect the chain from unbounded state
+growth. That cost is appropriate for permanent state, but it makes two bounded-lifetime flows too
+expensive:
 
-2. **Reducing upfront user costs:** 
-   The 250,000 gas introduced in TIP 1000, is necessary to control state growth, but also introduces higher costs for user onboarding. Introducing cheaper temporary storage primitives, would encourage app devs to use state efficient onboarding patterns which is a win-win for all parties.
+1. **MPP channel opens.** A payer often opens a short-lived payment channel, funds it, lets a payee
+   settle cumulative vouchers, then closes or lets the channel expire. The channel row is not meant
+   to be permanent, but the opener currently pays permanent-state economics.
+2. **Access keys.** Wallets commonly authorize short-lived access keys for session-style UX. These
+   keys expire by construction, but their key rows, spending limits, and call scopes can remain in
+   state unless they are explicitly cleaned up.
 
-This TIP introduces a small precompile dedicated to expiring slot storage, with a built-in cleanup path that any actor can trigger once an entry has expired.
+The cleanup for these flows is domain-specific. A channel cannot be safely removed by blindly
+clearing storage because any unsettled funds must be returned to the payer. Access-key cleanup must
+respect key expiry, revocation semantics, spending limits, and call scopes. This TIP therefore
+scopes temporary state to the precompiles that understand those semantics.
 
+## Constants
 
-
-## Assumptions
-
-- Expiry is measured against `block.timestamp`.
-- A slot is live while `block.timestamp <= expiry`.
-- A slot is expired once `block.timestamp > expiry`.
-- `XSTORE` rejects expiries that are not strictly greater than the current `block.timestamp`.
-- `XSTORE` and `XLOAD` key storage by the immediate `msg.sender`, not `tx.origin`.
-- `XCLEAR` can be called by any address and returns `true` only for an expired, not-yet-cleared slot.
-- Clearing a slot sets both its stored value and its expiry to zero.
-
----
-
-# Specification
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
-
-## Precompile Address
-
-The X storage precompile is deployed at the ASCII `X` address:
+This TIP defines the following gas constants:
 
 ```text
-0x5800000000000000000000000000000000000000
+TEMP_ROW_CLEANUP_REFUND_GAS = 15_000
+TEMP_ROW_RESIDUAL_GAS       = 20_000
+TEMP_ROW_CREATION_GAS       = 35_000
+MAX_TEMPORARY_TTL           = 30 days
 ```
 
-## Interface
+`TEMP_ROW_CREATION_GAS` is the minimum cost to create one temporary persistent storage row:
+
+```text
+TEMP_ROW_CREATION_GAS = TEMP_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS
+```
+
+The `15,000` gas cleanup refund is intentionally equal to the pre-TIP storage-clearing refund. The
+`20,000` gas residual ensures that even a perfectly cleaned temporary row has a positive net cost and
+cannot be used for refund farming.
+
+## Temporary Row Accounting
+
+A **temporary row** is a persistent storage row created by an eligible precompile operation and
+associated with an expiry no later than `MAX_TEMPORARY_TTL` from the creation timestamp.
+
+When an eligible operation creates a temporary row from zero to nonzero:
+
+1. The operation MUST charge `TEMP_ROW_CREATION_GAS` for that row instead of the TIP-1000
+   `250,000` gas storage-creation charge.
+2. The row MUST be marked as temporary or otherwise associated with a prepaid cleanup refund budget
+   of exactly `TEMP_ROW_CLEANUP_REFUND_GAS`.
+3. The operation MUST still charge ordinary read, write, log, transfer, and execution gas not
+   replaced by this TIP.
+
+When a temporary row is removed by a valid semantic cleanup path:
+
+1. The row MUST be set to zero or otherwise made absent.
+2. The transaction MUST receive exactly `TEMP_ROW_CLEANUP_REFUND_GAS` in generic gas refund for that
+   row.
+3. The row's cleanup refund budget MUST be consumed.
+4. The row MUST NOT mint a TIP-1060 storage credit.
+
+The cleanup refund is one-shot. A row that was never temporary, has already been cleaned, or has no
+remaining prepaid cleanup budget MUST NOT produce a TIP-1048 cleanup refund.
+
+## Generic Refund Semantics
+
+TIP-1048 cleanup refunds are generic transaction gas refunds. They can offset gas spent by the same
+transaction, including unrelated execution in the same transaction, but they MUST NOT produce a
+negative gas charge or any token payout.
+
+Implementations MUST enforce:
+
+- The total TIP-1048 cleanup refund credited for one transaction MUST NOT exceed the sum of prepaid
+  cleanup refund budgets consumed by that transaction.
+- A temporary row deletion MUST NOT also receive the ordinary storage-clearing refund for the same
+  row.
+- A temporary row deletion MUST NOT mint or consume TIP-1060 storage credits.
+- If an operation reverts, its temporary-row creations, cleanup-budget changes, and cleanup refunds
+  MUST revert with the same EVM execution scope.
+
+The standard refund cap MUST NOT apply to TIP-1048 cleanup refunds. The refund is prepaid at
+creation time and bounded by consumed cleanup budgets, so the cap is not needed to prevent
+net-positive gas accounting.
+
+## MPP Expiring Channels
+
+This TIP extends the TIP-20 Channel Reserve precompile with expiring channels. Existing permanent
+channels continue to use the existing TIP-1034 economics and behavior.
+
+### Channel Expiry
+
+An expiring channel has an `expiresAt` timestamp. The precompile MUST reject expiring channel opens
+unless:
+
+```text
+block.timestamp < expiresAt <= block.timestamp + MAX_TEMPORARY_TTL
+```
+
+The channel id for an expiring channel MUST include `expiresAt` and a domain separator that prevents
+collisions with legacy non-expiring channel ids.
+
+### Channel Creation Cost
+
+The packed channel state row created by an expiring channel open is a temporary row.
+
+Opening an expiring channel therefore charges:
+
+```text
+TEMP_ROW_CREATION_GAS = 35_000
+```
+
+for the channel state row, plus the ordinary gas required for validation, TIP-20 transfer, event
+emission, and any other execution work.
+
+Top-ups and settlements modify an existing channel row and MUST NOT create a new temporary-row
+cleanup budget for that row. Extending `expiresAt` is out of scope for this TIP; a channel that needs
+a later expiry should be closed or finalized and replaced with a new channel.
+
+### Expiry and Finalization
+
+When `block.timestamp < expiresAt`, the expiring channel behaves like a normal channel.
+
+When `block.timestamp >= expiresAt`, the channel is expired. Expiry starts the close window; it does
+not blindly delete the row. Until the existing channel close grace period has elapsed, the payee or
+operator MAY still close the channel with a valid voucher under the usual channel close rules.
+
+After:
+
+```text
+block.timestamp >= expiresAt + CLOSE_GRACE_PERIOD
+```
+
+any caller MAY finalize the expired channel. Finalization MUST:
+
+1. load the channel state,
+2. compute `refund = deposit - settled`,
+3. delete the temporary channel state row,
+4. transfer `refund` to the channel payer when `refund > 0`,
+5. emit the normal channel close event or a new expired-channel event,
+6. credit `TEMP_ROW_CLEANUP_REFUND_GAS` as a generic gas refund for the deleted temporary row.
+
+Finalization MUST NOT transfer any channel funds to the finalizing caller.
+
+Any valid channel close path that deletes an expiring channel state row MUST consume the row's
+cleanup refund budget and credit `TEMP_ROW_CLEANUP_REFUND_GAS`. This includes payee/operator close,
+payer withdraw after an explicit close request, and permissionless expired finalization. If a close
+path reverts, the deleted row, fund transfers, and cleanup refund MUST all revert together.
+
+### Replacement Flow
+
+The precompile MAY expose a helper that finalizes an expired channel and opens a replacement channel
+in one call. The helper MUST be equivalent to executing finalization followed by a new expiring
+channel open in the same transaction.
+
+Because TIP-1048 cleanup refunds are generic gas refunds, a transaction that finalizes one account's
+expired channel can use that prepaid refund to offset any other gas in the same transaction. This is
+intentional: the refund was prepaid by the temporary row's creator and remains capped by that prepaid
+budget.
+
+## Expiring Access Keys
+
+This TIP makes short-lived, non-admin AccountKeychain access-key rows temporary. Admin keys and
+non-expiring keys remain permanent.
+
+### Eligibility
+
+An access-key authorization is eligible for temporary pricing only when all of the following are
+true:
+
+1. The key is not an admin key.
+2. The key expiry is finite.
+3. `block.timestamp < expiry <= block.timestamp + MAX_TEMPORARY_TTL`.
+4. The key has not been revoked.
+
+Access-key authorizations that do not meet these requirements continue to use ordinary TIP-1000 and
+TIP-1060 storage economics.
+
+### Temporary Access-Key Rows
+
+Every persistent storage row created by an eligible access-key authorization is a temporary row. This
+includes:
+
+- the primary `keys[account][keyId]` row,
+- each spending-limit row created for the key,
+- each stored call-scope row created for the key,
+- any enumerable index row needed to later find and delete temporary spending limits or scopes.
+
+The precompile MUST charge `TEMP_ROW_CREATION_GAS` for each such row. If the implementation uses
+multiple physical storage slots for one logical restriction, each physical zero-to-nonzero storage
+slot is one temporary row and MUST be charged separately.
+
+Temporary access keys MUST maintain enough internal indexing to prune all temporary rows associated
+with the key after expiry. A row that cannot be found by the expiry cleanup path MUST NOT receive
+temporary pricing.
+
+Rows created later for an already-temporary access key, such as spending-limit or call-scope rows
+added by an update before the key expires, are temporary rows tied to the same key expiry and MUST be
+charged `TEMP_ROW_CREATION_GAS` per row.
+
+### Access-Key Pruning
+
+The AccountKeychain precompile MUST expose a permissionless cleanup path:
 
 ```solidity
-interface IXStorage {
-    /// @notice The requested slot is not currently live.
-    error Expired();
-
-    /// @notice The supplied expiry is not strictly in the future.
-    error InvalidExpiry();
-
-    /// @notice Stores or overwrites a slot owned by msg.sender.
-    /// @param slot Caller-defined slot key.
-    /// @param value Value to store.
-    /// @param expiry Inclusive unix timestamp after which the slot becomes expired.
-    /// @dev Reverts with InvalidExpiry if expiry <= block.timestamp.
-    function XSTORE(bytes32 slot, bytes32 value, uint64 expiry) external;
-
-    /// @notice Loads a slot owned by msg.sender.
-    /// @param slot Caller-defined slot key.
-    /// @return value Stored value.
-    /// @return expiry Stored inclusive unix expiry.
-    /// @dev Reverts with Expired if the slot is expired or has been cleared.
-    function XLOAD(bytes32 slot) external view returns (bytes32 value, uint64 expiry);
-
-    /// @notice Clears an expired slot for any address.
-    /// @param addr Owner of the slot.
-    /// @param slot Caller-defined slot key.
-    /// @return cleared True if the slot was cleared, false otherwise.
-    /// @dev  Returns false when the slot is still live,
-    /// was never written, or has already been cleared.
-    function XCLEAR(address addr, bytes32 slot) external returns (bool cleared);
-}
+function pruneExpiredKey(address account, address keyId) external returns (bool pruned);
 ```
 
-## Storage Model
+`pruneExpiredKey` MUST return `false` and MUST NOT modify state when:
 
-The precompile maintains the following logical mapping:
+- the key does not exist,
+- the key is revoked,
+- the key is not temporary,
+- the key has not expired.
 
-```solidity
-struct XEntry {
-    bytes32 value;
-    bytes32 metadata;
-}
+When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneExpiredKey` MUST:
 
-mapping(address => mapping(bytes32 => XEntry)) entries;
+1. delete the primary key row,
+2. delete all temporary spending-limit rows associated with the key,
+3. delete all temporary call-scope rows associated with the key,
+4. credit `TEMP_ROW_CLEANUP_REFUND_GAS` for each temporary row actually deleted,
+5. return `true`.
+
+After an expired key is pruned, a new authorization for the same `keyId` MAY succeed if it carries a
+new future expiry and otherwise passes AccountKeychain validation. Replaying the original
+authorization after pruning MUST fail because the original signed expiry is no longer in the future.
+
+Revoked keys are not pruned by this TIP. Revocation remains the permanent replay-prevention state for
+keys intentionally revoked before expiry.
+
+If a temporary key is revoked before expiry and the implementation keeps a permanent revoked-key
+tombstone, the revocation MUST convert the primary key row from temporary to permanent. The caller
+MUST be charged enough additional gas that the primary key row has paid at least the ordinary
+TIP-1000 permanent storage-creation cost in total. With the constants in this TIP, that additional
+charge is:
+
+```text
+250_000 - TEMP_ROW_CREATION_GAS = 215_000
 ```
 
-Each address has its own independent slot namespace. Two different callers using the same `slot` key MUST read and write different records.
-
-This mapping is a logical model. The implementation MAY use any internal layout so long as the externally visible behavior and gas accounting defined by this TIP are preserved.
-
-## Metadata Encoding
-
-The second storage slot of each entry uses the full 256-bit word with the following layout:
-
-| Bits | Meaning |
-|------|---------|
-| `255` | Version bit |
-| `254:64` | Reserved for future use |
-| `63:0` | expiry |
-
-In this TIP, the current version is `0`, so the version bit is `0`.
-
-For version `0`:
-
-- bit `255` MUST be `0`
-- bits `254:64` MUST be `0`
-- bits `63:0` contain the inclusive unix timestamp used for expiry checks
-
-The reserved middle bits are intentionally left empty for future use. The current API only exposes the `uint64 expiry` timestamp; callers do not provide or observe the other metadata bits in this version.
-
-Under this model, `value` and `expiry` are distinct storage fields. A fresh entry therefore behaves like creation of two state elements for economic analysis.
-
-## Function Semantics
-
-### `XSTORE(slot, value, expiry)`
-
-`XSTORE` uses `msg.sender` as the slot owner. It MUST write `value` and `expiry` into `entries[msg.sender][slot]`, replacing any previous record for that slot.
-
-`XSTORE` MUST revert with `InvalidExpiry()` unless `expiry > block.timestamp`.
-
-If the call succeeds, the precompile MUST store the expiry in the low 64 bits of the metadata slot, and MUST set the version bit and all reserved middle bits to `0`.
-
-### `XLOAD(slot)`
-
-`XLOAD` uses `msg.sender` as the slot owner and reads `entries[msg.sender][slot]`.
-
-If `block.timestamp > expiry`, the call MUST revert with `Expired()` and MUST NOT return the stored value. This includes slots that were previously cleared, since clearing sets `expiry = 0`.
-
-If `block.timestamp <= expiry`, the call MUST return the stored `value` and `expiry`.
-
-## Gas Accounting For `XLOAD`
-
-`XLOAD` MUST charge gas equal to two `SLOAD`s: one for reading the expiry field and one for reading the value field.
-
-Each read MUST be charged according to the warm or cold access state of the corresponding storage slot.
-
-### `XCLEAR(addr, slot)`
-
-`XCLEAR` reads `entries[addr][slot]`.
-
-If `expiry == 0`, the call MUST return `false`.
-
-If `block.timestamp <= expiry`, the call MUST return `false`.
-
-If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` and `expiry = 0`, and MUST return `true`.
-
-`XCLEAR` MAY be called by any address for any `addr`; there is no ownership check.
-
-## Gas Accounting For `XCLEAR`
-
-`XCLEAR` MUST first read the target entry's expiry to determine whether the entry is clearable.
-
-If `XCLEAR` does not clear the slot, the call MUST cost exactly as much gas as an `SLOAD` of the expiry slot in the corresponding warm or cold access state. An unsuccessful `XCLEAR` MUST return `false` and MUST NOT add any gas refund.
-
-If `XCLEAR` succeeds, the call MUST be free to execute, MUST return `true`, and MUST add 15,000 gas to the transaction's refund counter. This 15,000 gas refund is the only explicit cleanup incentive introduced by this TIP.
-
-## XSTORE Pricing
-
-Let `ttl = expiry - block.timestamp` as measured at execution time.
-
-`XSTORE` MUST charge gas according to the following lifetime buckets:
-
-| Lifetime | Gas |
-|----------|-----|
-| `ttl <= 1 hour` | 20,000 |
-| `1 hour < ttl <= 1 day` | 40,000 |
-| `1 day < ttl <= 1 week` | 80,000 |
-| `1 week < ttl <= 30 days` | 120,000 |
-| `30 days < ttl <= 365 days` | 200,000 |
-| `365 days < ttl` | 250,000 |
-
-These are the full `XSTORE` gas charges defined by this TIP. `XSTORE` does not additionally inherit ordinary `SSTORE` creation pricing on top of this table.
-
-The pricing follows one simple principle: the longer state is allowed to stay around, the closer it should get to ordinary persistent-state pricing.
-
-Short-lived entries are still cheaper than persistent storage, but they do not start below ordinary storage-write costs. The minimum `20,000` gas tier ensures that `XSTORE` plus a later successful `XCLEAR` can never create net-positive refund farming against the `15,000` gas cleanup refund.
-
-A one-year entry is still cheaper than permanent storage at `200,000` gas. Anything beyond one year is charged `250,000` gas, matching the [TIP-1000](./tip-1000.md) benchmark for permanent state growth.
-
-This keeps temporary storage useful for real application flows, while making sure that very long-lived entries do not underprice effectively persistent state.
-
-## Empty And Cleared Slots
-
-An entry with `expiry = 0` is treated as not live. As a result:
-
-- `XLOAD` on a never-written slot MUST revert with `Expired()`.
-- `XLOAD` on a cleared slot MUST revert with `Expired()`.
-- `XCLEAR` on a never-written or already-cleared slot MUST return `false`.
-
-## Expiring Nonces
-
-Expiring nonces are intentionally left out of this TIP.
-
-Once this precompile is live, we expect to propose a separate TIP that migrates expiring nonces away from the current ring buffer design and onto this precompile. That migration is straightforward because expiring nonces already have a very short maximum lifetime of 30 seconds, so we can just abandon the ring buffer when required
-
-## Future Compatibility
-
-This design intentionally separates the user-facing storage semantics from the cleanup mechanism.
-
-`XSTORE` and `XLOAD` define the core interface and semantics: write a value with an expiry, and read it while it is still live. A future TIP could keep those interfaces the same while changing how expired state is physically managed underneath, for example with separate temporary storage tries, system transactions, or other more sophisticated cleanup mechanisms.
-
-In this version, cleanup is exposed through `XCLEAR`. A future design may keep `XCLEAR` as a compatibility hook, or make it unnecessary if cleanup becomes fully protocol-driven.
-
-## XCLEAR Incentives
-
-This TIP keeps the incentive model simple: successful `XCLEAR` calls receive the existing `15,000` gas storage-clearing refund, and no additional incentive is introduced.
-
-We believe this is sufficient for two reasons - 
-1. Validators are naturally incentivized to keep the state they serve smaller, so many validators can justify running expiry cleanup as a protocol service even when the direct economic return is modest. 
-2. Searchers and arbitrage bots can bundle `XCLEAR` calls into transactions they already intend to send, using the refund to reduce the effective cost of those transactions.
-
-Because of these existing incentives, this TIP does not add any larger or special-purpose cleanup reward.
-
-## Race Conditions
-
-`XCLEAR` has ordering races, not correctness races.
-
-Execution is serialized, so the precompile always checks the current slot state at execution time. This means a stale `XCLEAR` cannot clear a slot that has already been reused with a fresh future expiry: in that case it will see the new live expiry and return `false`.
-
-The main remaining question is economic. There are two cases:
-
-1. **Unsuccessful `XCLEAR`**: costs one `SLOAD` of the expiry/metadata slot and returns `false`.
-2. **Successful `XCLEAR`**: clears the slot, returns `true`, and receives the `15,000` gas refund.
-
-If two actors race to clear the same expired slot, the loser only pays the cost of a single `SLOAD` instead of risking a full transaction revert. This makes `XCLEAR` safe to include inside larger flows and bundles.
-
-This design does not remove ordering races, but it reduces their downside to a small, bounded gas cost while preserving correct state transitions.
-
-## Events
-This TIP does not introduce any events.
-
-## Errors
-
-This TIP introduces the following custom errors:
-
-- `Expired()`: returned by `XLOAD` when the requested slot is not currently live.
-- `InvalidExpiry()`: returned by `XSTORE` when `expiry <= block.timestamp`.
-
-# Invariants
-
-- **Sender isolation**: `XSTORE` and `XLOAD` MUST only access the namespace keyed by `msg.sender`.
-- **Versioned metadata slot**: the metadata slot MUST use the packed layout above, with version bit `0` in this TIP.
-- **Reserved bits zero**: the reserved middle bits in the metadata slot MUST be zero in this version.
-- **Future expiry only**: `XSTORE` MUST only accept expiries strictly greater than the current `block.timestamp`.
-- **Live-read only**: `XLOAD` MUST only return data when `block.timestamp <= expiry`.
-- **Expired-read rejection**: `XLOAD` MUST revert once `block.timestamp > expiry`.
-- **XLOAD price**: `XLOAD` MUST charge gas equal to two `SLOAD`s.
-- **Permissionless cleanup**: Any caller MUST be able to clear an expired slot for any owner.
-- **No premature deletion**: `XCLEAR` MUST return `false` and MUST NOT modify a slot whose expiry has not yet passed.
-- **No repeated cleanup reward**: `XCLEAR` MUST return `false` for never-written and already-cleared slots.
-- **XCLEAR unsuccessful cost**: An unsuccessful `XCLEAR` MUST cost only the corresponding expiry-slot `SLOAD`.
-- **XCLEAR success incentive**: A successful `XCLEAR` MUST return `true` and MUST add exactly 15,000 gas to the transaction refund counter.
-- **Tiered XSTORE price**: `XSTORE` MUST charge according to the lifetime bucket table above.
-- **Overwrite behavior**: A later `XSTORE` for the same `(msg.sender, slot)` pair MUST fully replace the previous `value` and `expiry`.
+The primary key row's temporary cleanup refund budget MUST be cancelled during this conversion and
+MUST NOT be refunded. Temporary restriction rows that are deleted during revocation MAY receive their
+ordinary TIP-1048 cleanup refunds, because those rows do not become permanent tombstones.
+
+### Lazy Replacement
+
+The AccountKeychain precompile MAY expose a helper that prunes one expired key and authorizes a new
+key for the same account in one call. The helper MUST be equivalent to `pruneExpiredKey(account,
+oldKeyId)` followed by the ordinary authorization path for the new key in the same transaction.
+
+The helper MUST only authorize the new key for the same account whose expired key was pruned.
+Permissionless pruning remains available as a standalone operation, and any cleanup refund from that
+standalone operation is still generic transaction refund gas.
+
+## Interaction With TIP-1060
+
+TIP-1060 storage credits remain the mechanism for ordinary permanent storage churn. TIP-1048
+temporary rows are separate:
+
+- Creating a temporary row does not consume a TIP-1060 storage credit.
+- Deleting a temporary row does not mint a TIP-1060 storage credit.
+- The `20,000` residual and `15,000` cleanup refund are TIP-1048 accounting only.
+- Permanent channel rows, non-expiring access keys, admin keys, revoked-key tombstones, and other
+  non-temporary rows continue to use TIP-1000 and TIP-1060 economics.
+
+This separation prevents a caller from creating cheap temporary rows and later converting them into
+full `230,000` gas TIP-1060 storage credits.
+
+## Backward Compatibility
+
+Existing non-expiring channels and existing AccountKeychain behavior remain available. This TIP adds
+temporary pricing and cleanup paths for bounded-lifetime rows; it does not require users to migrate
+existing permanent rows.
+
+The main semantic change is that expired temporary access keys can be fully pruned and their key id
+can later be reused with a new authorization. This does not allow replay of the old authorization
+because the old authorization's signed expiry is in the past by the time pruning is allowed.
+
+## Invariants
+
+1. **Scoped use only.** TIP-1048 temporary pricing MUST apply only to MPP channel rows and
+   AccountKeychain access-key rows described in this TIP.
+2. **Minimum creation cost.** Every temporary row creation MUST charge at least
+   `TEMP_ROW_CLEANUP_REFUND_GAS + TEMP_ROW_RESIDUAL_GAS`.
+3. **Fixed cleanup refund.** Each temporary row MAY produce at most one
+   `TEMP_ROW_CLEANUP_REFUND_GAS` cleanup refund.
+4. **Prepaid refund bound.** Total cleanup refund credited MUST NOT exceed prepaid cleanup budgets
+   consumed by the transaction.
+5. **No TIP-1060 conversion.** Temporary row deletion MUST NOT mint TIP-1060 storage credits.
+6. **No double refund.** Temporary row deletion MUST NOT also receive an ordinary storage-clearing
+   refund for the same row.
+7. **Semantic channel cleanup.** An expired channel MUST NOT be deleted without returning
+   `deposit - settled` to the payer.
+8. **No finalizer bounty.** Channel finalization MUST NOT transfer channel funds to the finalizing
+   caller.
+9. **Access-key expiry gate.** `pruneExpiredKey` MUST NOT delete an unexpired key.
+10. **Revocation preservation.** Revoked keys MUST retain their revocation semantics and MUST NOT be
+    pruned as expired temporary keys.
+11. **Revert safety.** Temporary-row creation, cleanup-budget consumption, cleanup refunds, channel
+    fund transfers, and access-key pruning MUST revert with their EVM execution scope.

--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1048
 title: Temporary Access Key State
-description: Reduces upfront state-creation cost for bounded-lifetime AccountKeychain access-key rows, with prepaid generic gas refunds for semantic cleanup.
+description: Reduces upfront state-creation cost for bounded-lifetime AccountKeychain access-key rows, with prepaid generic gas refunds for expiry pruning.
 authors: TBD
 status: Draft
 related: TIP-1000, TIP-1011, TIP-1060
@@ -12,205 +12,96 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP replaces the previous general-purpose X storage precompile proposal with a scoped
-temporary-state mechanism for the AccountKeychain precompile.
+This TIP gives bounded-lifetime AccountKeychain access keys temporary state pricing and a
+permissionless expiry cleanup path.
 
-The goal is to make bounded-lifetime access-key authorizations cheaper upfront without creating a
-general temporary storage primitive. A temporary access key prepays a cleanup refund `X(config)`,
-where `X` is a function of the physical temporary slots needed for the key, plus a nonrefundable
-`20,000` gas buffer and a nonrefundable expiry premium based on the key lifetime.
-
-Temporary access-key rows MUST NOT mint TIP-1060 storage credits when deleted. The cleanup refund is
-generic gas accounting, not a token bounty and not a transferable credit.
+The access-key creator prepays a generic gas refund `X(config)`. Any caller can later prune the
+expired key and receive that refund in the pruning transaction. `X(config)` scales with the number
+of temporary storage slots created by the key's limits and call scopes.
 
 ## Motivation
 
-TIP-1000 prices net-new state creation at `250,000` gas to protect the chain from unbounded state
-growth. That cost is appropriate for permanent state, but it makes session-style wallet UX
-expensive. Wallets commonly authorize short-lived access keys, and those keys can include spending
-limits and call scopes that are useful only until the key expires.
-
-Expiry alone is not enough. Expired keys, spending limits, and call-scope rows still occupy state
-unless the AccountKeychain precompile removes them. Cleanup also cannot be a blind storage delete:
-the precompile must respect key expiry, revocation semantics, spending-limit indexes, and call-scope
-indexes. This TIP therefore scopes temporary state to the access-key precompile that understands
-those semantics.
+Short-lived access keys make wallet sessions cheaper and safer, but their storage can outlive the
+session. Charging full permanent-state pricing for a key with a bounded expiry makes session UX
+expensive. Expiry alone is not sufficient either: stale key rows, spending limits, and call scopes
+still need to be removed by the precompile that understands their semantics.
 
 ## Constants
 
-This TIP defines the following gas constants:
-
 ```text
-ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS       = 15_000
-ACCESS_KEY_CREATION_BUFFER_GAS           = 20_000
+ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS         = 15_000
+ACCESS_KEY_CREATION_BUFFER_GAS             = 20_000
 ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS = 1_000
-MAX_TEMPORARY_TTL                        = 30 days
+MAX_TEMPORARY_TTL                          = 30 days
 ```
 
-For a temporary access-key authorization:
+For an eligible access key:
 
 ```text
 temporary_slot_count(config) =
-    number of physical nonzero temporary storage slots the key cleanup path can delete
+    physical nonzero storage slots created for the key and reachable by pruneExpiry
 
-ACCESS_KEY_CLEANUP_REFUND_GAS(config) =
+X(config) =
     ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS * temporary_slot_count(config)
 
-ACCESS_KEY_EXPIRY_PREMIUM_GAS(config, expiry) =
+expiry_premium(config, expiry) =
     ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
     * temporary_slot_count(config)
     * ceil((expiry - block.timestamp) / 1 day)
 
-TEMP_ACCESS_KEY_CREATION_GAS(config, expiry) =
-    ACCESS_KEY_CLEANUP_REFUND_GAS(config)
+temporary_access_key_creation_gas(config, expiry) =
+    X(config)
     + ACCESS_KEY_CREATION_BUFFER_GAS
-    + ACCESS_KEY_EXPIRY_PREMIUM_GAS(config, expiry)
+    + expiry_premium(config, expiry)
 ```
 
-`ACCESS_KEY_CLEANUP_REFUND_GAS(config)` is the `X` value prepaid by the creator and later refunded
-to the transaction that prunes the expired key. The `20,000` gas buffer and the expiry premium are
-not refunded.
+The `20,000` gas buffer and expiry premium are nonrefundable. Only `X(config)` is refunded to the
+transaction that prunes the expired key.
 
-## Slot Counting
+## Benchmarks
 
-`temporary_slot_count(config)` is counted over physical storage slots, not logical objects. Every
-slot that receives temporary pricing MUST be reachable by `pruneExpiry`, and every slot that
-`pruneExpiry` refunds MUST have prepaid the refund during creation.
-
-For the current Rust AccountKeychain layout:
+The benchmark command is:
 
 ```text
-primary key row:
-  1 slot
-
-L spending-limit tokens:
-  if L == 0: 0 slots
-  if L > 0: 1 + 4L slots
-    - 2L spending-limit state slots
-    - 1 + 2L enumerable token-index slots
-
-call scopes:
-  allowAnyCalls = true:
-    0 slots
-
-  scoped deny-all with no targets:
-    1 slot
-    - key-level is_scoped flag
-
-  scoped key with T targets:
-    1 + (1 + 2T)
-    + per-target selector/recipient slots
-    - 1 key-level is_scoped flag
-    - 1 + 2T enumerable target-index slots
-
-  for target i with S_i selector rules:
-    if S_i == 0: 0 slots
-    if S_i > 0: 1 + ceil(S_i / 8) + S_i slots
-      - selector set length
-      - packed selector value slots
-      - selector position slots
-
-  for selector j with R_ij recipient restrictions:
-    if R_ij == 0: 0 slots
-    if R_ij > 0: 1 + 2R_ij slots
-      - recipient set length
-      - recipient value slots
-      - recipient position slots
+cargo test -p tempo-precompiles test_t3_access_key_tip_1048_benchmark_table -- --nocapture
 ```
 
-Examples:
+The benchmark runs Rust `authorize_key` to count temporary slots and Rust `prune_expiry` to measure
+cleanup execution. The table uses a seven-day key lifetime. Creation values are state-creation gas:
+`250,000 * measured slots` for the TIP-1000 column, and the formula above for the TIP-1048 column.
+Prune execution is storage execution inside the AccountKeychain precompile.
 
-```text
-bare temporary key:
-  temporary_slot_count = 1
-  X = 15_000
+| Access key config | Slots | Create without TIP | Create after TIP | Arb prune execution | Arb refund |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Bare key | 1 | 250,000 | 42,000 | 13,400 | 15,000 |
+| One spending limit | 6 | 1,500,000 | 152,000 | 47,100 | 90,000 |
+| Three spending limits | 14 | 3,500,000 | 328,000 | 104,100 | 210,000 |
+| One scoped call | 11 | 2,750,000 | 262,000 | 81,000 | 165,000 |
+| One spending limit and one scoped call | 16 | 4,000,000 | 372,000 | 114,700 | 240,000 |
 
-temporary key with one spending-limit token and no call scope:
-  temporary_slot_count = 6
-  X = 90_000
+These measurements justify `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS = 15,000`: the tightest case is a
+bare key, where pruning costs `13,400` gas and refunds `15,000` gas. Larger configurations have
+larger margins because the fixed key lookup cost is amortized across more slots.
 
-temporary key with three spending-limit tokens and no call scope:
-  temporary_slot_count = 14
-  X = 210_000
-
-temporary key with one target, one selector, and one recipient:
-  temporary_slot_count = 11
-  X = 165_000
-```
-
-## Cleanup Benchmark
-
-`ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS = 15,000` is based on the Rust AccountKeychain
-`pruneExpiry` implementation using the test storage provider's warm/cold SLOAD and SSTORE counters:
-
-```text
-cargo test -p tempo-precompiles test_t3_prune_expiry_storage_accounting_benchmark -- --nocapture
-
-bare temporary key:
-  4 cold SLOAD, 0 warm SLOAD, 0 cold SSTORE, 1 warm SSTORE
-  estimated storage gas = 13_400
-  cleanup refund = 15_000
-
-temporary key with three spending limits:
-  7 cold SLOAD, 5 warm SLOAD, 9 cold SSTORE, 5 warm SSTORE
-  estimated storage gas = 104_100
-  cleanup refund = 210_000
-
-temporary key with one target/selector/recipient scope:
-  9 cold SLOAD, 8 warm SLOAD, 3 cold SSTORE, 8 warm SSTORE
-  estimated storage gas = 81_000
-  cleanup refund = 165_000
-```
-
-The estimate uses `2,100` gas for cold `SLOAD`, `100` gas for warm storage reads, `7,100` gas for
-cold storage clears, and `5,000` gas for warm storage clears. The bare-key case is the tightest
-case because it has fixed read overhead and only one slot to refund; `15,000` still exceeds the
-measured `13,400` storage cleanup cost. Larger keys have more slots to clear, so the slot-scaled
-refund provides a wider margin.
-
-If the AccountKeychain storage layout changes, `temporary_slot_count(config)` and the benchmarked
-cleanup paths MUST be updated before the new layout can use this TIP's temporary pricing.
+`ACCESS_KEY_CREATION_BUFFER_GAS = 20,000` makes every temporary key pay a nonrefundable per-key
+cost even when it is pruned. `ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS = 1,000` makes larger and
+longer-lived keys pay more upfront. `MAX_TEMPORARY_TTL = 30 days` bounds the lifetime of discounted
+state.
 
 ## Eligibility
 
-An access-key authorization is eligible for temporary pricing only when all of the following are
-true:
+Temporary pricing applies only when all of the following are true:
 
 1. The key is not an admin key.
 2. The key expiry is finite.
 3. `block.timestamp < expiry <= block.timestamp + MAX_TEMPORARY_TTL`.
 4. The key has not been revoked.
 
-Access-key authorizations that do not meet these requirements continue to use ordinary TIP-1000 and
-TIP-1060 storage economics.
+All temporary slots created for an eligible key MUST be reachable by `pruneExpiry`.
 
-## Temporary Access-Key Rows
+## Pruning
 
-Every persistent storage row created by an eligible access-key authorization is a temporary row. This
-includes:
-
-- the primary `keys[account][keyId]` row,
-- each spending-limit row created for the key,
-- each stored call-scope row created for the key,
-- any enumerable index row needed to later find and delete temporary spending limits or scopes.
-
-The precompile MUST charge `TEMP_ACCESS_KEY_CREATION_GAS(config, expiry)` for the key. If rows are
-added later to an already-temporary access key, such as through `updateSpendingLimit` or call-scope
-updates before expiry, the operation MUST charge:
-
-```text
-ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS * added_temporary_slots
-+ ACCESS_KEY_EXPIRY_PREMIUM_PER_SLOT_DAY_GAS
-   * added_temporary_slots
-   * ceil((key.expiry - block.timestamp) / 1 day)
-```
-
-Those later-added rows share the key's original expiry. A row that cannot be found by the expiry
-cleanup path MUST NOT receive temporary pricing.
-
-## Access-Key Pruning
-
-The AccountKeychain precompile MUST expose a permissionless cleanup path:
+The AccountKeychain precompile MUST expose:
 
 ```solidity
 function pruneExpiry(address account, address keyId) external returns (bool pruned);
@@ -231,92 +122,20 @@ When the key exists, is temporary, and `block.timestamp >= key.expiry`, `pruneEx
 4. credit `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS` for each temporary slot actually deleted,
 5. return `true`.
 
-After an expired key is pruned, a new authorization for the same `keyId` MAY succeed if it carries a
-new future expiry and otherwise passes AccountKeychain validation. Replaying the original
-authorization after pruning MUST fail because the original signed expiry is no longer in the future.
+After pruning, a new authorization for the same `keyId` MAY succeed if it carries a new future
+expiry and passes AccountKeychain validation. Revoked keys are not pruneable.
 
-Revoked keys are not pruned by this TIP. Revocation remains the permanent replay-prevention state for
-keys intentionally revoked before expiry.
-
-If a temporary key is revoked before expiry and the implementation keeps a permanent revoked-key
-tombstone, the revocation MUST convert the primary key row from temporary to permanent. The caller
-MUST be charged enough additional gas that the primary key row has paid at least the ordinary
-TIP-1000 permanent storage-creation cost in total. The primary key row's temporary cleanup refund
-budget MUST be cancelled during this conversion and MUST NOT be refunded. Temporary restriction rows
-that are deleted during revocation MAY receive their ordinary TIP-1048 cleanup refunds, because
-those rows do not become permanent tombstones.
-
-## Generic Refund Semantics
+## Refund Rules
 
 TIP-1048 cleanup refunds are generic transaction gas refunds. They can offset gas spent by the same
-transaction, including unrelated execution in the same transaction, but they MUST NOT produce a
-negative gas charge or any token payout.
+transaction, but they MUST NOT produce a negative gas charge, token payout, or transferable credit.
 
 Implementations MUST enforce:
 
-- The total TIP-1048 cleanup refund credited for one transaction MUST NOT exceed the sum of prepaid
-  cleanup refund budgets consumed by that transaction.
-- A temporary slot deletion MUST NOT also receive the ordinary storage-clearing refund for the same
+- Total TIP-1048 cleanup refund credited in a transaction MUST NOT exceed prepaid cleanup budgets
+  consumed by that transaction.
+- A temporary slot deletion MUST NOT also receive an ordinary storage-clearing refund for the same
   slot.
 - A temporary slot deletion MUST NOT mint or consume TIP-1060 storage credits.
-- If an operation reverts, its temporary-slot creations, cleanup-budget changes, and cleanup refunds
-  MUST revert with the same EVM execution scope.
-
-The standard refund cap MUST NOT apply to TIP-1048 cleanup refunds. The refund is prepaid at
-creation time and bounded by consumed cleanup budgets, so the cap is not needed to prevent
-net-positive gas accounting.
-
-## Lazy Replacement
-
-The AccountKeychain precompile MAY expose a helper that prunes one expired key and authorizes a new
-key for the same account in one call. The helper MUST be equivalent to `pruneExpiry(account,
-oldKeyId)` followed by the ordinary authorization path for the new key in the same transaction.
-
-The helper MUST only authorize the new key for the same account whose expired key was pruned.
-Permissionless pruning remains available as a standalone operation, and any cleanup refund from that
-standalone operation is still generic transaction refund gas.
-
-## Interaction With TIP-1060
-
-TIP-1060 storage credits remain the mechanism for ordinary permanent storage churn. TIP-1048
-temporary rows are separate:
-
-- Creating a temporary row does not consume a TIP-1060 storage credit.
-- Deleting a temporary row does not mint a TIP-1060 storage credit.
-- The cleanup refund, `20,000` buffer, and expiry premium are TIP-1048 accounting only.
-- Non-expiring access keys, admin keys, revoked-key tombstones, and other non-temporary rows
-  continue to use TIP-1000 and TIP-1060 economics.
-
-This separation prevents a caller from creating cheap temporary rows and later converting them into
-full `230,000` gas TIP-1060 storage credits.
-
-## Backward Compatibility
-
-Existing AccountKeychain behavior remains available. This TIP adds temporary pricing and cleanup
-paths for bounded-lifetime access-key rows; it does not require users to migrate existing permanent
-rows.
-
-The main semantic change is that expired temporary access keys can be fully pruned and their key id
-can later be reused with a new authorization. This does not allow replay of the old authorization
-because the old authorization's signed expiry is in the past by the time pruning is allowed.
-
-## Invariants
-
-1. **Scoped use only.** TIP-1048 temporary pricing MUST apply only to AccountKeychain access-key
-   rows described in this TIP.
-2. **Minimum creation cost.** Every temporary access-key creation MUST charge at least
-   `ACCESS_KEY_CLEANUP_REFUND_GAS(config) + ACCESS_KEY_CREATION_BUFFER_GAS`.
-3. **Expiry premium.** Every temporary access-key creation MUST charge the expiry premium for the
-   key's configured lifetime and temporary slot count.
-4. **Fixed cleanup refund.** Each temporary access-key slot MAY produce at most one
-   `ACCESS_KEY_SLOT_CLEANUP_REFUND_GAS` cleanup refund.
-5. **Prepaid refund bound.** Total cleanup refund credited MUST NOT exceed prepaid cleanup budgets
-   consumed by the transaction.
-6. **No TIP-1060 conversion.** Temporary slot deletion MUST NOT mint TIP-1060 storage credits.
-7. **No double refund.** Temporary slot deletion MUST NOT also receive an ordinary storage-clearing
-   refund for the same slot.
-8. **Access-key expiry gate.** `pruneExpiry` MUST NOT delete an unexpired key.
-9. **Revocation preservation.** Revoked keys MUST retain their revocation semantics and MUST NOT be
-   pruned as expired temporary keys.
-10. **Revert safety.** Temporary-slot creation, cleanup-budget consumption, cleanup refunds, and
-    access-key pruning MUST revert with their EVM execution scope.
+- Temporary-slot creation, cleanup-budget consumption, cleanup refunds, and access-key pruning MUST
+  revert with their EVM execution scope.


### PR DESCRIPTION
## Abstract

This TIP introduces a new precompile that stores expiring key-value slots for an address.

The precompile exposes three entrypoints:

- `XSTORE(slot, value, expiry)`
- `XLOAD(slot)`
- `XCLEAR(addr, slot)`

`XSTORE` and `XLOAD` are scoped to `msg.sender`, so each caller gets an isolated slot namespace. `XCLEAR` is permissionless, but it may only succeed once an entry has expired.

This allows us to introduce an out-of-protocol solution for clearing expired state, without having to make involved changes to the state trie or introduce new system transactions.

> Note: The precompile logic can be built completely out-of-protocol, but we propose this as a TIP so that we can also introduce a discounted gas schedule that encourages the use of temporary storage.
