### PR TITLE
feat(ci): pass SHA in build-devnet event payload

### DIFF
--- a/.github/workflows/build-devnet.yml
+++ b/.github/workflows/build-devnet.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
           echo "branch=$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(echo "$PR_DATA" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,6 +33,7 @@ jobs:
             --arg event "build_devnet" \
             --arg name "devnet-pr-${{ github.event.issue.number }}" \
             --arg branch "${{ steps.pr.outputs.branch }}" \
+            --arg sha "${{ steps.pr.outputs.sha }}" \
             --arg requested_by "${{ github.event.comment.user.login }}" \
             --argjson pr_number "${{ github.event.issue.number }}" \
             '{
@@ -41,6 +43,7 @@ jobs:
                 name: $name,
                 pr_number: $pr_number,
                 branch: $branch,
+                sha: $sha,
                 requested_by: $requested_by
               }
             }')


### PR DESCRIPTION
Extracts PR head SHA and includes it in the build_devnet event payload so the Argo devnet-pr workflow can set GitHub commit status checks.

Prompted by: kamil