### PR TITLE
docs(tip-1027): tighten policy semantics and edge cases

### DIFF
--- a/tips/tip-1027.md
+++ b/tips/tip-1027.md
@@ -106,7 +106,7 @@ The `WithMemo` variants are separate functions rather than overloads with a defa
 Recipient validation MUST occur **before** routing, order fills, or any state mutation.
 
 - `recipient == address(0)` or any TIP-20 token address MUST revert with `InvalidRecipient()` (mirroring TIP-20's `check_recipient` logic).
-- `recipient == msg.sender` is allowed and follows the same settlement path as the existing no-recipient functions.
+- `recipient == msg.sender` is allowed and follows the same settlement path as the existing no-recipient functions, with no additional policy checks beyond what the existing swap functions perform (see **Output Settlement**).
 
 ### Special Case: `recipient == address(StablecoinDEX)`
 
@@ -116,8 +116,8 @@ Since no transfer of the TIP-20 output token occurs on this path, the DEX manual
 
 ```solidity
 uint64 policyId = ITIP20(tokenOut).transferPolicyId();
-// DEX must be authorized sender (issuer can freeze all DEX trading)
-if (!TIP403_REGISTRY.isAuthorizedSender(policyId, address(this))) {
+// Caller must be authorized to send the output token (logical sender check)
+if (!TIP403_REGISTRY.isAuthorizedSender(policyId, msg.sender)) {
     revert ITIP20.PolicyForbids();
 }
 // Caller must be authorized to receive the token
@@ -126,19 +126,36 @@ if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, msg.sender)) {
 }
 // Output token must not be paused
 if (ITIP20(tokenOut).paused()) {
-    revert ITIP20.TokenPaused();
+    revert ITIP20.ContractPaused();
 }
 ```
 
-Unlike the existing maker-fill path (where makers' internal balances are credited without checking pause, because the maker opted in before the pause by placing an order), the swap-and-send caller is newly acquiring a token position. Pause MUST be enforced to prevent users from building up positions in a paused token.
+For non-self-recipient swap-and-send paths, the caller is the logical sender on the output side. The DEX-credit path checks `msg.sender` as both sender and recipient, since the caller is newly acquiring a token position.
 
-This is different from the existing maker-fill path (where `_fillOrder` credits `balances[maker]` without re-checking policies). In that case, the maker was already policy-checked when they placed the order. Here, the caller is newly acquiring a token position via swap, so we must verify they are authorized to hold it.
+Note: paused tokens are already rejected at route validation time for all swap paths (including existing no-recipient swaps). The DEX-credit path MUST NOT bypass this — the pause check above is defense in depth.
 
 TIP-1028 address-level receive policies do not apply to the DEX-credit path, since no TIP-20 transfer occurs. Address-level receive policies govern actual token transfers, not internal DEX balance accounting.
 
+The DEX-recipient special case applies only when the literal `recipient` parameter equals `address(StablecoinDEX)`. A TIP-1022 virtual address that resolves to the DEX address is not treated as a DEX-recipient — it follows the external settlement path and the TIP-20 transfer will credit the DEX's external token balance, not the caller's internal balance.
+
 ## Output Settlement (External Recipient)
 
-For external recipients, the DEX calls `ITIP20(tokenOut).transfer(recipient, amountOut)` (or `transferWithMemo(recipient, amountOut, memo)` for the `WithMemo` variants) — a normal TIP-20 transfer from the DEX. This is identical to how existing swap functions settle output, just with `recipient` instead of `msg.sender`. All standard TIP-20 checks (TIP-403 token-level policies, TIP-1028 address-level receive policies, pause state, recipient validity) are enforced automatically by the TIP-20 transfer.
+For external recipients (where `recipient != msg.sender` and `recipient != address(StablecoinDEX)`), the DEX first checks that the caller is authorized as a sender on `tokenOut`:
+
+```solidity
+uint64 policyId = ITIP20(tokenOut).transferPolicyId();
+if (!TIP403_REGISTRY.isAuthorizedSender(policyId, msg.sender)) {
+    revert ITIP20.PolicyForbids();
+}
+```
+
+The DEX then settles via `ITIP20(tokenOut).transfer(recipient, amountOut)` (or `transferWithMemo(recipient, amountOut, memo)` for the `WithMemo` variants). The TIP-20 transfer enforces all remaining checks (TIP-403 recipient policy, TIP-1028 address-level receive policies, pause state, recipient validity).
+
+The caller-as-sender check ensures that a blacklisted user cannot use the DEX as a laundering proxy — without it, the TIP-20 transfer would only see the DEX as the sender.
+
+When `recipient == msg.sender`, the new functions skip the caller-as-sender check on `tokenOut` and behave identically to the existing `swapExactAmountIn` / `swapExactAmountOut` — the user is not sending the token to anyone else.
+
+The `recipient` parameter and memo apply only to the final `tokenOut` settlement. Intermediate hops in a multi-hop swap are transitory and are not affected by the recipient or memo.
 
 ## Memo Behavior
 
@@ -170,10 +187,11 @@ If output settlement fails for any reason (policy denial, paused token, invalid 
 
 ## Implementation Outline
 
-All four new functions MUST execute the same routing, pricing, fill, and input-debit logic as the corresponding existing swap function. The only semantic differences are the output settlement target and memo handling:
+All four new functions MUST execute the same routing, pricing, fill, and input-debit logic as the corresponding existing swap function. The only semantic differences are the output settlement target, policy checks, and memo handling:
 
-- If `recipient == address(StablecoinDEX)`: check policies, credit `balances[msg.sender][tokenOut]`. For `WithMemo` variants, if the input is pulled from the caller's external wallet (fully or partially), use `transferFromWithMemo` for the external portion so the memo is attached to the input leg. If the swap is funded entirely from internal DEX balance, emit a zero-value `Transfer` and `TransferWithMemo` on `tokenIn` to preserve the memo.
-- Otherwise: settle via `ITIP20(tokenOut).transfer(recipient, amountOut)` for base variants, or `ITIP20(tokenOut).transferWithMemo(recipient, amountOut, memo)` for `WithMemo` variants.
+- If `recipient == msg.sender`: settle identically to the existing swap functions. No additional policy checks on `tokenOut`.
+- If `recipient == address(StablecoinDEX)`: check caller-as-sender and caller-as-recipient policies on `tokenOut`, check pause, then credit `balances[msg.sender][tokenOut]`. For `WithMemo` variants, if the input is pulled from the caller's external wallet (fully or partially), use `transferFromWithMemo` for the external portion so the memo is attached to the input leg. If the swap is funded entirely from internal DEX balance, emit a zero-value `Transfer` and `TransferWithMemo` on `tokenIn` to preserve the memo.
+- Otherwise (external recipient): check caller-as-sender policy on `tokenOut`, then settle via `ITIP20(tokenOut).transfer(recipient, amountOut)` for base variants, or `ITIP20(tokenOut).transferWithMemo(recipient, amountOut, memo)` for `WithMemo` variants.
 
 The existing `swapExactAmountIn` and `swapExactAmountOut` remain unchanged — they are not refactored to delegate to the new functions, preserving identical behavior for existing callers.
 
@@ -189,7 +207,7 @@ The existing `swapExactAmountIn` and `swapExactAmountOut` remain unchanged — t
 
 4. **Existing function preservation**: `swapExactAmountIn` and `swapExactAmountOut` MUST behave identically to before this TIP. Their semantics, policy checks, and event emission MUST NOT change.
 
-5. **Settlement-only change**: The `recipient` parameter MUST affect only final `tokenOut` settlement. It MUST NOT change routing, price computation, fill order selection, or `tokenIn` source.
+5. **Settlement-only change**: The `recipient` parameter MUST affect only final `tokenOut` settlement. In multi-hop swaps, intermediate hop amounts are transitory — the recipient and memo apply only to the final hop. The `recipient` MUST NOT change routing, price computation, fill order selection, or `tokenIn` source.
 
 6. **Taker identity**: The `OrderFilled` event's `taker` field MUST be `msg.sender` regardless of the `recipient` parameter.
 
@@ -199,6 +217,8 @@ The existing `swapExactAmountIn` and `swapExactAmountOut` remain unchanged — t
 
 9. **Memo placement — DEX-recipient**: For `WithMemo` variants where `recipient == address(StablecoinDEX)`, the memo MUST be attached to the input transfer (the `tokenIn` transfer from caller to DEX), since no TIP-20 output transfer occurs.
 
+10. **Caller-as-sender on output**: When `recipient` is neither `msg.sender` nor `address(StablecoinDEX)`, the DEX MUST check `isAuthorizedSender(tokenOut.transferPolicyId(), msg.sender)` before settling. When `recipient == msg.sender`, no such check is applied. When `recipient == address(StablecoinDEX)`, the check is part of the DEX-credit policy enforcement.
+
 ## Test Cases
 
 ### Core Swap-and-Send
@@ -207,7 +227,7 @@ The existing `swapExactAmountIn` and `swapExactAmountOut` remain unchanged — t
 
 2. **Swap-and-send exact out**: `swapExactAmountOutTo` sends exact output to recipient. Verify `amountIn <= maxAmountIn`.
 
-3. **Self-recipient**: `swapExactAmountInTo(..., msg.sender)` behaves identically to `swapExactAmountIn(...)`.
+3. **Self-recipient**: `swapExactAmountInTo(..., msg.sender)` behaves identically to `swapExactAmountIn(...)` — no additional policy checks on `tokenOut` are applied.
 
 4. **DEX-recipient credits balance**: `swapExactAmountInTo(..., DEX_ADDRESS)` credits `balances[msg.sender][tokenOut]` and emits no TIP-20 `Transfer` event for the output.
 
@@ -233,24 +253,32 @@ The existing `swapExactAmountIn` and `swapExactAmountOut` remain unchanged — t
 
 14. **Exact-out memo on external recipient**: `swapExactAmountOutToWithMemo` emits a `TransferWithMemo` event on `tokenOut` immediately after the `Transfer` event.
 
-15. **Exact-out memo on DEX-recipient**: `swapExactAmountOutToWithMemo(..., DEX_ADDRESS, memo)` follows the same memo rules as the exact-in variant (memo on input transfer if external funding occurs, no memo if fully internal-funded).
+15. **Exact-out memo on DEX-recipient**: `swapExactAmountOutToWithMemo(..., DEX_ADDRESS, memo)` follows the same memo rules as the exact-in variant (memo on input transfer if external funding; zero-value `Transfer` and `TransferWithMemo` on `tokenIn` if fully internal-funded).
 
 ### Policy (TIP-403 / TIP-1015)
 
 16. **Policy: blocked recipient**: If `recipient` is blocked by `tokenOut`'s recipient policy, the swap-and-send reverts.
 
-17. **DEX frozen as sender**: If `tokenOut`'s policy blacklists the DEX as a sender, both `swapExactAmountInTo` (external recipient) and `swapExactAmountInTo` (DEX-balance credit) revert.
+17. **Caller blocked as sender on tokenOut**: If `tokenOut`'s policy blacklists `msg.sender` as a sender, `swapExactAmountInTo` to an external recipient reverts (caller-as-sender check), and `swapExactAmountInTo(..., DEX_ADDRESS)` reverts (DEX-credit path sender check).
 
 18. **DEX-recipient + blocked caller**: `swapExactAmountInTo(..., DEX_ADDRESS)` reverts if `msg.sender` is blocked by `tokenOut`'s recipient policy.
 
-19. **Paused token reverts (external recipient)**: If `tokenOut` is paused, `swapExactAmountInTo` to an external recipient reverts during settlement (enforced by TIP-20 `transfer`).
+19. **Paused token reverts (external recipient)**: If `tokenOut` is paused, `swapExactAmountInTo` to an external recipient reverts at route validation time.
 
-20. **Paused token reverts (DEX-recipient)**: If `tokenOut` is paused, `swapExactAmountInTo(..., DEX_ADDRESS)` reverts. The pause check is enforced by the DEX before crediting internal balance.
+20. **Paused token reverts (DEX-recipient)**: If `tokenOut` is paused, `swapExactAmountInTo(..., DEX_ADDRESS)` reverts at route validation time (same as all other swap paths).
+
+21. **Self-recipient skips sender check on tokenOut**: If `msg.sender` is blacklisted as a sender on `tokenOut`, `swapExactAmountInTo(..., msg.sender)` still succeeds (no caller-as-sender check is applied), matching the behavior of `swapExactAmountIn(...)`.
+
+22. **Caller-as-sender check on external path**: If `msg.sender` is blacklisted as a sender on `tokenOut`, `swapExactAmountInTo(..., thirdParty)` reverts even though the DEX itself is an authorized sender.
 
 ### Address-Level Policies (TIP-1028)
 
-21. **Recipient address-level receive policy**: If `recipient` has a whitelist receive policy that does not include the DEX address, the swap-and-send reverts (enforced by TIP-20 `transfer`).
+23. **Recipient address-level receive policy**: If `recipient` has a whitelist receive policy that does not include the DEX address, the swap-and-send reverts (enforced by TIP-20 `transfer`).
 
-22. **Recipient token set**: If `recipient` has a token set that does not include `tokenOut`, the swap-and-send reverts.
+24. **Recipient token set**: If `recipient` has a token set that does not include `tokenOut`, the swap-and-send reverts.
 
-23. **DEX-recipient skips address-level checks**: `swapExactAmountInTo(..., DEX_ADDRESS)` does NOT check TIP-1028 address-level controls, since no TIP-20 transfer occurs. Controls are enforced when the caller later calls `withdraw`.
+25. **DEX-recipient skips address-level checks**: `swapExactAmountInTo(..., DEX_ADDRESS)` does NOT check TIP-1028 address-level controls, since no TIP-20 transfer occurs. Controls are enforced when the caller later calls `withdraw`.
+
+### TIP-1022 Virtual Addresses
+
+26. **Virtual address resolving to DEX follows external path**: A TIP-1022 virtual address whose registered master is `address(StablecoinDEX)` is NOT treated as a DEX-recipient. The swap settles via TIP-20 `transfer` (external path), and no internal balance credit occurs.


### PR DESCRIPTION
Review-driven fixes for TIP-1027:

- Caller-as-sender check on `tokenOut` for external recipients (anti-laundering)
- Self-recipient (`msg.sender`) skips the sender check — no extra policy beyond existing swap behavior
- DEX-credit path sender check changed from `address(this)` to `msg.sender`
- Pause enforcement documented as route-validation-time (per PR #3204), DEX-credit pause check is defense in depth
- Fixed error name `TokenPaused` → `ContractPaused`
- TIP-1022 virtual address note: literal `recipient == DEX` only, not resolved addresses
- Multi-hop normative statement: recipient and memo apply only to final settlement
- Added invariant 10 (caller-as-sender) and test cases 21-26
- Renumbered test cases, fixed test case 15 inconsistency

Prompted by: Dan