### PR TITLE
deps: update reth from main (2026-04-23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8236,7 +8236,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8315,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8542,11 +8542,12 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "eyre",
+ "libc",
  "metrics",
  "page_size",
  "parking_lot",
@@ -8570,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8596,7 +8597,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8626,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8641,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8666,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8690,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8714,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8749,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8806,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8834,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8857,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8882,7 +8883,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8940,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8968,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8983,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8999,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9021,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9032,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9060,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9082,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9123,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "clap",
  "eyre",
@@ -9146,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9162,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9178,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9191,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9221,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9235,7 +9236,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9245,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9269,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9289,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9307,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9320,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9339,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9377,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9391,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "serde",
  "serde_json",
@@ -9401,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9429,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "bytes",
  "futures",
@@ -9449,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9466,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "bindgen",
  "cc",
@@ -9475,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "futures",
  "metrics",
@@ -9487,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9496,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9510,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9567,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9592,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9615,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9630,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9644,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9661,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9685,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9753,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9808,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9846,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9870,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9894,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "bytes",
  "eyre",
@@ -9923,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9935,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9971,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9995,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10038,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10084,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10113,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10129,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10144,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10221,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10251,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10294,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10314,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10345,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10391,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10439,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10453,7 +10454,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10484,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10536,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10564,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10578,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10598,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10613,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10637,7 +10638,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10655,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10676,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10692,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10702,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "clap",
  "eyre",
@@ -10721,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "clap",
  "eyre",
@@ -10739,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10784,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10810,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10837,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10857,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10886,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
+source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,21 +121,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
+checksum = "a547705d5c1b42575a0542bae2ba45bc62a6154be86611afaef1c0ab5c38598e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
+checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -188,24 +188,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
+checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c16fa30b623e40a5b216da00f3b61870f5cbe863b59816ac1ecc2489515a40"
+checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -349,7 +349,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -370,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fc4b83cb672156663e6094d098beb509965b7fe684bb3d6e44bb9ca2e9ae714"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -385,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
+checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "borsh",
  "serde",
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
+checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -441,19 +441,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
+checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
+checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
@@ -511,13 +511,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ba5468f78c8893be2d68a7f2fda61753336e5653f006af19781001b5f99e6c"
+checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffcefb5d3391a320eadb95d398e4135f8cc35c7bf29a6bdb357eadcfc5ee5638"
+checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
+checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974df1e56405c27cb8242381f45d8b212ba9df5006046ccf704764a2a4634366"
+checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -638,15 +638,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1d057dcbacf8be8f689a7737e0d697fd40a2dc5b664c9035f182ff016649ea"
+checksum = "670b3a8e0d1b32e9886b7a419b8efe6754ea00b9fdd4c0ea3c7411b6c30431f4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -656,38 +656,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bc10b0dca4f5bfc3cd30ed46eab5d651b5bb2cd300d683bdcdf5d2bfe6e82c"
+checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
+checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8f7fa8ca056bb797a368aeed329e6ace6b62ee4271432ac36ab8ae87a5e60d"
+checksum = "caf5d68ddca890854fb78291cbde06115473ded00b2337d0f815e92c0c1f8003"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301249e3c9e43661cfd7ebbb4746a00af6ce1ef58b5c968451882cd60438417d"
+checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -716,15 +716,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59bc947935732cae5b072753e5e034c0b70a8b031c2839f45e2659ba07df9ae"
+checksum = "5f05338cfb4ee5508ff76f01c88142cab8a4579db74b7d9432936c26e4f11374"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -736,17 +736,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
+checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -758,28 +758,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286c40ce0d715217a5bfa9fb452779b11e6769e56680afa0de691ae8f3a848ac"
+checksum = "0df223478aec91d8fb0f8643234764042fa432e6111aca126774802b2618a3a5"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede0458c51bef23620aa6bd01a0b4f608be7bcb61d98e91b8530208ae545f3c2"
+checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -787,13 +787,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f4df183248b57f3e0b99054b1b6786769d3fdff6d01a702234068140c8ba76"
+checksum = "f7fbf71892d4df9cae8d35dc96f15d522384bb93806205465e2c8c012b7f0a34"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "serde",
 ]
 
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
+checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a57d1e72b1f9b11e5e71ebdab0569cb02277a462bbea6793fcaebfcd794ae9"
+checksum = "a19d1985804e9a46d3b1b4f0654a68210b44007ffdaddd0e0a35d2b8db6cc1f0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b27f20b5298b76a5a3b7cdbe6bdb184ab1ebd6e120e00dad748867673f5c90"
+checksum = "34ce972f2ade53477e8e9336773a417f731fc7c02f41b9cd3b8a2a273e06363e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c7acc40ffbfd37d4113eb619863099f3235d78d044006a1eecb94d8b0b2f1a"
+checksum = "943c0105e0294b34cd06417129fadc591aed464d06f0614a7e998e585d27fbb1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
+checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a09a865ae9e1f05478429ef0d935b16467f35c6e0b02cb10f23f66a3b33fc3"
+checksum = "efe910cd3f56f7e4b26b8b7330b11c11c81286eaa8aa9fa6157e767a95e0f310"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
+checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
+checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b27802653330740c88c28394cdaf1d55190b15b48ef9b99a946f37c9cdb19fa"
+checksum = "cfad7aa9206fcb831ae401b6a1c893a402b8eed74f9c8ffbb7a7323afb0d9a4c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b71dc951db66795cfb52eef835f64cf15163bc93b656e061b457ce5ebff370"
+checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
+checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1204,6 +1204,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
@@ -2132,6 +2138,12 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -3704,7 +3716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5347,6 +5359,31 @@ checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -8198,11 +8235,11 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8225,11 +8262,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8257,12 +8294,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8277,8 +8314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8290,12 +8327,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8373,8 +8410,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8383,10 +8420,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8409,7 +8446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8436,8 +8473,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8452,8 +8489,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8465,11 +8502,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8478,11 +8515,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8504,8 +8541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8532,8 +8569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8558,8 +8595,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8588,10 +8625,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8603,8 +8640,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8628,8 +8665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8652,8 +8689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8676,11 +8713,11 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8711,11 +8748,11 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8768,8 +8805,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8796,8 +8833,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8819,11 +8856,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8844,12 +8881,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8902,8 +8939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8930,11 +8967,11 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8945,8 +8982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8961,8 +8998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8983,8 +9020,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8994,8 +9031,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9022,13 +9059,13 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9044,8 +9081,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9085,8 +9122,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -9108,11 +9145,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9124,10 +9161,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9140,8 +9177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9153,11 +9190,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9183,11 +9220,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9197,8 +9234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9207,11 +9244,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9231,11 +9268,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9251,8 +9288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9269,8 +9306,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9282,11 +9319,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9301,11 +9338,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9339,10 +9376,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9353,8 +9390,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9363,8 +9400,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9391,8 +9428,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bytes",
  "futures",
