### PR TITLE
feat: default bootnodes endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13013,9 +13013,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -117,8 +117,7 @@ struct TempoArgs {
     ///
     /// Bootnodes for the current chain are added as peer hints to the discovery service.
     ///
-    /// Defaults to the chain-specific endpoint (e.g. `https://peers.tempo.xyz` on mainnet,
-    /// `https://testnet-peers.tempo.xyz` on moderato). Set to "none" to disable.
+    /// Defaults to `https://peers.tempo.xyz`. Set to "none" to disable.
     #[arg(
         long = "tempo.bootnodes-endpoint",
         value_name = "URL",

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -117,13 +117,14 @@ struct TempoArgs {
     ///
     /// Bootnodes for the current chain are added as peer hints to the discovery service.
     ///
-    /// Defaults to `https://peers.tempo.xyz`. Set to "none" to disable.
+    /// Set to "none" to disable.
     #[arg(
         long = "tempo.bootnodes-endpoint",
         value_name = "URL",
+        default_value = "https://peers.tempo.xyz",
         env = "TEMPO_BOOTNODES_ENDPOINT"
     )]
-    pub bootnodes_endpoint: Option<String>,
+    pub bootnodes_endpoint: String,
 
     #[command(flatten)]
     pub telemetry: defaults::TelemetryArgs,
@@ -548,17 +549,11 @@ fn main() -> eyre::Result<()> {
         let chain_id = builder.config().chain.chain().id();
 
         // Resolve the bootnodes endpoint:
-        // --tempo.bootnodes-endpoint=URL -> use provided URL
         // --tempo.bootnodes-endpoint=none -> disabled
-        // not set -> use chain-specific default (if any)
-        let bootnodes_endpoint = match args.bootnodes_endpoint.as_deref().map(str::trim) {
-            Some(value) if value.eq_ignore_ascii_case("none") => None,
-            Some(url) => Some(url.to_string()),
-            None => builder
-                .config()
-                .chain
-                .default_bootnodes_endpoint()
-                .map(|s| s.to_string()),
+        // otherwise -> use the provided/default URL
+        let bootnodes_endpoint = match args.bootnodes_endpoint.trim() {
+            value if value.eq_ignore_ascii_case("none") => None,
+            url => Some(url.to_string()),
         };
 
         let NodeHandle {

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -116,6 +116,9 @@ struct TempoArgs {
     /// `{ "<chain_id>": ["enode://...", ...] }`
     ///
     /// Bootnodes for the current chain are added as peer hints to the discovery service.
+    ///
+    /// Defaults to the chain-specific endpoint (e.g. `https://peers.tempo.xyz` on mainnet,
+    /// `https://testnet-peers.tempo.xyz` on moderato). Set to "none" to disable.
     #[arg(
         long = "tempo.bootnodes-endpoint",
         value_name = "URL",
@@ -545,6 +548,20 @@ fn main() -> eyre::Result<()> {
         };
         let chain_id = builder.config().chain.chain().id();
 
+        // Resolve the bootnodes endpoint:
+        // --tempo.bootnodes-endpoint=URL -> use provided URL
+        // --tempo.bootnodes-endpoint=none -> disabled
+        // not set -> use chain-specific default (if any)
+        let bootnodes_endpoint = match args.bootnodes_endpoint.as_deref().map(str::trim) {
+            Some(value) if value.eq_ignore_ascii_case("none") => None,
+            Some(url) => Some(url.to_string()),
+            None => builder
+                .config()
+                .chain
+                .default_bootnodes_endpoint()
+                .map(|s| s.to_string()),
+        };
+
         let NodeHandle {
             node,
             node_exit_future,
@@ -600,7 +617,7 @@ fn main() -> eyre::Result<()> {
 
         // Fetch bootnodes from the endpoint in a background task and inject
         // them into the already-running discovery services.
-        if let Some(endpoint) = args.bootnodes_endpoint.clone() {
+        if let Some(endpoint) = bootnodes_endpoint {
             let network = node.network.clone();
             node.tasks().spawn_task(async move {
                 match fetch_bootnodes(&endpoint, chain_id).await {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -137,6 +137,7 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/moderato.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.moderato.tempo.xyz")
+        .with_default_bootnodes_endpoint("https://testnet-peers.tempo.xyz")
         .into()
 });
 
@@ -145,6 +146,7 @@ pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/presto.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.presto.tempo.xyz")
+        .with_default_bootnodes_endpoint("https://peers.tempo.xyz")
         .into()
 });
 
@@ -165,6 +167,8 @@ pub struct TempoChainSpec {
     pub info: TempoGenesisInfo,
     /// Default RPC URL for following this chain.
     pub default_follow_url: Option<&'static str>,
+    /// Default bootnodes endpoint URL for this chain.
+    pub default_bootnodes_endpoint: Option<&'static str>,
 }
 
 impl TempoChainSpec {
@@ -197,12 +201,24 @@ impl TempoChainSpec {
             }),
             info,
             default_follow_url: None,
+            default_bootnodes_endpoint: None,
         }
     }
 
     /// Sets the default follow URL for this chain spec.
     pub fn with_default_follow_url(mut self, url: &'static str) -> Self {
         self.default_follow_url = Some(url);
+        self
+    }
+
+    /// Returns the default bootnodes endpoint URL for this chain.
+    pub fn default_bootnodes_endpoint(&self) -> Option<&'static str> {
+        self.default_bootnodes_endpoint
+    }
+
+    /// Sets the default bootnodes endpoint URL for this chain spec.
+    pub fn with_default_bootnodes_endpoint(mut self, url: &'static str) -> Self {
+        self.default_bootnodes_endpoint = Some(url);
         self
     }
 
@@ -231,6 +247,7 @@ impl From<ChainSpec> for TempoChainSpec {
             }),
             info: TempoGenesisInfo::default(),
             default_follow_url: None,
+            default_bootnodes_endpoint: None,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -137,7 +137,6 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/moderato.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.moderato.tempo.xyz")
-        .with_default_bootnodes_endpoint("https://peers.tempo.xyz")
         .into()
 });
 
@@ -146,7 +145,6 @@ pub static PRESTO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/presto.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.presto.tempo.xyz")
-        .with_default_bootnodes_endpoint("https://peers.tempo.xyz")
         .into()
 });
 
