### PR TITLE
fix(alloy): add nonce filler cache controls

### DIFF
--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -222,6 +222,11 @@ impl NonceKeyFiller {
         self.cache_enabled = cache_enabled;
     }
 
+    /// Disables nonce caching.
+    pub fn disable_caching(&mut self) {
+        self.set_caching_enabled(false);
+    }
+
     /// Clears every tracked `(address, nonce_key)` pair.
     ///
     /// Future fills will refetch nonces from the chain.
@@ -389,7 +394,7 @@ mod tests {
         let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
             .connect_mocked_client(asserter.clone());
         let mut filler = NonceKeyFiller::default();
-        filler.set_caching_enabled(false);
+        filler.disable_caching();
         let account = Address::repeat_byte(0x22);
         let nonce_key = U256::from(7_u64);
         let mut tx = TempoTransactionRequest::default().with_nonce_key(nonce_key);

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -200,28 +200,6 @@ pub struct NonceKeyFiller {
 const NONCE_NOT_FETCHED: u64 = u64::MAX;
 
 impl NonceKeyFiller {
-    /// Creates a new filler with an empty tracked nonce cache.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the number of tracked `(address, nonce_key)` pairs.
-    pub fn len(&self) -> usize {
-        self.nonces.len()
-    }
-
-    /// Returns `true` when no nonce pairs are currently tracked.
-    pub fn is_empty(&self) -> bool {
-        self.nonces.is_empty()
-    }
-
-    /// Stops tracking one `(address, nonce_key)` pair.
-    ///
-    /// Returns `true` if the pair was present and future fills will refetch its nonce.
-    pub fn remove(&self, address: Address, nonce_key: U256) -> bool {
-        self.nonces.remove(&(address, nonce_key)).is_some()
-    }
-
     /// Clears every tracked `(address, nonce_key)` pair.
     ///
     /// Future fills will refetch nonces from the chain.
@@ -312,7 +290,7 @@ mod tests {
     use crate::{TempoNetwork, fillers::Random2DNonceFiller, rpc::TempoTransactionRequest};
     use alloy::sol_types::SolCall;
     use alloy_network::TransactionBuilder;
-    use alloy_primitives::{Address, Bytes, ruint::aliases::U256};
+    use alloy_primitives::{Bytes, ruint::aliases::U256};
     use alloy_provider::{ProviderBuilder, mock::Asserter};
     use eyre;
 
@@ -354,7 +332,7 @@ mod tests {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
             .connect_mocked_client(asserter.clone());
-        let filler = NonceKeyFiller::new();
+        let filler = NonceKeyFiller::default();
         let account = Address::repeat_byte(0x11);
         let nonce_key = U256::from(7_u64);
         let mut tx = TempoTransactionRequest::default().with_nonce_key(nonce_key);
@@ -369,12 +347,8 @@ mod tests {
 
         assert_eq!(first, 10);
         assert_eq!(second, 11);
-        assert_eq!(filler.len(), 1);
-        assert!(!filler.is_empty());
 
         filler.clear();
-
-        assert!(filler.is_empty());
 
         asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
             &42_u64,
@@ -383,58 +357,6 @@ mod tests {
         let reset = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
 
         assert_eq!(reset, 42);
-        assert_eq!(filler.len(), 1);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_nonce_key_filler_remove_forgets_one_pair() -> eyre::Result<()> {
-        let asserter = Asserter::new();
-        let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
-            .connect_mocked_client(asserter.clone());
-        let filler = NonceKeyFiller::new();
-        let account = Address::repeat_byte(0x22);
-        let nonce_key_a = U256::from(1_u64);
-        let nonce_key_b = U256::from(2_u64);
-        let mut tx_a = TempoTransactionRequest::default().with_nonce_key(nonce_key_a);
-        tx_a.set_from(account);
-        let mut tx_b = TempoTransactionRequest::default().with_nonce_key(nonce_key_b);
-        tx_b.set_from(account);
-
-        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
-            &3_u64,
-        )));
-        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
-            &9_u64,
-        )));
-
-        assert_eq!(
-            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_a).await?,
-            3
-        );
-        assert_eq!(
-            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_b).await?,
-            9
-        );
-        assert_eq!(filler.len(), 2);
-
-        assert!(filler.remove(account, nonce_key_a));
-        assert!(!filler.remove(account, nonce_key_a));
-        assert_eq!(filler.len(), 1);
-
-        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
-            &15_u64,
-        )));
-
-        assert_eq!(
-            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_a).await?,
-            15
-        );
-        assert_eq!(
-            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_b).await?,
-            10
-        );
 
         Ok(())
     }

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -217,6 +217,11 @@ impl NonceKeyFiller {
         self
     }
 
