### PR TITLE
docs(tip-1016): clarify reservoir model and block gas accounting

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -12,7 +12,7 @@ protocolVersion: T3
 
 ## Abstract
 
-Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, but this gas does not count against block gas limit or it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into regular and reservoir gas, ensuring the `GAS` opcode accurately reflects the regular execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput. 
+Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, this gas does not count against block gas limit but it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into regular and reservoir gas, ensuring the `GAS` opcode accurately reflects the regular execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput. 
 
 ## Motivation
 

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -44,7 +44,7 @@ The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) s
 * `reservoir` is holding overflow can be only be used for state creation
 * `state_gas` is tracking cumulative state gas consumed during execution.
 
-The `GAS` opcode returns only `remaining`, accurately reflecting available execution capacity. If reservoir is empty gas for state creation is deducted from `remaining` gas
+The `GAS` opcode returns only `remaining`, accurately reflecting available execution capacity. If the reservoir is empty, the gas for state creation is deducted from the `remaining` gas
 
 ---
 

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -12,7 +12,7 @@ protocolVersion: T3
 
 ## Abstract
 
-Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, but this gas does not count against transaction or block gas limits. Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into `gas_left` and `state_gas_reservoir`, ensuring the `GAS` opcode accurately reflects the remaining execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput.
+Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, but this gas does not count against block gas limit or it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into regular and reservoir gas, ensuring the `GAS` opcode accurately reflects the regular execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput. 
 
 ## Motivation
 
@@ -39,7 +39,12 @@ Simply exempting state gas from protocol limits without changing EVM internals c
 
 2. **Broken gas patterns**: Contracts relying on `gasleft()` for loop guards, subcall gas forwarding (63/64 rule), and relay/meta-transaction patterns would see incorrect values, potentially leading to unexpected OOG reverts.
 
-The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) solves this by maintaining two internal counters: `gas_left` (reflecting execution budget) and `state_gas_reservoir` (holding overflow for storage creation). The `GAS` opcode returns only `gas_left`, accurately reflecting available execution capacity.
+The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) solves this by maintaining three internal counters:
+* regular `remaining` gas is reflecting execution budget, used by cpu and state creation.
+* `reservoir` is holding overflow can be only be used for state creation
+* `state_gas` is tracking cumulative state gas consumed during execution.
+
+The `GAS` opcode returns only `remaining`, accurately reflecting available execution capacity. If reservoir is empty gas for state creation is deducted from `remaining` gas
 
 ---
 
@@ -148,10 +153,10 @@ The `state_gas_reservoir` holds gas that exceeds the per-transaction regular gas
 - The reservoir is passed **in full** to child frames (no 63/64 rule). On child success, the remaining `state_gas_reservoir` is returned to the parent.
 - On child **revert** or **exceptional halt**, all state gas consumed by the child, both from the reservoir and any that spilled into `gas_left`, is restored to the parent's reservoir. On child **exceptional halt**, only `gas_left` is consumed (zeroed). State gas is fully preserved on failure because state changes are reverted, so no state was actually grown.
   - **Note**: State gas that originally spilled from the reservoir into `gas_left` is restored as reservoir gas, not as `gas_left`. A child frame that performs cold SSTOREs drawing from `gas_left` (because the reservoir was exhausted) and then reverts will return that gas to the parent's reservoir, where it can only be used for future state operations — not for regular execution. This is a known consequence of the EIP-8037 design that avoids tracking the original source of state gas charges per frame. The effect is bounded: it can only convert `gas_left` that was spent on state operations into reservoir gas, and only on child failure paths.
