### PR TITLE
feat(cli): --dry-run to show consensus requests without sending

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -330,10 +330,6 @@ pub(crate) struct WalletArgs {
     /// GCP_KEY_VERSION env vars
     #[arg(long, help_heading = "Wallet options - remote")]
     gcp: bool,
-
-    /// Output the unsigned transaction and exit without signing or sending.
-    #[arg(long, help_heading = "Wallet options")]
-    unsigned: bool,
 }
 
 impl WalletArgs {
@@ -391,7 +387,7 @@ impl WalletArgs {
 
             Ok(EthereumWallet::new(signer))
         } else {
-            bail!("a signing wallet option must be set")
+            bail!("a wallet option must be set")
         }
     }
 }
@@ -409,6 +405,10 @@ pub(crate) struct ValidatorTransactionArgs {
     /// Skip the interactive confirmation prompt.
     #[arg(long, short = 'y')]
     yes: bool,
+
+    /// Skip signing and submitting the transaction. Only printing out the details
+    #[arg(long)]
+    dry_run: bool,
 }
 
 impl ValidatorTransactionArgs {
@@ -417,7 +417,7 @@ impl ValidatorTransactionArgs {
             .to(VALIDATOR_CONFIG_V2_ADDRESS)
             .input(call.abi_encode().into());
 
-        if self.wallet.unsigned {
+        if self.dry_run {
             println!("{}", &serde_json::json!(tx));
             return Ok(());
         }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -416,13 +416,20 @@ impl ValidatorTransactionArgs {
             .to(VALIDATOR_CONFIG_V2_ADDRESS)
             .input(call.abi_encode().into());
 
-        eprintln!("{}", &serde_json::json!(tx));
+        let mut output: Box<dyn std::io::Write + Send> = if self.yes {
+            Box::new(std::io::stderr())
+        } else {
+            Box::new(std::io::stdout())
+        };
+
+        writeln!(output, "{}", &serde_json::json!(tx))?;
         if self.dry_run {
             return Ok(());
         }
+
         if !self.yes {
-            eprint!("\nSubmit this transaction? [y/N] ");
-            std::io::stderr().flush()?;
+            write!(output, "\nSubmit this transaction? [y/N] ")?;
+            output.flush()?;
 
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
@@ -432,7 +439,12 @@ impl ValidatorTransactionArgs {
             }
         }
 
-        let wallet = self.wallet.build().await.wrap_err("failed to open wallet to send transaction")?;
+        let wallet = self
+            .wallet
+            .build()
+            .await
+            .wrap_err("failed to open wallet to send transaction")?;
+
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_gas_estimation()
             .wallet(wallet)
@@ -446,7 +458,8 @@ impl ValidatorTransactionArgs {
             .wrap_err("failed to send transaction")?;
 
         let tx_hash = pending.tx_hash();
-        println!("{tx_hash}");
+        writeln!(output, "{tx_hash}")?;
+
         Ok(())
     }
 

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -386,7 +386,7 @@ impl WalletArgs {
 
             Ok(EthereumWallet::new(signer))
         } else {
-            bail!("a wallet option must be set")
+            bail!("no wallet provided")
         }
     }
 }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -308,7 +308,6 @@ impl ValidatorSignatureArgs {
 }
 
 #[derive(Debug, clap::Args)]
-#[group(required = true, multiple = false)]
 pub(crate) struct WalletArgs {
     /// Path to the file holding the validator's Ethereum private key.
     #[arg(long, value_name = "FILE", help_heading = "Wallet options - raw")]

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -432,7 +432,7 @@ impl ValidatorTransactionArgs {
             }
         }
 
-        let wallet = self.wallet.build().await?;
+        let wallet = self.wallet.build().await.wrap_err("failed to open wallet to send transaction")?;
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_gas_estimation()
             .wallet(wallet)

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -332,63 +332,21 @@ pub(crate) struct WalletArgs {
     gcp: bool,
 }
 
-/// Shared arguments for commands that update the validator config contract.
-#[derive(Debug, clap::Args)]
-pub(crate) struct ValidatorTransactionArgs {
-    #[command(flatten)]
-    wallet: WalletArgs,
-
-    /// The RPC URL to submit the transaction to.
-    #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
-    rpc_url: String,
-
-    /// Skip the interactive confirmation prompt.
-    #[arg(long, short = 'y')]
-    yes: bool,
-}
-
-impl ValidatorTransactionArgs {
-    fn confirm<T: SolCall + Serialize>(&self, call: &T) -> eyre::Result<()> {
-        eprintln!(
-            "{}",
-            &serde_json::json!({
-                "to": VALIDATOR_CONFIG_V2_ADDRESS,
-                "signature": T::SIGNATURE,
-                "call": call,
-            })
-        );
-
-        if self.yes {
-            return Ok(());
-        }
-
-        eprint!("\nSubmit this transaction? [y/N] ");
-        std::io::stderr().flush()?;
-
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-
-        if !matches!(input.trim(), "y" | "Y" | "yes" | "YES") {
-            Err(eyre!("transaction cancelled by user"))
-        } else {
-            Ok(())
-        }
-    }
-
-    async fn wallet(&self) -> eyre::Result<EthereumWallet> {
-        if self.wallet.ledger {
+impl WalletArgs {
+    async fn build(&self) -> eyre::Result<EthereumWallet> {
+        if self.ledger {
             let signer = LedgerSigner::new(LedgerHDPath::LedgerLive(0), None)
                 .await
                 .wrap_err("failed to connect to Ledger device")?;
 
             Ok(EthereumWallet::new(signer))
-        } else if self.wallet.trezor {
+        } else if self.trezor {
             let signer = TrezorSigner::new(TrezorHDPath::TrezorLive(0), None)
                 .await
                 .wrap_err("failed to connect to Trezor device")?;
 
             Ok(EthereumWallet::new(signer))
-        } else if self.wallet.aws {
+        } else if self.aws {
             let key_id = get_env("AWS_KMS_KEY_ID")?;
             let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
             let client = aws_sdk_kms::Client::new(&config);
@@ -397,7 +355,7 @@ impl ValidatorTransactionArgs {
                 .wrap_err("failed to create AWS KMS signer")?;
 
             Ok(EthereumWallet::new(signer))
-        } else if self.wallet.gcp {
+        } else if self.gcp {
             let project = get_env("GCP_PROJECT_ID")?;
             let location = get_env("GCP_LOCATION")?;
             let keyring = get_env("GCP_KEY_RING")?;
@@ -422,7 +380,7 @@ impl ValidatorTransactionArgs {
                 .wrap_err("failed to create GCP KMS signer")?;
 
             Ok(EthereumWallet::new(signer))
-        } else if let Some(path) = &self.wallet.wallet_key {
+        } else if let Some(path) = &self.wallet_key {
             let signer = key_from_file(path).wrap_err_with(|| {
                 format!("failed reading private key from file `{}`", path.display())
             })?;
@@ -432,13 +390,72 @@ impl ValidatorTransactionArgs {
             bail!("a wallet option must be set")
         }
     }
+}
 
-    async fn provider(&self) -> eyre::Result<impl Provider<TempoNetwork>> {
-        let wallet = self.wallet().await?;
+/// Shared arguments for commands that update the validator config contract.
+#[derive(Debug, clap::Args)]
+pub(crate) struct ValidatorTransactionArgs {
+    #[command(flatten)]
+    wallet: WalletArgs,
+
+    /// The RPC URL to submit the transaction to.
+    #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
+    rpc_url: String,
+
+    /// Output transaction details
+    #[arg(long)]
+    create_only: bool,
+
+    /// Skip the interactive confirmation prompt.
+    #[arg(long, short = 'y')]
+    yes: bool,
+}
+
+impl ValidatorTransactionArgs {
+    async fn call<T: SolCall + Serialize>(&self, call: &T) -> eyre::Result<()> {
+        let tx = TransactionRequest::default()
+            .to(VALIDATOR_CONFIG_V2_ADDRESS)
+            .input(call.abi_encode().into());
+
+        if self.create_only {
+            println!("{}", &serde_json::json!(tx));
+            return Ok(());
+        }
+
+        if !self.yes {
+            eprintln!("{}", &serde_json::json!(tx));
+            eprint!("\nSubmit this transaction? [y/N] ");
+            std::io::stderr().flush()?;
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+
+            if !matches!(input.trim(), "y" | "Y" | "yes" | "YES") {
+                bail!("transaction cancelled by user")
+            }
+        }
+
+        let wallet = self.wallet.build().await?;
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .fetch_chain_id()
             .with_gas_estimation()
             .wallet(wallet)
+            .connect(&self.rpc_url)
+            .await
+            .wrap_err("failed to connect to RPC")?;
+
+        let pending = provider
+            .send_transaction(tx.into())
+            .await
+            .wrap_err("failed to send transaction")?;
+
+        let tx_hash = pending.tx_hash();
+        println!("{tx_hash}");
+        Ok(())
+    }
+
+    async fn provider(&self) -> eyre::Result<impl Provider<TempoNetwork>> {
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .fetch_chain_id()
             .connect(&self.rpc_url)
             .await
             .wrap_err("failed to connect to RPC")?;
@@ -453,11 +470,13 @@ pub(crate) struct AddValidator {
     identity: ValidatorIdentityArgs,
     #[command(flatten)]
     sig: ValidatorSignatureArgs,
-    #[command(flatten)]
-    submit: ValidatorTransactionArgs,
+
     /// The fee recipient address
     #[arg(long, value_name = "ETHEREUM_ADDRESS")]
     fee_recipient: Address,
+
+    #[command(flatten)]
+    submit: ValidatorTransactionArgs,
 }
 
 impl AddValidator {
@@ -488,20 +507,7 @@ impl AddValidator {
             feeRecipient: self.fee_recipient,
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }
@@ -511,13 +517,12 @@ pub(crate) struct TransferValidatorOwnership {
     /// Validator ethereum address, ed25519 public key, or index
     #[arg()]
     id: ValidatorId,
-
-    #[command(flatten)]
-    submit: ValidatorTransactionArgs,
-
     /// Path to the file holding the private key of the new validator address
     #[arg(long, value_name = "FILE")]
     new_private_key: PathBuf,
+
+    #[command(flatten)]
+    submit: ValidatorTransactionArgs,
 }
 
 impl TransferValidatorOwnership {
@@ -540,20 +545,7 @@ impl TransferValidatorOwnership {
             newAddress: new_validator_address,
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }
@@ -598,20 +590,7 @@ impl RotateValidator {
             signature,
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }
@@ -735,20 +714,7 @@ impl SetValidatorIpAddress {
             egress: self.egress.map_or(validator.egress, |v| v.to_string()),
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }
@@ -773,20 +739,7 @@ impl DeactivateValidator {
             idx: validator.index,
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }
@@ -807,7 +760,6 @@ pub(crate) struct SetValidatorFeeRecipient {
 impl SetValidatorFeeRecipient {
     async fn run(self) -> eyre::Result<()> {
         let provider = self.submit.provider().await?;
-
         let validator = read_validator_from_contract(&provider, self.id).await?;
 
         let call = IValidatorConfigV2::setFeeRecipientCall {
@@ -815,20 +767,7 @@ impl SetValidatorFeeRecipient {
             feeRecipient: self.fee_recipient,
         };
 
-        self.submit.confirm(&call)?;
-
-        let tx = TransactionRequest::default()
-            .to(VALIDATOR_CONFIG_V2_ADDRESS)
-            .input(call.abi_encode().into());
-
-        let pending = provider
-            .send_transaction(tx.into())
-            .await
-            .wrap_err("failed to send transaction")?;
-
-        let tx_hash = pending.tx_hash();
-        println!("transaction submitted: {tx_hash}");
-
+        self.submit.call(&call).await?;
         Ok(())
     }
 }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -391,7 +391,7 @@ impl WalletArgs {
 
             Ok(EthereumWallet::new(signer))
         } else {
-            bail!("a wallet option must be set")
+            bail!("a signing wallet option must be set")
         }
     }
 }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -405,7 +405,7 @@ pub(crate) struct ValidatorTransactionArgs {
     #[arg(long, short = 'y')]
     yes: bool,
 
-    /// Skip signing and submitting the transaction. Only printing out the details
+    /// Prints transaction and exits. Does not send sign or send the transaction.
     #[arg(long)]
     dry_run: bool,
 }

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -416,13 +416,11 @@ impl ValidatorTransactionArgs {
             .to(VALIDATOR_CONFIG_V2_ADDRESS)
             .input(call.abi_encode().into());
 
+        eprintln!("{}", &serde_json::json!(tx));
         if self.dry_run {
-            println!("{}", &serde_json::json!(tx));
             return Ok(());
         }
-
         if !self.yes {
-            eprintln!("{}", &serde_json::json!(tx));
             eprint!("\nSubmit this transaction? [y/N] ");
             std::io::stderr().flush()?;
 

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -330,6 +330,10 @@ pub(crate) struct WalletArgs {
     /// GCP_KEY_VERSION env vars
     #[arg(long, help_heading = "Wallet options - remote")]
     gcp: bool,
+
+    /// Output the unsigned transaction and exit without signing or sending.
+    #[arg(long, help_heading = "Wallet options")]
+    unsigned: bool,
 }
 
 impl WalletArgs {
@@ -402,10 +406,6 @@ pub(crate) struct ValidatorTransactionArgs {
     #[arg(long, default_value = "https://rpc.presto.tempo.xyz")]
     rpc_url: String,
 
-    /// Output transaction details
-    #[arg(long)]
-    create_only: bool,
-
     /// Skip the interactive confirmation prompt.
     #[arg(long, short = 'y')]
     yes: bool,
@@ -417,7 +417,7 @@ impl ValidatorTransactionArgs {
             .to(VALIDATOR_CONFIG_V2_ADDRESS)
             .input(call.abi_encode().into());
 
-        if self.create_only {
+        if self.wallet.unsigned {
             println!("{}", &serde_json::json!(tx));
             return Ok(());
         }


### PR DESCRIPTION
* Wallet Arg is not required, runtime fail if not provided and --dry-run is not set
* --dry-run simply emits tx details