### PR TITLE
feat: default dev.payload-wait-time to minimum_time_before_propose

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -545,6 +545,9 @@ fn main() -> eyre::Result<()> {
         };
         let chain_id = builder.config().chain.chain().id();
 
+        let minimum_time_before_propose =
+            args.consensus.minimum_time_before_propose.into_duration();
+
         let NodeHandle {
             node,
             node_exit_future,
@@ -572,6 +575,15 @@ fn main() -> eyre::Result<()> {
                         Some(follow.clone())
                     };
                     builder.config_mut().debug.rpc_consensus_url = follow_url;
+                }
+
+                // In dev mode, default payload-wait-time to minimum_time_before_propose
+                // so the LocalMiner sleeps between fcu and resolve, matching consensus behavior
+                if builder.config().dev.dev
+                    && builder.config().dev.payload_wait_time.is_none()
+                {
+                    builder.config_mut().dev.payload_wait_time =
+                        Some(minimum_time_before_propose);
                 }
 
                 builder

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -440,6 +440,7 @@ impl TestNodeBuilder {
             );
         node_config.txpool.max_account_slots = usize::MAX;
         node_config.dev.block_time = Some(Duration::from_millis(100));
+        node_config.dev.payload_wait_time = Some(Duration::from_millis(100));
 
         let node_handle = NodeBuilder::new(node_config.clone())
             .testing_node(runtime.clone())

--- a/scripts/Justfile
+++ b/scripts/Justfile
@@ -7,7 +7,6 @@ tempo-dev-up:
 		--datadir data \
 		--dev \
 		--dev.block-time 1sec \
-		--dev.payload-wait-time 450ms \
 		--http \
 		--http.addr 0.0.0.0 \
 		--http.port 8545 \

--- a/scripts/Justfile
+++ b/scripts/Justfile
@@ -7,6 +7,7 @@ tempo-dev-up:
 		--datadir data \
 		--dev \
 		--dev.block-time 1sec \
+		--dev.payload-wait-time 450ms \
 		--http \
 		--http.addr 0.0.0.0 \
 		--http.port 8545 \


### PR DESCRIPTION
When running in dev mode, programmatically sets `--dev.payload-wait-time` to `minimum_time_before_propose` (default 450ms) unless explicitly overridden via CLI. This ensures the `LocalMiner` sleeps between `fork_choice_updated` and `resolve_kind`, matching consensus behavior.

Removes the now-redundant explicit `--dev.payload-wait-time 450ms` from the Justfile.

Prompted by: alexey