@@ -9411,8 +9448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9428,8 +9465,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9437,8 +9474,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "futures",
  "metrics",
@@ -9449,8 +9486,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9458,8 +9495,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9472,11 +9509,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9529,8 +9566,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9554,11 +9591,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9577,8 +9614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9592,8 +9629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9606,8 +9643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9623,8 +9660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9647,11 +9684,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9715,11 +9752,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9770,10 +9807,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9808,8 +9845,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9832,11 +9869,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9856,8 +9893,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "bytes",
  "eyre",
@@ -9885,8 +9922,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9897,8 +9934,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9921,8 +9958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9933,11 +9970,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9957,8 +9994,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9972,7 +10009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10000,11 +10037,11 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10046,11 +10083,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10075,8 +10112,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10091,8 +10128,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10106,12 +10143,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10127,7 +10164,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10183,10 +10220,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10200,7 +10237,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10213,8 +10250,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10256,8 +10293,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10276,10 +10313,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10307,13 +10344,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10321,7 +10358,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10353,11 +10390,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -10401,8 +10438,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10415,10 +10452,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10446,11 +10483,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10498,10 +10535,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10526,8 +10563,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10540,8 +10577,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10560,8 +10597,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10575,11 +10612,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10599,10 +10636,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10617,8 +10654,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10638,11 +10675,11 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10654,8 +10691,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10664,8 +10701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -10683,8 +10720,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "clap",
  "eyre",
@@ -10701,17 +10738,18 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
  "bitflags 2.11.1",
  "futures-util",