@@ -167,8 +165,6 @@ pub struct TempoChainSpec {
     pub info: TempoGenesisInfo,
     /// Default RPC URL for following this chain.
     pub default_follow_url: Option<&'static str>,
-    /// Default bootnodes endpoint URL for this chain.
-    pub default_bootnodes_endpoint: Option<&'static str>,
 }
 
 impl TempoChainSpec {
@@ -201,24 +197,12 @@ impl TempoChainSpec {
             }),
             info,
             default_follow_url: None,
-            default_bootnodes_endpoint: None,
         }
     }
 
     /// Sets the default follow URL for this chain spec.
     pub fn with_default_follow_url(mut self, url: &'static str) -> Self {
         self.default_follow_url = Some(url);
-        self
-    }
-
-    /// Returns the default bootnodes endpoint URL for this chain.
-    pub fn default_bootnodes_endpoint(&self) -> Option<&'static str> {
-        self.default_bootnodes_endpoint
-    }
-
-    /// Sets the default bootnodes endpoint URL for this chain spec.
-    pub fn with_default_bootnodes_endpoint(mut self, url: &'static str) -> Self {
-        self.default_bootnodes_endpoint = Some(url);
         self
     }
 
@@ -247,7 +231,6 @@ impl From<ChainSpec> for TempoChainSpec {
             }),
             info: TempoGenesisInfo::default(),
             default_follow_url: None,
-            default_bootnodes_endpoint: None,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -137,7 +137,7 @@ pub static MODERATO: LazyLock<Arc<TempoChainSpec>> = LazyLock::new(|| {
         .expect("`./genesis/moderato.json` must be present and deserializable");
     TempoChainSpec::from_genesis(genesis)
         .with_default_follow_url("wss://rpc.moderato.tempo.xyz")
-        .with_default_bootnodes_endpoint("https://testnet-peers.tempo.xyz")
+        .with_default_bootnodes_endpoint("https://peers.tempo.xyz")
         .into()
 });
 


### PR DESCRIPTION
Default to `https://peers.tempo.xyz`. No new flags — opt out with `--tempo.bootnodes-endpoint=none` (or `TEMPO_BOOTNODES_ENDPOINT=none`).

Prompted by: kuyziss