### PR TITLE
fix(fast_sync_after_full_dkg): race between epoch_manager hints and gap repair

### DIFF
--- a/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
+++ b/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
@@ -29,7 +29,7 @@ fn validator_can_fast_sync_after_full_dkg() {
     let _ = tempo_eyre::install();
 
     let how_many_signers = 4;
-    let epoch_length = 40;
+    let epoch_length = 30;
     let full_dkg_epoch = 1;
     let blocks_before_late_join = 3 * epoch_length + 1;
 

--- a/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
+++ b/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
@@ -29,7 +29,7 @@ fn validator_can_fast_sync_after_full_dkg() {
     let _ = tempo_eyre::install();
 
     let how_many_signers = 4;
-    let epoch_length = 20;
+    let epoch_length = 40;
     let full_dkg_epoch = 1;
     let blocks_before_late_join = 3 * epoch_length + 1;
 

--- a/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
+++ b/crates/e2e/src/tests/dkg/fast_sync_after_full_dkg.rs
@@ -29,7 +29,11 @@ fn validator_can_fast_sync_after_full_dkg() {
     let _ = tempo_eyre::install();
 
     let how_many_signers = 4;
+
+    // MAX_REPAIR (concurrency) by default is 20, so we increase the epoch length such
+    // that the gap repair takes a long enough time that the DKG simply skips it
     let epoch_length = 30;
+
     let full_dkg_epoch = 1;
     let blocks_before_late_join = 3 * epoch_length + 1;
 


### PR DESCRIPTION
When the epoch manager hints, the gap repair might finish before the next hint comes in. Thus the late validator never ends up skipping a round

Marshal's `MAX_REPAIR=20` on the consensus engine makes this race very likely ~40%. Since the epoch length matches, it can gap repair this in one go. By increasing the epoch length, it requires two round trips and the second hint should thus process causing a skip of epoch 0.