### PR TITLE
chore(ci): add txgen backend arg to tempo bench workflow

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -35,6 +35,12 @@ on:
       feature:
         type: string
         required: true
+      backend:
+        type: string
+        required: true
+      txgen-ref:
+        type: string
+        required: false
       baseline-name:
         type: string
         required: true
@@ -128,6 +134,8 @@ jobs:
       BENCH_DURATION: ${{ inputs.duration }}
       BENCH_BLOAT: ${{ inputs.bloat }}
       BENCH_TPS: ${{ inputs.tps }}
+      BENCH_BACKEND: ${{ inputs.backend }}
+      BENCH_TXGEN_REF: ${{ inputs.txgen-ref }}
       BENCH_SAMPLY: ${{ inputs.samply }}
       BENCH_TRACY: ${{ inputs.tracy }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds }}
@@ -201,6 +209,22 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
 
+      - name: Checkout txgen repository
+        if: env.BENCH_BACKEND == 'txgen'
+        uses: actions/checkout@v6
+        with:
+          repository: tempoxyz/txgen
+          token: ${{ secrets.DEREK_PAT || github.token }}
+          path: txgen
+          fetch-depth: 0
+
+      - name: Checkout txgen ref
+        if: env.BENCH_BACKEND == 'txgen' && env.BENCH_TXGEN_REF != ''
+        working-directory: txgen
+        run: |
+          git fetch origin "$BENCH_TXGEN_REF" --quiet
+          git checkout --detach FETCH_HEAD
+
       - name: Resolve job URL and update status
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
@@ -223,6 +247,8 @@ jobs:
             const tps = process.env.BENCH_TPS;
             const baseline = '${{ inputs.baseline-name }}';
             const feature = '${{ inputs.feature-name }}';
+            const backend = process.env.BENCH_BACKEND;
+            const txgenRef = process.env.BENCH_TXGEN_REF || 'default';
             const samply = '${{ inputs.samply }}' === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = '${{ inputs.tracy }}';
@@ -230,7 +256,7 @@ jobs:
             const bHf2 = process.env.BENCH_BASELINE_HARDFORK || '';
             const fHf2 = process.env.BENCH_FEATURE_HARDFORK || '';
             const hfNote2 = bHf2 ? `, baseline-hardfork: \`${bHf2}\`, feature-hardfork: \`${fHf2}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${hfNote2}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, backend: \`${backend}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${hfNote2}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -243,6 +269,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@v0.0.9
         continue-on-error: true
+
+      - name: Build txgen backend
+        if: env.BENCH_BACKEND == 'txgen'
+        working-directory: txgen
+        run: |
+          cargo build --release --bin txgen-tempo --bin bench-cli
+          echo "TXGEN_REPO_DIR=$GITHUB_WORKSPACE/txgen" >> "$GITHUB_ENV"
+          echo "TXGEN_TEMPO_BIN=$GITHUB_WORKSPACE/txgen/target/release/txgen-tempo" >> "$GITHUB_ENV"
+          echo "TXGEN_BENCH_BIN=$GITHUB_WORKSPACE/txgen/target/release/bench-cli" >> "$GITHUB_ENV"
 
       - name: Resolve PR head branch
         id: pr-info
@@ -349,8 +384,12 @@ jobs:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
-          cmd=(
-            nu tempo.nu bench
+          if [ "$BENCH_BACKEND" = "txgen" ]; then
+            cmd=(nu contrib/bench/bench-txgen.nu run)
+          else
+            cmd=(nu tempo.nu bench)
+          fi
+          cmd+=(
             --preset "$BENCH_PRESET"
             --mode "$BENCH_MODE"
             --bloat "$BENCH_BLOAT"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,6 +34,8 @@ jobs:
       tps: ${{ steps.args.outputs.tps }}
       baseline: ${{ steps.args.outputs.baseline }}
       feature: ${{ steps.args.outputs.feature }}
+      backend: ${{ steps.args.outputs.backend }}
+      txgen-ref: ${{ steps.args.outputs.txgen-ref }}
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
@@ -78,17 +80,17 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, baseline, feature, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv;
+            let pr, actor, mode, preset, duration, bloat, tps, baseline, feature, backend, txgenRef, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv;
 
             pr = String(context.issue.number);
             actor = context.payload.comment.user.login;
 
             const body = context.payload.comment.body.trim();
             const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset']);
-            const refArgs = new Set(['baseline', 'feature']);
-            const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env']);
+            const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
+            const stringArgs = new Set(['mode', 'preset', 'backend', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-slack', 'no-existing-recipients']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', backend: 'tempo-bench', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '' };
             const unknown = [];
             const invalid = [];
             const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -147,7 +149,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -164,6 +166,8 @@ jobs:
             tps = defaults.tps;
             baseline = defaults.baseline;
             feature = defaults.feature;
+            backend = defaults.backend;
+            txgenRef = defaults['txgen-ref'];
             samply = defaults.samply;
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
@@ -184,11 +188,24 @@ jobs:
             const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate mode value
             if (!['e2e', 'replay'].includes(mode)) {
               const msg = `❌ **Invalid bench command**\n\n\`mode=${mode}\` is not valid. Must be \`e2e\` or \`replay\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+
+            // Validate backend value
+            if (!['tempo-bench', 'txgen'].includes(backend)) {
+              const msg = `❌ **Invalid bench command**\n\n\`backend=${backend}\` is not valid. Must be \`tempo-bench\` or \`txgen\`.\n\n${usageStr}`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -273,6 +290,8 @@ jobs:
             core.setOutput('tps', tps);
             core.setOutput('baseline', baseline);
             core.setOutput('feature', feature);
