### PR TITLE
fix(bench): allow disabling --existing-recipients via ArgAction::Set

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -346,7 +346,7 @@ jobs:
             const existingRecipients = context.eventName === 'workflow_dispatch'
               ? ('${{ github.event.inputs.existing-recipients }}' !== 'false')
               : (defaults?.['no-existing-recipients'] !== 'true');
-            const erFlag = `--existing-recipients ${existingRecipients}`;
+            const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
             const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -343,13 +343,12 @@ jobs:
               featureEnv = defaults['feature-env'];
             }
 
-            // Inject --existing-recipients false into bench-args when disabled
-            const noExistingRecipients = context.eventName === 'workflow_dispatch'
-              ? ('${{ github.event.inputs.existing-recipients }}' === 'false')
-              : (defaults?.['no-existing-recipients'] === 'true');
-            if (noExistingRecipients) {
-              benchArgs = benchArgs ? `${benchArgs} --existing-recipients false` : '--existing-recipients false';
-            }
+            // Always inject --existing-recipients (tempo.nu no longer hardcodes it)
+            const existingRecipients = context.eventName === 'workflow_dispatch'
+              ? ('${{ github.event.inputs.existing-recipients }}' !== 'false')
+              : (defaults?.['no-existing-recipients'] !== 'true');
+            const erFlag = `--existing-recipients ${existingRecipients}`;
+            benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
             const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -343,11 +343,10 @@ jobs:
               featureEnv = defaults['feature-env'];
             }
 
-            // Use bare flag for true (compatible with main), =false for disabling (needs feature branch)
             const existingRecipients = context.eventName === 'workflow_dispatch'
               ? ('${{ github.event.inputs.existing-recipients }}' !== 'false')
               : (defaults?.['no-existing-recipients'] !== 'true');
-            const erFlag = existingRecipients ? '--existing-recipients' : '--existing-recipients=false';
+            const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
             const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -102,6 +102,11 @@ on:
         required: false
         default: ""
         type: string
+      existing-recipients:
+        description: "Send transfers to existing signer accounts instead of random addresses"
+        required: false
+        default: true
+        type: boolean
       bench-args:
         description: "Additional tempo-bench arguments (e.g. --some-flag)"
         required: false
@@ -245,8 +250,8 @@ jobs:
               const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset']);
               const refArgs = new Set(['baseline', 'feature']);
               const stringArgs = new Set(['preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env']);
-              const boolArgs = new Set(['samply', 'force-bloat', 'no-slack']);
-              const defaults = { preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
+              const boolArgs = new Set(['samply', 'force-bloat', 'no-slack', 'no-existing-recipients']);
+              const defaults = { preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -283,6 +288,14 @@ jobs:
                   } else {
                     defaults[key] = value;
                   }
+                } else if (key === 'existing-recipients') {
+                  if (value === 'false') {
+                    defaults['no-existing-recipients'] = 'true';
+                  } else if (value === 'true') {
+                    defaults['no-existing-recipients'] = 'false';
+                  } else {
+                    invalid.push(`\`${key}=${value}\` (must be true or false)`);
+                  }
                 } else if (stringArgs.has(key)) {
                   if (!value) {
                     invalid.push(`\`${key}=\` (must not be empty)`);
@@ -297,7 +310,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -330,7 +343,15 @@ jobs:
               featureEnv = defaults['feature-env'];
             }
 
-            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            // Inject --existing-recipients false into bench-args when disabled
+            const noExistingRecipients = context.eventName === 'workflow_dispatch'
+              ? ('${{ github.event.inputs.existing-recipients }}' === 'false')
+              : (defaults?.['no-existing-recipients'] === 'true');
+            if (noExistingRecipients) {
+              benchArgs = benchArgs ? `${benchArgs} --existing-recipients false` : '--existing-recipients false';
+            }
+
+            const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate tracy value
             if (!['off', 'on', 'full'].includes(tracy)) {

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -343,7 +343,6 @@ jobs:
               featureEnv = defaults['feature-env'];
             }
 
-            // Always inject --existing-recipients (tempo.nu no longer hardcodes it)
             const existingRecipients = context.eventName === 'workflow_dispatch'
               ? ('${{ github.event.inputs.existing-recipients }}' !== 'false')
               : (defaults?.['no-existing-recipients'] !== 'true');

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -343,10 +343,11 @@ jobs:
               featureEnv = defaults['feature-env'];
             }
 
+            // Use bare flag for true (compatible with main), =false for disabling (needs feature branch)
             const existingRecipients = context.eventName === 'workflow_dispatch'
               ? ('${{ github.event.inputs.existing-recipients }}' !== 'false')
               : (defaults?.['no-existing-recipients'] !== 'true');
-            const erFlag = `--existing-recipients=${existingRecipients}`;
+            const erFlag = existingRecipients ? '--existing-recipients' : '--existing-recipients=false';
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
             const usageStr = '**Usage:** `@decofe bench [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -181,7 +181,7 @@ pub struct MaxTpsArgs {
     /// When enabled, TIP-20 and ERC-20 transfers are sent to the bench's own signer addresses
     /// (which already exist on-chain), avoiding cold SSTORE for account creation. This tests
     /// pure transfer throughput without state growth.
-    #[arg(long, default_value_t = true)]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     existing_recipients: bool,
 
     /// An amount of receipts to wait for after sending all the transactions.

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -181,7 +181,7 @@ pub struct MaxTpsArgs {
     /// When enabled, TIP-20 and ERC-20 transfers are sent to the bench's own signer addresses
     /// (which already exist on-chain), avoiding cold SSTORE for account creation. This tests
     /// pure transfer throughput without state growth.
-    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, overrides_with = "existing_recipients")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     existing_recipients: bool,
 
     /// An amount of receipts to wait for after sending all the transactions.

--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -181,7 +181,7 @@ pub struct MaxTpsArgs {
     /// When enabled, TIP-20 and ERC-20 transfers are sent to the bench's own signer addresses
     /// (which already exist on-chain), avoiding cold SSTORE for account creation. This tests
     /// pure transfer throughput without state growth.
-    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, overrides_with = "existing_recipients")]
     existing_recipients: bool,
 
     /// An amount of receipts to wait for after sending all the transactions.

--- a/tempo.nu
+++ b/tempo.nu
@@ -592,7 +592,6 @@ def run-bench-single [
     | append (if $bloat > 0 {
         [
             "--mnemonic" $"'($BLOAT_MNEMONIC)'"
-            "--existing-recipients"
         ]
     } else { [] })
     | append (if $bench_args != "" { $bench_args | split row " " } else { [] })
@@ -2171,7 +2170,6 @@ def "main bench" [
     | append (if $bloat > 0 {
         [
             "--mnemonic" "'test test test test test test test test test test test junk'"
-            "--existing-recipients"
         ]
     } else { [] })
     | append (if $bench_args != "" { $bench_args | split row " " } else { [] })


### PR DESCRIPTION
Adds `action = clap::ArgAction::Set` to the `--existing-recipients` flag so it can be explicitly set to `false` (`--existing-recipients false`). Previously the bool defaulted to `true` with no way to disable it from the CLI.

Prompted by: alexey