+ "imbl",
  "metrics",
  "parking_lot",
  "paste",
@@ -10745,11 +10783,11 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10771,14 +10809,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -10798,8 +10836,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10818,8 +10856,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10847,13 +10885,12 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=98ebc34#98ebc3454f339bdaf8901a24a0be4c4ba539e77a"
+version = "2.1.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=122c5b3#122c5b322bf8549aba1b17cacb01fddee22d206d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "auto_impl",
  "metrics",
  "rayon",
  "reth-execution-errors",
@@ -11469,6 +11506,15 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "salsa20"
@@ -12350,12 +12396,12 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12412,7 +12458,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.3"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12657,14 +12703,14 @@ name = "tempo-node"
 version = "1.6.0"
 dependencies = [
  "alloy",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -12758,7 +12804,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.6.0"
 dependencies = [
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -12818,12 +12864,12 @@ name = "tempo-primitives"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.0",
+ "alloy-serde 2.0.1",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12856,7 +12902,7 @@ name = "tempo-revm"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12924,7 +12970,7 @@ name = "tempo-transaction-pool"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.0",
+ "alloy-eips 2.0.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",
@@ -14218,6 +14264,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8236,7 +8236,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8263,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8315,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8542,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8571,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8597,7 +8597,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8715,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8858,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8883,7 +8883,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8984,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9033,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "clap",
  "eyre",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9236,7 +9236,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9246,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9290,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9340,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "serde",
  "serde_json",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "bytes",
  "futures",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "bindgen",
  "cc",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "futures",
  "metrics",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9568,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9662,7 +9662,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9686,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9754,7 +9754,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9809,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "bytes",
  "eyre",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9936,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9960,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9972,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10039,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10114,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10222,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10295,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10392,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10440,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10454,7 +10454,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10485,7 +10485,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10537,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10579,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10599,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10614,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10638,7 +10638,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "clap",
  "eyre",
@@ -10722,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "clap",
  "eyre",
@@ -10740,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10811,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10838,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10858,7 +10858,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fe7a4c8#fe7a4c80b602ab834ca362677275784225c70fca"
+source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "98ebc34", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,34 +178,34 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", feat
 ] }
 revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
-alloy = { version = "2.0.0", default-features = false }
-alloy-consensus = { version = "2.0.0", default-features = false }
-alloy-contract = { version = "2.0.0", default-features = false }
-alloy-eips = { version = "2.0.0", default-features = false }
-alloy-evm = { version = "0.33.2", default-features = false }
+alloy = { version = "2.0.1", default-features = false }
+alloy-consensus = { version = "2.0.1", default-features = false }
+alloy-contract = { version = "2.0.1", default-features = false }
+alloy-eips = { version = "2.0.1", default-features = false }
+alloy-evm = { version = "0.33.0", default-features = false }
 revm-inspectors = "0.39.0"
-alloy-genesis = { version = "2.0.0", default-features = false }
+alloy-genesis = { version = "2.0.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.5.7", default-features = false }
-alloy-network = { version = "2.0.0", default-features = false }
+alloy-network = { version = "2.0.1", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "2.0.0", default-features = false }
+alloy-provider = { version = "2.0.1", default-features = false }
 alloy-rlp = { version = "0.3.15", default-features = false }
-alloy-rpc-types-admin = "2.0.0"
-alloy-rpc-types-engine = "2.0.0"
-alloy-rpc-types-eth = { version = "2.0.0" }
-alloy-serde = { version = "2.0.0", default-features = false }
-alloy-signer = "2.0.0"
-alloy-signer-aws = "2.0.0"
-alloy-signer-gcp = "2.0.0"
-alloy-signer-ledger = "2.0.0"
-alloy-signer-local = "2.0.0"
-alloy-signer-trezor = "2.0.0"
+alloy-rpc-types-admin = "2.0.1"
+alloy-rpc-types-engine = "2.0.1"
+alloy-rpc-types-eth = { version = "2.0.1" }
+alloy-serde = { version = "2.0.1", default-features = false }
+alloy-signer = "2.0.1"
+alloy-signer-aws = "2.0.1"
+alloy-signer-gcp = "2.0.1"
+alloy-signer-ledger = "2.0.1"
+alloy-signer-local = "2.0.1"
+alloy-signer-trezor = "2.0.1"
 
 coins-bip32 = "0.12"
 zeroize = "1"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "2.0.0"