-- On **exceptional halt**, remaining `gas_left` is attributed to `execution_regular_gas_used` and set to zero (all regular gas consumed), consistent with existing EVM out-of-gas semantics. The `state_gas_reservoir` is not consumed — it is returned to the parent frame or preserved at the top level for refund, consistent with the principle that state gas pays for long-term state growth which does not occur on failure.
+- On **exceptional halt**, remaining `gas_left` is attributed to `execution_regular_gas_used` and set to zero (all regular gas consumed), consistent with existing EVM out-of-gas semantics. The `state_gas_reservoir` is not consumed — it is returned to the parent frame or preserved at the top level, consistent with the principle that state gas pays for long-term state growth which does not occur on failure.
 - **System transactions** are not subject to the `max_transaction_gas_limit` cap; their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
 
-The two counters are returned by the transaction output. Besides the two counters, the EVM also keeps track of `execution_state_gas_used` and `execution_regular_gas_used` during transaction execution. `state_gas` costs are added to `execution_state_gas_used` while `regular_gas` costs are added to `execution_regular_gas_used`. These two counters are also returned by the transaction output.
+The two counters are returned by the transaction output. Besides the two counters, the EVM also keeps track of `execution_state_gas_used` and `execution_regular_gas_used` during block execution. `state_gas` costs are added to `execution_state_gas_used` while `regular_gas` costs are added to `execution_regular_gas_used`. These two counters are also returned by the transaction output.
 
 ## Transaction Gas Used
 
@@ -166,7 +171,7 @@ tx_gas_used_after_refund = max(
 )
 ```
 
-The refund cap remains at 20% of gas used. The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures the user always pays at least the calldata floor, even if refunds would bring the total below it.
+The refund cap remains at 20% of gas used. The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures the user always pays at least the calldata floor, even if refunds would bring the total below it. Refunds apply only to user-paid gas; block-level accounting uses `tx_regular_gas` (regular gas only, no refund subtracted) — see [Block-Level Gas Accounting](#block-level-gas-accounting).
 
 **Note**: EIP-8037 uses `tx_gas_used` in the refund and post-refund formulas, but that variable is not defined in the same code block. TIP-1016 uses `tx_gas_used_before_refund` consistently to avoid ambiguity.
 
@@ -181,6 +186,8 @@ block_output.block_regular_gas_used += max(tx_regular_gas, calldata_floor_gas_co
 ```
 
 The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures calldata-heavy transactions consume at least the floor cost worth of block capacity. The floor applies to regular gas only — state gas remains fully exempt from block limits.
+
+Per [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), `tx_regular_gas` is the pre-refund value: `tx_gas_refund` is **not** subtracted from block accounting. This prevents block gas limit circumvention via refundable operations while preserving user incentives to clean up state.
 
 The block header `gas_used` field is set to:
 

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -40,11 +40,9 @@ Simply exempting state gas from protocol limits without changing EVM internals c
 2. **Broken gas patterns**: Contracts relying on `gasleft()` for loop guards, subcall gas forwarding (63/64 rule), and relay/meta-transaction patterns would see incorrect values, potentially leading to unexpected OOG reverts.
 
 The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) solves this by maintaining three internal counters:
-* regular `remaining` gas is reflecting execution budget, used by cpu and state creation.
+* regular `remaining` gas is reflecting execution budget, used by cpu and state creation. Returned by `GAS` opcode.
 * `reservoir` is holding overflow can be only be used for state creation
 * `state_gas` is tracking cumulative state gas consumed during execution.
-
-The `GAS` opcode returns only `remaining`, accurately reflecting available execution capacity. If the reservoir is empty, the gas for state creation is deducted from the `remaining` gas
 
 ---
 


### PR DESCRIPTION
## Summary
- Rework abstract and rationale to describe the three internal counters (`remaining`, `reservoir`, `state_gas`) and note that state creation falls back to `remaining` when the reservoir is empty.
- Clarify exceptional-halt wording around reservoir preservation.
- Note that refunds apply only to user-paid gas and that block-level accounting uses pre-refund `tx_regular_gas` per [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778).
- Tie the block-limit exemption language to [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825).

## Test plan
- [ ] Spec-only change — no code affected; review rendered Markdown on GitHub.