### PR TITLE
feat(primitives): add `TempoAddressExt` with built-in helper fns

### DIFF
--- a/.changelog/nice-winds-break.md
+++ b/.changelog/nice-winds-break.md
@@ -1,0 +1,6 @@
+---
+tempo-primitives: minor
+tempo-alloy: minor
+---
+
+Moved TIP-20 and TIP-1022 virtual-address helpers (`is_tip20_prefix`, `is_virtual_address`, `decode_virtual_address`, `make_virtual_address`, `MasterId`, `UserTag`) from `tempo-precompiles` into a new `TempoAddressExt` trait on `Address` in `tempo-primitives`. Updated all consumers to use the new trait methods (`address.is_tip20()`, `address.is_virtual()`, `Address::new_virtual(...)`, etc.).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12876,6 +12876,7 @@ dependencies = [
  "rustls",
  "tempo-alloy",
  "tempo-precompiles",
+ "tempo-primitives",
  "tempo-telemetry-util",
  "tokio",
  "tracing",

--- a/bin/tempo-bench/src/cmd/max_tps/virtual_address.rs
+++ b/bin/tempo-bench/src/cmd/max_tps/virtual_address.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::{Address, B256, address, hex_literal::hex};
-use tempo_precompiles::address_registry::{MasterId, VIRTUAL_MAGIC};
+use tempo_alloy::primitives::{MasterId, TempoAddressExt, UserTag};
 
 /// Pre-mined TIP-1022 PoW salts for the first 7 anvil mnemonic accounts.
 ///
@@ -50,9 +50,5 @@ pub(crate) const ANVIL_VIRTUAL_SALTS: [(Address, B256); 6] = [
 ///
 /// Layout: `[4-byte masterId][10-byte 0xFD MAGIC][6-byte random userTag]`.
 pub(crate) fn make_virtual_address(master_id: MasterId) -> Address {
-    let mut bytes = [0u8; 20];
-    bytes[0..4].copy_from_slice(master_id.as_slice());
-    bytes[4..14].copy_from_slice(&VIRTUAL_MAGIC);
-    rand::fill(&mut bytes[14..20]);
-    Address::from(bytes)
+    Address::new_virtual(master_id, UserTag::random())
 }

--- a/bin/tempo-sidecar/Cargo.toml
+++ b/bin/tempo-sidecar/Cargo.toml
@@ -8,6 +8,11 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
+
+tempo-alloy.workspace = true
+tempo-primitives.workspace = true
+tempo-precompiles = { workspace = true, features = ["rpc"] }
+
 clap.workspace = true
 alloy = { workspace = true, default-features = false, features = [
     "network",
@@ -22,12 +27,10 @@ alloy = { workspace = true, default-features = false, features = [
     "signer-mnemonic",
     "rand",
 ] }
-tempo-alloy.workspace = true
 eyre.workspace = true
 futures.workspace = true
 hex = "0.4"
 itertools = "0.14.0"
-tempo-precompiles = { workspace = true, features = ["rpc"] }
 reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls",

--- a/bin/tempo-sidecar/src/cmd/monitor.rs
+++ b/bin/tempo-sidecar/src/cmd/monitor.rs
@@ -6,7 +6,7 @@ use metrics::{describe_counter, describe_gauge};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use poem::{EndpointExt, Route, Server, get, listener::TcpListener};
 use reqwest::Url;
-use tempo_precompiles::tip20::is_tip20_prefix;
+use tempo_primitives::TempoAddressExt;
 use tokio::signal;
 use tracing_subscriber::EnvFilter;
 
@@ -43,7 +43,7 @@ impl MonitorArgs {
             .install_recorder()
             .context("failed to install recorder")?;
 
-        if self.tokens.iter().any(|t| !is_tip20_prefix(*t)) {
+        if self.tokens.iter().any(|t| !t.is_tip20()) {
             return Err(eyre!("Invalid input. Pools require TIP20 tokens."));
         }
 

--- a/crates/node/src/rpc/simulate.rs
+++ b/crates/node/src/rpc/simulate.rs
@@ -18,10 +18,8 @@ use std::{
 };
 use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_evm::TempoStateAccess;
-use tempo_precompiles::{
-    error::TempoPrecompileError,
-    tip20::{TIP20Token, is_tip20_prefix},
-};
+use tempo_precompiles::{error::TempoPrecompileError, tip20::TIP20Token};
+use tempo_primitives::TempoAddressExt;
 
 /// keccak256("Transfer(address,address,uint256)")
 static TRANSFER_TOPIC: LazyLock<B256> =
@@ -93,21 +91,21 @@ fn extract_tip20_targets(
         for call in &block.calls {
             // Standard `to` field
             if let Some(to) = call.to.as_ref().and_then(|k| k.to())
-                && is_tip20_prefix(*to)
+                && to.is_tip20()
             {
                 addrs.insert(*to);
             }
             // AA calls array
             for c in &call.calls {
                 if let Some(to) = c.to.to()
-                    && is_tip20_prefix(*to)
+                    && to.is_tip20()
                 {
                     addrs.insert(*to);
                 }
             }
             // Fee token
             if let Some(ft) = call.fee_token
-                && is_tip20_prefix(ft)
+                && ft.is_tip20()
             {
                 addrs.insert(ft);
             }
@@ -146,7 +144,7 @@ impl<N: FullNodeTypes<Types = TempoNode>> TempoSimulateApiServer for TempoSimula
         for sim_block in &blocks {
             for call in &sim_block.calls {
                 for log in &call.logs {
-                    if is_tip20_prefix(log.address())
+                    if log.address().is_tip20()
                         && log.topics().first() == Some(&*TRANSFER_TOPIC)
                         && !token_metadata.contains_key(&log.address())
                     {

--- a/crates/node/tests/it/tip20.rs
+++ b/crates/node/tests/it/tip20.rs
@@ -10,8 +10,9 @@ use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{IAddressRegistry, ITIP20, ITIP403Registry, TIP20Error};
 use tempo_precompiles::{
     ADDRESS_REGISTRY_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    test_util::{VIRTUAL_MASTER, VIRTUAL_SALT, make_virtual_address},
+    test_util::{VIRTUAL_MASTER, VIRTUAL_SALT},
 };
+use tempo_primitives::TempoAddressExt;
 
 use crate::utils::{TestNodeBuilder, await_receipts, setup_test_token};
 
@@ -973,8 +974,7 @@ async fn setup_virtual_test() -> eyre::Result<(
         .expect("MasterRegistered event should be emitted");
     assert_eq!(master_event.masterAddress, VIRTUAL_MASTER);
 
-    let virtual_addr =
-        make_virtual_address(master_event.masterId, FixedBytes::from([1, 2, 3, 4, 5, 6]));
+    let virtual_addr = Address::new_virtual(master_event.masterId, FixedBytes::random());
 
     Ok((setup, http_url, admin, token, virtual_addr))
 }

--- a/crates/node/tests/it/tip20_factory.rs
+++ b/crates/node/tests/it/tip20_factory.rs
@@ -6,7 +6,8 @@ use alloy::{
 };
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{ITIP20, ITIP20Factory};
-use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::is_tip20_prefix};
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS};
+use tempo_primitives::TempoAddressExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_token() -> eyre::Result<()> {
@@ -54,10 +55,7 @@ async fn test_create_token() -> eyre::Result<()> {
     assert_eq!(event.salt, salt);
 
     // Verify the token address has TIP20 prefix
-    assert!(
-        is_tip20_prefix(event.token),
-        "Token should have TIP20 prefix"
-    );
+    assert!(event.token.is_tip20(), "Token should have TIP20 prefix");
 
     let token = ITIP20::new(event.token, provider);
     assert_eq!(token.name().call().await?, name);
@@ -93,7 +91,7 @@ async fn test_is_tip20_checks_code_deployment() -> eyre::Result<()> {
 
     // Verify this address has valid TIP20 prefix
     assert!(
-        is_tip20_prefix(non_existent_tip20_addr),
+        non_existent_tip20_addr.is_tip20(),
         "Address should have valid TIP20 prefix"
     );
 

--- a/crates/precompiles/src/address_registry/dispatch.rs
+++ b/crates/precompiles/src/address_registry/dispatch.rs
@@ -1,13 +1,10 @@
 use crate::{
-    Precompile,
-    address_registry::{
-        AddressRegistry, MasterId, UserTag, decode_virtual_address, is_virtual_address,
-    },
-    charge_input_cost, dispatch_call, mutate, view,
+    Precompile, address_registry::AddressRegistry, charge_input_cost, dispatch_call, mutate, view,
 };
 use alloy::{primitives::Address, sol_types::SolInterface};
 use revm::precompile::PrecompileResult;
 use tempo_contracts::precompiles::IAddressRegistry::IAddressRegistryCalls;
+use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
 impl Precompile for AddressRegistry {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
@@ -36,10 +33,10 @@ impl Precompile for AddressRegistry {
                 }
                 // Pure functions
                 IAddressRegistryCalls::isVirtualAddress(call) => {
-                    view(call, |c| Ok(is_virtual_address(c.addr)))
+                    view(call, |c| Ok(c.addr.is_virtual()))
                 }
                 IAddressRegistryCalls::decodeVirtualAddress(call) => view(call, |c| {
-                    let (is_virtual, master_id, user_tag) = match decode_virtual_address(c.addr) {
+                    let (is_virtual, master_id, user_tag) = match c.addr.decode_virtual() {
                         Some((mid, tag)) => (true, mid, tag),
                         None => (false, MasterId::ZERO, UserTag::ZERO),
                     };

--- a/crates/precompiles/src/address_registry/mod.rs
+++ b/crates/precompiles/src/address_registry/mod.rs
@@ -11,7 +11,6 @@ use crate::{
     ADDRESS_REGISTRY_ADDRESS,
     error::Result,
     storage::{Handler, Mapping},
-    tip20::is_tip20_prefix,
 };
 use alloy::{
     primitives::{Address, FixedBytes, keccak256},
@@ -19,43 +18,7 @@ use alloy::{
 };
 pub use tempo_contracts::precompiles::{AddrRegistryError, AddrRegistryEvent, IAddressRegistry};
 use tempo_precompiles_macros::{Storable, contract};
-
-/// 4-byte master identifier derived from the registration hash.
-pub type MasterId = FixedBytes<4>;
-
-/// 6-byte user tag occupying the trailing bytes of a virtual address.
-pub type UserTag = FixedBytes<6>;
-
-/// 10-byte magic value identifying virtual addresses at bytes `[4:14]`.
-pub const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
-
-/// Returns `true` if `addr` matches the [TIP-1022] virtual-address format
-/// (bytes `[4:14]` == [`VIRTUAL_MAGIC`]).
-///
-/// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
-pub fn is_virtual_address(addr: Address) -> bool {
-    addr.as_slice()[4..14] == VIRTUAL_MAGIC
-}
-
-/// Returns `true` if `addr` is eligible to be a virtual-address master per TIP-1022.
-pub fn is_valid_master_address(addr: Address) -> bool {
-    !addr.is_zero() && !is_virtual_address(addr) && !is_tip20_prefix(addr)
-}
-
-/// Decodes a virtual address into its `(masterId, userTag)` components.
-///
-/// Returns `None` if the address does not match [`is_virtual_address`] format.
-pub fn decode_virtual_address(addr: Address) -> Option<(MasterId, UserTag)> {
-    if !is_virtual_address(addr) {
-        return None;
-    }
-
-    let bytes = addr.as_slice();
-    Some((
-        MasterId::from_slice(&bytes[0..4]),
-        UserTag::from_slice(&bytes[14..20]),
-    ))
-}
+pub use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
 /// [TIP-1022] virtual address registry contract.
 ///
@@ -116,7 +79,7 @@ impl AddressRegistry {
         call: IAddressRegistry::registerVirtualMasterCall,
     ) -> Result<MasterId> {
         // Validate master address
-        if !is_valid_master_address(msg_sender) {
+        if !msg_sender.is_valid_master() {
             return Err(AddrRegistryError::invalid_master_address().into());
         }
 
@@ -175,7 +138,7 @@ impl AddressRegistry {
             return Ok(to);
         }
 
-        match decode_virtual_address(to) {
+        match to.decode_virtual() {
             None => Ok(to),
             Some((master_id, _)) => self
                 .get_master(master_id)?
@@ -187,7 +150,7 @@ impl AddressRegistry {
     ///
     /// Returns `address(0)` if the address is not virtual or the [`MasterId`] is unregistered.
     pub fn resolve_virtual_address(&self, addr: Address) -> Result<Address> {
-        match decode_virtual_address(addr) {
+        match addr.decode_virtual() {
             None => Ok(Address::ZERO),
             Some((master_id, _)) => Ok(self.get_master(master_id)?.unwrap_or(Address::ZERO)),
         }
@@ -200,7 +163,7 @@ mod tests {
     use crate::{
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        test_util::{VIRTUAL_MASTER, VIRTUAL_SALT, make_virtual_address},
+        test_util::{VIRTUAL_MASTER, VIRTUAL_SALT},
     };
     use alloy_primitives::hex_literal::hex;
     use tempo_chainspec::hardfork::TempoHardfork;
@@ -272,13 +235,11 @@ mod tests {
     fn test_register_rejects_virtual_address_as_master() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
 
-        let virtual_addr = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
-
         StorageCtx::enter(&mut storage, || {
             let mut registry = AddressRegistry::new();
 
             let result = registry.register_virtual_master(
-                virtual_addr,
+                Address::new_virtual(MasterId::ZERO, UserTag::ZERO),
                 IAddressRegistry::registerVirtualMasterCall {
                     salt: FixedBytes::ZERO,
                 },
@@ -345,27 +306,21 @@ mod tests {
 
     #[test]
     fn test_is_virtual_address() {
-        let random_addr = Address::random();
-        assert!(!is_virtual_address(random_addr));
-
-        let virtual_addr = make_virtual_address(
-            MasterId::new(hex!("07A3B1C2")),
-            UserTag::new(hex!("D4E5A7C3F19E")),
-        );
-        assert!(is_virtual_address(virtual_addr));
+        assert!(!Address::random().is_virtual());
+        assert!(Address::new_virtual(MasterId::random(), UserTag::random()).is_virtual());
     }
 
     #[test]
     fn test_decode_virtual_address() {
-        let mid = MasterId::new(hex!("07A3B1C2"));
-        let tag = UserTag::new(hex!("D4E5A7C3F19E"));
-        let addr = make_virtual_address(mid, tag);
+        let mid = MasterId::random();
+        let tag = UserTag::random();
+        let addr = Address::new_virtual(mid, tag);
 
-        let (master_id, user_tag) = decode_virtual_address(addr).unwrap();
+        let (master_id, user_tag) = addr.decode_virtual().unwrap();
         assert_eq!(master_id, mid);
         assert_eq!(user_tag, tag);
 
-        assert!(decode_virtual_address(Address::random()).is_none());
+        assert!(Address::random().decode_virtual().is_none());
     }
 
     #[test]
@@ -386,7 +341,7 @@ mod tests {
     #[test]
     fn test_resolve_recipient_virtual_unregistered_reverts() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
-        let virtual_addr = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+        let virtual_addr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
 
         StorageCtx::enter(&mut storage, || {
             let registry = AddressRegistry::new();
@@ -416,7 +371,7 @@ mod tests {
                 IAddressRegistry::registerVirtualMasterCall { salt },
             )?;
 
-            let virtual_addr = make_virtual_address(master_id, UserTag::new(hex!("010203040506")));
+            let virtual_addr = Address::new_virtual(master_id, UserTag::new(hex!("010203040506")));
 
             let resolved = registry.resolve_recipient(virtual_addr)?;
             assert_eq!(resolved, master);
@@ -440,7 +395,7 @@ mod tests {
             );
 
             // Unregistered virtual → zero
-            let unregistered = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+            let unregistered = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
             assert_eq!(
                 registry.resolve_virtual_address(unregistered)?,
                 Address::ZERO
@@ -451,7 +406,7 @@ mod tests {
                 master,
                 IAddressRegistry::registerVirtualMasterCall { salt },
             )?;
-            let virtual_addr = make_virtual_address(master_id, UserTag::new(hex!("aabbccddeeff")));
+            let virtual_addr = Address::new_virtual(master_id, UserTag::new(hex!("aabbccddeeff")));
             assert_eq!(registry.resolve_virtual_address(virtual_addr)?, master);
 
             Ok(())
@@ -461,7 +416,7 @@ mod tests {
     #[test]
     fn test_resolve_recipient_pre_t3_returns_literal() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
-        let virtual_addr = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+        let virtual_addr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
 
         StorageCtx::enter(&mut storage, || {
             let registry = AddressRegistry::new();
@@ -472,16 +427,9 @@ mod tests {
 
     #[test]
     fn test_is_valid_master_address() {
-        // Zero → invalid
-        assert!(!is_valid_master_address(Address::ZERO));
-        // Virtual address → invalid
-        assert!(!is_valid_master_address(make_virtual_address(
-            MasterId::ZERO,
-            UserTag::ZERO
-        )));
-        // TIP-20 prefix → invalid
-        assert!(!is_valid_master_address(crate::PATH_USD_ADDRESS));
-        // Normal address → valid
-        assert!(is_valid_master_address(Address::repeat_byte(0x42)));
+        assert!(!Address::ZERO.is_valid_master());
+        assert!(!Address::new_virtual(MasterId::ZERO, UserTag::ZERO).is_valid_master());
+        assert!(!crate::PATH_USD_ADDRESS.is_valid_master());
+        assert!(Address::repeat_byte(0x42).is_valid_master());
     }
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -25,20 +25,14 @@ pub mod validator_config_v2;
 pub mod test_util;
 
 use crate::{
-    account_keychain::AccountKeychain,
-    address_registry::AddressRegistry,
-    nonce::NonceManager,
-    signature_verifier::SignatureVerifier,
-    stablecoin_dex::StablecoinDEX,
-    storage::StorageCtx,
-    tip_fee_manager::TipFeeManager,
-    tip20::{TIP20Token, is_tip20_prefix},
-    tip20_factory::TIP20Factory,
-    tip403_registry::TIP403Registry,
-    validator_config::ValidatorConfig,
+    account_keychain::AccountKeychain, address_registry::AddressRegistry, nonce::NonceManager,
+    signature_verifier::SignatureVerifier, stablecoin_dex::StablecoinDEX, storage::StorageCtx,
+    tip_fee_manager::TipFeeManager, tip20::TIP20Token, tip20_factory::TIP20Factory,
+    tip403_registry::TIP403Registry, validator_config::ValidatorConfig,
     validator_config_v2::ValidatorConfigV2,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::TempoAddressExt;
 
 #[cfg(test)]
 use alloy::sol_types::SolInterface;
@@ -121,7 +115,7 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
     let cfg = cfg.clone();
 
     precompiles.set_precompile_lookup(move |address: &Address| {
-        if is_tip20_prefix(*address) {
+        if address.is_tip20() {
             Some(TIP20Token::create_precompile(*address, &cfg))
         } else if *address == TIP20_FACTORY_ADDRESS {
             Some(TIP20Factory::create_precompile(&cfg))

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -23,12 +23,13 @@ use crate::{
     error::{Result, TempoPrecompileError},
     stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, compute_book_key},
     storage::{Handler, Mapping},
-    tip20::{ITIP20, TIP20Token, is_tip20_prefix, validate_usd_currency},
+    tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
     tip403_registry::{AuthRole, TIP403Registry, is_policy_lookup_error},
 };
 use alloy::primitives::{Address, B256, U256};
 use tempo_precompiles_macros::contract;
+use tempo_primitives::TempoAddressExt;
 
 /// Minimum order size of $100 USD
 pub const MIN_ORDER_AMOUNT: u128 = 100_000_000;
@@ -1339,7 +1340,7 @@ impl StablecoinDEX {
         }
 
         // Validate that both tokens are TIP20 tokens
-        if !is_tip20_prefix(token_in) || !is_tip20_prefix(token_out) {
+        if !token_in.is_tip20() || !token_out.is_tip20() {
             return Err(StablecoinDEXError::invalid_token().into());
         }
 

--- a/crates/precompiles/src/test_util.rs
+++ b/crates/precompiles/src/test_util.rs
@@ -4,7 +4,7 @@
 use crate::error::TempoPrecompileError;
 use crate::{
     PATH_USD_ADDRESS, Precompile, Result,
-    address_registry::{AddressRegistry, IAddressRegistry, MasterId, UserTag, VIRTUAL_MAGIC},
+    address_registry::{AddressRegistry, IAddressRegistry},
     storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
     tip20::{self, ITIP20, TIP20Token},
     tip20_factory::{self, TIP20Factory},
@@ -17,6 +17,7 @@ use revm::precompile::PrecompileError;
 #[cfg(any(test, feature = "test-utils"))]
 use tempo_contracts::precompiles::TIP20Error;
 use tempo_contracts::precompiles::{TIP20_FACTORY_ADDRESS, UnknownFunctionSelector};
+use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
 /// Checks that all selectors in an interface have dispatch handlers.
 ///
@@ -459,15 +460,6 @@ pub const VIRTUAL_MASTER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffF
 pub const VIRTUAL_SALT: [u8; 32] =
     hex!("00000000000000000000000000000000000000000000000000000000abf52baf");
 
-/// Builds a virtual address from a `masterId` and `userTag`.
-pub fn make_virtual_address(master_id: MasterId, user_tag: UserTag) -> Address {
-    let mut bytes = [0u8; 20];
-    bytes[0..4].copy_from_slice(master_id.as_slice());
-    bytes[4..14].copy_from_slice(&VIRTUAL_MAGIC);
-    bytes[14..20].copy_from_slice(user_tag.as_slice());
-    Address::from(bytes)
-}
-
 /// Registers [`VIRTUAL_MASTER`] and returns `(master_id, virtual_address)`.
 pub fn register_virtual_master(registry: &mut AddressRegistry) -> Result<(MasterId, Address)> {
     let master_id = registry.register_virtual_master(
@@ -476,6 +468,6 @@ pub fn register_virtual_master(registry: &mut AddressRegistry) -> Result<(Master
             salt: VIRTUAL_SALT.into(),
         },
     )?;
-    let virtual_addr = make_virtual_address(master_id, UserTag::new(hex!("010203040506")));
+    let virtual_addr = Address::new_virtual(master_id, UserTag::new(hex!("010203040506")));
     Ok((master_id, virtual_addr))
 }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -37,6 +37,7 @@ use alloy::{
 use std::sync::LazyLock;
 use tempo_precompiles_macros::contract;
 use tempo_primitives::TempoAddressExt;
+pub use tempo_primitives::is_tip20_prefix;
 use tracing::trace;
 
 /// u128::MAX as U256

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -31,30 +31,18 @@ use crate::{
     tip403_registry::{AuthRole, ITIP403Registry, TIP403Registry},
 };
 use alloy::{
-    hex,
     primitives::{Address, B256, U256, keccak256, uint},
     sol_types::SolValue,
 };
 use std::sync::LazyLock;
 use tempo_precompiles_macros::contract;
+use tempo_primitives::TempoAddressExt;
 use tracing::trace;
 
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
 use tempo_contracts::precompiles::DECIMALS as TIP20_DECIMALS;
-
-/// TIP20 token address prefix (12 bytes)
-/// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)
-const TIP20_TOKEN_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
-
-/// Returns true if the address has the TIP20 prefix.
-///
-/// NOTE: This only checks the prefix, not whether the token was actually created.
-/// Use `TIP20Factory::is_tip20()` for full validation.
-pub fn is_tip20_prefix(token: Address) -> bool {
-    token.as_slice().starts_with(&TIP20_TOKEN_PREFIX)
-}
 
 /// Validates that the given token's currency is `"USD"`.
 ///
@@ -846,7 +834,7 @@ impl TIP20Token {
     /// # Errors
     /// - `InvalidToken` — address does not carry the `0x20C0` TIP-20 prefix
     pub fn from_address(address: Address) -> Result<Self> {
-        if !is_tip20_prefix(address) {
+        if !address.is_tip20() {
             return Err(TIP20Error::invalid_token().into());
         }
         Ok(Self::__new(address))
@@ -858,7 +846,7 @@ impl TIP20Token {
     /// Caller must ensure `is_tip20_prefix(address)` returns true.
     #[inline]
     pub fn from_address_unchecked(address: Address) -> Self {
-        debug_assert!(is_tip20_prefix(address), "address must have TIP20 prefix");
+        debug_assert!(address.is_tip20(), "address must have TIP20 prefix");
         Self::__new(address)
     }
 
@@ -1179,7 +1167,7 @@ impl Recipient {
     /// - the zero address (preventing accidental burns)
     /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
     pub(crate) fn validate(&self) -> Result<()> {
-        if self.target.is_zero() || is_tip20_prefix(self.target) {
+        if self.target.is_zero() || self.target.is_tip20() {
             return Err(TIP20Error::invalid_recipient().into());
         }
         Ok(())
@@ -1217,7 +1205,7 @@ mod recipient_tests {
         address_registry::{AddressRegistry, MasterId, UserTag},
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        test_util::{VIRTUAL_MASTER, make_virtual_address, register_virtual_master},
+        test_util::{VIRTUAL_MASTER, register_virtual_master},
     };
     use alloy::primitives::{Address, U256};
     use tempo_chainspec::hardfork::TempoHardfork;
@@ -1259,7 +1247,7 @@ mod recipient_tests {
             );
 
             // T3: unregistered virtual → error
-            let unregistered = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+            let unregistered = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
             assert!(Recipient::resolve(unregistered).is_err());
 
             Ok::<_, TempoPrecompileError>(())
@@ -1268,7 +1256,7 @@ mod recipient_tests {
         // Pre-T3: virtual address passed through as literal
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T2);
         StorageCtx::enter(&mut storage, || {
-            let virtual_addr = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+            let virtual_addr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
             let r = Recipient::resolve(virtual_addr)?;
             assert_eq!(
                 r,
@@ -1327,8 +1315,8 @@ mod recipient_tests {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, FixedBytes, IntoLogData, U256};
-    use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20Factory};
+    use alloy::primitives::{Address, FixedBytes, IntoLogData, U256, hex};
+    use tempo_contracts::precompiles::ITIP20Factory;
 
     use super::*;
     use crate::{
@@ -1340,10 +1328,7 @@ pub(crate) mod tests {
         address_registry::{AddressRegistry, MasterId, UserTag},
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        test_util::{
-            TIP20Setup, VIRTUAL_MASTER, make_virtual_address, register_virtual_master,
-            setup_storage,
-        },
+        test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master, setup_storage},
     };
     use rand_08::{Rng, distributions::Alphanumeric, thread_rng};
     use tempo_chainspec::hardfork::TempoHardfork;
@@ -2103,17 +2088,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_tip20_token_prefix() {
-        assert_eq!(
-            TIP20_TOKEN_PREFIX,
-            [
-                0x20, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-            ]
-        );
-        assert_eq!(&DEFAULT_FEE_TOKEN.as_slice()[..12], &TIP20_TOKEN_PREFIX);
-    }
-
-    #[test]
     fn test_arbitrary_currency() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let admin = Address::random();
@@ -2292,9 +2266,9 @@ pub(crate) mod tests {
             )?;
             let non_tip20 = Address::random();
 
-            assert!(is_tip20_prefix(PATH_USD_ADDRESS));
-            assert!(is_tip20_prefix(created_tip20));
-            assert!(!is_tip20_prefix(non_tip20));
+            assert!(PATH_USD_ADDRESS.is_tip20());
+            assert!(created_tip20.is_tip20());
+            assert!(!non_tip20.is_tip20());
             Ok(())
         })
     }
@@ -2919,7 +2893,7 @@ pub(crate) mod tests {
         let admin = Address::random();
         let sender = Address::random();
         let spender = Address::random();
-        let to = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+        let to = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
         let amount = U256::from(100);
         let memo = FixedBytes::ZERO;
 

--- a/crates/precompiles/src/tip20/rewards.rs
+++ b/crates/precompiles/src/tip20/rewards.rs
@@ -7,7 +7,6 @@
 //! [Reward system]: <https://docs.tempo.xyz/protocol/tip20-rewards/overview>
 
 use crate::{
-    address_registry,
     error::{Result, TempoPrecompileError},
     storage::Handler,
     tip20::{Recipient, TIP20Token},
@@ -15,6 +14,7 @@ use crate::{
 use alloy::primitives::{Address, U256, uint};
 use tempo_contracts::precompiles::{ITIP20, TIP20Error, TIP20Event};
 use tempo_precompiles_macros::Storable;
+use tempo_primitives::TempoAddressExt;
 
 /// Precision multiplier for reward-per-token accumulator (1e18).
 pub const ACC_PRECISION: U256 = uint!(1000000000000000000_U256);
@@ -136,7 +136,7 @@ impl TIP20Token {
         self.check_not_paused()?;
 
         // TIP-1022: reject virtual addresses as reward recipients
-        if self.storage.spec().is_t3() && address_registry::is_virtual_address(call.recipient) {
+        if self.storage.spec().is_t3() && call.recipient.is_virtual() {
             return Err(TIP20Error::invalid_recipient().into());
         }
 
@@ -389,7 +389,7 @@ mod tests {
         address_registry::{MasterId, UserTag},
         error::TempoPrecompileError,
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        test_util::{TIP20Setup, make_virtual_address},
+        test_util::TIP20Setup,
         tip403_registry::TIP403Registry,
     };
     use alloy::primitives::{Address, U256};
@@ -729,7 +729,7 @@ mod tests {
 
     #[test]
     fn test_set_reward_recipient_rejects_virtual_on_t3() -> eyre::Result<()> {
-        let virtual_addr = make_virtual_address(MasterId::ZERO, UserTag::ZERO);
+        let virtual_addr = Address::new_virtual(MasterId::ZERO, UserTag::ZERO);
 
         for hardfork in [TempoHardfork::T2, TempoHardfork::T3] {
             let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -10,12 +10,13 @@ use tempo_precompiles_macros::contract;
 use crate::{
     PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS,
     error::{Result, TempoPrecompileError},
-    tip20::{TIP20Error, TIP20Token, USD_CURRENCY, is_tip20_prefix},
+    tip20::{TIP20Error, TIP20Token, USD_CURRENCY},
 };
 use alloy::{
     primitives::{Address, B256, keccak256},
     sol_types::SolValue,
 };
+use tempo_primitives::TempoAddressExt;
 use tracing::trace;
 
 /// Number of reserved addresses (0 to RESERVED_SIZE-1) that cannot be deployed via factory
@@ -82,7 +83,7 @@ impl TIP20Factory {
 
     /// Returns `true` if `token` has the correct TIP-20 prefix and has code deployed.
     pub fn is_tip20(&self, token: Address) -> Result<bool> {
-        if !is_tip20_prefix(token) {
+        if !token.is_tip20() {
             return Ok(false);
         }
         // Check if the token has code deployed (non-empty code hash)
@@ -178,7 +179,7 @@ impl TIP20Factory {
         admin: Address,
     ) -> Result<Address> {
         // Validate that the address has a TIP20 prefix
-        if !is_tip20_prefix(address) {
+        if !address.is_tip20() {
             return Err(TIP20Error::invalid_token().into());
         }
 
@@ -268,26 +269,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_tip20_prefix() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
-
-        StorageCtx::enter(&mut storage, || {
-            // PATH_USD has correct prefix
-            assert!(is_tip20_prefix(PATH_USD_ADDRESS));
-
-            // Address with TIP20 prefix (0x20C0...)
-            let tip20_addr = Address::from(alloy::hex!("20C0000000000000000000000000000000001234"));
-            assert!(is_tip20_prefix(tip20_addr));
-
-            // Random address does not have TIP20 prefix
-            let random = Address::random();
-            assert!(!is_tip20_prefix(random));
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn test_is_tip20() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let sender = Address::random();
@@ -364,11 +345,11 @@ mod tests {
         assert_ne!(lower4, lower5);
 
         // All addresses should have TIP20 prefix
-        assert!(is_tip20_prefix(addr1));
-        assert!(is_tip20_prefix(addr2));
-        assert!(is_tip20_prefix(addr3));
-        assert!(is_tip20_prefix(addr4));
-        assert!(is_tip20_prefix(addr5));
+        assert!(addr1.is_tip20());
+        assert!(addr2.is_tip20());
+        assert!(addr3.is_tip20());
+        assert!(addr4.is_tip20());
+        assert!(addr5.is_tip20());
     }
 
     #[test]
@@ -406,8 +387,8 @@ mod tests {
             assert_ne!(token_addr_1, token_addr_2);
 
             // Verify addresses have TIP20 prefix
-            assert!(is_tip20_prefix(token_addr_1));
-            assert!(is_tip20_prefix(token_addr_2));
+            assert!(token_addr_1.is_tip20());
+            assert!(token_addr_2.is_tip20());
 
             // Verify tokens are valid TIP20s
             assert!(factory.is_tip20(token_addr_1)?);
@@ -778,7 +759,7 @@ mod tests {
         assert_ne!(address, Address::ZERO);
 
         // Address should have TIP20 prefix
-        assert!(is_tip20_prefix(address));
+        assert!(address.is_tip20());
 
         // Same inputs should produce same outputs (deterministic)
         let (address2, lower_bytes2) = compute_tip20_address(sender, salt);
@@ -812,7 +793,7 @@ mod tests {
             assert_ne!(address, Address::ZERO);
 
             // Should have TIP20 prefix
-            assert!(is_tip20_prefix(address));
+            assert!(address.is_tip20());
 
             // Should be deterministic
             let address2 =

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -16,11 +16,11 @@ use tempo_precompiles_macros::{Storable, contract};
 
 use crate::{
     TIP403_REGISTRY_ADDRESS,
-    address_registry::is_virtual_address,
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
 };
 use alloy::primitives::Address;
+use tempo_primitives::TempoAddressExt;
 
 /// Built-in policy ID that always rejects authorization.
 pub const REJECT_ALL_POLICY_ID: u64 = 0;
@@ -294,7 +294,7 @@ impl TIP403Registry {
         // TIP-1022: reject virtual addresses in initial account set (spec T3+)
         if self.storage.spec().is_t3() {
             for account in call.accounts.iter() {
-                if is_virtual_address(*account) {
+                if account.is_virtual() {
                     return Err(TIP403RegistryError::virtual_address_not_allowed().into());
                 }
             }
@@ -412,7 +412,7 @@ impl TIP403Registry {
         call: ITIP403Registry::modifyPolicyWhitelistCall,
     ) -> Result<()> {
         // TIP-1022: virtual addresses are forwarding aliases, not valid policy members (spec: T3+)
-        if self.storage.spec().is_t3() && is_virtual_address(call.account) {
+        if self.storage.spec().is_t3() && call.account.is_virtual() {
             return Err(TIP403RegistryError::virtual_address_not_allowed().into());
         }
 
@@ -453,7 +453,7 @@ impl TIP403Registry {
         call: ITIP403Registry::modifyPolicyBlacklistCall,
     ) -> Result<()> {
         // TIP-1022: virtual addresses are forwarding aliases, not valid policy members (spec: T3+)
-        if self.storage.spec().is_t3() && is_virtual_address(call.account) {
+        if self.storage.spec().is_t3() && call.account.is_virtual() {
             return Err(TIP403RegistryError::virtual_address_not_allowed().into());
         }
 
@@ -748,6 +748,7 @@ mod tests {
     use rand_08::Rng;
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
+    use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
     #[test]
     fn test_create_policy() -> eyre::Result<()> {
@@ -2270,14 +2271,6 @@ mod tests {
 
     // ────────────────── TIP-1022 Virtual Address Rejection ──────────────────
 
-    /// Builds a virtual address from a `masterId` and `userTag`.
-    fn make_virtual_address() -> Address {
-        use crate::address_registry::VIRTUAL_MAGIC;
-        let mut bytes = [0u8; 20];
-        bytes[4..14].copy_from_slice(&VIRTUAL_MAGIC);
-        Address::from(bytes)
-    }
-
     #[test]
     fn test_modify_whitelist_rejects_virtual_address() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
@@ -2297,7 +2290,7 @@ mod tests {
                 admin,
                 ITIP403Registry::modifyPolicyWhitelistCall {
                     policyId: policy_id,
-                    account: make_virtual_address(),
+                    account: Address::new_virtual(MasterId::ZERO, UserTag::ZERO),
                     allowed: true,
                 },
             );
@@ -2331,7 +2324,7 @@ mod tests {
                 admin,
                 ITIP403Registry::modifyPolicyBlacklistCall {
                     policyId: policy_id,
-                    account: make_virtual_address(),
+                    account: Address::new_virtual(MasterId::ZERO, UserTag::ZERO),
                     restricted: true,
                 },
             );
@@ -2359,7 +2352,10 @@ mod tests {
                 ITIP403Registry::createPolicyWithAccountsCall {
                     admin,
                     policyType: PolicyType::WHITELIST,
-                    accounts: vec![Address::random(), make_virtual_address()],
+                    accounts: vec![
+                        Address::random(),
+                        Address::new_virtual(MasterId::ZERO, UserTag::ZERO),
+                    ],
                 },
             );
             assert!(matches!(

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,0 +1,78 @@
+use alloy_primitives::{Address, FixedBytes, hex};
+
+/// 4-byte master identifier derived from the registration hash.
+pub type MasterId = FixedBytes<4>;
+
+/// 6-byte user tag occupying the trailing bytes of a virtual address.
+pub type UserTag = FixedBytes<6>;
+
+pub trait TempoAddressExt {
+    /// 12-byte prefix shared by all TIP-20 token addresses.
+    ///
+    /// NOTE: prefix alone does not prove a token exists — use `TIP20Factory::is_tip20()` for that.
+    const TIP20_PREFIX: [u8; 12];
+
+    /// 10-byte magic value occupying bytes `[4:14]` of every [TIP-1022] virtual address.
+    ///
+    /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
+    const VIRTUAL_MAGIC: [u8; 10];
+
+    /// Returns `true` if the address has the TIP-20 token prefix.
+    ///
+    /// NOTE: This only checks the prefix, not whether the token was actually created.
+    /// Use `TIP20Factory::is_tip20()` for full validation.
+    fn is_tip20(&self) -> bool;
+
+    /// Returns `true` if the address matches the [TIP-1022] virtual-address format
+    /// (bytes `[4:14]` == [`Self::VIRTUAL_MAGIC`]).
+    ///
+    /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
+    fn is_virtual(&self) -> bool;
+
+    /// Returns `true` if the address is eligible to be a virtual-address master per TIP-1022.
+    fn is_valid_master(&self) -> bool;
+
+    /// Decodes a virtual address into its `(masterId, userTag)` components.
+    ///
+    /// Returns `None` if the address does not match the virtual-address format.
+    fn decode_virtual(&self) -> Option<(MasterId, UserTag)>;
+
+    fn new_virtual(master_id: MasterId, user_tag: UserTag) -> Self;
+}
+
+impl TempoAddressExt for Address {
+    const TIP20_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
+    const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
+
+    fn is_tip20(&self) -> bool {
+        self.as_slice().starts_with(&Self::TIP20_PREFIX)
+    }
+
+    fn is_virtual(&self) -> bool {
+        self.as_slice()[4..14] == Self::VIRTUAL_MAGIC
+    }
+
+    fn is_valid_master(&self) -> bool {
+        !self.is_zero() && !self.is_virtual() && !self.is_tip20()
+    }
+
+    fn decode_virtual(&self) -> Option<(MasterId, UserTag)> {
+        if !self.is_virtual() {
+            return None;
+        }
+        let bytes = self.as_slice();
+        Some((
+            MasterId::from_slice(&bytes[0..4]),
+            UserTag::from_slice(&bytes[14..20]),
+        ))
+    }
+
+    /// Builds a virtual address from a `masterId` and `userTag`.
+    fn new_virtual(master_id: MasterId, user_tag: UserTag) -> Self {
+        let mut bytes = [0u8; 20];
+        bytes[0..4].copy_from_slice(master_id.as_slice());
+        bytes[4..14].copy_from_slice(&Self::VIRTUAL_MAGIC);
+        bytes[14..20].copy_from_slice(user_tag.as_slice());
+        Self::from(bytes)
+    }
+}

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,12 +1,14 @@
 use alloy_primitives::{Address, FixedBytes, hex};
 
+/// TIP20 token address prefix (12 bytes)
+/// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)
 const TIP20_TOKEN_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
 
 /// Returns `true` if `addr` has the TIP-20 token prefix.
 ///
 /// NOTE: This only checks the prefix, not whether the token was actually created.
 /// Use `TIP20Factory::is_tip20()` for full validation.
-pub fn is_tip20_prefix(addr: &Address) -> bool {
+pub fn is_tip20_prefix(addr: Address) -> bool {
     addr.as_slice().starts_with(&TIP20_TOKEN_PREFIX)
 }
 
@@ -61,7 +63,7 @@ impl TempoAddressExt for Address {
     const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
 
     fn is_tip20(&self) -> bool {
-        is_tip20_prefix(self)
+        is_tip20_prefix(*self)
     }
 
     fn is_virtual(&self) -> bool {

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,11 +1,22 @@
 use alloy_primitives::{Address, FixedBytes, hex};
 
+const TIP20_TOKEN_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
+
+/// Returns `true` if `addr` has the TIP-20 token prefix.
+///
+/// NOTE: This only checks the prefix, not whether the token was actually created.
+/// Use `TIP20Factory::is_tip20()` for full validation.
+pub fn is_tip20_prefix(addr: &Address) -> bool {
+    addr.as_slice().starts_with(&TIP20_TOKEN_PREFIX)
+}
+
 /// 4-byte master identifier derived from the registration hash.
 pub type MasterId = FixedBytes<4>;
 
 /// 6-byte user tag occupying the trailing bytes of a virtual address.
 pub type UserTag = FixedBytes<6>;
 
+/// Extension trait with helper functions for Tempo addresses.
 pub trait TempoAddressExt {
     /// 12-byte prefix shared by all TIP-20 token addresses.
     ///
@@ -17,10 +28,12 @@ pub trait TempoAddressExt {
     /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
     const VIRTUAL_MAGIC: [u8; 10];
 
-    /// Returns `true` if the address has the TIP-20 token prefix.
+    /// Returns `true` if the address has the [TIP-20] token prefix.
     ///
     /// NOTE: This only checks the prefix, not whether the token was actually created.
     /// Use `TIP20Factory::is_tip20()` for full validation.
+    ///
+    /// [TIP-20]: <https://docs.tempo.xyz/protocol/tip20>
     fn is_tip20(&self) -> bool;
 
     /// Returns `true` if the address matches the [TIP-1022] virtual-address format
@@ -37,15 +50,18 @@ pub trait TempoAddressExt {
     /// Returns `None` if the address does not match the virtual-address format.
     fn decode_virtual(&self) -> Option<(MasterId, UserTag)>;
 
+    /// Builds a [TIP-1022] virtual address from a `masterId` and `userTag`.
+    ///
+    /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
     fn new_virtual(master_id: MasterId, user_tag: UserTag) -> Self;
 }
 
 impl TempoAddressExt for Address {
-    const TIP20_PREFIX: [u8; 12] = hex!("20C000000000000000000000");
+    const TIP20_PREFIX: [u8; 12] = TIP20_TOKEN_PREFIX;
     const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
 
     fn is_tip20(&self) -> bool {
-        self.as_slice().starts_with(&Self::TIP20_PREFIX)
+        is_tip20_prefix(self)
     }
 
     fn is_virtual(&self) -> bool {
@@ -67,7 +83,6 @@ impl TempoAddressExt for Address {
         ))
     }
 
-    /// Builds a virtual address from a `masterId` and `userTag`.
     fn new_virtual(master_id: MasterId, user_tag: UserTag) -> Self {
         let mut bytes = [0u8; 20];
         bytes[0..4].copy_from_slice(master_id.as_slice());

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,7 @@
 pub use alloy_consensus::Header;
 
 mod address;
-pub use address::{MasterId, TempoAddressExt, UserTag};
+pub use address::{MasterId, TempoAddressExt, UserTag, is_tip20_prefix};
 pub mod ed25519;
 
 pub mod transaction;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub use alloy_consensus::Header;
 
+mod address;
+pub use address::{MasterId, TempoAddressExt, UserTag};
 pub mod ed25519;
 
 pub mod transaction;

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -17,10 +17,10 @@ use tempo_precompiles::{
     error::{Result as TempoResult, TempoPrecompileError},
     storage::{Handler, PrecompileStorageProvider, StorageCtx},
     tip_fee_manager::TipFeeManager,
-    tip20::{ITIP20, TIP20Token, is_tip20_prefix},
+    tip20::{ITIP20, TIP20Token},
     tip403_registry::{AuthRole, TIP403Registry},
 };
-use tempo_primitives::TempoTxEnvelope;
+use tempo_primitives::{TempoAddressExt, TempoTxEnvelope};
 
 /// Returns true if the calldata is for a TIP-20 function that should trigger fee token inference.
 /// Only `transfer`, `transferWithMemo`, and `distributeReward` qualify.
@@ -214,7 +214,7 @@ pub trait TempoStateAccess<M = ()> {
         Self: Sized,
     {
         // Must have TIP20 prefix to be a valid fee token
-        if !is_tip20_prefix(fee_token) {
+        if !fee_token.is_tip20() {
             return Ok(false);
         }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -51,11 +51,14 @@ use tempo_precompiles::{
         Handler as _, PrecompileStorageProvider, StorageCtx, evm::EvmPrecompileStorageProvider,
     },
     tip_fee_manager::TipFeeManager,
-    tip20::{ITIP20::InsufficientBalance, TIP20Error, TIP20Token, is_tip20_prefix},
+    tip20::{ITIP20::InsufficientBalance, TIP20Error, TIP20Token},
 };
-use tempo_primitives::transaction::{
-    PrimitiveSignature, SignatureType, TEMPO_EXPIRING_NONCE_KEY, TempoSignature,
-    calc_gas_balance_spending, validate_calls,
+use tempo_primitives::{
+    TempoAddressExt,
+    transaction::{
+        PrimitiveSignature, SignatureType, TEMPO_EXPIRING_NONCE_KEY, TempoSignature,
+        calc_gas_balance_spending, validate_calls,
+    },
 };
 
 use crate::{
@@ -890,7 +893,7 @@ where
 
         // Always validate TIP20 prefix to prevent panics in get_token_balance.
         // This is a protocol-level check since validators could bypass initial validation.
-        if !is_tip20_prefix(fee_token) {
+        if !fee_token.is_tip20() {
             return Err(TempoInvalidTransaction::InvalidFeeToken(fee_token).into());
         }
 
@@ -2151,7 +2154,7 @@ mod tests {
         // guards against invalid tokens reaching get_token_balance.
         let invalid_token = Address::random(); // Random address won't have TIP20 prefix
         assert!(
-            !is_tip20_prefix(invalid_token),
+            !invalid_token.is_tip20(),
             "Test requires a non-TIP20 address"
         );
 

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -26,9 +26,8 @@ use tempo_chainspec::TempoChainSpec;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
-    tip20::is_tip20_prefix,
 };
-use tempo_primitives::{TempoHeader, TempoPrimitives};
+use tempo_primitives::{TempoAddressExt, TempoHeader, TempoPrimitives};
 use tracing::{debug, error};
 
 /// Evict transactions this many seconds before they expire to reduce propagation
@@ -162,7 +161,7 @@ impl TempoPoolUpdates {
                 }
             }
             // Fee token pause events and balance changes
-            else if is_tip20_prefix(log.address) {
+            else if log.address.is_tip20() {
                 if let Ok(event) = ITIP20::PauseStateUpdate::decode_log(log) {
                     updates.pause_events.push((log.address, event.isPaused));
                 } else if ITIP20::TransferPolicyUpdate::decode_log(log).is_ok() {


### PR DESCRIPTION
this PR encapsulates all the helper fns related to the `Address` into a single `trait TempoAddressExt`, so that consumers of `tempo-primitives` can easily use all those helpers.

review note:
- the trait is defined in `crates/primitives/src/address.rs`
- the other changes simply make use of the new ergonomic APIs