### PR TITLE
fix(account-keychain): gate empty-recipient delete at T4

### DIFF
--- a/crates/precompiles/src/account_keychain/mod.rs
+++ b/crates/precompiles/src/account_keychain/mod.rs
@@ -862,7 +862,16 @@ impl AccountKeychain {
                 .selectors
                 .insert(selector)?;
 
-            if !rule.recipients.is_empty() {
+            if rule.recipients.is_empty() {
+                if !self.storage.spec().is_t4() {
+                    // Keep the pre-T4 empty-set delete to preserve the original storage-touch
+                    // pattern. Removing it earlier changes same-tx call-scope warmness without
+                    // changing persisted state.
+                    self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
+                        .recipients
+                        .delete()?;
+                }
+            } else {
                 // `validate_selector_rules` already rejected duplicates.
                 self.key_scopes[account_key].target_scopes[target].selector_scopes[selector]
                     .recipients
@@ -4202,6 +4211,78 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_empty_recipient_selector_delete_is_gated_at_t4() -> eyre::Result<()> {
+        let account = Address::random();
+        let key_id = Address::random();
+        let target = Address::random();
+
+        let mut t3_sstores = 0;
+        let mut t4_sstores = 0;
+
+        for (hardfork, writes) in [
+            (TempoHardfork::T3, &mut t3_sstores),
+            (TempoHardfork::T4, &mut t4_sstores),
+        ] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, hardfork);
+            StorageCtx::enter(&mut storage, || {
+                let mut keychain = AccountKeychain::new();
+                keychain.initialize()?;
+                keychain.set_transaction_key(Address::ZERO)?;
+                keychain.set_tx_origin(account)?;
+
+                keychain.authorize_key(
+                    account,
+                    authorizeKeyCall {
+                        keyId: key_id,
+                        signatureType: SignatureType::Secp256k1,
+                        config: KeyRestrictions {
+                            expiry: u64::MAX,
+                            enforceLimits: false,
+                            limits: vec![],
+                            allowAnyCalls: true,
+                            allowedCalls: vec![],
+                        },
+                    },
+                )?;
+
+                let before = StorageCtx.counter_sstore();
+                keychain.set_allowed_calls(
+                    account,
+                    setAllowedCallsCall {
+                        keyId: key_id,
+                        scopes: vec![CallScope {
+                            target,
+                            selectorRules: vec![SelectorRule {
+                                selector: TIP20_TRANSFER_SELECTOR.into(),
+                                recipients: vec![],
+                            }],
+                        }],
+                    },
+                )?;
+                *writes = StorageCtx.counter_sstore() - before;
+
+                let scopes = keychain.get_allowed_calls(getAllowedCallsCall {
+                    account,
+                    keyId: key_id,
+                })?;
+                assert!(scopes.isScoped);
+                assert_eq!(scopes.scopes.len(), 1);
+                assert!(scopes.scopes[0].selectorRules[0].recipients.is_empty());
+
+                Ok::<_, eyre::Report>(())
+            })?;
+        }
+
+        assert_eq!(
+            t3_sstores,
+            t4_sstores + 1,
+            "pre-T4 should retain the redundant empty-recipient delete"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -23,6 +23,7 @@ pub struct HashMapStorageProvider {
     spec: TempoHardfork,
     is_static: bool,
     counter_sload: u64,
+    counter_sstore: u64,
     snapshots: Vec<Snapshot>,
 
     /// Emitted events keyed by contract address.
@@ -65,6 +66,7 @@ impl HashMapStorageProvider {
             spec,
             is_static: false,
             counter_sload: 0,
+            counter_sstore: 0,
         }
     }
 
@@ -115,6 +117,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        self.counter_sstore += 1;
         self.internals.insert((address, key), value);
         Ok(())
     }
@@ -277,6 +280,10 @@ impl HashMapStorageProvider {
 
     pub fn counter_sload(&self) -> u64 {
         self.counter_sload
+    }
+
+    pub fn counter_sstore(&self) -> u64 {
+        self.counter_sstore
     }
 
     /// Returns all storage entries as `(address, slot, value)`.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -454,6 +454,11 @@ impl StorageCtx {
         self.as_hashmap().counter_sload()
     }
 
+    /// NOTE: assumes storage tests always use the `HashMapStorageProvider`
+    pub fn counter_sstore(&self) -> u64 {
+        self.as_hashmap().counter_sstore()
+    }
+
     /// Checks if a contract at the given address has bytecode deployed.
     pub fn has_bytecode(&self, address: Address) -> Result<bool> {
         self.with_account_info(address, |info| Ok(!info.is_empty_code_hash()))


### PR DESCRIPTION
The redundant empty-recipient `delete()` in `upsert_target_scope()` was originally introduced in #3577 and currently changes the storage-touch pattern for selector-any-recipient scopes without changing persisted state. That affects same-transaction call-scope warmness, so keeping it active on T3 risks a consensus-relevant gas change relative to the shipped release.

This moves the optimization to T4 instead: T3 keeps the old `delete()` path, and T4+ skips it. A focused unit test asserts that the extra storage write is still present on T3 and disappears at T4.

Tests:
- cargo test -p tempo-precompiles test_empty_recipient_selector_delete_is_gated_at_t4 --lib
- cargo test -p tempo-precompiles test_t3_set_allowed_calls_empty_selector_rules_allow_all_selectors --lib