### PR TITLE
docs(tip-1016): mark release as T4

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -5,7 +5,7 @@ description: Storage creation gas costs are charged but don't count against tran
 authors: Dankrad Feist @dankrad
 status: Approved
 related: TIP-1000, TIP-1010, EIP-8037, EIP-8011, EIP-7825, EIP-7623
-protocolVersion: T3
+protocolVersion: T4
 ---
 
 # TIP-1016: Exempt Storage Creation from Gas Limits

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -5,7 +5,7 @@ description: Storage creation gas costs are charged but don't count against tran
 authors: Dankrad Feist @dankrad
 status: Approved
 related: TIP-1000, TIP-1010, EIP-8037, EIP-8011, EIP-7825, EIP-7623
-protocolVersion: T4
+protocolVersion: TBD
 ---
 
 # TIP-1016: Exempt Storage Creation from Gas Limits


### PR DESCRIPTION
Fixes the remaining spec metadata mismatch for TIP-1016. The TIP frontmatter still declared protocolVersion: T3, but the final release scope and implementation work for this change are tracked as T4.
