### PR TITLE
fix: skip re-execute trigger in merge queue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -194,7 +194,7 @@ jobs:
           done
 
       - name: Publish event (sha tag)
-        if: ${{ github.repository == 'tempoxyz/tempo' }}
+        if: ${{ github.repository == 'tempoxyz/tempo' && github.event_name != 'merge_group' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
The Docker workflow fires on both `merge_group` and `push` to `main`, so every PR going through the merge queue publishes a `registry_package` event twice — once for the queue ref and again when the SHA lands on main. This caused duplicate re-execute workflows to pile up (33 pending right now).

Skip the event publish for `merge_group` runs. The image still gets built (validating it compiles), but downstream tests (tempo-tests, tempo-bench, re-execute) only trigger once the commit lands on main.

Prompted by: Jen