### PR TITLE
fix(revm): gate key auth scope surcharge at T4

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -172,7 +172,7 @@ fn call_scope_storage_slots(auth: &tempo_primitives::transaction::KeyAuthorizati
     }
 }
 
-/// Charges the unpriced scope-helper bookkeeping for T3 key authorizations.
+/// Charges the unpriced scope-helper bookkeeping for T4 key authorizations.
 ///
 /// The dynamic SSTORE rows are already counted by `call_scope_storage_slots()`. What remains is the
 /// helper work around them: clearing the empty scope tree for fresh keys, target/set maintenance,
@@ -314,11 +314,14 @@ fn calculate_key_authorization_gas(
 
         // T3+: include scoped-call storage rows in intrinsic gas.
         if spec.is_t3() {
-            total = total
-                .saturating_add(
-                    sstore_cost.saturating_mul(call_scope_storage_slots(&key_auth.authorization)),
-                )
-                .saturating_add(call_scope_extra_gas(&key_auth.authorization));
+            total = total.saturating_add(
+                sstore_cost.saturating_mul(call_scope_storage_slots(&key_auth.authorization)),
+            );
+        }
+
+        // T4+: add the rounded scope-helper surcharge introduced in PR 3595.
+        if spec.is_t4() {
+            total = total.saturating_add(call_scope_extra_gas(&key_auth.authorization));
         }
 
         total
@@ -2849,9 +2852,19 @@ mod tests {
                 &t1b_gas_params,
                 TempoHardfork::T3,
             );
+            let expected = ECRECOVER_GAS + sload + sstore * (1 + 2 * num_limits as u64) + BUFFER;
+            assert_eq!(gas, expected, "T3 with {num_limits} limits");
+        }
+
+        for num_limits in 0..=3 {
+            let gas = calculate_key_authorization_gas(
+                &create_key_auth(num_limits),
+                &t1b_gas_params,
+                TempoHardfork::T4,
+            );
             let expected =
                 ECRECOVER_GAS + sload + sstore * (1 + 2 * num_limits as u64) + BUFFER + 5_000;
-            assert_eq!(gas, expected, "T3 with {num_limits} limits");
+            assert_eq!(gas, expected, "T4 with {num_limits} limits");
         }
 
         let scoped = SignedKeyAuthorization {
@@ -2874,10 +2887,20 @@ mod tests {
         // 1 key write + 12 scope slots:
         // account mode(1) + target insertion rows(3) + selector insertion rows(3)
         // + constrained selector recipient-length(1) + recipients values+positions(2*2).
+        let expected = ECRECOVER_GAS + sload + sstore * (1 + 12) + BUFFER;
+        assert_eq!(gas, expected, "T3 scope writes should charge storage rows");
+
+        let gas = calculate_key_authorization_gas(&scoped, &t1b_gas_params, TempoHardfork::T4);
+        // 1 key write + 12 scope slots:
+        // account mode(1) + target insertion rows(3) + selector insertion rows(3)
+        // + constrained selector recipient-length(1) + recipients values+positions(2*2).
         // The rounded surcharge adds 5k base + 7k per target + 7k per selector + 5k per
         // recipient, which keeps larger scope trees from being materially underpriced.
         let expected = ECRECOVER_GAS + sload + sstore * (1 + 12) + BUFFER + 29_000;
-        assert_eq!(gas, expected, "T3 scope writes should be fully charged");
+        assert_eq!(
+            gas, expected,
+            "T4 scope writes should include the rounded surcharge"
+        );
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -319,7 +319,7 @@ fn calculate_key_authorization_gas(
             );
         }
 
-        // T4+: add the rounded scope-helper surcharge introduced in PR 3595.
+        // T4+: add the rounded scope-helper surcharge.
         if spec.is_t4() {
             total = total.saturating_add(call_scope_extra_gas(&key_auth.authorization));
         }

--- a/tips/tip-1011.md
+++ b/tips/tip-1011.md
@@ -435,7 +435,7 @@ Implementations may also charge a small rounded helper overhead for scoped-key a
 
 This overhead exists because fresh scope persistence includes additional bookkeeping such as clearing the empty scope tree, maintaining per-layer set metadata, and materializing recipient sets.
 
-Tempo's T3 implementation rounds this overhead upward using the same scope cardinalities:
+Tempo's T4 implementation rounds this overhead upward using the same scope cardinalities:
 
 ```text
 extra_scope_gas = 5_000 + 7_000*S + 7_000*K + 5_000*W


### PR DESCRIPTION
Follow-up to #3595.

Keeps the existing T3 scoped-call storage row pricing in place, but moves the rounded helper surcharge introduced in PR 3595 to T4.

The regression test now covers both sides of the split: T3 charges only the storage rows, while T4 adds the rounded helper overhead. TIP-1011 is updated to describe the surcharge as a T4 behavior.