+    /// Enables or disables nonce caching.
+    pub fn set_caching_enabled(&mut self, cache_enabled: bool) {
+        self.cache_enabled = cache_enabled;
+    }
+
     /// Clears every tracked `(address, nonce_key)` pair.
     ///
     /// Future fills will refetch nonces from the chain.
@@ -383,7 +388,8 @@ mod tests {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
             .connect_mocked_client(asserter.clone());
-        let filler = NonceKeyFiller::default().with_caching_enabled(false);
+        let mut filler = NonceKeyFiller::default();
+        filler.set_caching_enabled(false);
         let account = Address::repeat_byte(0x22);
         let nonce_key = U256::from(7_u64);
         let mut tx = TempoTransactionRequest::default().with_nonce_key(nonce_key);

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -223,28 +223,6 @@ impl NonceKeyFiller {
     pub fn clear(&self) {
         self.nonces.clear();
     }
-
-    async fn fetch_nonce<P, N>(
-        &self,
-        provider: &P,
-        from: Address,
-        nonce_key: U256,
-    ) -> TransportResult<u64>
-    where
-        P: Provider<N>,
-        N: Network<TransactionRequest = TempoTransactionRequest>,
-    {
-        if nonce_key.is_zero() {
-            provider.get_transaction_count(from).await
-        } else {
-            let contract = INonce::new(NONCE_PRECOMPILE_ADDRESS, provider);
-            contract
-                .getNonce(from, nonce_key)
-                .call()
-                .await
-                .map_err(|e| TransportErrorKind::custom_str(&e.to_string()))
-        }
-    }
 }
 
 impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for NonceKeyFiller {
@@ -284,10 +262,6 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
             return Ok(0);
         }
 
-        if !self.cache_enabled {
-            return self.fetch_nonce(provider, from, nonce_key).await;
-        }
-
         let key = (from, nonce_key);
         let mutex = self
             .nonces
@@ -297,8 +271,17 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
 
         let mut nonce = mutex.lock().await;
 
-        if *nonce == NONCE_NOT_FETCHED {
-            *nonce = self.fetch_nonce(provider, from, nonce_key).await?;
+        if *nonce == NONCE_NOT_FETCHED || !self.cache_enabled {
+            *nonce = if nonce_key.is_zero() {
+                provider.get_transaction_count(from).await?
+            } else {
+                let contract = INonce::new(NONCE_PRECOMPILE_ADDRESS, provider);
+                contract
+                    .getNonce(from, nonce_key)
+                    .call()
+                    .await
+                    .map_err(|e| TransportErrorKind::custom_str(&e.to_string()))?
+            };
         } else {
             *nonce += 1;
         }

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -182,16 +182,18 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for E
 /// A [`TxFiller`] that fills the nonce for transactions with a pre-set `nonce_key`.
 ///
 /// This filler requires `nonce_key` to already be set on the transaction request and fills
-/// the correct next nonce by querying the chain. Nonces are cached per `(address, nonce_key)`
-/// pair so that batched sends get sequential nonces without extra RPC calls.
+/// the correct next nonce by querying the chain. By default, nonces are cached per
+/// `(address, nonce_key)` pair so that batched sends get sequential nonces without extra RPC
+/// calls. Caching can be disabled to force every fill to refetch from the chain.
 ///
 /// Nonce resolution depends on the key:
 /// - `U256::ZERO` (protocol nonce): uses `get_transaction_count`
 /// - `TEMPO_EXPIRING_NONCE_KEY` (U256::MAX): always 0, no caching (use [`ExpiringNonceFiller`]
 ///   instead for full expiring nonce support including `valid_before`)
 /// - Any other key: queries the `NonceManager` precompile via `eth_call`
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct NonceKeyFiller {
+    cache_enabled: bool,
     #[allow(clippy::type_complexity)]
     nonces: Arc<DashMap<(Address, U256), Arc<futures::lock::Mutex<u64>>>>,
 }
@@ -199,12 +201,49 @@ pub struct NonceKeyFiller {
 /// Sentinel value indicating the nonce has not been fetched yet.
 const NONCE_NOT_FETCHED: u64 = u64::MAX;
 
+impl Default for NonceKeyFiller {
+    fn default() -> Self {
+        Self {
+            cache_enabled: true,
+            nonces: Arc::default(),
+        }
+    }
+}
+
 impl NonceKeyFiller {
+    /// Enables or disables nonce caching.
+    pub const fn with_caching_enabled(mut self, cache_enabled: bool) -> Self {
+        self.cache_enabled = cache_enabled;
+        self
+    }
+
     /// Clears every tracked `(address, nonce_key)` pair.
     ///
     /// Future fills will refetch nonces from the chain.
     pub fn clear(&self) {
         self.nonces.clear();
+    }
+
+    async fn fetch_nonce<P, N>(
+        &self,
+        provider: &P,
+        from: Address,
+        nonce_key: U256,
+    ) -> TransportResult<u64>
+    where
+        P: Provider<N>,
+        N: Network<TransactionRequest = TempoTransactionRequest>,
+    {
+        if nonce_key.is_zero() {
+            provider.get_transaction_count(from).await
+        } else {
+            let contract = INonce::new(NONCE_PRECOMPILE_ADDRESS, provider);
+            contract
+                .getNonce(from, nonce_key)
+                .call()
+                .await
+                .map_err(|e| TransportErrorKind::custom_str(&e.to_string()))
+        }
     }
 }
 
@@ -245,6 +284,10 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
             return Ok(0);
         }
 
+        if !self.cache_enabled {
+            return self.fetch_nonce(provider, from, nonce_key).await;
+        }
+
         let key = (from, nonce_key);
         let mutex = self
             .nonces
@@ -255,16 +298,7 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
         let mut nonce = mutex.lock().await;
 
         if *nonce == NONCE_NOT_FETCHED {
-            *nonce = if nonce_key.is_zero() {
-                provider.get_transaction_count(from).await?
-            } else {
-                let contract = INonce::new(NONCE_PRECOMPILE_ADDRESS, provider);
-                contract
-                    .getNonce(from, nonce_key)
-                    .call()
-                    .await
-                    .map_err(|e| TransportErrorKind::custom_str(&e.to_string()))?
-            };
+            *nonce = self.fetch_nonce(provider, from, nonce_key).await?;
         } else {
             *nonce += 1;
         }
@@ -357,6 +391,33 @@ mod tests {
         let reset = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
 
         assert_eq!(reset, 42);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nonce_key_filler_can_disable_caching() -> eyre::Result<()> {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+            .connect_mocked_client(asserter.clone());
+        let filler = NonceKeyFiller::default().with_caching_enabled(false);
+        let account = Address::repeat_byte(0x22);
+        let nonce_key = U256::from(7_u64);
+        let mut tx = TempoTransactionRequest::default().with_nonce_key(nonce_key);
+        tx.set_from(account);
+
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &10_u64,
+        )));
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &42_u64,
+        )));
+
+        let first = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
+        let second = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
+
+        assert_eq!(first, 10);
+        assert_eq!(second, 42);
 
         Ok(())
     }

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -199,6 +199,37 @@ pub struct NonceKeyFiller {
 /// Sentinel value indicating the nonce has not been fetched yet.
 const NONCE_NOT_FETCHED: u64 = u64::MAX;
 
+impl NonceKeyFiller {
+    /// Creates a new filler with an empty tracked nonce cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of tracked `(address, nonce_key)` pairs.
+    pub fn len(&self) -> usize {
+        self.nonces.len()
+    }
+
+    /// Returns `true` when no nonce pairs are currently tracked.
+    pub fn is_empty(&self) -> bool {
+        self.nonces.is_empty()
+    }
+
+    /// Stops tracking one `(address, nonce_key)` pair.
+    ///
+    /// Returns `true` if the pair was present and future fills will refetch its nonce.
+    pub fn remove(&self, address: Address, nonce_key: U256) -> bool {
+        self.nonces.remove(&(address, nonce_key)).is_some()
+    }
+
+    /// Clears every tracked `(address, nonce_key)` pair.
+    ///
+    /// Future fills will refetch nonces from the chain.
+    pub fn clear(&self) {
+        self.nonces.clear();
+    }
+}
+
 impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for NonceKeyFiller {
     type Fillable = u64;
 
@@ -277,9 +308,11 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{TempoNetwork, fillers::Random2DNonceFiller, rpc::TempoTransactionRequest};
+    use alloy::sol_types::SolCall;
     use alloy_network::TransactionBuilder;
-    use alloy_primitives::ruint::aliases::U256;
+    use alloy_primitives::{Address, Bytes, ruint::aliases::U256};
     use alloy_provider::{ProviderBuilder, mock::Asserter};
     use eyre;
 
@@ -312,6 +345,96 @@ mod tests {
             .try_into_request()?;
         assert_eq!(filled_request.nonce_key, Some(U256::ONE));
         assert!(filled_request.nonce().is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nonce_key_filler_clear_refetches_chain_nonce() -> eyre::Result<()> {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+            .connect_mocked_client(asserter.clone());
+        let filler = NonceKeyFiller::new();
+        let account = Address::repeat_byte(0x11);
+        let nonce_key = U256::from(7_u64);
+        let mut tx = TempoTransactionRequest::default().with_nonce_key(nonce_key);
+        tx.set_from(account);
+
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &10_u64,
+        )));
+
+        let first = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
+        let second = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
+
+        assert_eq!(first, 10);
+        assert_eq!(second, 11);
+        assert_eq!(filler.len(), 1);
+        assert!(!filler.is_empty());
+
+        filler.clear();
+
+        assert!(filler.is_empty());
+
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &42_u64,
+        )));
+
+        let reset = TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx).await?;
+
+        assert_eq!(reset, 42);
+        assert_eq!(filler.len(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nonce_key_filler_remove_forgets_one_pair() -> eyre::Result<()> {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+            .connect_mocked_client(asserter.clone());
+        let filler = NonceKeyFiller::new();
+        let account = Address::repeat_byte(0x22);
+        let nonce_key_a = U256::from(1_u64);
+        let nonce_key_b = U256::from(2_u64);
+        let mut tx_a = TempoTransactionRequest::default().with_nonce_key(nonce_key_a);
+        tx_a.set_from(account);
+        let mut tx_b = TempoTransactionRequest::default().with_nonce_key(nonce_key_b);
+        tx_b.set_from(account);
+
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &3_u64,
+        )));
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &9_u64,
+        )));
+
+        assert_eq!(
+            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_a).await?,
+            3
+        );
+        assert_eq!(
+            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_b).await?,
+            9
+        );
+        assert_eq!(filler.len(), 2);
+
+        assert!(filler.remove(account, nonce_key_a));
+        assert!(!filler.remove(account, nonce_key_a));
+        assert_eq!(filler.len(), 1);
+
+        asserter.push_success(&Bytes::from(INonce::getNonceCall::abi_encode_returns(
+            &15_u64,
+        )));
+
+        assert_eq!(
+            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_a).await?,
+            15
+        );
+        assert_eq!(
+            TxFiller::<TempoNetwork>::prepare(&filler, &provider, &tx_b).await?,
+            10
+        );
 
         Ok(())
     }

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -135,16 +135,6 @@ pub trait TempoProviderBuilderExt {
     fn with_nonce_key_filler(
         self,
     ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>;
-
-    /// Returns a provider builder with the recommended Tempo fillers and a caller-provided nonce
-    /// key filler handle.
-    ///
-    /// Use this when the caller needs to inspect or clear the tracked nonce cache via the
-    /// [`NonceKeyFiller`] instance they hold.
-    fn with_nonce_key_filler_handle(
-        self,
-        nonce_key_filler: NonceKeyFiller,
-    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>;
 }
 
 impl TempoProviderBuilderExt
@@ -178,15 +168,7 @@ impl TempoProviderBuilderExt
         self,
     ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
     {
-        self.with_nonce_key_filler_handle(NonceKeyFiller::default())
-    }
-
-    fn with_nonce_key_filler_handle(
-        self,
-        nonce_key_filler: NonceKeyFiller,
-    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
-    {
-        ProviderBuilder::default().filler(TempoFillers::new(nonce_key_filler, Default::default()))
+        ProviderBuilder::default().filler(TempoFillers::default())
     }
 }
 
@@ -231,14 +213,6 @@ mod tests {
     fn test_with_nonce_key_filler() {
         let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
             ProviderBuilder::new_with_network::<TempoNetwork>().with_nonce_key_filler();
-    }
-
-    #[test]
-    fn test_with_nonce_key_filler_handle() {
-        let filler = NonceKeyFiller::new();
-        let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
-            ProviderBuilder::new_with_network::<TempoNetwork>()
-                .with_nonce_key_filler_handle(filler);
     }
 
     #[tokio::test]

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -135,6 +135,16 @@ pub trait TempoProviderBuilderExt {
     fn with_nonce_key_filler(
         self,
     ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>;
+
+    /// Returns a provider builder with the recommended Tempo fillers and a caller-provided nonce
+    /// key filler handle.
+    ///
+    /// Use this when the caller needs to inspect or clear the tracked nonce cache via the
+    /// [`NonceKeyFiller`] instance they hold.
+    fn with_nonce_key_filler_handle(
+        self,
+        nonce_key_filler: NonceKeyFiller,
+    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>;
 }
 
 impl TempoProviderBuilderExt
@@ -168,7 +178,15 @@ impl TempoProviderBuilderExt
         self,
     ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
     {
-        ProviderBuilder::default().filler(TempoFillers::default())
+        self.with_nonce_key_filler_handle(NonceKeyFiller::default())
+    }
+
+    fn with_nonce_key_filler_handle(
+        self,
+        nonce_key_filler: NonceKeyFiller,
+    ) -> ProviderBuilder<Identity, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, TempoNetwork>
+    {
+        ProviderBuilder::default().filler(TempoFillers::new(nonce_key_filler, Default::default()))
     }
 }
 
@@ -213,6 +231,14 @@ mod tests {
     fn test_with_nonce_key_filler() {
         let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
             ProviderBuilder::new_with_network::<TempoNetwork>().with_nonce_key_filler();
+    }
+
+    #[test]
+    fn test_with_nonce_key_filler_handle() {
+        let filler = NonceKeyFiller::new();
+        let _: ProviderBuilder<_, JoinFill<Identity, TempoFillers<NonceKeyFiller>>, _> =
+            ProviderBuilder::new_with_network::<TempoNetwork>()
+                .with_nonce_key_filler_handle(filler);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds `NonceKeyFiller::clear()` so callers can drop all tracked `(address, nonce_key)` pairs and force the next fill to refetch nonces from the chain.

Also adds cache controls via `with_caching_enabled(false)`, `set_caching_enabled(false)`, and `disable_caching()`. When caching is disabled, every fill refetches the nonce from the chain instead of reusing the cached value or incrementing it locally.

Includes focused tests for the cache clear path and the cache-disabled refetch behavior.