+alloy-transport = "2.0.1"
 
 commonware-broadcast = "2026.4.0"
 commonware-codec = "2026.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,59 +120,59 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
 reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "122c5b3", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fe7a4c8", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -186,9 +186,7 @@ impl Consensus<Block> for TempoConsensus {
         // Validate that the sequence of end-of-block system txs is correct
         for (tx, expected_to) in end_of_block_system_txs.into_iter().zip(SYSTEM_TX_ADDRESSES) {
             if tx.to().unwrap_or_default() != expected_to {
-                return Err(ConsensusError::msg(
-                    "Invalid end-of-block system tx order",
-                ));
+                return Err(ConsensusError::msg("Invalid end-of-block system tx order"));
             }
         }
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -63,8 +63,8 @@ impl TempoConsensus {
 
         // Validate the timestamp milliseconds part
         if header.timestamp_millis_part >= 1000 {
-            return Err(ConsensusError::Other(
-                "Timestamp milliseconds part must be less than 1000".to_string(),
+            return Err(ConsensusError::msg(
+                "Timestamp milliseconds part must be less than 1000",
             ));
         }
 
@@ -76,8 +76,8 @@ impl TempoConsensus {
         }
 
         if header.shared_gas_limit != header.gas_limit() / TEMPO_SHARED_GAS_DIVISOR {
-            return Err(ConsensusError::Other(
-                "Shared gas limit does not match header gas limit".to_string(),
+            return Err(ConsensusError::msg(
+                "Shared gas limit does not match header gas limit",
             ));
         }
 
@@ -89,7 +89,7 @@ impl TempoConsensus {
         );
 
         if header.general_gas_limit != expected_general_gas_limit {
-            return Err(ConsensusError::Other(format!(
+            return Err(ConsensusError::msg(format!(
                 "General gas limit {} does not match expected {}",
                 header.general_gas_limit, expected_general_gas_limit
             )));
@@ -160,7 +160,7 @@ impl Consensus<Block> for TempoConsensus {
         if let Some(tx) = transactions.iter().find(|&tx| {
             tx.is_system_tx() && !tx.is_valid_system_tx(self.inner.chain_spec().chain().id())
         }) {
-            return Err(ConsensusError::Other(format!(
+            return Err(ConsensusError::msg(format!(
                 "Invalid system transaction: {}",
                 tx.tx_hash()
             )));
@@ -178,16 +178,16 @@ impl Consensus<Block> for TempoConsensus {
             .unwrap_or_default();
 
         if end_of_block_system_txs.len() != SYSTEM_TX_COUNT {
-            return Err(ConsensusError::Other(
-                "Block must contain end-of-block system txs".to_string(),
+            return Err(ConsensusError::msg(
+                "Block must contain end-of-block system txs",
             ));
         }
 
         // Validate that the sequence of end-of-block system txs is correct
         for (tx, expected_to) in end_of_block_system_txs.into_iter().zip(SYSTEM_TX_ADDRESSES) {
             if tx.to().unwrap_or_default() != expected_to {
-                return Err(ConsensusError::Other(
-                    "Invalid end-of-block system tx order".to_string(),
+                return Err(ConsensusError::msg(
+                    "Invalid end-of-block system tx order",
                 ));
             }
         }

--- a/deny.toml
+++ b/deny.toml
@@ -65,7 +65,12 @@ allow = [
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [{ allow = ["MPL-2.0"], name = "option-ext" }]
+exceptions = [
+  { allow = ["MPL-2.0"], name = "option-ext" },
+  { allow = ["MPL-2.0"], name = "bitmaps" },
+  { allow = ["MPL-2.0"], name = "imbl" },
+  { allow = ["MPL-2.0"], name = "imbl-sized-chunks" },
+]
 
 [[licenses.clarify]]
 name = "rustls-webpki"


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`98ebc34...7839f3d`](https://github.com/paradigmxyz/reth/compare/98ebc34...7839f3d)

🔗 Amp thread: https://ampcode.com/threads/T-019db884-a7c3-738b-8f38-cc04f8942d8a
**Engine**
- Suppress persistence during payload building ([#23618](https://github.com/paradigmxyz/reth/pull/23618))
- Align Amsterdam endpoint validation ([#23625](https://github.com/paradigmxyz/reth/pull/23625))
- Revert [#23541](https://github.com/paradigmxyz/reth/pull/23541) and [#23578](https://github.com/paradigmxyz/reth/pull/23578) ([#23646](https://github.com/paradigmxyz/reth/pull/23646))
- Let consensus impls control which errors are transient ([#23668](https://github.com/paradigmxyz/reth/pull/23668))
- Configure invalid header cache hit eviction ([#23670](https://github.com/paradigmxyz/reth/pull/23670))

**Perf**
- Relax executor reset thresholds for re-execute ([#23617](https://github.com/paradigmxyz/reth/pull/23617))
- Replace `BTreeMap` with `imbl::OrdMap` in `BestTransactions` ([#23621](https://github.com/paradigmxyz/reth/pull/23621))
- Avoid reopening `.csoff` on every changeset lookup ([#23687](https://github.com/paradigmxyz/reth/pull/23687))
- Disable read tx timeout during re-execute ([#23680](https://github.com/paradigmxyz/reth/pull/23680))

**P2P / Net**
- Add snap/2 wire helpers and messages ([#23611](https://github.com/paradigmxyz/reth/pull/23611))
- Optionally fetch BAL with full blocks ([#23629](https://github.com/paradigmxyz/reth/pull/23629))
- Discv5 enabled by default ([#23686](https://github.com/paradigmxyz/reth/pull/23686))

**DB**
- Add `reth db migrate-v2` for v1→v2 storage migration ([#23422](https://github.com/paradigmxyz/reth/pull/23422))
- Detect and warn about ZFS ([#23685](https://github.com/paradigmxyz/reth/pull/23685))

**BAL**
- Scaffold BAL store abstraction ([#23596](https://github.com/paradigmxyz/reth/pull/23596))
- Enable BAL building in ethereum payload ([#23597](https://github.com/paradigmxyz/reth/pull/23597))
- Add parallelization and batch IO flags ([#23663](https://github.com/paradigmxyz/reth/pull/23663))

**Refactor**
- Make `WorkerPool` lazy by default ([#23627](https://github.com/paradigmxyz/reth/pull/23627))
- Encapsulate state fetching in db provider ([#23656](https://github.com/paradigmxyz/reth/pull/23656))
- Remove `TrieNodeProvider` ([#23658](https://github.com/paradigmxyz/reth/pull/23658))
- Unify opaque consensus error helpers ([#23669](https://github.com/paradigmxyz/reth/pull/23669))

**Payload**
- Add gas limit and slot number to `BlockOrPayload` ([#23624](https://github.com/paradigmxyz/reth/pull/23624), [#23626](https://github.com/paradigmxyz/reth/pull/23626))

**Bench**
- Add CLI flag to fetch balances by default; require local benchmark data ([#23655](https://github.com/paradigmxyz/reth/pull/23655), [#23679](https://github.com/paradigmxyz/reth/pull/23679))

**Deps**
- Bump alloy crates to 2.0.1 ([#23677](https://github.com/paradigmxyz/reth/pull/23677)), rustls-webpki ([#23681](https://github.com/paradigmxyz/reth/pull/23681)), weekly `cargo update` ([#23628](https://github.com/paradigmxyz/reth/pull/23628))

**Testing**
- Remove unsafe `env::set_var(RUST_LOG)` from tests ([#23672](https://github.com/paradigmxyz/reth/pull/23672))
- Address nightly clippy warnings ([#23630](https://github.com/paradigmxyz/reth/pull/23630))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019db884-dc46-71f5-a823-00c3a16191d4
- **Reth dependency bump**: All `reth-*` git dependencies updated from rev `98ebc34` to `7839f3d`
- **Alloy version bump**: `alloy-*` crates updated from `2.0.0` to `2.0.1`; `alloy-evm` changed from `0.33.2` to `0.33.0`
- **`ConsensusError::Other` → `ConsensusError::msg`**: All `ConsensusError::Other(...)` calls migrated to `ConsensusError::msg(...)`, which accepts `&str`/`impl Display` directly instead of requiring `String` (removes `.to_string()` calls for string literals)
- **`deny.toml` license exceptions**: Added MPL-2.0 exceptions for `bitmaps`, `imbl`, and `imbl-sized-chunks` (new transitive dependencies)

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/24816009191)
