### PR TITLE
fix(consensus): prevent broadcast race condition by updating state be…

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -371,23 +371,31 @@ impl Inner<Init> {
             "constructed proposal",
         );
 
+        // If re-proposing, then don't store the parent for broadcasting and
+        // don't touch the execution layer.
+        if proposal_digest == parent_digest {
+            response.send(proposal_digest).map_err(|_| {
+                eyre!(
+                    "failed returning proposal to consensus engine: response \
+                    channel was already closed"
+                )
+            })?;
+            return Ok(());
+        }
+
+        // Update latest_proposed_block BEFORE sending response to avoid race condition
+        // where broadcast is requested before the state is updated
+        {
+            let mut lock = self.state.latest_proposed_block.write().await;
+            *lock = Some((round, proposal.clone()));
+        }
+
         response.send(proposal_digest).map_err(|_| {
             eyre!(
                 "failed returning proposal to consensus engine: response \
                 channel was already closed"
             )
         })?;
-
-        // If re-proposing, then don't store the parent for broadcasting and
-        // don't touch the execution layer.
-        if proposal_digest == parent_digest {
-            return Ok(());
-        }
-
-        {
-            let mut lock = self.state.latest_proposed_block.write().await;
-            *lock = Some((round, proposal.clone()));
-        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Fix critical race condition in consensus logic where broadcast was requested before `latest_proposed_block` state was updated, causing payload mismatch errors.

## Problem

The consensus engine would request broadcast of a newly proposed block before the `latest_proposed_block` state was updated in the application actor. This caused the following error:

```
ERROR handle_broadcast: broadcast of payload X was requested, 
but digest of latest proposed block is Y
```

The root cause was that `response.send(proposal_digest)` was called **before** updating `latest_proposed_block`, creating a race condition where:
1. Response is sent to consensus engine
2. Consensus engine immediately requests broadcast
3. `handle_broadcast` reads `latest_proposed_block` → gets OLD value
4. Payload mismatch error occurs

## Solution

Reorder operations in `handle_propose()`:
1. Update `latest_proposed_block` state **first**
2. Then send response to consensus engine

This ensures the state is ready before any broadcast requests can be made.

## Changes

**File**: `crates/commonware-node/src/consensus/application/actor.rs`

- Move `latest_proposed_block.write()` before `response.send()`
- Handle re-proposing case separately (returns early without updating state)
- Add detailed comments explaining the race condition fix

## Testing

✅ Tested with Docker Compose (validator + full node)
✅ 300+ blocks created successfully without errors
✅ No `handle_broadcast` errors
✅ No `proposal return channel was closed` errors
✅ Full node syncs correctly from validator

## Impact

- **Fixes**: Race condition causing consensus failures
- **Risk**: Low - only reorders operations within same function
- **Backwards compatible**: Yes - no API or state format changes