### PR TITLE
chore: box the testing node started future

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -125,25 +125,6 @@ where
             + Network
             + BufferPooler,
     {
-        Box::pin(self.try_init_inner(context)).await
-    }
-
-    async fn try_init_inner<TContext>(
-        self,
-        context: TContext,
-    ) -> eyre::Result<Engine<TContext, TBlocker, TPeerManager>>
-    where
-        TContext: Clock
-            + governor::clock::Clock
-            + Rng
-            + CryptoRng
-            + Pacer
-            + Spawner
-            + Storage
-            + Metrics
-            + Network
-            + BufferPooler,
-    {
         let execution_node = self
             .execution_node
             .clone()

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -125,6 +125,25 @@ where
             + Network
             + BufferPooler,
     {
+        Box::pin(self.try_init_inner(context)).await
+    }
+
+    async fn try_init_inner<TContext>(
+        self,
+        context: TContext,
+    ) -> eyre::Result<Engine<TContext, TBlocker, TPeerManager>>
+    where
+        TContext: Clock
+            + governor::clock::Clock
+            + Rng
+            + CryptoRng
+            + Pacer
+            + Spawner
+            + Storage
+            + Metrics
+            + Network
+            + BufferPooler,
+    {
         let execution_node = self
             .execution_node
             .clone()

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -193,6 +193,10 @@ where
     /// # Panics
     /// Panics if either consensus or execution is already running.
     pub async fn start(&mut self, context: &Context) {
+        Box::pin(self.start_inner(context)).await
+    }
+
+    async fn start_inner(&mut self, context: &Context) {
         self.start_execution().await;
         self.start_consensus(context).await;
         self.n_starts += 1;


### PR DESCRIPTION
Creating the engine allocates a lot on the stack leading to an overflow. Box these futures -- commonware's deterministic runtime does everything on 1 thread