### PR TITLE
chore(alloy): add `is_active_harfork` to provider

### DIFF
--- a/.changelog/rich-whales-spin.md
+++ b/.changelog/rich-whales-spin.md
@@ -1,0 +1,5 @@
+---
+tempo-alloy: minor
+---
+
+Added `is_hardfork_active` helper to `TempoProviderExt` and re-exported `tempo-chainspec` as a non-optional dependency. Updated the crates.io publish pipeline to include `tempo-chainspec` as a published crate.

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 tempo-contracts = { workspace = true, features = ["rpc"] }
 tempo-primitives = { workspace = true, features = ["serde", "rpc"] }
-tempo-chainspec = { workspace = true, optional = true }
+tempo-chainspec = { workspace = true, default-features = false }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
 
@@ -53,7 +53,6 @@ tokio.workspace = true
 [features]
 default = []
 reth = [
-    "dep:tempo-chainspec",
     "dep:tempo-evm",
     "dep:tempo-revm",
     "dep:reth-evm",
@@ -61,6 +60,7 @@ reth = [
     "dep:reth-rpc-convert",
     "dep:reth-rpc-eth-types",
     "tempo-primitives/reth",
+    "tempo-chainspec/reth",
 ]
 asm-keccak = [
     "alloy-primitives/asm-keccak",

--- a/crates/alloy/src/lib.rs
+++ b/crates/alloy/src/lib.rs
@@ -18,3 +18,6 @@ pub use tempo_primitives as primitives;
 
 #[doc(inline)]
 pub use tempo_contracts as contracts;
+
+#[doc(inline)]
+pub use tempo_chainspec as chainspec;

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -11,6 +11,8 @@ use tempo_contracts::precompiles::{
 };
 use tempo_primitives::transaction::CallScope;
 
+use tempo_chainspec::hardfork::TempoHardfork;
+
 use crate::{
     TempoFillers, TempoNetwork,
     fillers::{ExpiringNonceFiller, NonceKeyFiller, Random2DNonceFiller},
@@ -93,6 +95,29 @@ pub trait TempoProviderExt: Provider<TempoNetwork> {
         Self: Sized,
     {
         self.account_keychain().getTransactionKey().call().await
+    }
+
+    /// Returns `true` if the given Tempo hardfork is active on the connected chain.
+    ///
+    /// Queries the node's `tempo_forkSchedule` RPC to determine the currently active hardfork.
+    async fn is_hardfork_active(
+        &self,
+        hardfork: TempoHardfork,
+    ) -> Result<bool, alloy_transport::TransportError>
+    where
+        Self: Sized,
+    {
+        #[derive(Debug, serde::Deserialize)]
+        struct Response {
+            active: String,
+        }
+
+        let resp: Response = self.raw_request("tempo_forkSchedule".into(), ()).await?;
+
+        Ok(resp
+            .active
+            .parse::<TempoHardfork>()
+            .is_ok_and(|h| h >= hardfork))
     }
 }
 

--- a/crates/alloy/src/provider/ext.rs
+++ b/crates/alloy/src/provider/ext.rs
@@ -4,14 +4,13 @@ use alloy_provider::{
     Identity, Provider, ProviderBuilder,
     fillers::{JoinFill, RecommendedFillers},
 };
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     IAccountKeychain::{IAccountKeychainInstance, KeyInfo},
     getAllowedCallsReturn, getRemainingLimitReturn,
 };
 use tempo_primitives::transaction::CallScope;
-
-use tempo_chainspec::hardfork::TempoHardfork;
 
 use crate::{
     TempoFillers, TempoNetwork,

--- a/crates/node/tests/it/fork_schedule.rs
+++ b/crates/node/tests/it/fork_schedule.rs
@@ -1,6 +1,7 @@
 use crate::utils::TestNodeBuilder;
 use alloy::providers::{Provider, ProviderBuilder};
 use reth_chainspec::Hardfork;
+use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt};
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_node::rpc::fork_schedule::ForkSchedule;
 
@@ -59,6 +60,24 @@ async fn test_fork_schedule() -> eyre::Result<()> {
         active_entry.fork_id.as_deref().unwrap(),
         eth_config["current"]["forkId"].as_str().unwrap()
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_is_hardfork_active() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(setup.http_url);
+
+    // Devnet activates all forks at t=0, so every known hardfork should be active.
+    for fork in TempoHardfork::VARIANTS {
+        assert!(
+            provider.is_hardfork_active(*fork).await?,
+            "{fork:?} should be active on devnet",
+        );
+    }
 
     Ok(())
 }

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Publish tempo-contracts, tempo-primitives, and tempo-alloy to crates.io
+# Publish tempo-contracts, tempo-primitives, tempo-chainspec, and tempo-alloy to crates.io
 # by stripping all reth-specific code and dependencies.
 #
 # Usage:
@@ -113,6 +113,7 @@ trap 'rm -rf "$TMP_WORK_DIR"' EXIT
 log "Copying crates to temporary directory …"
 cp -R "$REPO_ROOT/crates/contracts"  "$TMP_WORK_DIR/contracts"
 cp -R "$REPO_ROOT/crates/primitives" "$TMP_WORK_DIR/primitives"
+cp -R "$REPO_ROOT/crates/chainspec"  "$TMP_WORK_DIR/chainspec"
 cp -R "$REPO_ROOT/crates/alloy"      "$TMP_WORK_DIR/alloy"
 
 # ── 1. Delete compat modules ──────────────────────────────────────────────────
@@ -122,7 +123,15 @@ rm -f  "$TMP_WORK_DIR/alloy/src/rpc/reth_compat.rs"
 
 # ── 2. Strip reth/compat references from source ──────────────────────────────
 log "Stripping reth references from source …"
-python3 "$SANITIZE_RS" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/alloy"
+python3 "$SANITIZE_RS" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/alloy" "$TMP_WORK_DIR/chainspec"
+
+# All crate Cargo.toml files (used by multiple pipeline stages)
+CRATE_TOMLS=(
+    "$TMP_WORK_DIR/contracts/Cargo.toml"
+    "$TMP_WORK_DIR/primitives/Cargo.toml"
+    "$TMP_WORK_DIR/chainspec/Cargo.toml"
+    "$TMP_WORK_DIR/alloy/Cargo.toml"
+)
 
 # ── 3. Sanitize Cargo.toml (strip deps/features, keep workspace refs) ────────
 log "Sanitizing Cargo.toml files …"
@@ -130,28 +139,29 @@ log "Sanitizing Cargo.toml files …"
 WS_VERSION=$(python3 "$SANITIZE_PY" get_version "$REPO_ROOT/Cargo.toml")
 log "Workspace version: $WS_VERSION"
 
-for crate_toml in "$TMP_WORK_DIR/primitives/Cargo.toml" "$TMP_WORK_DIR/alloy/Cargo.toml" "$TMP_WORK_DIR/contracts/Cargo.toml"; do
+for crate_toml in "${CRATE_TOMLS[@]}"; do
     python3 "$SANITIZE_PY" sanitize_base "$crate_toml" "$WS_VERSION" "$REPO_ROOT/Cargo.toml"
 done
 
 python3 "$SANITIZE_PY" sanitize_primitives "$TMP_WORK_DIR/primitives/Cargo.toml"
+python3 "$SANITIZE_PY" sanitize_chainspec "$TMP_WORK_DIR/chainspec/Cargo.toml"
 python3 "$SANITIZE_PY" sanitize_alloy "$TMP_WORK_DIR/alloy/Cargo.toml" "$REPO_ROOT/Cargo.toml"
 
 # ── 4. Verify compilation (before resolving workspace deps) ───────────────────
 # Use a temp workspace that provides all workspace deps via the real root,
-# plus local path overrides for the three internal crates.
+# plus local path overrides for the publish-target crates.
 log "Verifying compilation …"
 
 cat > "$TMP_WORK_DIR/Cargo.toml" <<EOF
 [workspace]
-members = ["contracts", "primitives", "alloy"]
+members = ["contracts", "primitives", "chainspec", "alloy"]
 resolver = "3"
 EOF
 
 # Generate workspace deps, dynamically filtering out reth-* and all internal
-# path-only crates, then overriding the 3 publish targets with local paths.
+# path-only crates, then overriding the publish targets with local paths.
 python3 "$SANITIZE_PY" gen_workspace "$REPO_ROOT/Cargo.toml" "$TMP_WORK_DIR/Cargo.toml" \
-    "tempo-contracts,tempo-primitives,tempo-alloy"
+    "tempo-contracts,tempo-primitives,tempo-chainspec,tempo-alloy"
 
 log "Running cargo check …"
 if ! cargo check --manifest-path "$TMP_WORK_DIR/Cargo.toml" 2>&1; then
@@ -179,12 +189,12 @@ INTERNAL_PATH_DEPS=$(python3 -c "
 import sys; sys.path.insert(0, '$SANITIZE_DIR')
 from sanitize_toml import parse_workspace_deps
 _, _, ws_path_deps, _, _ = parse_workspace_deps('$REPO_ROOT/Cargo.toml')
-keep = {'tempo-contracts', 'tempo-primitives', 'tempo-alloy'}
+keep = {'tempo-contracts', 'tempo-primitives', 'tempo-chainspec', 'tempo-alloy'}
 for d in sorted(ws_path_deps - keep):
     print(d)
 ")
 
-for crate_toml in "$TMP_WORK_DIR/primitives/Cargo.toml" "$TMP_WORK_DIR/alloy/Cargo.toml" "$TMP_WORK_DIR/contracts/Cargo.toml"; do
+for crate_toml in "${CRATE_TOMLS[@]}"; do
     crate_name=$(basename "$(dirname "$crate_toml")")
 
     # No reth-* deps should remain
@@ -219,19 +229,22 @@ grep -qE "^\s*reth\s*=" "$TMP_WORK_DIR/alloy/Cargo.toml" && \
 grep -rq 'feature = "reth"' "$TMP_WORK_DIR/alloy/src/" && \
     err "reth-gated code still in tempo-alloy source"
 
+grep -rq 'feature = "reth"' "$TMP_WORK_DIR/chainspec/src/" && \
+    err "reth-gated code still in tempo-chainspec source"
+
 log "Pre-resolve validation passed ✓"
 
 # ── 6. Resolve workspace deps to concrete versions for publishing ─────────────
 log "Resolving workspace dependencies …"
 
-for crate_toml in "$TMP_WORK_DIR/primitives/Cargo.toml" "$TMP_WORK_DIR/alloy/Cargo.toml" "$TMP_WORK_DIR/contracts/Cargo.toml"; do
+for crate_toml in "${CRATE_TOMLS[@]}"; do
     python3 "$SANITIZE_PY" resolve_deps "$crate_toml" "$REPO_ROOT/Cargo.toml"
 done
 
 # ── 7. Post-resolve validation ────────────────────────────────────────────────
 log "Post-resolve validation …"
 
-for crate_toml in "$TMP_WORK_DIR/primitives/Cargo.toml" "$TMP_WORK_DIR/alloy/Cargo.toml" "$TMP_WORK_DIR/contracts/Cargo.toml"; do
+for crate_toml in "${CRATE_TOMLS[@]}"; do
     crate_name=$(basename "$(dirname "$crate_toml")")
     grep -q 'workspace = true' "$crate_toml" && \
         err "Unresolved 'workspace = true' in $crate_name/Cargo.toml"
@@ -250,12 +263,13 @@ log "Final build check on resolved manifests …"
 
 cat > "$TMP_WORK_DIR/Cargo.toml" <<EOF
 [workspace]
-members = ["contracts", "primitives", "alloy"]
+members = ["contracts", "primitives", "chainspec", "alloy"]
 resolver = "3"
 
 [patch.crates-io]
 tempo-contracts = { path = "contracts" }
 tempo-primitives = { path = "primitives" }
+tempo-chainspec = { path = "chainspec" }
 tempo-alloy = { path = "alloy" }
 EOF
 
@@ -281,8 +295,8 @@ if $SEMVER_CHECK; then
     append_contracts_semver_overrides "$TMP_WORK_DIR/contracts/Cargo.toml"
     SEMVER_FAILED=false
     SEMVER_SKIPPED_ALL=true
-    PUBLISH_CRATES=("tempo-contracts" "tempo-primitives" "tempo-alloy")
-    for crate_dir in "$TMP_WORK_DIR/contracts" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/alloy"; do
+    PUBLISH_CRATES=("tempo-contracts" "tempo-primitives" "tempo-chainspec" "tempo-alloy")
+    for crate_dir in "$TMP_WORK_DIR/contracts" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/chainspec" "$TMP_WORK_DIR/alloy"; do
         crate_name=$(grep -m1 'name = ' "$crate_dir/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
         crate_ver=$(grep -m1 'version = ' "$crate_dir/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
         log "Checking $crate_name@$crate_ver …"
@@ -373,8 +387,8 @@ retry_publish() {
     err "Failed to publish $name after $max_attempts attempts"
 }
 
-# Publish order: contracts → primitives → alloy
-CRATES=("$TMP_WORK_DIR/contracts" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/alloy")
+# Publish order: contracts → primitives → chainspec → alloy
+CRATES=("$TMP_WORK_DIR/contracts" "$TMP_WORK_DIR/primitives" "$TMP_WORK_DIR/chainspec" "$TMP_WORK_DIR/alloy")
 
 if $DRY_RUN; then
     log "Dry-run complete. Use --publish to actually publish."

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -163,6 +163,9 @@ EOF
 python3 "$SANITIZE_PY" gen_workspace "$REPO_ROOT/Cargo.toml" "$TMP_WORK_DIR/Cargo.toml" \
     "tempo-contracts,tempo-primitives,tempo-chainspec,tempo-alloy"
 
+# Seed the lockfile so transitive deps use the same versions as the main workspace
+cp "$REPO_ROOT/Cargo.lock" "$TMP_WORK_DIR/Cargo.lock"
+
 log "Running cargo check …"
 if ! cargo check --manifest-path "$TMP_WORK_DIR/Cargo.toml" 2>&1; then
     err "Stripped crates failed to compile!"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -232,7 +232,9 @@ grep -qE "^\s*reth\s*=" "$TMP_WORK_DIR/alloy/Cargo.toml" && \
 grep -rq 'feature = "reth"' "$TMP_WORK_DIR/alloy/src/" && \
     err "reth-gated code still in tempo-alloy source"
 
-grep -rq 'feature = "reth"' "$TMP_WORK_DIR/chainspec/src/" && \
+# Exclude hardfork.rs: the tempo_hardfork! macro generates #[cfg(feature = "reth")]
+# blocks that are dead code when the reth feature is absent (suppressed via check-cfg).
+grep -rq --exclude='hardfork.rs' 'feature = "reth"' "$TMP_WORK_DIR/chainspec/src/" && \
     err "reth-gated code still in tempo-chainspec source"
 
 log "Pre-resolve validation passed ✓"

--- a/scripts/sanitize_source.py
+++ b/scripts/sanitize_source.py
@@ -5,7 +5,7 @@ Every edit asserts an expected match count. If a pattern matches 0 times,
 the source has drifted and the script fails — preventing silent breakage.
 
 Usage:
-    sanitize_source.py <primitives_dir> <alloy_dir>
+    sanitize_source.py <primitives_dir> <alloy_dir> <chainspec_dir>
 """
 import os
 import re
@@ -273,6 +273,22 @@ def _strip_rust_strings(line):
     return ''.join(result)
 
 
+def sanitize_chainspec(chainspec_dir):
+    """Strip reth-gated code from tempo-chainspec source files."""
+    lib_rs = f"{chainspec_dir}/src/lib.rs"
+
+    # Delete #![cfg_attr(all(not(test), feature = "reth"), warn(unused_crate_dependencies))]
+    delete_lines(lib_rs, r'^#!\[cfg_attr\(all\(not\(test\), feature = "reth"\), warn\(unused_crate_dependencies\)\)\]\n', expected=1)
+
+    # Delete #[cfg(feature = "reth")] extern crate alloc;
+    delete_lines(lib_rs, r'^#\[cfg\(feature = "reth"\)\]\nextern crate alloc;\n', expected=1)
+
+    # Delete #[cfg(feature = "reth")] gated mod/pub declarations (bootnodes, spec)
+    _delete_cfg_gated_block(lib_rs, '#[cfg(feature = "reth")]', expected=3)
+
+    print(f"  chainspec/src/lib.rs: stripped reth-gated code", file=sys.stderr)
+
+
 def sanitize_alloy(alloy_dir):
     """Strip node-internal code from tempo-alloy source files.
 
@@ -288,12 +304,14 @@ def sanitize_alloy(alloy_dir):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print("Usage: sanitize_source.py <primitives_dir> <alloy_dir>", file=sys.stderr)
+    if len(sys.argv) != 4:
+        print("Usage: sanitize_source.py <primitives_dir> <alloy_dir> <chainspec_dir>", file=sys.stderr)
         sys.exit(1)
 
     prim_dir = sys.argv[1]
     alloy_dir = sys.argv[2]
+    chainspec_dir = sys.argv[3]
 
     sanitize_primitives(prim_dir)
     sanitize_alloy(alloy_dir)
+    sanitize_chainspec(chainspec_dir)

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -371,6 +371,25 @@ def main():
         text = re.sub(r', "rpc"', '', text)
         text = re.sub(r'"rpc", ', '', text)
 
+    elif action == "sanitize_chainspec":
+        # Remove reth and cli feature blocks entirely
+        text = strip_feature_blocks(text, ['reth', 'cli'])
+
+        # Track removed deps so we can auto-strip orphaned feature entries
+        removed = set()
+
+        # Remove reth and eyre (only used by cli feature) dependency lines
+        text = strip_dep_lines(text, lambda n: n.startswith('reth-'), removed)
+        text = strip_dep_lines(text, lambda n: n == 'eyre', removed)
+        # Remove # Reth comment
+        text = re.sub(r'^# Reth\n', '', text, flags=re.MULTILINE)
+
+        # Auto-strip feature entries referencing removed deps
+        text = strip_orphaned_feature_entries(text, removed)
+
+        # Remove "reth" and "cli" from the default feature array
+        text = strip_feature_array_entries(text, {'reth', 'cli'})
+
     elif action == "resolve_deps":
         ws_toml_path = sys.argv[3]
         ws_deps, ws_no_default, _, _, _ = parse_workspace_deps(ws_toml_path)

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -360,7 +360,7 @@ def main():
         # the crates we're publishing: tempo-contracts and tempo-primitives)
         ws_toml_path = sys.argv[3]
         _, _, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
-        publish_keep = {'tempo-contracts', 'tempo-primitives', 'tempo-alloy'}
+        publish_keep = {'tempo-contracts', 'tempo-primitives', 'tempo-chainspec', 'tempo-alloy'}
         internal_deps = ws_path_deps - publish_keep
         text = strip_dep_lines(text, lambda n: n in internal_deps)
 
@@ -389,6 +389,11 @@ def main():
 
         # Remove "reth" and "cli" from the default feature array
         text = strip_feature_array_entries(text, {'reth', 'cli'})
+
+        # The tempo_hardfork! macro generates #[cfg(feature = "reth")] blocks that remain in source.
+        # Tell check-cfg that "reth" is an expected (but never enabled) feature to suppress warnings.
+        if '[lints.rust]' not in text:
+            text += '\n[lints.rust]\nunexpected_cfgs = { level = "allow", check-cfg = [\'cfg(feature, values("reth"))\'] }\n'
 
     elif action == "resolve_deps":
         ws_toml_path = sys.argv[3]
@@ -481,7 +486,7 @@ def main():
         out_path = sys.argv[3]
         publish_crates = set(sys.argv[4].split(',')) if len(sys.argv) > 4 else set()
 
-        ws_deps, _, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
+        ws_deps, ws_no_default, ws_path_deps, _, _ = parse_workspace_deps(ws_toml_path)
 
         # Read the [workspace.dependencies] section text
         ws_text = Path(ws_toml_path).read_text(encoding='utf-8')
@@ -508,7 +513,10 @@ def main():
         existing += filtered + '\n'
         for crate in sorted(publish_crates):
             dirname = crate.removeprefix('tempo-')
-            existing += f'{crate} = {{ path = "{dirname}" }}\n'
+            parts = [f'path = "{dirname}"']
+            if crate in ws_no_default:
+                parts.append('default-features = false')
+            existing += f'{crate} = {{ {", ".join(parts)} }}\n'
 
         Path(out_path).write_text(existing, encoding='utf-8')
         sys.exit(0)


### PR DESCRIPTION
this PR adds a new `is_active_hardfork()` method to the `TempoProviderExt` trait.

additionally, it also adds `tempo-chainspec` to the alloy release pipeline so that `TempoHardfork` is available to the sdk users.