### PR TITLE
chore: add tempo-chainspec to SDK release workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - crates/contracts/**
       - crates/primitives/**
+      - crates/chainspec/**
       - crates/alloy/**
 
 jobs:

--- a/.github/workflows/publish-check.yml
+++ b/.github/workflows/publish-check.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - crates/contracts/**
       - crates/primitives/**
+      - crates/chainspec/**
       - crates/alloy/**
       - scripts/publish-crates.sh
       - scripts/sanitize_source.py

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,7 +25,7 @@ jobs:
           from pathlib import Path
           import re
 
-          targets = {"tempo-alloy", "tempo-primitives", "tempo-contracts"}
+          targets = {"tempo-alloy", "tempo-primitives", "tempo-chainspec", "tempo-contracts"}
 
           for path in Path(".changelog").glob("*.md"):
               text = path.read_text(encoding="utf-8")

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - crates/contracts/**
       - crates/primitives/**
+      - crates/chainspec/**
       - crates/alloy/**
       - scripts/publish-crates.sh
       - scripts/sanitize_source.py


### PR DESCRIPTION
The chainspec crate was missing from the changelog, release-pr, semver-check, and publish-check workflow path filters. PRs touching `crates/chainspec/` never triggered SDK CI and the crate was excluded from release PRs.

`publish-crates.sh`, `check_no_std.sh`, and `CODEOWNERS` already had it — this closes the gap in the four remaining workflows.

Prompted by: rusowsky