+            core.setOutput('backend', backend);
+            core.setOutput('txgen-ref', txgenRef || '');
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
@@ -319,6 +338,8 @@ jobs:
             const tps = '${{ steps.args.outputs.tps }}';
             const baseline = '${{ steps.args.outputs.baseline-name }}';
             const feature = '${{ steps.args.outputs.feature-name }}';
+            const backend = '${{ steps.args.outputs.backend }}';
+            const txgenRef = '${{ steps.args.outputs.txgen-ref }}' || 'default';
             const samply = '${{ steps.args.outputs.samply }}' === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = '${{ steps.args.outputs.tracy }}';
@@ -329,7 +350,7 @@ jobs:
             const bHf = '${{ steps.args.outputs.baseline-hardfork }}';
             const fHf = '${{ steps.args.outputs.feature-hardfork }}';
             const hfNote = bHf ? `, baseline-hardfork: \`${bHf}\`, feature-hardfork: \`${fHf}\`` : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${naNote}${hfNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} MiB\`, tps: \`${tps}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, backend: \`${backend}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${naNote}${hfNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -353,6 +374,8 @@ jobs:
       tps: ${{ needs.tempo-bench-ack.outputs.tps }}
       baseline: ${{ needs.tempo-bench-ack.outputs.baseline }}
       feature: ${{ needs.tempo-bench-ack.outputs.feature }}
+      backend: ${{ needs.tempo-bench-ack.outputs.backend }}
+      txgen-ref: ${{ needs.tempo-bench-ack.outputs.txgen-ref }}
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -1,0 +1,44 @@
+# Bootstrap stub for the txgen benchmark backend.
+#
+# This file exists on main so the benchmark workflow can reference a real
+# entrypoint before the txgen harness lands on a PR branch.
+
+def main [] {
+    print "Tempo txgen benchmark helper"
+    print ""
+    print "Usage:"
+    print "  nu contrib/bench/bench-txgen.nu run [flags]"
+    print ""
+    print "This is a bootstrap stub. The txgen harness is not implemented on this branch."
+}
+
+def "main run" [
+    --preset: string = ""
+    --mode: string = ""
+    --bloat: string = ""
+    --duration: string = ""
+    --tps: string = ""
+    --no-infra
+    --baseline: string = ""
+    --feature: string = ""
+    --bench-datadir: string = ""
+    --tune
+    --gas-limit: string = ""
+    --samply
+    --tracy: string = ""
+    --tracy-seconds: string = ""
+    --tracy-offset: string = ""
+    --baseline-args: string = ""
+    --feature-args: string = ""
+    --baseline-hardfork: string = ""
+    --feature-hardfork: string = ""
+    --force
+    --bench-args: string = ""
+    --bench-env: string = ""
+    --baseline-env: string = ""
+    --feature-env: string = ""
+] {
+    print "txgen benchmark backend is not implemented on this branch."
+    print "Add the txgen harness in this branch to make `@decofe bench backend=txgen` runnable."
+    exit 1
+}


### PR DESCRIPTION
This is so we can incrementally work on adding txgen as a replacement for tempo-bench, and run it with the normal workflow triggers (`derek bench`), without impacting the tempo-bench workflow itself.

`backend` and optional `txgen-ref` arguments are added to `derek bench`, defaulting to `tempo-bench`. Conditional `txgen` checkout, ref selection, and binary build are added.

Adds a stub `bench-txgen.nu` which is where the `txgen` bench logic will live