### PR TITLE
docs(tip-1050): add P384 and SHA-384 signature verifier extension

### DIFF
--- a/tips/tip-1050.md
+++ b/tips/tip-1050.md
@@ -1,0 +1,237 @@
+---
+id: TIP-1050
+title: P384 and SHA-384 Extension for the Signature Verification Precompile
+description: Extends TIP-1020 with P384 signature verification and SHA-384 helper methods for onchain attestation and certificate validation flows.
+authors: Zygimantas Magelinskas (@zhygis)
+status: Draft
+related: TIP-1020, Tempo Transaction Spec
+protocolVersion: TBD
+---
+
+# TIP-1050: P384 and SHA-384 Extension for the Signature Verification Precompile
+
+## Abstract
+
+This TIP extends TIP-1020 by adding secp384r1 (`P384`) support to the Signature Verification precompile's `recover()` and `verify()` entrypoints. It also adds two raw cryptography helper methods: `verifyES384()` for ECDSA-P384 signatures over SHA-384 digests, and `sha384()` for hashing arbitrary byte strings.
+
+The extension is additive. It keeps the TIP-1020 precompile address and error model unchanged, does not introduce a new Tempo transaction signature type, and preserves the behavior of the existing secp256k1, P256, and WebAuthn paths.
+
+## Motivation
+
+TIP-1020 gives contracts a stable onchain interface for Tempo signature verification, but it does not cover the secp384r1 / SHA-384 combinations used by a number of attestation and certificate-validation systems.
+
+This gap matters for contracts that need to verify offchain-authenticated material such as:
+
+1. Hardware attestation documents and certificate chains that use P384 keys.
+2. Service-issued credentials where the signature scheme is ES384 rather than P256.
+3. General-purpose cryptographic workflows that need SHA-384 onchain but do not need a full certificate parser or custom verifier contract.
+
+Without native support, contracts must embed custom Solidity verifiers or call out to specialized verifier contracts, which increases deployment size, gas cost, and audit surface area. Extending TIP-1020 keeps this capability behind the same stable precompile boundary already used for signature verification.
+
+The raw ES384 and SHA-384 helper methods are included because address-oriented Tempo signature recovery is not sufficient for certificate and attestation flows. Those flows often verify a raw public key against a SHA-384 digest and do not map cleanly onto TIP-1020's existing `recover(bytes32,bytes)` interface.
+
+## Assumptions
+
+1. TIP-1020 remains the canonical precompile for onchain signature verification at `0x5165300000000000000000000000000000000000`.
+2. This TIP extends only the precompile interface and verification logic; it does not add P384 as a Tempo transaction signature type.
+3. `recover()` and `verify()` remain address-oriented APIs over a `bytes32` input hash, while raw P384 + SHA-384 workflows use the new helper methods.
+4. Keychain signature prefixes (`0x03` and `0x04`) remain reserved and are not repurposed by this TIP.
+
+## Threat Model
+
+This TIP adds new cryptographic entrypoints but intentionally does not solve higher-level certificate semantics.
+
+1. The precompile verifies signatures and hashes bytes. It does not validate certificate chains, issuance policy, expiration, revocation, or application-specific trust roots.
+2. The address-oriented P384 path must reject malleable high-`s` signatures so it matches Tempo's existing signature-hardening expectations.
+3. The raw ES384 helper must distinguish malformed encodings from simple cryptographic mismatch so callers can reject bad inputs deterministically without conflating them with an invalid signer.
+4. The new hashing entrypoint must remain exempt from TIP-1020's signature-size guard so large attestation payloads can still be hashed.
+
+---
+
+# Specification
+
+This TIP amends TIP-1020.
+
+## Precompile Address
+
+The precompile address is unchanged from TIP-1020:
+
+```
+0x5165300000000000000000000000000000000000
+```
+
+## Interface
+
+After this TIP, the precompile interface is:
+
+```solidity
+interface ISignatureVerifier {
+    error InvalidFormat();
+    error InvalidSignature();
+
+    /// @notice Recovers the signer of a Tempo signature (secp256k1, P256, P384, WebAuthn).
+    /// @param hash The message hash that was signed.
+    /// @param signature The encoded signature.
+    /// @return signer Address of the signer if valid, reverts otherwise.
+    function recover(bytes32 hash, bytes calldata signature) external view returns (address signer);
+
+    /// @notice Verifies a signer against a Tempo signature (secp256k1, P256, P384, WebAuthn).
+    /// @param signer The input address verified against the recovered signer.
+    /// @param hash The message hash that was signed.
+    /// @param signature The encoded signature.
+    /// @return True if the input address signed, false otherwise. Reverts on invalid signatures.
+    function verify(address signer, bytes32 hash, bytes calldata signature) external view returns (bool);
+
+    /// @notice Verifies an ES384 signature over a SHA-384 digest.
+    /// @param digest The 48-byte SHA-384 digest that was signed.
+    /// @param signature The raw ES384 signature encoded as `r || s`.
+    /// @param publicKey The P-384 public key encoded as `x || y` or `0x04 || x || y`.
+    /// @return True if the signature is valid for the digest and public key, false otherwise.
+    function verifyES384(bytes calldata digest, bytes calldata signature, bytes calldata publicKey)
+        external
+        view
+        returns (bool);
+
+    /// @notice Computes the SHA-384 digest of the input data.
+    /// @param data The input bytes to hash.
+    /// @return digest The 48-byte SHA-384 digest.
+    function sha384(bytes calldata data) external view returns (bytes memory digest);
+}
+```
+
+## P384 Signature Encoding for `recover()` and `verify()`
+
+This TIP adds a precompile-native P384 signature encoding to TIP-1020:
+
+| Type | Format | Length |
+|------|--------|--------|
+| P384 | `0x05 || r || s || x || y || prehash` | 194 bytes |
+
+Encoding rules:
+
+1. `0x05` is the P384 type byte. `0x03` and `0x04` remain reserved for keychain signatures, so `0x05` is the next free discriminant.
+2. `r`, `s`, `x`, and `y` are 48-byte big-endian field elements.
+3. `prehash` is a single byte.
+4. If `prehash == 0`, the `hash` argument passed to `recover()` / `verify()` is treated as the final SHA-256 digest to verify.
+5. If `prehash != 0`, the precompile MUST first compute `sha256(hash)` and verify that derived 32-byte digest.
+
+Successful P384 recovery derives the signer address as:
+
+```text
+address = last_20_bytes(keccak256(x || y))
+```
+
+This matches the existing Tempo curve-key address derivation pattern used by non-secp256k1 keys.
+
+## Verification Behavior
+
+### Existing TIP-1020 Paths
+
+All existing TIP-1020 signature types keep their current behavior unchanged:
+
+1. secp256k1 continues to use the unprefixed 65-byte `r || s || v` form.
+2. P256 continues to use the TIP-1020 encoding and semantics.
+3. WebAuthn continues to use the TIP-1020 encoding and semantics.
+4. Keychain-prefixed signatures (`0x03`, `0x04`) continue to revert with `InvalidFormat()`.
+
+### P384 Recovery Rules
+
+For the new P384 path:
+
+1. `recover()` and `verify()` MUST accept only the exact 194-byte encoding defined above.
+2. The precompile MUST reject malformed P384 encodings with `InvalidFormat()`.
+3. The precompile MUST reject high-`s` signatures where `s > n / 2` with `InvalidSignature()`.
+4. The precompile MUST verify the signature against the supplied public key coordinates and derived message digest.
+5. `recover()` MUST return the derived Tempo address on success and revert on failure.
+6. `verify()` MUST return `true` only when the recovered signer equals the supplied `signer`, return `false` for a signer mismatch, and otherwise inherit the same revert behavior as `recover()`.
+
+## `verifyES384()` Helper
+
+`verifyES384(bytes digest, bytes signature, bytes publicKey)` provides raw ECDSA-P384 verification over a SHA-384 digest.
+
+Input rules:
+
+1. `digest` MUST be exactly 48 bytes.
+2. `signature` MUST be exactly 96 bytes encoded as `r || s`.
+3. `publicKey` MUST be encoded as either `x || y` (96 bytes) or `0x04 || x || y` (97 bytes).
+
+Behavior rules:
+
+1. The helper MUST verify using the ES384 scheme: ECDSA over secp384r1 with a SHA-384 digest.
+2. The helper MUST return `true` when the signature matches the digest and public key.
+3. The helper MUST return `false` on cryptographic mismatch.
+4. The helper MUST revert with `InvalidFormat()` for malformed digests, signatures, or public keys.
+5. The helper MUST NOT impose TIP-1020-specific address derivation or transaction-signature rules.
+6. The helper MUST NOT require the low-`s` normalization rule used by address-oriented Tempo signatures.
+
+The helper accepts raw `r || s` signatures instead of DER-encoded ASN.1 signatures to keep the ABI compact and deterministic.
+
+## `sha384()` Helper
+
+`sha384(bytes data)` returns the SHA-384 digest of arbitrary input bytes.
+
+Behavior rules:
+
+1. The helper MUST return exactly 48 output bytes.
+2. The helper MUST compute the standard SHA-384 hash of the input.
+3. The helper MUST accept arbitrary-length inputs.
+4. The helper MUST be exempt from TIP-1020's signature-size guard.
+
+## Calldata Limits
+
+The existing TIP-1020 size rules continue to apply to `recover()` and `verify()`. After this TIP, the allowed signature sizes are:
+
+| Type | Exact / Max Length |
+|------|-------------------|
+| secp256k1 | exactly 65 bytes |
+| P256 | exactly 130 bytes |
+| P384 | exactly 194 bytes |
+| WebAuthn | 129–2049 bytes |
+
+`sha384(bytes)` is intentionally exempt from the signature-size guard because it must support arbitrary-length inputs.
+
+## Gas Costs
+
+All calls continue to pay the standard Tempo precompile calldata cost of 6 gas per 32-byte word, rounded up, on the full ABI-encoded input.
+
+The function-specific execution gas after this TIP is:
+
+| Function / Type | Verification / Execution Gas |
+|-----------------|------------------------------|
+| `recover()` / `verify()` secp256k1 | 3,000 |
+| `recover()` / `verify()` P256 | 8,000 |
+| `recover()` / `verify()` P384 | 12,000 |
+| `recover()` / `verify()` WebAuthn | 8,000 |
+| `verifyES384()` | 12,000 |
+| `sha384(data)` | `60 + 12 * ceil(data_len / 32)` |
+
+Total gas remains:
+
+```text
+input_cost(calldata_len) + function_specific_execution_gas
+```
+
+The precompile MUST charge function-specific gas before performing cryptographic verification or hashing, and MUST revert with out-of-gas when insufficient gas is available.
+
+## Compatibility
+
+This TIP is additive with respect to TIP-1020.
+
+1. The precompile address is unchanged.
+2. Existing secp256k1, P256, and WebAuthn callers do not need to change their calldata.
+3. Existing revert behavior for malformed or unsupported signature encodings is preserved.
+4. This TIP does not add P384 as a new Tempo transaction signature type and does not change Tempo transaction encodings.
+5. Contracts that need raw ES384 or SHA-384 functionality can use the new helper methods without composing custom verifier contracts.
+
+# Invariants
+
+| ID | Invariant | Description |
+|----|-----------|-------------|
+| **SV1050-1** | TIP-1020 compatibility | Existing secp256k1, P256, and WebAuthn behavior remains unchanged after activation of this TIP. |
+| **SV1050-2** | P384 encoding disambiguation | `0x05` uniquely identifies the P384 precompile-native encoding; `0x03` and `0x04` remain reserved for keychain signatures. |
+| **SV1050-3** | P384 size enforcement | `recover()` / `verify()` MUST accept P384 only when the signature length is exactly 194 bytes. |
+| **SV1050-4** | P384 low-s enforcement | Address-oriented P384 signatures MUST reject high-`s` values (`s > n/2`) to prevent malleable recoveries. |
+| **SV1050-5** | P384 address derivation | Successful P384 recovery MUST derive the signer address as `last20(keccak256(x || y))`. |
+| **SV1050-6** | ES384 helper correctness | `verifyES384()` MUST accept only 48-byte digests, 96-byte raw signatures, and 96/97-byte uncompressed public keys; it MUST return `true` on success, `false` on cryptographic mismatch, and `InvalidFormat()` on malformed input. |
+| **SV1050-7** | SHA-384 helper correctness | `sha384()` MUST return the standard 48-byte SHA-384 digest of the input and MUST not be subject to the signature-size guard. |
+| **SV1050-8** | Gas schedule consistency | P384 verification and ES384 helper calls MUST charge 12,000 execution gas, while `sha384()` MUST charge `60 + 12 * ceil(data_len / 32)` execution gas, in addition to standard calldata cost. |


### PR DESCRIPTION
Adds a draft TIP extending TIP-1020 with P384 signer recovery and raw ES384/SHA-384 helper methods.

The spec covers calldata encoding, gas pricing, compatibility expectations, and invariants for certificate and attestation verification flows.