### PR TITLE
fix(tip-1016): update the CREATE behavior

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -65,7 +65,7 @@ Storage creation operations split their cost between regular gas (computational 
 | Hot SSTORE (non-zero → non-zero) | 2,900 | 0 | 2,900 |
 | Account creation (nonce 0 → 1) | 25,000 | 225,000 | 250,000 |
 | Contract code storage (per byte) | 200 | 2,300 | 2,500 |
-| Contract metadata (keccak + nonce) | 32,000 | 468,000 | 500,000 |
+| Contract creation (nonce + code hash) | 32,000 | 468,000 | 500,000 |
 | EIP-7702 delegation (per auth) | 25,000 | 225,000 | 250,000 |
 
 ### EIP-7702 Delegation Pricing
@@ -236,15 +236,15 @@ When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed,
 **During initcode execution:** Charge the actual gas consumed by the initcode execution
 
 **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
-- If the target account is new, charge account creation (25,000 regular + 225,000 state)
 - Charge `GAS_CODE_DEPOSIT * L` (200 regular + 2,300 state per byte) and persist `B` under `H`, then link `codeHash` to `H`
+- Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
 
 **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
-- Do NOT charge account creation or `GAS_CODE_DEPOSIT * L`
+- Do NOT charge `GAS_CODE_DEPOSIT * L` or `HASH_COST(L)`
 - No code is stored; no `codeHash` is linked to the account
 - The account remains unchanged or non-existent
 
-This is aligned with EIP-8037's deployment flow, where `GAS_NEW_ACCOUNT` is charged only on the success path.
+This is aligned with EIP-8037's deployment flow, where `GAS_CODE_DEPOSIT` is charged only on the success path.
 
 ### Example: 24KB Contract Deployment
 
@@ -252,7 +252,6 @@ Operation | Regular | State gas
 ----------|---------|----------
 Contract code | `24,576 × 200 = 4,915,200` | `24,576 × 2,300 = 56,524,800`
 Contract fixed upfront | `32,000` | `468,000`
-Account creation | `25,000` | `225,000`
 Deployment logic | ~2M | 0
 ----------|---------|----------
 **Totals:** | ~7M (counts toward protocol limits via `gas_left`) | ~57M (served from `state_gas_reservoir`, doesn't count toward protocol limits)

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -65,7 +65,7 @@ Storage creation operations split their cost between regular gas (computational 
 | Hot SSTORE (non-zero → non-zero) | 2,900 | 0 | 2,900 |
 | Account creation (nonce 0 → 1) | 25,000 | 225,000 | 250,000 |
 | Contract code storage (per byte) | 200 | 2,300 | 2,500 |
-| Contract creation (nonce + code hash) | 32,000 | 468,000 | 500,000 |
+| Contract creation (fixed upfront cost) | 32,000 | 468,000 | 500,000 |
 | EIP-7702 delegation (per auth) | 25,000 | 225,000 | 250,000 |
 
 ### EIP-7702 Delegation Pricing


### PR DESCRIPTION
Updates the spec to not imply that account creation is charged additionally on top of 500k CREATE cost