### PR TITLE
fix(ci): foundry patch fine-tunning

### DIFF
--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -79,8 +79,10 @@ done <<< "$PATCHES"
 echo "Updated Cargo.toml patch sections:"
 sed -n '/^\[patch\./,$p' "$FOUNDRY_CARGO"
 
-# ── 4. Re-resolve the lockfile ──────────────────────────────────────────────
-(cd "$FOUNDRY_ROOT" && cargo update)
+# ── 4. Re-resolve the lockfile without upgrading unrelated crates ──────────
+# `cargo update` can pull newer upstream deps from Foundry's workspace, which is non-deterministic.
+# A normal resolver pass is enough to rewrite the lockfile entries for the tempo path overrides.
+(cd "$FOUNDRY_ROOT" && cargo metadata --format-version=1 >/dev/null)
 
 if grep -q '^source = "git+https://github.com/tempoxyz/tempo?rev=' "$FOUNDRY_ROOT/Cargo.lock"; then
   echo "ERROR: Tempo git sources still present in Cargo.lock after patching:" >&2


### PR DESCRIPTION
this PR makes the Foundry patch step re-resolve tempo path overrides without running `cargo update`, so CI becomes deterministic and no longer drifts onto unrelated upstream deps upgrades.