### PR TITLE
ci(bench): feature parity with Reth's bench.yml

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -255,6 +255,128 @@ function buildFailureBlocks({ prNumber, actor, actorSlackId, jobUrl, repo, faile
   ];
 }
 
+// ==================== Replay summary support ====================
+
+function isReplaySummary(summary) {
+  return summary.paired != null && summary.changes != null;
+}
+
+function replayHasSignificantChange(changes) {
+  return Object.values(changes).some(c => c.sig !== 'neutral');
+}
+
+function replayVerdict(changes) {
+  const hasBad = Object.values(changes).some(c => c.sig === 'bad');
+  const hasGood = Object.values(changes).some(c => c.sig === 'good');
+  if (hasBad && hasGood) return { emoji: ':warning:', label: 'Mixed Results' };
+  if (hasBad) return { emoji: ':x:', label: 'Regression' };
+  if (hasGood) return { emoji: ':white_check_mark:', label: 'Improvement' };
+  return { emoji: ':white_circle:', label: 'No Significant Change' };
+}
+
+function replayFmtChange(change, inverse = false) {
+  if (!change) return '';
+  const pct = change.pct;
+  const sig = change.sig;
+  const sign = pct >= 0 ? '+' : '';
+  const emoji = sig === 'neutral' ? '⚪' : sig === 'good' ? '✅' : '❌';
+  return `${sign}${pct.toFixed(2)}% ${emoji}`;
+}
+
+function buildReplayMetricRows(summary) {
+  const b = summary.baseline.stats;
+  const f = summary.feature.stats;
+  const c = summary.changes;
+  return [
+    { label: 'newPayload P50', baseline: fmtMs(b.p50_ms), feature: fmtMs(f.p50_ms), change: replayFmtChange(c.p50) },
+    { label: 'newPayload P90', baseline: fmtMs(b.p90_ms), feature: fmtMs(f.p90_ms), change: replayFmtChange(c.p90) },
+    { label: 'newPayload P99', baseline: fmtMs(b.p99_ms), feature: fmtMs(f.p99_ms), change: replayFmtChange(c.p99) },
+    { label: 'Mgas/s', baseline: fmtVal(b.mean_mgas_s, '', 2), feature: fmtVal(f.mean_mgas_s, '', 2), change: replayFmtChange(c.mgas_s) },
+    { label: 'Wall Clock', baseline: fmtVal(b.wall_clock_s, 's', 2), feature: fmtVal(f.wall_clock_s, 's', 2), change: replayFmtChange(c.wall_clock) },
+    { label: 'Persist Wait', baseline: fmtMs(b.mean_persist_ms), feature: fmtMs(f.mean_persist_ms), change: replayFmtChange(c.persist_wait) },
+  ];
+}
+
+function buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo }) {
+  const { emoji, label } = replayVerdict(summary.changes);
+
+  const prUrl = prNumber ? `https://github.com/${repo}/pull/${prNumber}` : '';
+  const commitUrl = `https://github.com/${repo}/commit`;
+  const baselineName = summary.baseline.name || process.env.BENCH_BASELINE_NAME || 'baseline';
+  const featureName = summary.feature.name || process.env.BENCH_FEATURE_NAME || 'feature';
+  const baselineLink = refLink(commitUrl, summary.baseline.ref, baselineName, 'baseline');
+  const featureLink = refLink(commitUrl, summary.feature.ref, featureName, 'feature');
+
+  const metaParts = [];
+  if (prNumber) metaParts.push(`*<${prUrl}|PR #${prNumber}>*`);
+  metaParts.push(`triggered by ${actorSlackId ? `<@${actorSlackId}>` : `@${actor}`}`);
+
+  const chain = process.env.BENCH_CHAIN || 'mainnet';
+  const blocks = summary.blocks || process.env.BENCH_BLOCKS || '-';
+  const warmup = process.env.BENCH_WARMUP_BLOCKS || '-';
+
+  const sectionText = [
+    metaParts.join(' | '),
+    '',
+    `*Baseline:* ${baselineLink}`,
+    `*Feature:* ${featureLink}`,
+    '',
+    `*Mode:* \`replay\` | *Chain:* \`${chain}\``,
+    `*Blocks:* \`${blocks}\` | *Warmup:* \`${warmup}\``,
+  ].join('\n');
+
+  const rows = buildReplayMetricRows(summary);
+  const tableRows = [
+    [cell('Metric'), cell('Baseline'), cell('Feature'), cell('Change')],
+    ...rows.map(r => [cell(r.label), cell(r.baseline), cell(r.feature), cell(r.change || ' ')]),
+  ];
+
+  const buttons = [
+    {
+      type: 'button',
+      text: { type: 'plain_text', text: 'CI :github:', emoji: true },
+      url: jobUrl,
+      action_id: 'ci_button',
+    },
+  ];
+  if (prNumber) {
+    const diffUrl = `https://github.com/${repo}/pull/${prNumber}/files`;
+    buttons.push({
+      type: 'button',
+      text: { type: 'plain_text', text: 'Diff :github:', emoji: true },
+      url: diffUrl,
+      action_id: 'diff_button',
+    });
+  }
+
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${emoji} Tempo Replay Bench ${label}`, emoji: true },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: sectionText },
+    },
+    {
+      type: 'table',
+      column_settings: [
+        { align: 'left' },
+        { align: 'right' },
+        { align: 'right' },
+        { align: 'right' },
+      ],
+      rows: tableRows,
+    },
+    {
+      type: 'actions',
+      elements: buttons,
+    },
+  ];
+}
+
+// ================================================================
+
 async function success({ core, context }) {
   const token = process.env.SLACK_BENCH_BOT_TOKEN;
   if (!token) {
@@ -279,15 +401,20 @@ async function success({ core, context }) {
   const slackUsers = loadSlackUsers(process.env.GITHUB_WORKSPACE || '.');
   const actorSlackId = slackUsers[actor];
 
-  const blocks = buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo });
-  const text = `Tempo bench: baseline vs feature`;
+  const isReplay = isReplaySummary(summary);
+  const blocks = isReplay
+    ? buildReplaySuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo })
+    : buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo });
+  const text = isReplay ? `Tempo replay bench: baseline vs feature` : `Tempo bench: baseline vs feature`;
 
-  const deltas = summary.results.deltas;
+  const hasSignificant = isReplay
+    ? replayHasSignificantChange(summary.changes)
+    : hasSignificantChange(summary.results.deltas);
   const channel = process.env.SLACK_BENCH_CHANNEL;
   let postedToChannel = false;
 
   // Post to public channel if any metric shows significant change
-  if (channel && hasSignificantChange(deltas)) {
+  if (channel && hasSignificant) {
     await postToSlack(token, channel, blocks, text, core);
     postedToChannel = true;
   } else if (channel) {

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -13,6 +13,8 @@
 #   BENCH_BASELINE_ARGS           – extra node args for baseline (optional)
 #   BENCH_FEATURE_ARGS            – extra node args for feature (optional)
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
+#   BENCH_CORES                   – limit node to N CPU cores, 0=all (optional)
+#   BENCH_ABBA                    – "true" for B-F-F-B, "false" for single A/B (optional)
 set -euxo pipefail
 
 SCHELK_MOUNT="/reth-bench"
@@ -47,6 +49,30 @@ echo "Chain: $CHAIN_NAME (id=$CHAIN_ID, rpc=$REPLAY_RPC_URL)"
 MC="mc"
 BLOCKS="${BENCH_BLOCKS:-5000}"
 WARMUP="${BENCH_WARMUP_BLOCKS:-1000}"
+
+# ============================================================================
+# CPU pinning: reserve core 0 for OS/IRQs, give remaining cores to the node
+# ============================================================================
+
+compute_allowed_cpus() {
+  local max_cores="${BENCH_CORES:-0}"
+  local online_cpus
+  online_cpus=$(nproc --all)
+  local max_worker=$(( online_cpus - 1 ))
+
+  if [ "$max_cores" -gt 0 ] 2>/dev/null && [ "$max_cores" -lt "$max_worker" ]; then
+    max_worker=$max_cores
+  fi
+
+  if [ "$max_worker" -le 0 ]; then
+    echo "0"
+  else
+    echo "1-${max_worker}"
+  fi
+}
+
+ALLOWED_CPUS=$(compute_allowed_cpus)
+echo "CPU pinning: node AllowedCPUs=$ALLOWED_CPUS (BENCH_CORES=${BENCH_CORES:-0}, online=$(nproc --all))"
 
 mkdir -p "$BENCH_WORK_DIR"
 
@@ -214,7 +240,7 @@ run_single() {
     local samply_bin
     samply_bin="$(which samply)"
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
-      -p MemoryMax="$mem_limit" \
+      -p MemoryMax="$mem_limit" -p AllowedCPUs="$ALLOWED_CPUS" \
       nice -n -20 \
       "$samply_bin" record --save-only --presymbolicate --rate 10000 \
       --output "$output_dir/samply-profile.json.gz" \
@@ -222,7 +248,7 @@ run_single() {
       > "$log" 2>&1 &
   else
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
-      -p MemoryMax="$mem_limit" \
+      -p MemoryMax="$mem_limit" -p AllowedCPUs="$ALLOWED_CPUS" \
       nice -n -20 "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   fi
@@ -292,7 +318,9 @@ run_single() {
 
 run_single baseline-1 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-1"
 run_single feature-1  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-1"
-run_single feature-2  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-2"
-run_single baseline-2 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-2"
+if [ "${BENCH_ABBA:-true}" != "false" ]; then
+  run_single feature-2  "$FEATURE_BIN"  "$BENCH_WORK_DIR/feature-2"
+  run_single baseline-2 "$BASELINE_BIN" "$BENCH_WORK_DIR/baseline-2"
+fi
 
 echo "All replay benchmark runs complete."

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -43,6 +43,14 @@ on:
         description: "Extra node args for feature"
         type: string
         default: ""
+      cores:
+        description: "Limit node to N CPU cores (0=all)"
+        type: string
+        default: "0"
+      abba:
+        description: "Run B-F-F-B interleaved (true) or single A/B (false)"
+        type: string
+        default: "true"
   workflow_call:
     inputs:
       chain:
@@ -82,6 +90,18 @@ on:
       warmup:
         type: string
         required: true
+      cores:
+        type: string
+        required: false
+        default: "0"
+      abba:
+        type: string
+        required: false
+        default: "true"
+      no-slack:
+        type: string
+        required: false
+        default: "false"
       comment-id:
         type: string
         required: false
@@ -89,6 +109,10 @@ on:
       DEREK_PAT:
         required: false
       DEREK_TOKEN:
+        required: false
+      SLACK_BENCH_BOT_TOKEN:
+        required: false
+      SLACK_BENCH_CHANNEL:
         required: false
 
 env:
@@ -113,8 +137,13 @@ jobs:
       BENCH_FEATURE_ARGS: "--dev.block-time 999999s ${{ inputs.feature-args }}"
       BENCH_BLOCKS: ${{ inputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ inputs.warmup }}
+      BENCH_CORES: ${{ inputs.cores || '0' }}
+      BENCH_ABBA: ${{ inputs.abba || 'true' }}
+      BENCH_NO_SLACK: ${{ inputs.no-slack || 'false' }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_WORK_DIR: bench-results/replay
+      SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+      SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
     steps:
       - name: Resolve checkout ref
         id: checkout-ref
@@ -201,7 +230,11 @@ jobs:
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const chain = process.env.BENCH_CHAIN || 'mainnet';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}`);
+            const cores = process.env.BENCH_CORES || '0';
+            const coresNote = cores !== '0' ? `, cores: \`${cores}\`` : '';
+            const abba = process.env.BENCH_ABBA || 'true';
+            const abbaNote = abba === 'false' ? ', abba: `off`' : '';
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${coresNote}${abbaNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -284,6 +317,56 @@ jobs:
             core.setOutput('feature-ref', featureRef);
             core.setOutput('feature-name', featureName);
 
+      - name: System setup
+        run: |
+          echo passive | sudo tee /sys/devices/system/cpu/amd_pstate/status 2>/dev/null || true
+          sudo cpupower frequency-set -g performance || true
+          NOMINAL_KHZ=""
+          if [ -f /sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq ]; then
+            NOMINAL_MHZ=$(cat /sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq)
+            NOMINAL_KHZ=$((NOMINAL_MHZ * 1000))
+          elif [ -f /sys/devices/system/cpu/cpu0/cpufreq/base_frequency ]; then
+            NOMINAL_KHZ=$(cat /sys/devices/system/cpu/cpu0/cpufreq/base_frequency)
+          fi
+          if [ -n "$NOMINAL_KHZ" ] && [ "$NOMINAL_KHZ" -gt 0 ] 2>/dev/null; then
+            echo "Pinning all cores to nominal frequency: $((NOMINAL_KHZ / 1000)) MHz"
+            for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_max_freq; do
+              echo "$NOMINAL_KHZ" | sudo tee "$f" > /dev/null
+            done
+            for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_min_freq; do
+              echo "$NOMINAL_KHZ" | sudo tee "$f" > /dev/null
+            done
+          fi
+          sudo swapoff -a || true
+          echo 0 | sudo tee /proc/sys/kernel/randomize_va_space || true
+          for cpu in /sys/devices/system/cpu/cpu*/topology/thread_siblings_list; do
+            first=$(cut -d, -f1 < "$cpu" | cut -d- -f1)
+            current=$(echo "$cpu" | grep -o 'cpu[0-9]*' | grep -o '[0-9]*')
+            if [ "$current" != "$first" ]; then
+              echo 0 | sudo tee "/sys/devices/system/cpu/cpu${current}/online" || true
+            fi
+          done
+          echo "Online CPUs: $(nproc)"
+          for p in /sys/kernel/mm/transparent_hugepage /sys/kernel/mm/transparent_hugepages; do
+            [ -d "$p" ] && echo never | sudo tee "$p/enabled" && echo never | sudo tee "$p/defrag" && break
+          done || true
+          sudo pkill -f '^bench-cpu-dma-latency' 2>/dev/null || true
+          sudo bash -c 'exec 3<>/dev/cpu_dma_latency; printf "\0\0\0\0" >&3; exec -a bench-cpu-dma-latency sleep infinity' &
+          echo "BENCH_CPU_DMA_LATENCY_PID=$!" >> "$GITHUB_ENV"
+          for irq in /proc/irq/*/smp_affinity_list; do
+            echo 0 | sudo tee "$irq" 2>/dev/null || true
+          done
+          sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          echo "=== Benchmark environment ==="
+          uname -r
+          lscpu | grep -E 'Model name|CPU\(s\)|MHz|NUMA'
+          cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+          cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq
+          echo "scaling_min_freq: $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq)"
+          echo "scaling_max_freq: $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq)"
+          cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || cat /sys/kernel/mm/transparent_hugepages/enabled 2>/dev/null || echo "THP: unknown"
+          free -h
+
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
@@ -317,8 +400,12 @@ jobs:
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-name ${BASELINE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-name ${FEATURE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-ref ${FEATURE_REF}"
-          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json $BENCH_WORK_DIR/baseline-2/report.json"
-          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json $BENCH_WORK_DIR/feature-2/report.json"
+          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json"
+          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json"
+          if [ "${BENCH_ABBA}" != "false" ]; then
+            BASELINE_JSONS="$BASELINE_JSONS $BENCH_WORK_DIR/baseline-2/report.json"
+            FEATURE_JSONS="$FEATURE_JSONS $BENCH_WORK_DIR/feature-2/report.json"
+          fi
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-json $BASELINE_JSONS"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-json $FEATURE_JSONS"
           # shellcheck disable=SC2086
@@ -331,8 +418,12 @@ jobs:
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         run: |
           CHART_ARGS="--output-dir $BENCH_WORK_DIR/charts"
-          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json $BENCH_WORK_DIR/feature-2/report.json"
-          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json $BENCH_WORK_DIR/baseline-2/report.json"
+          FEATURE_JSONS="$BENCH_WORK_DIR/feature-1/report.json"
+          BASELINE_JSONS="$BENCH_WORK_DIR/baseline-1/report.json"
+          if [ "${BENCH_ABBA}" != "false" ]; then
+            FEATURE_JSONS="$FEATURE_JSONS $BENCH_WORK_DIR/feature-2/report.json"
+            BASELINE_JSONS="$BASELINE_JSONS $BENCH_WORK_DIR/baseline-2/report.json"
+          fi
           CHART_ARGS="$CHART_ARGS --feature $FEATURE_JSONS"
           CHART_ARGS="$CHART_ARGS --baseline $BASELINE_JSONS"
           CHART_ARGS="$CHART_ARGS --baseline-name ${BASELINE_NAME}"
@@ -346,6 +437,25 @@ jobs:
         with:
           name: tempo-bench-replay-results
           path: bench-results/
+
+      - name: Upload samply profiles
+        if: success() && env.BENCH_SAMPLY == 'true'
+        run: |
+          RUNS="baseline-1 feature-1"
+          if [ "${BENCH_ABBA}" != "false" ]; then
+            RUNS="baseline-1 feature-1 feature-2 baseline-2"
+          fi
+          for run in $RUNS; do
+            PROFILE="$BENCH_WORK_DIR/$run/samply-profile.json.gz"
+            if [ -f "$PROFILE" ]; then
+              echo "Uploading samply profile for $run..."
+              URL=$(bash contrib/bench/upload-samply-profile.sh "$PROFILE") || true
+              if [ -n "$URL" ]; then
+                echo "$URL" > "$BENCH_WORK_DIR/$run/samply-profile-url.txt"
+                echo "$run: $URL"
+              fi
+            fi
+          done
 
       - name: Push charts
         id: push-charts
@@ -373,17 +483,18 @@ jobs:
           echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"
 
-      - name: Compare & comment
-        if: success() && env.BENCH_COMMENT_ID
+      - name: Build final comment
+        id: final-comment
+        if: success()
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const fs = require('fs');
+            const workDir = process.env.BENCH_WORK_DIR;
 
             let comment = '';
             try {
-              comment = fs.readFileSync(process.env.BENCH_WORK_DIR + '/comment.md', 'utf8');
+              comment = fs.readFileSync(workDir + '/comment.md', 'utf8');
             } catch (e) {
               comment = '⚠️ Replay benchmark completed but failed to generate comparison.';
             }
@@ -408,11 +519,44 @@ jobs:
               comment += chartMarkdown;
             }
 
+            // Samply profile links
+            if (process.env.BENCH_SAMPLY === 'true') {
+              const abba = process.env.BENCH_ABBA !== 'false';
+              const runs = abba
+                ? ['baseline-1', 'feature-1', 'feature-2', 'baseline-2']
+                : ['baseline-1', 'feature-1'];
+              const links = [];
+              for (const run of runs) {
+                try {
+                  const url = fs.readFileSync(`${workDir}/${run}/samply-profile-url.txt`, 'utf8').trim();
+                  if (url) links.push(`- **${run}**: [Firefox Profiler](${url})`);
+                } catch (e) {}
+              }
+              if (links.length > 0) {
+                comment += `\n\n### Samply Profiles\n\n${links.join('\n')}\n`;
+              }
+            }
+
+            fs.writeFileSync(workDir + '/final-comment.md', comment);
+
+      - name: Compare & comment
+        if: success() && env.BENCH_COMMENT_ID
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEREK_PAT }}
+          script: |
+            const fs = require('fs');
+            const workDir = process.env.BENCH_WORK_DIR;
+
+            let comment = '';
+            try {
+              comment = fs.readFileSync(workDir + '/final-comment.md', 'utf8');
+            } catch (e) {
+              comment = '⚠️ Replay benchmark completed but failed to generate comparison.';
+            }
+
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const chain = process.env.BENCH_CHAIN || 'mainnet';
-            const blocks = process.env.BENCH_BLOCKS || '5000';
-            const warmup = process.env.BENCH_WARMUP_BLOCKS || '1000';
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\n\n${comment}`;
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\n${process.env.BENCH_CONFIG}\n\n${comment}`;
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
@@ -424,9 +568,34 @@ jobs:
       - name: Write job summary
         if: success()
         run: |
-          if [ -f "$BENCH_WORK_DIR/comment.md" ]; then
+          if [ -f "$BENCH_WORK_DIR/final-comment.md" ]; then
+            echo "## Replay Benchmark" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "${BENCH_CONFIG}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat "$BENCH_WORK_DIR/final-comment.md" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f "$BENCH_WORK_DIR/comment.md" ]; then
             cat "$BENCH_WORK_DIR/comment.md" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Send Slack notification (success)
+        if: success() && env.BENCH_NO_SLACK != 'true'
+        uses: actions/github-script@v8
+        env:
+          BENCH_BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
+          BENCH_FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
+        with:
+          script: |
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            await notify.success({ core, context });
+
+      - name: Send Slack notification (failure)
+        if: failure() && env.BENCH_NO_SLACK != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            await notify.failure({ core, context, failedStep: 'running replay benchmark' });
 
       - name: Update status (failed)
         if: failure() && env.BENCH_COMMENT_ID
@@ -455,3 +624,25 @@ jobs:
               comment_id: parseInt(process.env.BENCH_COMMENT_ID),
               body: `cc @${process.env.BENCH_ACTOR}\n\n⚠️ Replay benchmark cancelled. [View logs](${jobUrl})`,
             });
+
+      - name: Clean build outputs
+        if: always()
+        run: |
+          sudo rm -rf ../tempo-baseline/target ../tempo-feature/target 2>/dev/null || true
+
+      - name: Restore system settings
+        if: always()
+        run: |
+          for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_min_freq; do
+            cat "$(dirname "$f")/cpuinfo_min_freq" | sudo tee "$f" > /dev/null 2>&1 || true
+          done
+          for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_max_freq; do
+            cat "$(dirname "$f")/cpuinfo_max_freq" | sudo tee "$f" > /dev/null 2>&1 || true
+          done
+          echo active | sudo tee /sys/devices/system/cpu/amd_pstate/status 2>/dev/null || true
+          if [ -n "${BENCH_CPU_DMA_LATENCY_PID:-}" ]; then
+            sudo kill "$BENCH_CPU_DMA_LATENCY_PID" 2>/dev/null || true
+          fi
+          sudo pkill -f '^bench-cpu-dma-latency' 2>/dev/null || true
+          sudo cpupower frequency-set -g powersave 2>/dev/null || true
+          sudo systemctl start irqbalance cron atd 2>/dev/null || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,6 +56,8 @@ jobs:
       blocks: ${{ steps.args.outputs.blocks }}
       warmup: ${{ steps.args.outputs.warmup }}
       chain: ${{ steps.args.outputs.chain }}
+      cores: ${{ steps.args.outputs.cores }}
+      abba: ${{ steps.args.outputs.abba }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
     steps:
       - name: Check org membership
@@ -91,11 +93,11 @@ jobs:
             actor = context.payload.comment.user.login;
 
             const body = context.payload.comment.body.trim();
-            const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup']);
+            const intArgs = new Set(['duration', 'bloat', 'tps', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup', 'cores']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
-            const stringArgs = new Set(['mode', 'preset', 'backend', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain']);
+            const stringArgs = new Set(['mode', 'preset', 'backend', 'tracy', 'baseline-args', 'feature-args', 'baseline-hardfork', 'feature-hardfork', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'abba']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-slack', 'no-existing-recipients']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', backend: 'tempo-bench', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '1000', chain: 'mainnet' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', baseline: '', feature: '', backend: 'tempo-bench', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'baseline-hardfork': '', 'feature-hardfork': '', 'force-bloat': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '1000', chain: 'mainnet', cores: '0', abba: 'true' };
             const unknown = [];
             const invalid = [];
             const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -154,7 +156,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [cores=N] [abba=BOOL] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -191,12 +193,14 @@ jobs:
             blocks = defaults.blocks;
             warmup = defaults.warmup;
             var chain = defaults.chain;
+            var cores = defaults.cores;
+            var abba = defaults.abba;
 
             const existingRecipients = defaults['no-existing-recipients'] !== 'true';
             const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [cores=N] [abba=BOOL] [preset=NAME] [duration=N] [bloat=N] [tps=N] [baseline=REF] [feature=REF] [backend=NAME] [txgen-ref=REF] [samply] [force-bloat] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [baseline-hardfork=FORK] [feature-hardfork=FORK] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -214,6 +218,19 @@ jobs:
             // Validate mode value
             if (!['e2e', 'replay'].includes(mode)) {
               const msg = `❌ **Invalid bench command**\n\n\`mode=${mode}\` is not valid. Must be \`e2e\` or \`replay\`.\n\n${usageStr}`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              });
+              core.setFailed(msg);
+              return;
+            }
+
+            // Validate abba value
+            if (!['true', 'false'].includes(abba)) {
+              const msg = `❌ **Invalid bench command**\n\n\`abba=${abba}\` is not valid. Must be \`true\` or \`false\`.\n\n${usageStr}`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -333,6 +350,8 @@ jobs:
             core.setOutput('blocks', blocks);
             core.setOutput('warmup', warmup);
             core.setOutput('chain', chain);
+            core.setOutput('cores', cores);
+            core.setOutput('abba', abba);
 
       - name: Acknowledge request
         id: ack
@@ -464,6 +483,11 @@ jobs:
       blocks: ${{ needs.tempo-bench-ack.outputs.blocks }}
       warmup: ${{ needs.tempo-bench-ack.outputs.warmup }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
+      cores: ${{ needs.tempo-bench-ack.outputs.cores }}
+      abba: ${{ needs.tempo-bench-ack.outputs.abba }}
+      no-slack: ${{ needs.tempo-bench-ack.outputs.no-slack }}
     secrets:
       DEREK_PAT: ${{ secrets.DEREK_PAT }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+      SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+      SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}


### PR DESCRIPTION
- System tuning: CPU freq lock, disable swap/ASLR/SMT/THP, C-state hold, IRQ pinning, stop noisy services
- System restore: always() step undoes all tuning
- CPU pinning: AllowedCPUs via systemd-run, configurable via cores= arg
- ABBA toggle: abba=false for single A/B pass
- Samply upload: profiles uploaded to Firefox Profiler with links in PR comment
- Slack notifications: success/failure via bench-slack-notify.js (replay-aware)
- Clean build outputs: always() deletes target/ dirs
- Richer job summary with config header