### PR TITLE
fix(bench): allow --existing-recipients without explicit value

### DIFF
--- a/bin/tempo-bench/src/cmd/max_tps.rs
+++ b/bin/tempo-bench/src/cmd/max_tps.rs
@@ -181,7 +181,7 @@ pub struct MaxTpsArgs {
     /// When enabled, TIP-20 and ERC-20 transfers are sent to the bench's own signer addresses
     /// (which already exist on-chain), avoiding cold SSTORE for account creation. This tests
     /// pure transfer throughput without state growth.
-    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    #[arg(long, default_value_t = true, default_missing_value = "true", num_args = 0..=1, action = clap::ArgAction::Set)]
     existing_recipients: bool,
 
     /// An amount of receipts to wait for after sending all the transactions.


### PR DESCRIPTION
Adds `default_missing_value` and `num_args = 0..=1` so `--existing-recipients` can be passed as a bare flag (defaults to `true`) instead of requiring `--existing-recipients true`.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey