### PR TITLE
docs(tip-1049): System-Contract Transfer Policy Exemption

### DIFF
--- a/tips/tip-1049.md
+++ b/tips/tip-1049.md
@@ -1,0 +1,230 @@
+---
+id: TIP-1049
+title: System-Contract Transfer Policy Exemption
+description: Defines a privileged TIP-20 transfer path that bypasses TIP-403 policy checks for a protocol-maintained list of system contracts that need guaranteed liveness for refunds and recoveries.
+authors: Dankrad Feist
+status: Draft
+related: TIP-20, TIP-403, TIP-1025, TIP-1035
+---
+
+# TIP-1049: System-Contract Transfer Policy Exemption
+
+## Abstract
+
+This TIP introduces a privileged TIP-20 transfer function, `systemForceTransfer`, that moves tokens while skipping TIP-403 transfer-policy authorization checks. It may only be invoked by an explicit, enumerated set of system contracts — the **Transfer Policy Exemption List**. Entries on the list may be literal addresses or *authority predicates* (contracts whose `isAuthorizedSystemContract(address)` view returns true), which lets the list grow to cover families of contracts that are deployed dynamically, such as per-zone [`ZonePortal`](../../zones/specs/spec.md#izoneportal) instances.
+
+This is a narrow, auditable exemption. It does not affect balance checks, spending-limit checks, event emission, or the allowance rules introduced by [TIP-1035](./tip-1035.md). It specifically addresses scenarios where a system contract must *return* tokens that it already custodies — most notably deposit and withdrawal bounce-backs for Zones — and where failing the transfer would either strand user funds or stall protocol progress.
+
+## Motivation
+
+### The problem: policy drift on refund paths
+
+Some system contracts custody user tokens and owe the user a refund under well-defined conditions. Two concrete examples in the current protocol:
+
+1. **Zone deposit bounce-backs.** A user deposits a TIP-20 token on Tempo and the sequencer relays the deposit to a zone. If the zone-side mint reverts (for example, because a TIP-403 policy active on the zone at processing time forbids minting to the recipient), the deposit must bounce back to a `bouncebackRecipient` on Tempo. The refund transfer is executed by the `ZonePortal` contract and is `ITIP20.transfer(bouncebackRecipient, amount)`.
+2. **Zone withdrawal bounce-backs.** Symmetric case: a Tempo-side withdrawal that fails (the recipient's `transfer` reverts or the callback reverts) is re-enqueued as a bounce-back to the sender's `fallbackRecipient` on the zone.
+
+Both refund paths already exist. In both, the assumption is that the refund transfer *will succeed*. That assumption can break because TIP-403 policies are mutable — an issuer can edit a policy, or the zone's view of policy state can diverge from the Tempo view — so by the time the refund is processed, the refund recipient or the system contract itself may be blocked by the policy.
+
+When a refund reverts, two things happen today:
+
+- The [Zones spec](../../zones/specs/spec.md#deposit-failures-and-bounce-back) guarantees that progress is not stalled; the refund is re-enqueued and retried.
+- But the refund recipient is not changing between retries (it's a user-specified address), so if the policy continues to forbid it, the funds are effectively stranded until the policy changes.
+
+Worse, in the current zones reference implementation, a re-enqueued failed refund has `fallbackRecipient = address(0)`, which — if processed — attempts a mint to `address(0)` on the zone and stalls `ZoneInbox.advanceTempo`. The spec claims "no recursive bounces," but that invariant is enforced only if the refund transfer itself is guaranteed to succeed.
+
+### Why a policy exemption is the right tool
+
+Refund paths are fundamentally different from ordinary transfers:
+
+- The funds already belong to the user in an economic sense: the system contract is only custody.
+- The user cannot "route around" a failed refund — they deposited with a specific `bouncebackRecipient`, or withdrew to a specific `fallbackRecipient`, and the protocol has locked in that destination.
+- If the refund fails, the protocol either strands the user's funds or stalls chain progress (when the refund is in a queue that blocks progress).
+
+Policy authors expect to control *new economic flows*. They do not generally expect to veto a *reversal* of a flow that their policy already permitted at origination time (in the deposit case, `bouncebackRecipient` is TIP-403-validated when `deposit()` is called). Exempting the reversal path preserves this expectation: the user's funds return on the same side of the policy decision they started on.
+
+### Why not a per-caller or per-role bypass in TIP-20 itself?
+
+Three alternatives were considered and rejected:
+
+1. **Hard-code each system contract into TIP-20.** This is how the current protocol handles the fee manager via `systemTransferFrom` (see [TIP-1025](./tip-1025.md), generalized by [TIP-1035](./tip-1035.md)). It doesn't work for per-zone deployments: every zone has its own `ZonePortal`, so a static allowlist would need to be amended every time a zone is created.
+2. **Give the portal a TIP-20 role.** Roles are per-token (each TIP-20 has its own `TIP20RolesAuth` instance). Granting every zone portal a role on every token the zone enables is operationally expensive, requires issuer cooperation for every token, and leaks a privileged role into the token's role graph that could be accidentally retained or misused.
+3. **Rely on `systemTransferFrom` plus extension of TIP-1035.** TIP-1035's Implicit Approval List bypasses the *allowance check*, not the TIP-403 check. `systemTransferFrom` still calls `ensure_transfer_authorized` and therefore cannot serve as a refund path under policy drift. Extending TIP-1035 semantics to also bypass policy would conflate two independent concerns (approval vs. policy authorization) and silently weaken the security model of every contract already on the Implicit Approval List.
+
+TIP-1049 therefore introduces a dedicated, narrowly-scoped function and a dedicated list, with its own admission criteria.
+
+## Assumptions
+
+1. **TIP-20 precompile semantics.** This TIP modifies the TIP-20 token precompile. All TIP-20 tokens on Tempo share a single precompile implementation; this TIP changes that implementation uniformly for all tokens.
+2. **TIP-403 semantics unchanged.** The TIP-403 registry and its authorization functions are unchanged. Policy authors continue to control `isAuthorizedSender`, `isAuthorizedRecipient`, and `isAuthorizedMintRecipient` for their policies.
+3. **Authority predicates are honest.** An authority predicate contract that vouches for system callers (e.g., `ZoneFactory.isAuthorizedSystemContract(address)`) is part of the protocol's trusted computing base. Adding an authority predicate to the Transfer Policy Exemption List is a protocol-level decision made via this TIP or a subsequent amendment; it requires the same level of review as granting a direct exemption.
+4. **Callers use the function only for refunds/recoveries.** Contracts that use `systemForceTransfer` must confine their usage to paths that return tokens already held in custody to a destination fixed at the time the custody was established. This is a social/protocol-level constraint, enforced by review of each admission to the list (see [Eligibility Guidelines](#eligibility-guidelines)). The TIP-20 precompile does not and cannot enforce it structurally.
+5. **Hardfork activation.** The new function and the Transfer Policy Exemption List are gated behind a specific protocol hardfork. Pre-fork behavior is preserved to keep state roots consistent across replay.
+
+If any assumption is violated (for example, an authority predicate returns true for an attacker-controlled contract), the attacker obtains an arbitrary policy bypass for the tokens custodied by the authorized contract. For this reason, the eligibility criteria and admission process are a core part of the specification.
+
+---
+
+# Specification
+
+## 1. New TIP-20 function
+
+The TIP-20 interface gains the following function:
+
+```solidity
+/// @notice Transfers tokens from `from` to `to`, bypassing the TIP-403 transfer policy
+///         check. All other TIP-20 checks (pause, balance, spending limits, zero-recipient,
+///         events) MUST be enforced exactly as for `transfer`/`systemTransferFrom`.
+/// @dev MUST revert unless the direct caller (msg.sender) is on the Transfer Policy
+///      Exemption List. The caller's restriction on `from` is the caller's own
+///      responsibility; the list's admission criteria govern that invariant.
+/// @param from   The address to debit.
+/// @param to     The address to credit. MUST NOT be the zero address.
+/// @param amount The amount of tokens to move.
+/// @return success True on success; reverts otherwise.
+function systemForceTransfer(address from, address to, uint256 amount)
+    external
+    returns (bool success);
+```
+
+### Event
+
+A distinct event MUST be emitted so that indexers, compliance tooling, and issuers can audit every policy-exempt transfer separately from ordinary transfers:
+
+```solidity
+event SystemForceTransfer(
+    address indexed caller,
+    address indexed from,
+    address indexed to,
+    uint256 amount
+);
+```
+
+A standard TIP-20 `Transfer(from, to, amount)` event MUST also be emitted, so that balance-tracking indexers continue to work without modification. The `SystemForceTransfer` event is additive.
+
+### Precompile semantics
+
+The TIP-20 precompile MUST implement `systemForceTransfer(from, to, amount)` as follows, in order:
+
+1. Revert if the token is paused (same as `transfer`).
+2. Revert if `to == address(0)` (`ZeroRecipient`).
+3. Revert if `msg.sender` is not admitted by the Transfer Policy Exemption List (`NotPolicyExempt`); see §2.
+4. Skip `ensure_transfer_authorized(from, to)`. This is the only behavioral difference from `systemTransferFrom`.
+5. Enforce AccountKeychain spending limits for `from` (`check_and_update_spending_limit`). Refund paths still count against the user's spending limits if `from` is an access-key-bound address.
+6. Debit `from` by `amount`. Revert with `InsufficientBalance` if the balance is insufficient.
+7. Credit `to` by `amount`.
+8. Emit `Transfer(from, to, amount)`.
+9. Emit `SystemForceTransfer(msg.sender, from, to, amount)`.
+10. Return `true`.
+
+### Relationship to `transferFrom`
+
+`systemForceTransfer` does not consult the allowance mapping. This matches the semantics of `systemTransferFrom` (see [TIP-1035](./tip-1035.md)): the caller is a trusted system contract and the `from`-consent contract is the caller itself, not an approval record.
+
+### No `mint` variant
+
+This TIP does **not** introduce a policy-exempt `mint`. Minting creates new supply and is governed by the token issuer's `ISSUER_ROLE`; issuers that need policy-exempt minting can already arrange it via `isAuthorizedMintRecipient` and their own role graph. A uniform bypass on `mint` would let listed system contracts create supply anywhere, which is a materially larger change than moving already-custodied tokens and is out of scope.
+
+## 2. Transfer Policy Exemption List
+
+The protocol maintains a **Transfer Policy Exemption List**: the set of direct callers authorized to invoke `systemForceTransfer`. Each list entry is one of:
+
+- A **literal address**: `systemForceTransfer` accepts calls if `msg.sender == entry.address`.
+- An **authority predicate**: `systemForceTransfer` accepts calls if the contract at `entry.authority` implements the following interface and returns `true`:
+
+  ```solidity
+  interface ITransferPolicyExemptAuthority {
+      /// @notice Returns true if `caller` is authorized by this authority to call
+      ///         `systemForceTransfer` on any TIP-20 token.
+      /// @dev MUST be deterministic, MUST NOT consume significant gas (the TIP-20
+      ///      precompile invokes this on every call), and MUST NOT revert.
+      function isAuthorizedSystemContract(address caller) external view returns (bool);
+  }
+  ```
+
+Authority predicates let the list cover dynamically-deployed families of system contracts (e.g., every `ZonePortal` minted by the canonical `ZoneFactory`) without requiring a hardfork for each new instance.
+
+### Initial list
+
+At the activation of this TIP on Tempo mainnet, the Transfer Policy Exemption List contains:
+
+| Entry type | Address | Rationale |
+|---|---|---|
+| Authority predicate | Tempo `ZoneFactory` (canonical Tempo-side deployment; see the Zones specification for the mainnet address) | Every per-zone `ZonePortal` deployed by the canonical factory is the custodian of locked deposits for its zone. Bounce-backs for those deposits must always succeed to preserve the Zones [Deposit Failures and Bounce-Back](../../zones/specs/spec.md#deposit-failures-and-bounce-back) invariant. `ZoneFactory` already tracks `isZonePortal(address)` on-chain; the authority predicate `isAuthorizedSystemContract(c)` is defined to return `isZonePortal(c)`. |
+
+A `ZoneFactory` deployment that has **not** been designated by protocol governance as canonical MUST NOT satisfy the authority predicate. On Tempo mainnet the canonical address is set at hardfork activation and is immutable thereafter.
+
+Other Tempo system contracts that already exist (the fee manager, the StablecoinDEX) are **not** on the Transfer Policy Exemption List. They do not custody user funds on refund paths and do not need this bypass.
+
+### List permanence
+
+Entries on the Transfer Policy Exemption List MUST NOT be removed except via an explicit amendment TIP that documents the migration plan for any funds currently refundable via that entry. Contracts and users MAY depend on the fact that a listed entry continues to be listed.
+
+## 3. Eligibility Guidelines
+
+A system contract MAY be added to the Transfer Policy Exemption List (directly or via an authority predicate) if it satisfies all of the following. An amendment TIP MAY admit a contract that does not satisfy these guidelines, but MUST include an explicit safety argument.
+
+1. **Custody-only refunds.** Every code path that invokes `systemForceTransfer` MUST be a refund or recovery path. The contract debits only `from` addresses that are *itself* (or a contract it wholly controls), and only up to tokens it already custodies. Policy-exempt transfers MUST NOT debit arbitrary user addresses.
+2. **Destination pre-validated.** The destination `to` of every policy-exempt transfer MUST have been authorized under the then-current TIP-403 policy at the time the custody relationship was established. For zone deposit bounce-backs, this is enforced by validating `bouncebackRecipient` against the token's TIP-403 policy at `deposit()` time. This preserves the invariant that a user never receives tokens at an address the policy never approved.
+3. **Bounded amount.** The `amount` of every policy-exempt transfer MUST be bounded by the amount originally custodied on behalf of the user, minus any amounts already released. This prevents a listed contract from "minting" value via repeated refunds.
+4. **No EOA callers on the hot path.** `systemForceTransfer` MUST be reachable only via privileged internal paths of the listed contract (for Zones, only `ZonePortal.processWithdrawal` with `gasLimit == 0`), never via a public entry point that accepts arbitrary `from`/`to`/`amount` from an EOA.
+5. **Events observable off-chain.** The listed contract MUST emit an event that uniquely identifies the originating custody event, so that issuers and compliance tooling can reconcile `SystemForceTransfer` events against their origin (e.g., the zone deposit hash).
+6. **Upgrade path via hardfork.** A listed contract that is upgradeable in the usual EVM sense (proxy + implementation) does not satisfy these guidelines. Upgrade MUST proceed via protocol hardfork, so that every listed entry is subject to the TIP process.
+
+## 4. Integration with Zones
+
+Zones integrates this TIP as follows (normative for the Zones implementation; documented here so that implementers can review the end-to-end behavior):
+
+- `ZonePortal.processWithdrawal(withdrawal, remainingQueue)` replaces the `ITIP20.transfer(withdrawal.to, withdrawal.amount)` call on the `gasLimit == 0` path (the deposit-bounce-back path) with:
+
+  ```solidity
+  ITIP20(_token).systemForceTransfer(address(this), withdrawal.to, withdrawal.amount);
+  ```
+
+- The current `try/catch` around the transfer is retained for defense-in-depth. After this TIP activates, the transfer MUST NOT revert for policy reasons, and falling into the `catch` indicates either a balance accounting bug or a token-specific revert (e.g., the token is paused). In that case the existing `_enqueueWithdrawalBounceBack` path remains as a non-happy fallback — but with this TIP in place, that fallback is only reached in exceptional circumstances and no longer papers over policy drift. The separate issue of a bounce-back's bounce-back having `fallbackRecipient = address(0)` should be addressed independently (see [zones#167](https://github.com/tempoxyz/zones/issues/167)).
+
+- The `ZonePortal` does **not** call `systemForceTransfer` on any other path. In particular, the `gasLimit > 0` callback-carrying withdrawal path continues to use the `IZoneMessenger.relayMessage` indirection, and callback execution continues to respect TIP-403 policies.
+
+- The Zones specification's [Deposit Failures and Bounce-Back](../../zones/specs/spec.md#deposit-failures-and-bounce-back) section MUST be updated to cite this TIP and describe the guaranteed-liveness property of the refund transfer.
+
+## 5. Hardfork activation
+
+This TIP MUST be gated behind a specific hardfork. Before activation:
+
+- `systemForceTransfer` does not exist and any call to its selector reverts with the standard "function not found" behavior.
+- The Transfer Policy Exemption List is empty and `ZoneFactory.isAuthorizedSystemContract` is undefined.
+
+After activation, all listed behavior is in effect uniformly across all TIP-20 tokens.
+
+## 6. Backward compatibility
+
+- Existing TIP-20 tokens and their holders are unaffected. No transfer that was authorized under TIP-403 before this TIP is denied after it.
+- `transfer`, `transferFrom`, `transferWithMemo`, `systemTransferFrom`, and `mint` are unchanged, including their TIP-403 policy checks.
+- `allowance` and `permit` are unchanged; `systemForceTransfer` does not read or mutate allowance state (consistent with `systemTransferFrom`).
+- Issuers can continue to migrate users to new policies by editing the policy; this TIP does not widen the set of transfers an adversarial policy can be forced to accept. The only "force" is applied by explicitly listed system contracts on refund paths they already control.
+
+---
+
+# Invariants
+
+1. **Caller gating.** `systemForceTransfer` MUST revert unless `msg.sender` is admitted by the Transfer Policy Exemption List. Admission is evaluated at call time; a literal-address entry is admitted iff `msg.sender == entry.address`, and an authority-predicate entry is admitted iff `entry.authority.isAuthorizedSystemContract(msg.sender)` returns `true`.
+2. **Policy bypass is local to the TIP-403 check.** `systemForceTransfer` MUST skip `ensure_transfer_authorized(from, to)` and MUST enforce every other TIP-20 check (pause, zero-recipient, spending limits, balance sufficiency).
+3. **Event parity.** Every successful `systemForceTransfer` MUST emit exactly one `Transfer(from, to, amount)` event and exactly one `SystemForceTransfer(caller, from, to, amount)` event. Unsuccessful calls MUST NOT emit either.
+4. **No allowance interaction.** `systemForceTransfer` MUST NOT read, write, or depend on the allowance mapping.
+5. **No mint interaction.** `systemForceTransfer` MUST NOT change `totalSupply`.
+6. **List consistency.** The Transfer Policy Exemption List MUST match the set defined in this TIP and any amendments. No address or authority may be admitted without a corresponding TIP.
+7. **List permanence.** Entries MUST NOT be removed from the Transfer Policy Exemption List except by an amendment TIP that documents the migration plan for in-flight custody.
+8. **Authority soundness.** An authority predicate contract on the list MUST implement `isAuthorizedSystemContract` as a deterministic, non-reverting, view-only function. A reverting or non-deterministic authority makes every TIP-20 token relying on that authority's entry DoS-vulnerable; admission of such an authority is a protocol bug.
+9. **Hardfork gating.** The behavior defined in this TIP MUST activate exactly at the specified hardfork boundary. Pre-fork transactions replay with pre-fork semantics.
+
+## Test cases
+
+1. **Reverts for unlisted caller.** A call to `systemForceTransfer` from an address that is neither on the list nor admitted by any authority predicate reverts with `NotPolicyExempt`.
+2. **Succeeds when blocked by TIP-403.** A listed caller's `systemForceTransfer(from, to, amount)` succeeds even when `TIP403Registry.isAuthorized(policyId, from)` or `isAuthorized(policyId, to)` returns `false`.
+3. **Still fails for non-policy reasons.** `systemForceTransfer` reverts on insufficient balance, on `to == address(0)`, and when the token is paused.
+4. **Emits both events.** A successful `systemForceTransfer` emits exactly one `Transfer` and one `SystemForceTransfer` with matching `(from, to, amount)`.
+5. **Ignores allowance.** With `allowance[from][caller] == 0`, `systemForceTransfer(from, to, amount)` still succeeds (caller is listed; no allowance decrement occurs and no `Approval` event is emitted).
+6. **Authority-predicate integration.** Given a `ZoneFactory` authority entry and a `ZonePortal` created by that factory, a call from the `ZonePortal` succeeds. A call from a self-deployed contract identical in code but not registered with the factory reverts with `NotPolicyExempt`.
+7. **Bounce-back end-to-end.** In a zones integration test, a zone deposit whose `bouncebackRecipient` is subsequently added to the TIP-403 blacklist still bounces back successfully on the Tempo side after this TIP activates.
+8. **Spending-limit enforcement preserved.** When `from` is an access-key-bound address with an insufficient spending limit, `systemForceTransfer` reverts. (The bypass is for policy, not for keys.)
+9. **No state change on revert.** A reverting `systemForceTransfer` leaves all balances, the allowance mapping, spending-limit counters, `totalSupply`, and the `Transfer`/`SystemForceTransfer` event logs unchanged.

--- a/tips/tip-1052.md
+++ b/tips/tip-1052.md
@@ -1,5 +1,5 @@
 ---
-id: TIP-1049
+id: TIP-1052
 title: System-Contract Transfer Policy Exemption
 description: Defines a privileged TIP-20 transfer path that bypasses TIP-403 policy checks for a protocol-maintained list of system contracts that need guaranteed liveness for refunds and recoveries.
 authors: Dankrad Feist
@@ -7,7 +7,7 @@ status: Draft
 related: TIP-20, TIP-403, TIP-1025, TIP-1035
 ---
 
-# TIP-1049: System-Contract Transfer Policy Exemption
+# TIP-1052: System-Contract Transfer Policy Exemption
 
 ## Abstract
 
@@ -51,7 +51,7 @@ Three alternatives were considered and rejected:
 2. **Give the portal a TIP-20 role.** Roles are per-token (each TIP-20 has its own `TIP20RolesAuth` instance). Granting every zone portal a role on every token the zone enables is operationally expensive, requires issuer cooperation for every token, and leaks a privileged role into the token's role graph that could be accidentally retained or misused.
 3. **Rely on `systemTransferFrom` plus extension of TIP-1035.** TIP-1035's Implicit Approval List bypasses the *allowance check*, not the TIP-403 check. `systemTransferFrom` still calls `ensure_transfer_authorized` and therefore cannot serve as a refund path under policy drift. Extending TIP-1035 semantics to also bypass policy would conflate two independent concerns (approval vs. policy authorization) and silently weaken the security model of every contract already on the Implicit Approval List.
 
-TIP-1049 therefore introduces a dedicated, narrowly-scoped function and a dedicated list, with its own admission criteria.
+TIP-1052 therefore introduces a dedicated, narrowly-scoped function and a dedicated list, with its own admission criteria.
 
 ## Assumptions
 


### PR DESCRIPTION
## Summary

Introduces **TIP-1049: System-Contract Transfer Policy Exemption**.

This TIP defines a new privileged TIP-20 function, `systemForceTransfer(from, to, amount)`, that moves tokens while **skipping the TIP-403 policy check** and enforcing every other TIP-20 check (pause, balance, zero-recipient, AccountKeychain spending limits). It is gated behind a protocol-maintained **Transfer Policy Exemption List** of system contracts authorized to call it, with list entries being either literal addresses or *authority predicates* (contracts that vouch for a dynamic family of system contracts).

## Why

A system contract that custodies user tokens on behalf of a refund path needs a liveness guarantee: the refund must succeed regardless of TIP-403 policy drift between the time the custody was established and the time the refund is processed. The canonical example is Zones deposit/withdrawal bounce-backs, where today a `ZonePortal`'s refund `transfer` can revert if the recipient is subsequently blocked by a TIP-403 policy — leaving funds stranded and, in the current zones reference implementation, risking a stall in `ZoneInbox.advanceTempo` via a re-enqueued bounce with `fallbackRecipient = address(0)`.

Neither of the two existing bypasses is suitable:
- `systemTransferFrom` (TIP-1025/[TIP-1035](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1038.md)) bypasses **allowance**, not policy — it still calls `ensure_transfer_authorized`.
- Hard-coding each system contract into TIP-20 or granting per-token roles doesn't scale to per-zone `ZonePortal` instances.

TIP-1049 introduces a dedicated, narrowly-scoped function and a dedicated list with its own admission criteria.

## What's in the TIP

- New TIP-20 function `systemForceTransfer(from, to, amount)` with precompile semantics spelled out step-by-step (pause → zero-recipient → caller gating → skip TIP-403 → spending limit → balance debit/credit → `Transfer` + new `SystemForceTransfer` events).
- A new `SystemForceTransfer(caller, from, to, amount)` event emitted alongside the standard `Transfer`, so compliance tooling can audit every policy-exempt refund separately.
- The **Transfer Policy Exemption List** structure, with literal-address and authority-predicate entry kinds, plus an `ITransferPolicyExemptAuthority` interface for the predicate form.
- Initial list on Tempo mainnet: a single authority entry for the canonical Tempo-side `ZoneFactory`, which exposes `isAuthorizedSystemContract(c) := isZonePortal(c)`. This covers every per-zone `ZonePortal` automatically and requires no per-zone amendment.
- Eligibility Guidelines: custody-only refunds, destination pre-validated at custody time (the existing deposit-time TIP-403 check on `bouncebackRecipient` anchors this), bounded amount, no EOA on the hot path, upgrade via hardfork, observable origin events.
- **No `mint` variant** — bypassing policy on mint would let listed contracts create supply at arbitrary addresses, which is materially wider than moving already-custodied tokens and is out of scope.
- Zones integration guidance: `ZonePortal.processWithdrawal` on the `gasLimit == 0` path should switch to `systemForceTransfer(address(this), withdrawal.to, amount)`. The existing `try/catch` stays for defense in depth but becomes exceptional rather than load-bearing, which in turn defuses the latent recursive-bounce issue with `fallbackRecipient = 0` ([zones#167](https://github.com/tempoxyz/zones/issues/167)).
- Backward compatibility: no existing transfer that TIP-403 authorized before this TIP is denied after it; `transfer`, `transferFrom`, `transferWithMemo`, `systemTransferFrom`, `allowance`, `permit`, and `mint` are unchanged.
- Hardfork-gated activation, list permanence, and explicit invariants and test cases.

## Relationship to existing TIPs

- **TIP-20**: extended with one new function and one new event.
- **TIP-403**: unchanged. Policy authors retain full control of `isAuthorizedSender`/`isAuthorizedRecipient`/`isAuthorizedMintRecipient`.
- **TIP-1025 / TIP-1035** (Implicit Approval List): independent axis. Allowance vs. policy bypasses are intentionally kept separate so the two don't get conflated in the security model.

## Test plan

- [ ] `systemForceTransfer` reverts with `NotPolicyExempt` for unlisted callers.
- [ ] Succeeds when TIP-403 would otherwise deny the transfer on `from` or `to`.
- [ ] Still reverts on insufficient balance, on `to == address(0)`, and when the token is paused.
- [ ] Emits exactly one `Transfer` and one `SystemForceTransfer` per successful call.
- [ ] Does not read or mutate allowance state.
- [ ] Enforces AccountKeychain spending limits on `from`.
- [ ] Authority-predicate integration: calls from a registered `ZonePortal` succeed; an unregistered look-alike reverts.
- [ ] End-to-end: a Zones deposit whose `bouncebackRecipient` is subsequently TIP-403-blocked still bounces back successfully on Tempo.
- [ ] No state changes on revert (balances, allowances, spending-limit counters, `totalSupply`, events).
- [ ] Hardfork gating: pre-fork calls to the `systemForceTransfer` selector revert with "function not found" and post-fork calls follow the new semantics.


Made with [Cursor](https://cursor.com)