### PR TITLE
fix(evm): align tip-1016 gas accounting + docs/tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12798,6 +12798,7 @@ dependencies = [
  "tempo-evm",
  "tempo-precompiles-macros",
  "tempo-primitives",
+ "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -40,6 +40,7 @@ proptest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempo-evm.workspace = true
+tempo-revm.workspace = true
 
 [features]
 default = ["rpc"]

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -104,6 +104,7 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
         let code_len = code.len();
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
+        self.deduct_gas(self.gas_params.keccak256_cost(code_len))?;
 
         // Track state gas for code deposit
         self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
@@ -358,7 +359,6 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use revm::{
-        context_interface::cfg::GasId,
         database::{CacheDB, EmptyDB},
         interpreter::StateLoad,
     };
@@ -370,23 +370,14 @@ mod tests {
 
     impl TestEvm {
         fn default() -> Self {
-            Self::with_gas_overrides(TempoHardfork::default(), [])
+            Self::new(TempoHardfork::default())
         }
 
         fn new(spec: TempoHardfork) -> Self {
-            Self::with_gas_overrides(spec, [])
-        }
-
-        fn with_gas_overrides<const N: usize>(
-            spec: TempoHardfork,
-            overrides: [(GasId, u64); N],
-        ) -> Self {
             let db = CacheDB::new(EmptyDB::new());
             let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
             cfg.spec = spec;
             cfg.gas_params = tempo_gas_params(spec);
-            cfg.gas_params
-                .override_gas(overrides.into_iter().collect::<Vec<_>>());
 
             Self(TempoEvmFactory::default().create_evm(
                 db,
@@ -732,15 +723,7 @@ mod tests {
 
     #[test]
     fn test_state_gas_used_only_counts_state_creating_ops() -> eyre::Result<()> {
-        let mut evm = TestEvm::with_gas_overrides(
-            TempoHardfork::T4,
-            [
-                (GasId::sstore_set_without_load_cost(), 19_900),
-                (GasId::sstore_set_state_gas(), 230_000),
-                (GasId::code_deposit_cost(), 200),
-                (GasId::code_deposit_state_gas(), 2_300),
-            ],
-        );
+        let mut evm = TestEvm::new(TempoHardfork::T4);
         let gas_params = evm.ctx().cfg.gas_params.clone();
         let mut provider = evm.provider_with_reservoir(0);
 
@@ -797,13 +780,7 @@ mod tests {
     /// spills into regular gas once the reservoir is exhausted.
     #[test]
     fn test_state_gas_spills_from_reservoir_to_regular_gas() -> eyre::Result<()> {
-        let mut evm = TestEvm::with_gas_overrides(
-            TempoHardfork::T4,
-            [
-                (GasId::sstore_set_without_load_cost(), 19_900),
-                (GasId::sstore_set_state_gas(), 230_000),
-            ],
-        );
+        let mut evm = TestEvm::new(TempoHardfork::T4);
 
         // Reservoir = 500k: enough for 2 full SSTOREs (2 × 230k = 460k)
         // but the 3rd SSTORE (230k) must spill 190k into regular gas.
@@ -870,20 +847,18 @@ mod tests {
         Ok(())
     }
 
-    // -- FOUND DIVERGENCES VS TIP-1016 SPEC -------------------------------------------------------
-
     #[test]
-    #[ignore = "TIP-1016 mismatch: runtime still charges the Berlin cold-slot surcharge (extra 21k)"]
     fn test_t4_cold_sstore_matches_tip1016_spec() -> eyre::Result<()> {
-        let expected_regular_gas = 20_000u64;
         let mut evm = TestEvm::new(TempoHardfork::T4);
-        let mut provider = evm.provider_with_reservoir(230_000);
+        let mut provider = evm.provider_with_reservoir(460_000);
 
-        provider.sstore(Address::random(), U256::ONE, U256::ONE)?;
+        let (address, cold_slot, warm_slot) = (Address::random(), U256::ONE, U256::from(2));
+
+        provider.sstore(address, cold_slot, U256::ONE)?;
         assert_eq!(
             provider.gas_used(),
-            expected_regular_gas,
-            "TIP-1016 cold SSTORE should consume 20,000 regular gas"
+            22_200,
+            "TIP-1016 cold SSTORE should consume 22,200 regular gas including the retained Berlin cold-slot access charge"
         );
         assert_eq!(
             provider.state_gas_used(),
@@ -891,38 +866,26 @@ mod tests {
             "TIP-1016 cold SSTORE should consume 230,000 state gas"
         );
 
-        Ok(())
-    }
+        provider.sload(address, warm_slot)?;
+        let gas_before_warm_sstore = provider.gas_used();
+        let state_gas_before_warm_sstore = provider.state_gas_used();
 
-    #[test]
-    fn test_t4_cold_sstore_matches_tip1016_spec_poc() -> eyre::Result<()> {
-        // POC: if the Berlin cold-slot surcharge is zeroed, the runtime path matches the TIP-1016 cold SSTORE split.
-        let mut evm = TestEvm::with_gas_overrides(
-            TempoHardfork::T4,
-            [
-                (GasId::sstore_set_without_load_cost(), 19_900),
-                (GasId::cold_storage_cost(), 0),
-            ],
-        );
-        let mut provider = evm.provider_with_reservoir(230_000);
-
-        provider.sstore(Address::random(), U256::ONE, U256::ONE)?;
+        provider.sstore(address, warm_slot, U256::ONE)?;
         assert_eq!(
-            provider.gas_used(),
-            20_000,
-            "with cold_storage_cost zeroed, cold SSTORE regular gas matches TIP-1016"
+            provider.gas_used() - gas_before_warm_sstore,
+            20_100,
+            "TIP-1016 warm zero-to-non-zero SSTORE should consume 20,100 regular gas after the slot is warmed by SLOAD"
         );
         assert_eq!(
-            provider.state_gas_used(),
+            provider.state_gas_used() - state_gas_before_warm_sstore,
             230_000,
-            "with cold_storage_cost zeroed, cold SSTORE state gas still matches TIP-1016"
+            "TIP-1016 warm zero-to-non-zero SSTORE should still consume 230,000 state gas"
         );
 
         Ok(())
     }
 
     #[test]
-    #[ignore = "TIP-1016 mismatch: set_code path does not charge HASH_COST (missing 6 gas)"]
     fn test_t4_set_code_new_account_matches_tip1016_success_path() -> eyre::Result<()> {
         let mut evm = TestEvm::new(TempoHardfork::T4);
         let gas_params = evm.ctx().cfg.gas_params.clone();
@@ -955,7 +918,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TIP-1016 mismatch: 0->X->0 refund math does not net to GAS_WARM_ACCESS (100 gas)"]
+    #[ignore = "TIP-1016 mismatch: 0->X->0 refund math does not net to GAS_WARM_ACCESS (100 gas) yet"]
     fn test_t4_sstore_restore_refund_matches_tip1016_spec() -> eyre::Result<()> {
         let mut evm = TestEvm::new(TempoHardfork::T4);
         let mut provider = evm.provider_with_reservoir(230_000);

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -353,7 +353,7 @@ pub fn deduct_gas(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{B256, address, b256, bytes, keccak256};
+    use alloy::primitives::{B256, b256, bytes, keccak256};
     use alloy_evm::{EvmEnv, EvmFactory, EvmInternals, revm::context::Host};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
@@ -362,42 +362,111 @@ mod tests {
         database::{CacheDB, EmptyDB},
         interpreter::StateLoad,
     };
-    use tempo_evm::TempoEvmFactory;
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_evm::{TempoEvmFactory, evm::TempoEvm};
+    use tempo_revm::gas_params::tempo_gas_params;
+
+    struct TestEvm(TempoEvm<CacheDB<EmptyDB>>);
+
+    impl TestEvm {
+        fn default() -> Self {
+            Self::with_gas_overrides(TempoHardfork::default(), [])
+        }
+
+        fn new(spec: TempoHardfork) -> Self {
+            Self::with_gas_overrides(spec, [])
+        }
+
+        fn with_gas_overrides<const N: usize>(
+            spec: TempoHardfork,
+            overrides: [(GasId, u64); N],
+        ) -> Self {
+            let db = CacheDB::new(EmptyDB::new());
+            let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
+            cfg.spec = spec;
+            cfg.gas_params = tempo_gas_params(spec);
+            cfg.gas_params
+                .override_gas(overrides.into_iter().collect::<Vec<_>>());
+
+            Self(TempoEvmFactory::default().create_evm(
+                db,
+                EvmEnv {
+                    cfg_env: cfg,
+                    ..Default::default()
+                },
+            ))
+        }
+
+        fn provider_with_gas_limit(
+            &mut self,
+            gas_limit: u64,
+            reservoir: u64,
+        ) -> EvmPrecompileStorageProvider<'_> {
+            let ctx = self.0.ctx_mut();
+            let spec = ctx.cfg.spec;
+            let gas_params = ctx.cfg.gas_params.clone();
+            let evm_internals =
+                EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
+
+            EvmPrecompileStorageProvider::new(
+                evm_internals,
+                gas_limit,
+                reservoir,
+                spec,
+                false,
+                gas_params,
+            )
+        }
+
+        fn provider_with_reservoir(&mut self, reservoir: u64) -> EvmPrecompileStorageProvider<'_> {
+            self.provider_with_gas_limit(u64::MAX, reservoir)
+        }
+
+        fn provider_max_gas(&mut self) -> EvmPrecompileStorageProvider<'_> {
+            let ctx = self.0.ctx_mut();
+            let evm_internals =
+                EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
+            EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg)
+        }
+    }
+
+    impl std::ops::Deref for TestEvm {
+        type Target = TempoEvm<CacheDB<EmptyDB>>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl std::ops::DerefMut for TestEvm {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
 
     #[test]
     fn test_sstore_sload() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
 
         let addr = Address::random();
         let key = U256::random();
-
         let value = U256::random();
 
         provider.sstore(addr, key, value)?;
         let sload_val = provider.sload(addr, key)?;
-
         assert_eq!(sload_val, value);
         Ok(())
     }
 
     #[test]
     fn test_set_code() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
+        let mut evm = TestEvm::default();
         let addr = Address::random();
         let code = Bytecode::new_raw(vec![0xff].into());
-        provider.set_code(addr, code.clone())?;
-        drop(provider);
+        {
+            let mut provider = evm.provider_max_gas();
+            provider.set_code(addr, code.clone())?;
+        }
 
         let Some(StateLoad { data, is_cold: _ }) = evm.load_account_code(addr) else {
             panic!("Failed to load account code")
@@ -409,14 +478,9 @@ mod tests {
 
     #[test]
     fn test_get_account_info() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("3000000000000000000000000000000000000003");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
 
         // Get account info for a new account
         provider.with_account_info(address, &mut |info| {
@@ -434,14 +498,9 @@ mod tests {
 
     #[test]
     fn test_emit_event() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("4000000000000000000000000000000000000004");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
         let topic = b256!("0000000000000000000000000000000000000000000000000000000000000001");
         let data = bytes!(
             "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001"
@@ -457,14 +516,9 @@ mod tests {
 
     #[test]
     fn test_multiple_storage_operations() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("5000000000000000000000000000000000000005");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
 
         // Store multiple values
         for i in 0..10 {
@@ -486,14 +540,9 @@ mod tests {
 
     #[test]
     fn test_overwrite_storage() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("6000000000000000000000000000000000000006");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
         let key = U256::from(99);
 
         // Store initial value
@@ -511,15 +560,9 @@ mod tests {
 
     #[test]
     fn test_different_addresses() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address1 = address!("7000000000000000000000000000000000000001");
-        let address2 = address!("7000000000000000000000000000000000000002");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let (address1, address2) = (Address::random(), Address::random());
         let key = U256::from(42);
 
         // Store different values at the same key for different addresses
@@ -538,14 +581,9 @@ mod tests {
 
     #[test]
     fn test_multiple_transient_storage_operations() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("8000000000000000000000000000000000000001");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
 
         // Store multiple values
         for i in 0..10 {
@@ -567,14 +605,9 @@ mod tests {
 
     #[test]
     fn test_overwrite_transient_storage() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("9000000000000000000000000000000000000001");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
         let key = U256::from(99);
 
         // Store initial value
@@ -592,16 +625,10 @@ mod tests {
 
     #[test]
     fn test_transient_storage_different_addresses() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address1 = address!("a000000000000000000000000000000000000001");
-        let address2 = address!("a000000000000000000000000000000000000002");
-        let key = U256::from(42);
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let (address1, address2) = (Address::random(), Address::random());
+        let key = U256::ONE;
 
         // Store different values at the same key for different addresses
         let value1 = U256::from(100);
@@ -619,14 +646,9 @@ mod tests {
 
     #[test]
     fn test_transient_storage_isolation_from_persistent() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("b000000000000000000000000000000000000001");
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+        let address = Address::random();
         let key = U256::from(123);
         let persistent_value = U256::from(456);
         let transient_value = U256::from(789);
@@ -646,28 +668,22 @@ mod tests {
 
     #[test]
     fn test_keccak256_gas() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        // 1 word: KECCAK256(30) + KECCAK256WORD(6) * ceil(11/32) = 36
-        let data = b"hello world";
-        assert_eq!(provider.keccak256(data)?, keccak256(data));
-        assert_eq!(provider.gas_used(), 36);
-
-        // 2 words: 30 + 6*2 = 42, cumulative = 78
-        provider.keccak256(&[0u8; 64])?;
-        assert_eq!(provider.gas_used(), 78);
-        std::mem::drop(provider);
+        let mut evm = TestEvm::default();
+        {
+            let mut provider = evm.provider_max_gas();
+            // 1 word: KECCAK256(30) + KECCAK256WORD(6) * ceil(11/32) = 36
+            assert_eq!(
+                provider.keccak256(b"hello world")?,
+                keccak256(b"hello world")
+            );
+            assert_eq!(provider.gas_used(), 36);
+            // 2 words: 30 + 6*2 = 42, cumulative = 78
+            provider.keccak256(&[0u8; 64])?;
+            assert_eq!(provider.gas_used(), 78);
+        }
 
         // OOG: 30 gas is not enough (needs 36 for 1 word)
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider =
-            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 30, 0);
+        let mut provider = evm.provider_with_gas_limit(30, 0);
         assert!(matches!(
             provider.keccak256(b"hello"),
             Err(TempoPrecompileError::OutOfGas)
@@ -678,12 +694,15 @@ mod tests {
 
     #[test]
     fn test_recover_signer_gas() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut evm = TempoEvmFactory::default().create_evm(db, EvmEnv::default());
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+
+        let signer = PrivateKeySigner::random();
+        let digest = keccak256(b"test message");
+        let sig = signer.sign_hash_sync(&digest).unwrap();
+        let v = sig.v() as u8 + 27;
+        let r: B256 = sig.r().into();
+        let s: B256 = sig.s().into();
 
         // Invalid v → None, gas still charged
         assert!(
@@ -694,12 +713,6 @@ mod tests {
         assert_eq!(provider.gas_used(), crate::ECRECOVER_GAS);
 
         // Valid signature → correct recovery
-        let signer = PrivateKeySigner::random();
-        let digest = keccak256(b"test message");
-        let sig = signer.sign_hash_sync(&digest).unwrap();
-        let v = sig.v() as u8 + 27;
-        let r: B256 = sig.r().into();
-        let s: B256 = sig.s().into();
         assert_eq!(
             provider.recover_signer(digest, v, r, s)?,
             Some(signer.address())
@@ -708,10 +721,7 @@ mod tests {
         std::mem::drop(provider);
 
         // OOG: 100 gas is not enough (needs 3000)
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider =
-            EvmPrecompileStorageProvider::new_with_gas_limit(evm_internals, &ctx.cfg, 100, 0);
+        let mut provider = evm.provider_with_gas_limit(100, 0);
         assert!(matches!(
             provider.recover_signer(digest, v, r, s),
             Err(TempoPrecompileError::OutOfGas)
@@ -722,33 +732,22 @@ mod tests {
 
     #[test]
     fn test_state_gas_used_only_counts_state_creating_ops() -> eyre::Result<()> {
-        use revm::context_interface::cfg::GasId;
-        use tempo_chainspec::hardfork::TempoHardfork;
+        let mut evm = TestEvm::with_gas_overrides(
+            TempoHardfork::T4,
+            [
+                (GasId::sstore_set_without_load_cost(), 19_900),
+                (GasId::sstore_set_state_gas(), 230_000),
+                (GasId::code_deposit_cost(), 200),
+                (GasId::code_deposit_state_gas(), 2_300),
+            ],
+        );
+        let gas_params = evm.ctx().cfg.gas_params.clone();
+        let mut provider = evm.provider_with_reservoir(0);
 
-        let db = CacheDB::new(EmptyDB::new());
-        let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
-        cfg.set_spec_and_mainnet_gas_params(TempoHardfork::T4);
-        // Apply TIP-1016 state gas overrides (normally done by tempo_gas_params)
-        cfg.gas_params.override_gas(vec![
-            (GasId::sstore_set_without_load_cost(), 19_900),
-            (GasId::sstore_set_state_gas(), 230_000),
-            (GasId::code_deposit_cost(), 200),
-            (GasId::code_deposit_state_gas(), 2_300),
-        ]);
-        let evm_env = EvmEnv {
-            cfg_env: cfg.clone(),
-            ..Default::default()
-        };
-        let mut evm = TempoEvmFactory::default().create_evm(db, evm_env);
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new_max_gas(evm_internals, &ctx.cfg);
-
-        let address = address!("5000000000000000000000000000000000000005");
+        let (address, code_address, slot) = (Address::random(), Address::random(), U256::ONE);
 
         // SLOADs should not add state gas
-        provider.sload(address, U256::from(1))?;
+        provider.sload(address, slot)?;
         assert_eq!(
             provider.state_gas_used(),
             0,
@@ -758,7 +757,7 @@ mod tests {
 
         // SSTORE zero->non-zero should add state gas
         let gas_before = provider.gas_used();
-        provider.sstore(address, U256::from(1), U256::from(42))?;
+        provider.sstore(address, slot, U256::from(1))?;
         let state_gas_after_set = provider.state_gas_used();
         assert_eq!(
             state_gas_after_set, 230_000,
@@ -770,7 +769,7 @@ mod tests {
         );
 
         // SSTORE non-zero->non-zero should NOT add more state gas
-        provider.sstore(address, U256::from(1), U256::from(99))?;
+        provider.sstore(address, slot, U256::from(2))?;
         assert_eq!(
             provider.state_gas_used(),
             state_gas_after_set,
@@ -779,11 +778,16 @@ mod tests {
 
         // Code deposit should add state gas (2,300 per byte)
         let state_gas_before_code = provider.state_gas_used();
-        provider.set_code(address, revm::state::Bytecode::new_raw(vec![0xef].into()))?;
+        provider.set_code(
+            code_address,
+            revm::state::Bytecode::new_raw(vec![0xef].into()),
+        )?;
         assert_eq!(
             provider.state_gas_used(),
-            state_gas_before_code + 2_300,
-            "set_code(1 byte) should add 2,300 state gas"
+            state_gas_before_code
+                + gas_params.create_state_gas()
+                + gas_params.code_deposit_state_gas(1),
+            "set_code(new account, 1 byte) should add CREATE state gas plus 2,300 code deposit state gas"
         );
 
         Ok(())
@@ -793,38 +797,21 @@ mod tests {
     /// spills into regular gas once the reservoir is exhausted.
     #[test]
     fn test_state_gas_spills_from_reservoir_to_regular_gas() -> eyre::Result<()> {
-        let db = CacheDB::new(EmptyDB::new());
-        let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
-        cfg.set_spec_and_mainnet_gas_params(TempoHardfork::T4);
-        cfg.gas_params.override_gas(vec![
-            (GasId::sstore_set_without_load_cost(), 19_900),
-            (GasId::sstore_set_state_gas(), 230_000),
-        ]);
-        let evm_env = EvmEnv {
-            cfg_env: cfg.clone(),
-            ..Default::default()
-        };
+        let mut evm = TestEvm::with_gas_overrides(
+            TempoHardfork::T4,
+            [
+                (GasId::sstore_set_without_load_cost(), 19_900),
+                (GasId::sstore_set_state_gas(), 230_000),
+            ],
+        );
 
         // Reservoir = 500k: enough for 2 full SSTOREs (2 × 230k = 460k)
         // but the 3rd SSTORE (230k) must spill 190k into regular gas.
         let gas_limit = 1_000_000u64;
         let reservoir = 500_000u64;
         let state_gas_per_sstore = 230_000u64;
-
-        let mut evm = TempoEvmFactory::default().create_evm(db, evm_env);
-        let ctx = evm.ctx_mut();
-        let evm_internals =
-            EvmInternals::new(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx);
-        let mut provider = EvmPrecompileStorageProvider::new(
-            evm_internals,
-            gas_limit,
-            reservoir,
-            cfg.spec,
-            false,
-            cfg.gas_params.clone(),
-        );
-
-        let address = address!("5000000000000000000000000000000000000005");
+        let mut provider = evm.provider_with_gas_limit(gas_limit, reservoir);
+        let address = Address::random();
 
         // --- First SSTORE (zero→non-zero): fully covered by reservoir ---
         provider.sstore(address, U256::from(1), U256::from(42))?;
@@ -878,6 +865,110 @@ mod tests {
             provider.gas_used(),
             expected_regular_after,
             "regular gas should include spill of {spill} from exhausted reservoir"
+        );
+
+        Ok(())
+    }
+
+    // -- FOUND DIVERGENCES VS TIP-1016 SPEC -------------------------------------------------------
+
+    #[test]
+    #[ignore = "TIP-1016 mismatch: runtime still charges the Berlin cold-slot surcharge (extra 21k)"]
+    fn test_t4_cold_sstore_matches_tip1016_spec() -> eyre::Result<()> {
+        let expected_regular_gas = 20_000u64;
+        let mut evm = TestEvm::new(TempoHardfork::T4);
+        let mut provider = evm.provider_with_reservoir(230_000);
+
+        provider.sstore(Address::random(), U256::ONE, U256::ONE)?;
+        assert_eq!(
+            provider.gas_used(),
+            expected_regular_gas,
+            "TIP-1016 cold SSTORE should consume 20,000 regular gas"
+        );
+        assert_eq!(
+            provider.state_gas_used(),
+            230_000,
+            "TIP-1016 cold SSTORE should consume 230,000 state gas"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_t4_cold_sstore_matches_tip1016_spec_poc() -> eyre::Result<()> {
+        // POC: if the Berlin cold-slot surcharge is zeroed, the runtime path matches the TIP-1016 cold SSTORE split.
+        let mut evm = TestEvm::with_gas_overrides(
+            TempoHardfork::T4,
+            [
+                (GasId::sstore_set_without_load_cost(), 19_900),
+                (GasId::cold_storage_cost(), 0),
+            ],
+        );
+        let mut provider = evm.provider_with_reservoir(230_000);
+
+        provider.sstore(Address::random(), U256::ONE, U256::ONE)?;
+        assert_eq!(
+            provider.gas_used(),
+            20_000,
+            "with cold_storage_cost zeroed, cold SSTORE regular gas matches TIP-1016"
+        );
+        assert_eq!(
+            provider.state_gas_used(),
+            230_000,
+            "with cold_storage_cost zeroed, cold SSTORE state gas still matches TIP-1016"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "TIP-1016 mismatch: set_code path does not charge HASH_COST (missing 6 gas)"]
+    fn test_t4_set_code_new_account_matches_tip1016_success_path() -> eyre::Result<()> {
+        let mut evm = TestEvm::new(TempoHardfork::T4);
+        let gas_params = evm.ctx().cfg.gas_params.clone();
+
+        let code = Bytecode::new_raw(vec![0xef].into());
+        let expected_state_gas =
+            gas_params.create_state_gas() + gas_params.code_deposit_state_gas(code.len());
+        let expected_regular_gas =
+            gas_params.create_cost() + gas_params.code_deposit_cost(code.len());
+        let expected_hash_cost = gas_params.keccak256_cost(code.len());
+        let mut provider = evm.provider_with_reservoir(expected_state_gas);
+
+        provider.set_code(Address::random(), code)?;
+        assert_eq!(
+            expected_hash_cost, 6,
+            "TIP-1016/evm CREATE success path expects HASH_COST(len)=6*ceil(len/32)"
+        );
+        assert_eq!(
+            provider.gas_used(),
+            expected_regular_gas + expected_hash_cost,
+            "TIP-1016 CREATE success path should charge CREATE + code deposit + HASH_COST"
+        );
+        assert_eq!(
+            provider.state_gas_used(),
+            expected_state_gas,
+            "set_code on a new account should charge CREATE state gas plus code deposit state gas"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "TIP-1016 mismatch: 0->X->0 refund math does not net to GAS_WARM_ACCESS (100 gas)"]
+    fn test_t4_sstore_restore_refund_matches_tip1016_spec() -> eyre::Result<()> {
+        let mut evm = TestEvm::new(TempoHardfork::T4);
+        let mut provider = evm.provider_with_reservoir(230_000);
+
+        let (address, slot) = (Address::random(), U256::ONE);
+        provider.sstore(address, slot, U256::ONE)?;
+        provider.sstore(address, slot, U256::ZERO)?;
+        assert_eq!(provider.gas_refunded(), 247_800);
+        let net_gas_after_refund =
+            provider.gas_used() + provider.state_gas_used() - provider.gas_refunded() as u64;
+        assert_eq!(
+            net_gas_after_refund, 100,
+            "TIP-1016 says 0->X->0 should net to GAS_WARM_ACCESS (100)"
         );
 
         Ok(())

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -104,7 +104,6 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
         let code_len = code.len();
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
-        self.deduct_gas(self.gas_params.keccak256_cost(code_len))?;
 
         // Track state gas for code deposit
         self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
@@ -116,10 +115,15 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
             was_empty
         };
 
-        // T4: charge TIP20 creations as CREATE
-        if self.spec.is_t4() && was_empty {
-            self.deduct_gas(self.gas_params.create_cost())?;
-            self.deduct_state_gas(self.gas_params.create_state_gas())?;
+        if self.spec.is_t4() {
+            // T4: charge cost per word
+            self.deduct_gas(self.gas_params.keccak256_cost(code_len))?;
+
+            // T4: charge TIP20 creations as CREATE
+            if was_empty {
+                self.deduct_gas(self.gas_params.create_cost())?;
+                self.deduct_state_gas(self.gas_params.create_state_gas())?;
+            }
         }
 
         Ok(())

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -373,10 +373,6 @@ mod tests {
     struct TestEvm(TempoEvm<CacheDB<EmptyDB>>);
 
     impl TestEvm {
-        fn default() -> Self {
-            Self::new(TempoHardfork::default())
-        }
-
         fn new(spec: TempoHardfork) -> Self {
             let db = CacheDB::new(EmptyDB::new());
             let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
@@ -425,6 +421,12 @@ mod tests {
         }
     }
 
+    impl Default for TestEvm {
+        fn default() -> Self {
+            Self::new(TempoHardfork::default())
+        }
+    }
+
     impl std::ops::Deref for TestEvm {
         type Target = TempoEvm<CacheDB<EmptyDB>>;
         fn deref(&self) -> &Self::Target {
@@ -456,12 +458,13 @@ mod tests {
     #[test]
     fn test_set_code() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+
         let addr = Address::random();
         let code = Bytecode::new_raw(vec![0xff].into());
-        {
-            let mut provider = evm.provider_max_gas();
-            provider.set_code(addr, code.clone())?;
-        }
+
+        provider.set_code(addr, code.clone())?;
+        std::mem::drop(provider);
 
         let Some(StateLoad { data, is_cold: _ }) = evm.load_account_code(addr) else {
             panic!("Failed to load account code")
@@ -475,10 +478,9 @@ mod tests {
     fn test_get_account_info() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
         let mut provider = evm.provider_max_gas();
-        let address = Address::random();
 
         // Get account info for a new account
-        provider.with_account_info(address, &mut |info| {
+        provider.with_account_info(Address::random(), &mut |info| {
             // Should be an empty account
             assert!(info.balance.is_zero());
             assert_eq!(info.nonce, 0);
@@ -495,7 +497,7 @@ mod tests {
     fn test_emit_event() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
         let mut provider = evm.provider_max_gas();
-        let address = Address::random();
+
         let topic = b256!("0000000000000000000000000000000000000000000000000000000000000001");
         let data = bytes!(
             "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001"
@@ -504,7 +506,7 @@ mod tests {
         let log_data = LogData::new_unchecked(vec![topic], data);
 
         // Should not error even though events can't be emitted from handlers
-        provider.emit_event(address, log_data)?;
+        provider.emit_event(Address::random(), log_data)?;
 
         Ok(())
     }
@@ -664,18 +666,18 @@ mod tests {
     #[test]
     fn test_keccak256_gas() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
-        {
-            let mut provider = evm.provider_max_gas();
-            // 1 word: KECCAK256(30) + KECCAK256WORD(6) * ceil(11/32) = 36
-            assert_eq!(
-                provider.keccak256(b"hello world")?,
-                keccak256(b"hello world")
-            );
-            assert_eq!(provider.gas_used(), 36);
-            // 2 words: 30 + 6*2 = 42, cumulative = 78
-            provider.keccak256(&[0u8; 64])?;
-            assert_eq!(provider.gas_used(), 78);
-        }
+        let mut provider = evm.provider_max_gas();
+
+        // 1 word: KECCAK256(30) + KECCAK256WORD(6) * ceil(11/32) = 36
+        assert_eq!(
+            provider.keccak256(b"hello world")?,
+            keccak256(b"hello world")
+        );
+        assert_eq!(provider.gas_used(), 36);
+        // 2 words: 30 + 6*2 = 42, cumulative = 78
+        provider.keccak256(&[0u8; 64])?;
+        assert_eq!(provider.gas_used(), 78);
+        std::mem::drop(provider);
 
         // OOG: 30 gas is not enough (needs 36 for 1 word)
         let mut provider = evm.provider_with_gas_limit(30, 0);

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -105,9 +105,6 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         let code_len = code.len();
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
-        // Track state gas for code deposit
-        self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
-
         let was_empty = {
             let mut account = self.internals.load_account_mut(address)?;
             let was_empty = account.data.account().info.is_empty();
@@ -116,8 +113,8 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         };
 
         if self.spec.is_t4() {
-            // T4: charge cost per word
-            self.deduct_gas(self.gas_params.keccak256_cost(code_len))?;
+            // Track state gas for code deposit
+            self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
 
             // T4: charge TIP20 creations as CREATE
             if was_empty {
@@ -901,17 +898,12 @@ mod tests {
             gas_params.create_state_gas() + gas_params.code_deposit_state_gas(code.len());
         let expected_regular_gas =
             gas_params.create_cost() + gas_params.code_deposit_cost(code.len());
-        let expected_hash_cost = gas_params.keccak256_cost(code.len());
         let mut provider = evm.provider_with_reservoir(expected_state_gas);
 
         provider.set_code(Address::random(), code)?;
         assert_eq!(
-            expected_hash_cost, 6,
-            "TIP-1016/evm CREATE success path expects HASH_COST(len)=6*ceil(len/32)"
-        );
-        assert_eq!(
             provider.gas_used(),
-            expected_regular_gas + expected_hash_cost,
+            expected_regular_gas,
             "TIP-1016 CREATE success path should charge CREATE + code deposit + HASH_COST"
         );
         assert_eq!(

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -113,7 +113,7 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         };
 
         if self.spec.is_t4() {
-            // Track state gas for code deposit
+            // T4: Track state gas for code deposit
             self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
 
             // T4: charge TIP20 creations as CREATE
@@ -904,7 +904,7 @@ mod tests {
         assert_eq!(
             provider.gas_used(),
             expected_regular_gas,
-            "TIP-1016 CREATE success path should charge CREATE + code deposit + HASH_COST"
+            "TIP-1016 CREATE success path should charge CREATE + code deposit"
         );
         assert_eq!(
             provider.state_gas_used(),

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -34,7 +34,7 @@ const EIP7702_PER_EMPTY_ACCOUNT_COST_T1: u64 = 12_500;
 // These values are "at least the pre-TIP-1000 (standard EVM) cost" per spec invariant 15.
 //
 // For SSTORE: revm decomposes the cost as sstore_static(WARM_STORAGE_READ=100) +
-// sstore_set_without_load_cost. So the GasId value = 20,000 - 100 = 19,900.
+// sstore_set_without_load_cost(20,000), with the cold-slot surcharge applied separately.
 const T4_SSTORE_SET_REGULAR: u64 = 20_000;
 const T4_NEW_ACCOUNT_REGULAR: u64 = 25_000;
 const T4_CREATE_REGULAR: u64 = 32_000;
@@ -157,25 +157,26 @@ mod tests {
     ///
     /// | Operation                      | Execution Gas | Storage Gas | Total   |
     /// |--------------------------------|---------------|-------------|---------|
-    /// | Cold SSTORE (zero → non-zero)  | 20,000        | 230,000     | 250,000 |
+    /// | Cold SSTORE (zero → non-zero)  | 22,200        | 230,000     | 252,200 |
     /// | Account creation (nonce 0 → 1) | 25,000        | 225,000     | 250,000 |
     /// | Contract metadata (CREATE)     | 32,000        | 468,000     | 500,000 |
     /// | Contract code storage (/byte)  | 200           | 2,300       | 2,500   |
     /// | EIP-7702 delegation (per auth) | 25,000        | 225,000     | 250,000 |
     ///
-    /// Note: For SSTORE, `sstore_set_without_load_cost` excludes the warm storage
-    /// read cost (100) that revm charges as `sstore_static_gas`. So the GasId value
-    /// = spec_regular - WARM_STORAGE_READ_COST = 20,000 - 100 = 19,900.
+    /// Note: The cold SSTORE total keeps Berlin's access charging. In revm terms the
+    /// zero->non-zero write path is: warm read (100) + `sstore_set_without_load_cost` (20,000)
+    /// + cold slot surcharge (2,100) + state gas (230,000) = 252,200.
     #[test]
     fn test_t4_gas_params_splits_storage_costs() {
         let gas_params = tempo_gas_params(TempoHardfork::T4);
 
         // T4 execution gas (regular/computational overhead)
-        // SSTORE: spec says 20,000 regular; revm decomposes as static(100) + sstore_set_without_load
+        // SSTORE keeps revm's decomposed accounting: static(100) + sstore_set_without_load(20,000),
+        // with cold slot access (2,100) retained separately through `cold_storage_cost`.
         assert_eq!(
             gas_params.get(GasId::sstore_set_without_load_cost()),
             20_000,
-            "SSTORE set_without_load = spec 20,000"
+            "SSTORE set_without_load matches the retained zero->non-zero write component"
         );
         assert_eq!(
             gas_params.get(GasId::new_account_cost()),
@@ -260,21 +261,31 @@ mod tests {
         );
     }
 
-    /// TIP-1016: Verify totals (regular + state) match spec table.
-    /// Note: SSTORE total comparison needs to account for revm decomposition.
+    /// TIP-1016: Verify totals (regular + state) match the clarified spec table.
+    /// Note: SSTORE total comparison needs to account for revm decomposition and the cold-slot charge.
+    ///
     /// T1 sstore_set_without_load_cost = 250,000 (full TIP-1000 cost as override).
-    /// T4 total SSTORE = sstore_set_without_load_cost(19,900) + warm_read(100) + state(230,000) = 250,000.
+    /// T4 warm SSTORE = sstore_set_without_load_cost(20,000) + warm_read(100) + state(230,000) = 250,100.
+    /// T4 cold SSTORE = warm path + cold_slot_access(2,100) = 252,200.
     #[test]
     fn test_t4_totals_match_spec() {
         let t4 = tempo_gas_params(TempoHardfork::T4);
 
-        // SSTORE set total: regular(20,000) + state(230,000) = 250,000
-        // In revm terms: sstore_set_without_load_cost(19,900) + warm_read(100) + state(230,000)
-        let sstore_regular = t4.get(GasId::sstore_set_without_load_cost()) + 100; // add warm_storage_read
+        // Warm SSTORE total: write component(20,000) + warm read(100) + state(230,000)
+        let warm_sstore_regular =
+            t4.get(GasId::sstore_set_without_load_cost()) + t4.warm_storage_read_cost();
         assert_eq!(
-            sstore_regular + t4.get(GasId::sstore_set_state_gas()),
+            warm_sstore_regular + t4.get(GasId::sstore_set_state_gas()),
             250_100,
-            "SSTORE total must be 250,000 + storage read (100)"
+            "warm SSTORE total must be 250,100"
+        );
+
+        // Cold SSTORE total: warm path + Berlin cold slot access(2,100)
+        let cold_sstore_regular = warm_sstore_regular + t4.cold_storage_cost();
+        assert_eq!(
+            cold_sstore_regular + t4.get(GasId::sstore_set_state_gas()),
+            252_200,
+            "cold SSTORE total must include Berlin cold slot access charging"
         );
 
         // New account: 25,000 + 225,000 = 250,000

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -222,6 +222,9 @@ fn call_scope_extra_gas(auth: &tempo_primitives::transaction::KeyAuthorization) 
 /// one top-level transaction result instead, so the gas field must be normalized to the full tx
 /// budget. Reverts preserve the exact gas spent across prior successful steps plus the failed step,
 /// while halts such as OOG consume the entire remaining transaction budget.
+///
+/// NOTE: in AA batches, non-refundable state-gas charges that are known upfront, are already
+/// included in `initial_state_gas`, so this only refunds per-step execution state gas on failure.
 fn normalize_failed_batch_result_gas(
     frame_result: &mut FrameResult,
     final_gas_limit: u64,
@@ -2149,7 +2152,8 @@ mod tests {
         database::{CacheDB, EmptyDB},
         handler::Handler,
         interpreter::{
-            InstructionResult, gas::COLD_ACCOUNT_ACCESS_COST, instructions::utility::IntoU256,
+            InstructionResult, InterpreterResult, gas::COLD_ACCOUNT_ACCESS_COST,
+            instructions::utility::IntoU256,
         },
         primitives::hardfork::SpecId,
     };
@@ -2166,6 +2170,92 @@ mod tests {
         Journal::new(db)
     }
 
+    type TestHandlerEvmResult<T> =
+        Result<T, EVMError<<CacheDB<EmptyDB> as revm::Database>::Error, TempoInvalidTransaction>>;
+
+    struct TestHandlerEvm {
+        evm: TempoEvm<CacheDB<EmptyDB>, ()>,
+        handler: TempoEvmHandler<CacheDB<EmptyDB>, ()>,
+    }
+
+    impl TestHandlerEvm {
+        fn tx(spec: TempoHardfork, configure_tx_env: impl FnOnce(&mut TempoTxEnv)) -> Self {
+            let mut tx_env = TempoTxEnv::default();
+            configure_tx_env(&mut tx_env);
+            Self::new(spec, tx_env)
+        }
+
+        fn aa(
+            spec: TempoHardfork,
+            aa_env: TempoBatchCallEnv,
+            configure_tx_env: impl FnOnce(&mut TempoTxEnv),
+        ) -> Self {
+            let mut tx_env = TempoTxEnv {
+                tempo_tx_env: Some(Box::new(aa_env)),
+                ..Default::default()
+            };
+            configure_tx_env(&mut tx_env);
+            Self::new(spec, tx_env)
+        }
+
+        fn new(spec: TempoHardfork, tx_env: TempoTxEnv) -> Self {
+            Self::with_cfg(spec, tx_env, |_| {})
+        }
+
+        fn with_cfg(
+            spec: TempoHardfork,
+            tx_env: TempoTxEnv,
+            configure: impl FnOnce(&mut CfgEnv<TempoHardfork>),
+        ) -> Self {
+            let mut cfg = CfgEnv::<TempoHardfork>::default();
+            cfg.spec = spec;
+            cfg.gas_params = tempo_gas_params(spec);
+            cfg.enable_amsterdam_eip8037 = spec.is_t4();
+            configure(&mut cfg);
+
+            let ctx = Context::mainnet()
+                .with_db(CacheDB::new(EmptyDB::default()))
+                .with_block(TempoBlockEnv::default())
+                .with_cfg(cfg)
+                .with_tx(tx_env)
+                .with_new_journal(create_test_journal());
+
+            Self {
+                evm: TempoEvm::new(ctx, ()),
+                handler: TempoEvmHandler::new(),
+            }
+        }
+
+        fn cfg(&mut self) -> &CfgEnv<TempoHardfork> {
+            &self.evm.ctx().cfg
+        }
+
+        fn gas_params(&mut self) -> &GasParams {
+            &self.cfg().gas_params
+        }
+
+        fn validate_env(&mut self) -> TestHandlerEvmResult<()> {
+            self.handler.validate_env(&mut self.evm)
+        }
+
+        fn validate_initial_tx_gas(&mut self) -> InitialAndFloorGas {
+            self.handler
+                .validate_initial_tx_gas(&mut self.evm)
+                .expect("initial gas validation should succeed")
+        }
+
+        fn validate_against_state_and_deduct_caller(&mut self) -> TestHandlerEvmResult<()> {
+            self.handler
+                .validate_against_state_and_deduct_caller(&mut self.evm, &mut Default::default())
+        }
+
+        fn execute(&mut self, init_gas: &InitialAndFloorGas) -> FrameResult {
+            self.handler
+                .execution(&mut self.evm, init_gas)
+                .expect("execution should return a frame result")
+        }
+    }
+
     #[test]
     fn test_invalid_fee_token_rejected() {
         // Test that an invalid fee token (non-TIP20 address) is rejected with InvalidFeeToken error
@@ -2177,25 +2267,11 @@ mod tests {
             "Test requires a non-TIP20 address"
         );
 
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::default();
+        let mut test = TestHandlerEvm::tx(TempoHardfork::default(), |tx_env| {
+            tx_env.fee_token = Some(invalid_token);
+        });
 
-        // Set up tx with the invalid token as fee_token
-        let tx_env = TempoTxEnv {
-            fee_token: Some(invalid_token),
-            ..Default::default()
-        };
-
-        let mut evm: TempoEvm<CacheDB<EmptyDB>, ()> = TempoEvm::new(
-            Context::mainnet()
-                .with_db(CacheDB::new(EmptyDB::default()))
-                .with_block(TempoBlockEnv::default())
-                .with_cfg(Default::default())
-                .with_tx(tx_env),
-            (),
-        );
-
-        let result =
-            handler.validate_against_state_and_deduct_caller(&mut evm, &mut Default::default());
+        let result = test.validate_against_state_and_deduct_caller();
 
         assert!(
             matches!(
@@ -2211,30 +2287,13 @@ mod tests {
         let caller = Address::random();
         let invalid_token = Address::random();
 
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::default();
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T2;
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T2, |tx_env| {
+            tx_env.inner.caller = caller;
+            tx_env.fee_token = Some(invalid_token);
+            tx_env.fee_payer = Some(Some(caller));
+        });
 
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                caller,
-                ..Default::default()
-            },
-            fee_token: Some(invalid_token),
-            fee_payer: Some(Some(caller)),
-            ..Default::default()
-        };
-
-        let mut evm: TempoEvm<CacheDB<EmptyDB>, ()> = TempoEvm::new(
-            Context::mainnet()
-                .with_db(CacheDB::new(EmptyDB::default()))
-                .with_block(TempoBlockEnv::default())
-                .with_cfg(cfg)
-                .with_tx(tx_env),
-            (),
-        );
-
-        let result = handler.validate_env(&mut evm);
+        let result = test.validate_env();
         assert!(matches!(
             result,
             Err(EVMError::Transaction(
@@ -3330,17 +3389,11 @@ mod tests {
             ..Default::default()
         };
 
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(create_test_journal());
+        let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T3, tx_env, |cfg_override| {
+            *cfg_override = cfg;
+        });
 
-        let mut evm: TempoEvm<_, ()> = TempoEvm::new(ctx, ());
-        let mut handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
-        StorageCtx::enter_ctx(&mut evm.inner.ctx, || {
+        StorageCtx::enter_ctx(&mut test.evm.inner.ctx, || {
             let mut keychain = AccountKeychain::new();
 
             keychain.initialize().expect("keychain initialized");
@@ -3374,23 +3427,18 @@ mod tests {
                 .expect("access key authorization succeeds");
         });
 
-        let init_gas = handler
-            .validate_initial_tx_gas(&mut evm)
-            .expect("initial gas validation should succeed");
+        let init_gas = test.validate_initial_tx_gas();
         assert!(
             init_gas.floor_gas <= init_gas.initial_total_gas,
             "test requires floor gas to not exceed intrinsic gas"
         );
 
-        evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas;
+        test.evm.inner.ctx.tx.inner.gas_limit = init_gas.initial_total_gas;
 
-        handler
-            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+        test.validate_against_state_and_deduct_caller()
             .expect("scope validation no longer runs during state validation");
 
-        let result = handler
-            .execution(&mut evm, &init_gas)
-            .expect("execution should return a frame result");
+        let result = test.execute(&init_gas);
 
         assert!(
             matches!(
@@ -4730,39 +4778,18 @@ mod tests {
     /// initial_state_gas when T4 is active and state gas is enabled.
     #[test]
     fn test_state_gas_validate_initial_tx_gas_create_t4() {
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T4;
-        cfg.gas_params = tempo_gas_params(TempoHardfork::T4);
-        cfg.enable_amsterdam_eip8037 = true;
-
         let initcode = Bytes::from(vec![0x60, 0x80]);
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T4, |tx_env| {
+            tx_env.inner.gas_limit = 60_000_000;
+            tx_env.inner.kind = TxKind::Create;
+            tx_env.inner.data = initcode;
+        });
+        let init_gas = test.validate_initial_tx_gas();
 
         // create_state_gas (from upstream initial_tx_gas for CREATE) +
         // new_account_state_gas (from Tempo's nonce==0 check for the caller)
         let expected_state_gas =
-            cfg.gas_params.create_state_gas() + cfg.gas_params.new_account_state_gas();
-
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000, // Above cap to test cap bypass
-                kind: TxKind::Create,
-                data: initcode,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
-        let init_gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
+            test.gas_params().create_state_gas() + test.gas_params().new_account_state_gas();
 
         assert_eq!(
             init_gas.initial_state_gas, expected_state_gas,
@@ -4774,18 +4801,11 @@ mod tests {
     /// (upstream revm validation skips the cap check).
     #[test]
     fn test_state_gas_tx_gas_limit_above_cap_allowed() {
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T4;
-        cfg.gas_params = tempo_gas_params(TempoHardfork::T4);
-        cfg.enable_amsterdam_eip8037 = true;
-        cfg.tx_gas_limit_cap = Some(30_000_000);
-
         let calldata = Bytes::from(vec![1, 2, 3]);
 
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
         let tx_env = TempoTxEnv {
             inner: revm::context::TxEnv {
-                gas_limit: 60_000_000, // Double the cap
+                gas_limit: 60_000_000,
                 kind: TxKind::Call(Address::random()),
                 data: calldata,
                 ..Default::default()
@@ -4793,17 +4813,12 @@ mod tests {
             ..Default::default()
         };
 
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
+        let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T4, tx_env, |cfg| {
+            cfg.tx_gas_limit_cap = Some(30_000_000);
+        });
 
         // validate_env should pass even though gas_limit > cap
-        let result = handler.validate_env(&mut evm);
+        let result = test.validate_env();
         assert!(
             result.is_ok(),
             "With enable_amsterdam_eip8037=true, tx gas limit above cap should be allowed, got: {:?}",
@@ -4814,15 +4829,8 @@ mod tests {
     /// TIP-1016: When enable_amsterdam_eip8037 is false (pre-T4), tx gas limit above cap is rejected.
     #[test]
     fn test_state_gas_tx_gas_limit_above_cap_rejected_pre_t4() {
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T1;
-        cfg.gas_params = tempo_gas_params(TempoHardfork::T1);
-        cfg.enable_amsterdam_eip8037 = false;
-        cfg.tx_gas_limit_cap = Some(30_000_000);
-
         let calldata = Bytes::from(vec![1, 2, 3]);
 
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
         let tx_env = TempoTxEnv {
             inner: revm::context::TxEnv {
                 gas_limit: 60_000_000, // Double the cap
@@ -4833,17 +4841,12 @@ mod tests {
             ..Default::default()
         };
 
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
+        let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T1, tx_env, |cfg| {
+            cfg.tx_gas_limit_cap = Some(30_000_000);
+        });
 
         // validate_env should reject: gas_limit > cap with state gas disabled
-        let result = handler.validate_env(&mut evm);
+        let result = test.validate_env();
         assert!(
             result.is_err(),
             "With enable_amsterdam_eip8037=false, tx gas limit above cap should be rejected"
@@ -5087,8 +5090,6 @@ mod tests {
     /// TIP-1016: AA nonce==0 new account should track state gas in T4.
     #[test]
     fn test_state_gas_aa_nonce_zero_new_account() {
-        let gas_params = tempo_gas_params(TempoHardfork::T4);
-
         let aa_env = TempoBatchCallEnv {
             signature: TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
                 alloy_primitives::Signature::test_signature(),
@@ -5102,36 +5103,15 @@ mod tests {
             ..Default::default()
         };
 
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000,
-                nonce: 0,
-                ..Default::default()
-            },
-            tempo_tx_env: Some(Box::new(aa_env)),
-            ..Default::default()
-        };
-
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T4;
-        cfg.gas_params = gas_params.clone();
-        cfg.enable_amsterdam_eip8037 = true;
-
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
-        let init_gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
+        let mut test = TestHandlerEvm::aa(TempoHardfork::T4, aa_env, |tx_env| {
+            tx_env.inner.gas_limit = 60_000_000;
+            tx_env.inner.nonce = 0;
+        });
+        let init_gas = test.validate_initial_tx_gas();
 
         assert_eq!(
             init_gas.initial_state_gas,
-            gas_params.new_account_state_gas(),
+            test.gas_params().new_account_state_gas(),
             "AA tx with nonce==0 should track new_account_state_gas in T4"
         );
     }
@@ -5187,39 +5167,18 @@ mod tests {
     /// TIP-1016: Standard tx with nonce==0 should track state gas on T4 only.
     #[test]
     fn test_state_gas_standard_tx_nonce_zero_t4() {
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T4;
-        cfg.gas_params = tempo_gas_params(TempoHardfork::T4);
-        cfg.enable_amsterdam_eip8037 = true;
-
         let calldata = Bytes::from(vec![1, 2, 3]);
-        let expected_state_gas = cfg.gas_params.new_account_state_gas();
-
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000,
-                kind: TxKind::Call(Address::random()),
-                nonce: 0,
-                data: calldata,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
-        let init_gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T4, |tx_env| {
+            tx_env.inner.gas_limit = 60_000_000;
+            tx_env.inner.kind = TxKind::Call(Address::random());
+            tx_env.inner.nonce = 0;
+            tx_env.inner.data = calldata;
+        });
+        let init_gas = test.validate_initial_tx_gas();
 
         assert_eq!(
-            init_gas.initial_state_gas, expected_state_gas,
+            init_gas.initial_state_gas,
+            test.gas_params().new_account_state_gas(),
             "T4 standard tx with nonce==0 should track new_account_state_gas"
         );
     }
@@ -5227,34 +5186,15 @@ mod tests {
     /// TIP-1016: Standard tx with nonce==0 should NOT track state gas on T1.
     #[test]
     fn test_state_gas_standard_tx_nonce_zero_t1_no_state_gas() {
-        let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = TempoHardfork::T1;
-        cfg.gas_params = tempo_gas_params(TempoHardfork::T1);
-
         let calldata = Bytes::from(vec![1, 2, 3]);
 
-        let journal = Journal::new(CacheDB::new(EmptyDB::default()));
-        let tx_env = TempoTxEnv {
-            inner: revm::context::TxEnv {
-                gas_limit: 60_000_000,
-                kind: TxKind::Call(Address::random()),
-                nonce: 0,
-                data: calldata,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ctx = Context::mainnet()
-            .with_db(CacheDB::new(EmptyDB::default()))
-            .with_block(TempoBlockEnv::default())
-            .with_cfg(cfg)
-            .with_tx(tx_env)
-            .with_new_journal(journal);
-        let mut evm = TempoEvm::<_, ()>::new(ctx, ());
-        let handler: TempoEvmHandler<CacheDB<EmptyDB>, ()> = TempoEvmHandler::new();
-
-        let init_gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T1, |tx_env| {
+            tx_env.inner.gas_limit = 60_000_000;
+            tx_env.inner.kind = TxKind::Call(Address::random());
+            tx_env.inner.nonce = 0;
+            tx_env.inner.data = calldata;
+        });
+        let init_gas = test.validate_initial_tx_gas();
 
         assert_eq!(
             init_gas.initial_state_gas, 0,
@@ -5347,5 +5287,79 @@ mod tests {
             gas.initial_total_gas,
             gas.initial_state_gas,
         );
+    }
+
+    /// TIP-1016: CREATE state gas is charged upfront and must be spent even if a later AA step reverts.
+    #[test]
+    fn test_state_gas_failed_batch_preserves_upfront_create_intrinsic_gas() {
+        let tx_gas_limit = 1_000_000u64;
+        let (calls, call_results) = (
+            vec![
+                Call {
+                    to: TxKind::Create,
+                    value: U256::ZERO,
+                    input: Bytes::from(vec![0x60, 0x80]),
+                },
+                Call {
+                    to: TxKind::Call(Address::random()),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+            ],
+            [
+                (InstructionResult::Stop, 10_000u64),
+                (InstructionResult::Revert, 7_000u64),
+            ],
+        );
+
+        let aa_env = make_aa_env(calls.clone());
+        let mut test = TestHandlerEvm::aa(TempoHardfork::T4, aa_env, |tx_env| {
+            tx_env.inner.caller = Address::random();
+            tx_env.inner.gas_limit = tx_gas_limit;
+            // Keep nonce != 0 so this isolates CREATE state gas from caller account-creation gas.
+            tx_env.inner.nonce = 1;
+        });
+
+        let init_gas = test.validate_initial_tx_gas();
+        assert_eq!(
+            init_gas.initial_state_gas,
+            test.gas_params().create_state_gas(),
+            "first-call CREATE should contribute create_state_gas to AA intrinsic gas"
+        );
+        let (gas_limit, reservoir) = test.evm.initial_gas_and_reservoir(&init_gas);
+
+        let mut call_idx = 0usize;
+        let result = test
+            .handler
+            .execute_multi_call_with(
+                &mut test.evm,
+                gas_limit,
+                reservoir,
+                calls,
+                |_handler, _evm, gas, _reservoir| {
+                    // Feed the batch executor deterministic per-call outcomes without running real EVM code.
+                    let (instruction_result, spent) = call_results[call_idx];
+                    call_idx += 1;
+
+                    let mut gas = Gas::new(gas);
+                    gas.set_spent(spent);
+
+                    Ok(FrameResult::Call(CallOutcome::new(
+                        InterpreterResult::new(instruction_result, Bytes::new(), gas),
+                        0..0,
+                    )))
+                },
+            )
+            .expect("execute_multi_call_with should return a failed frame result");
+
+        let expected_spent =
+            init_gas.initial_total_gas + call_results.iter().map(|(_, spent)| spent).sum::<u64>();
+
+        // Pays CREATE state gas + both call costs. CREATE is charged upfront via intrinsic gas, and NOT refunded.
+        assert_eq!(result.instruction_result(), InstructionResult::Revert);
+        assert_eq!(result.gas().total_gas_spent(), expected_spent);
+        assert_eq!(result.gas().remaining(), tx_gas_limit - expected_spent);
+        assert_eq!(result.gas().state_gas_spent(), 0);
+        assert_eq!(result.gas().reservoir(), 0);
     }
 }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -2928,6 +2928,34 @@ mod tests {
     }
 
     #[test]
+    fn test_t4_key_authorization_matches_tip1016_sstore_regular_cost() {
+        use tempo_primitives::transaction::{
+            KeyAuthorization, SignatureType, SignedKeyAuthorization,
+        };
+
+        let key_auth = SignedKeyAuthorization {
+            authorization: KeyAuthorization::unrestricted(
+                1,
+                SignatureType::Secp256k1,
+                Address::random(),
+            ),
+            signature: PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()),
+        };
+
+        let gas_params = crate::gas_params::tempo_gas_params(TempoHardfork::T4);
+
+        let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+        let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
+        let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
+        let (gas, state_gas) =
+            calculate_key_authorization_gas(&key_auth, &gas_params, TempoHardfork::T4);
+        let helper_sstore_regular = gas - state_gas - sig_gas - sload - 2_000 - scope_extra_gas;
+
+        assert_eq!(helper_sstore_regular, 20_000);
+        assert_eq!(state_gas, 230_000);
+    }
+
+    #[test]
     fn test_translate_allowed_calls_for_precompile_preserves_empty_nested_allow_all_lists() {
         use tempo_primitives::transaction::{
             CallScope, KeyAuthorization, SelectorRule, SignatureType, SignedKeyAuthorization,
@@ -3143,7 +3171,7 @@ mod tests {
                     // Pre-T1: charges gas_new_nonce_key for new 2D key
                     BASE_INTRINSIC_GAS + spec.gas_new_nonce_key()
                 };
-                let mut evm = make_evm(0, U256::from(42));
+                let mut evm = make_evm(0, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
                     gas.initial_total_gas, expected,
@@ -3153,7 +3181,7 @@ mod tests {
 
             // Case 3: Existing 2D nonce key (nonce_key != 0, nonce > 0)
             {
-                let mut evm = make_evm(5, U256::from(42));
+                let mut evm = make_evm(5, U256::ONE);
                 let gas = handler.validate_initial_tx_gas(&mut evm).unwrap();
                 assert_eq!(
                     gas.initial_total_gas,
@@ -3227,7 +3255,7 @@ mod tests {
                                 value: U256::ZERO,
                                 input: Bytes::new(),
                             }],
-                            nonce_key: U256::from(1), // Non-zero to trigger 2D nonce gas
+                            nonce_key: U256::ONE,
                             ..Default::default()
                         })),
                         ..Default::default()
@@ -5027,7 +5055,7 @@ mod tests {
             tempo_authorization_list: vec![RecoveredTempoAuthorization::new(
                 TempoSignedAuthorization::new_unchecked(
                     alloy_eips::eip7702::Authorization {
-                        chain_id: U256::from(1),
+                        chain_id: U256::ONE,
                         address: Address::random(),
                         nonce: 0,
                     },
@@ -5070,7 +5098,7 @@ mod tests {
                 value: U256::ZERO,
                 input: Bytes::from(vec![1, 2, 3]),
             }],
-            nonce_key: U256::from(1),
+            nonce_key: U256::ONE,
             ..Default::default()
         };
 
@@ -5130,7 +5158,7 @@ mod tests {
             tempo_authorization_list: vec![RecoveredTempoAuthorization::new(
                 TempoSignedAuthorization::new_unchecked(
                     alloy_eips::eip7702::Authorization {
-                        chain_id: U256::from(1),
+                        chain_id: U256::ONE,
                         address: Address::random(),
                         nonce: 0,
                     },
@@ -5293,7 +5321,7 @@ mod tests {
             tempo_authorization_list: vec![RecoveredTempoAuthorization::new(
                 TempoSignedAuthorization::new_unchecked(
                     alloy_eips::eip7702::Authorization {
-                        chain_id: U256::from(1),
+                        chain_id: U256::ONE,
                         address: Address::random(),
                         nonce: 0,
                     },

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -245,10 +245,9 @@ When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed,
 
 **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
 - Charge `GAS_CODE_DEPOSIT * L` (200 regular + 2,300 state per byte) and persist `B` under `H`, then link `codeHash` to `H`
-- Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
 
 **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
-- Do NOT charge `GAS_CODE_DEPOSIT * L` or `HASH_COST(L)`
+- Do NOT charge `GAS_CODE_DEPOSIT * L`
 - No code is stored; no `codeHash` is linked to the account
 - The account remains unchanged or non-existent
 

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -61,12 +61,17 @@ Storage creation operations split their cost between regular gas (computational 
 
 | Operation | Execution Gas | Storage Gas | Total |
 |-----------|---------------|-------------|-------|
-| Cold SSTORE (zero → non-zero) | 20,000 | 230,000 | 250,000 |
+| Cold SSTORE (zero → non-zero) | 22,200 | 230,000 | 252,200 |
 | Hot SSTORE (non-zero → non-zero) | 2,900 | 0 | 2,900 |
 | Account creation (nonce 0 → 1) | 25,000 | 225,000 | 250,000 |
 | Contract code storage (per byte) | 200 | 2,300 | 2,500 |
 | Contract creation (fixed upfront cost) | 32,000 | 468,000 | 500,000 |
 | EIP-7702 delegation (per auth) | 25,000 | 225,000 | 250,000 |
+
+For zero-to-non-zero `SSTORE`, Tempo keeps revm's decomposed Berlin accounting: `GAS_WARM_ACCESS`
+(100) plus `sstore_set_without_load_cost` (20,000), for a 20,100 regular-gas write path.
+When the slot is cold, the existing Berlin cold-slot access charge (`GAS_COLD_SLOAD = 2,100`) is
+retained on top of that write component, for a total of 22,200 regular gas before state gas.
 
 ### EIP-7702 Delegation Pricing
 
@@ -84,11 +89,14 @@ Keychain `authorize_key` is charged as intrinsic gas (T1B+). The SSTORE componen
 |-----------|-------------|-----------|-------|
 | Signature verification | 3,000+ | 0 | ecrecover + P256/WebAuthn if applicable |
 | Existing key check (SLOAD) | 2,100 | 0 | Cold SLOAD |
-| Key slot write (SSTORE) | 20,000 | 230,000 | Cold SSTORE (zero → non-zero) |
-| Per spending limit (SSTORE × N) | 20,000 × N | 230,000 × N | Cold SSTORE per token limit |
+| Key slot write (SSTORE) | 20,000 | 230,000 | Zero-to-non-zero write component only; cold-slot access charged separately |
+| Per spending limit (SSTORE × N) | 20,000 × N | 230,000 × N | Zero-to-non-zero write component only per token limit; cold-slot access charged separately |
 | Buffer (TSTORE, keccak, event) | 2,000 | 0 | Computational overhead |
 
 **Total per authorization:** ~27,100 + 20,000 × N regular gas, 230,000 × (1 + N) state gas.
+
+The table above isolates the write component itself. Any first access to a cold storage slot still
+incurs the standard Berlin cold-access charge separately.
 
 ### Precompile and Intrinsic Storage Operations
 
@@ -337,5 +345,3 @@ This TIP adopts the **reservoir model** from [EIP-8037](https://eips.ethereum.or
 | Quantization | Top-5 significant bits with offset for `cost_per_state_byte` | Not applicable (fixed costs) |
 
 The core EVM mechanism — reservoir model, `GAS` opcode semantics, SSTORE refund/revert behavior, contract deployment flow, and receipt semantics — is shared with EIP-8037, minimizing implementation divergence from upstream. The key divergence is at the block level: TIP-1016 exempts state gas entirely from block limits rather than using EIP-8037's bottleneck model.
-
-


### PR DESCRIPTION
this PR updates the TIP-1016 docs and tests to reflect that Tempo keeps the Berlin cold-slot surcharge on cold zero-to-non-zero `SSTORE`. Additionally, drops `HASH_COST` charge  from the spec.

the precompile tests now build from `tempo_gas_params(T4)` so they exercise the same gas table the runtime uses, and they verify both cold and warm `SSTORE` behavior.

the `0 -> X -> 0` refund test stays ignored because that behavior is still planned but not implemented yet.