### PR TITLE
fix(precompiles): improve Make precompiles initialize themselves

### DIFF
--- a/crates/contracts/src/precompiles/tip20.rs
+++ b/crates/contracts/src/precompiles/tip20.rs
@@ -199,6 +199,7 @@ impl ITIP20::ITIP20Calls {
             || is_call::<ITIP20::transferFromCall>(input)
             || is_call::<ITIP20::transferFromWithMemoCall>(input)
             || is_call::<ITIP20::approveCall>(input)
+            || is_call::<ITIP20::burnBlockedCall>(input)
             || is_call::<ITIP20::mintCall>(input)
             || is_call::<ITIP20::mintWithMemoCall>(input)
             || is_call::<ITIP20::burnCall>(input)


### PR DESCRIPTION
## Summary

Make precompiles initialize themselves — modified `crates/contracts/src/precompiles/tip20.rs`.

Refs #1254

## Changes

- crates/contracts/src/precompiles/tip20.rs (+1)

## Rationale

Applied fix for Make precompiles initialize themselves in `tip20.rs`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to crates/contracts/src/precompiles/tip20.rs.

## Validation

Basic lint and formatting checks passed.