### PR TITLE
deps: update reth from main (2026-04-29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,14 +303,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
  "borsh",
+ "once_cell",
  "serde",
 ]
 
@@ -1723,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "0fc35b7a14cabdad13795fbbbd26d5ddec0882c01492ceedf2af575aad5f37dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1915,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",
@@ -3296,9 +3297,9 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.5.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
@@ -3701,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5522,9 +5523,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -5532,7 +5533,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5631,9 +5632,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -5644,9 +5645,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6002,9 +6003,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libflate"
@@ -6056,12 +6057,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -6425,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -8221,7 +8221,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8300,7 +8300,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8313,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8396,7 +8396,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8426,9 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
+checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8447,9 +8447,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5dbae40c272b8a1b4fcc08ee2d4e77d3b0ccdb187c1313f412a73ff54ff2a2"
+checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8459,7 +8459,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8475,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8527,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8556,7 +8556,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8735,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8962,6 +8962,7 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
@@ -8969,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9008,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9148,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9164,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9207,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9221,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9255,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9275,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9325,7 +9326,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9363,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9377,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9436,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "futures",
  "metrics",
@@ -9473,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9482,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9496,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9553,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9578,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9601,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9616,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9630,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9647,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9671,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9739,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9794,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9832,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9856,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9880,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "bytes",
  "eyre",
@@ -9909,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9921,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9945,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9957,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9981,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9990,9 +9991,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
+checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10024,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10070,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10099,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10115,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10130,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10207,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10237,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10280,7 +10281,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10300,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10331,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10377,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10425,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10439,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10454,9 +10455,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b766da61ec7c46596386b4bc88d9b57d1939d3da2bc9e927567a8a23650e5ce9"
+checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10470,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10522,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10550,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10564,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10584,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10599,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10623,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10641,7 +10642,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10662,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10678,7 +10679,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10688,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "clap",
  "eyre",
@@ -10707,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "clap",
  "eyre",
@@ -10725,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10770,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10796,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10823,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10843,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10872,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7839f3d#7839f3d876b32842b059ca8171242b807ba1fc80"
+source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10892,9 +10893,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fa54c341d926ec9b0f7fc0c87f831aa4959de699e69caab1a0bfd914326c09"
+checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
 dependencies = [
  "zstd",
 ]
@@ -11074,6 +11075,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
@@ -11205,9 +11207,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -11251,9 +11253,9 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -11261,9 +11263,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -11367,9 +11369,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -11886,9 +11888,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -12152,9 +12154,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "symbolic-common"
-version = "12.18.0"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -12164,14 +12166,20 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.18.0"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595bddd9d363c2ef6fc9fb33b98416ff209c5aae8bdca89a7dbbf2ef5e0ecc45"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
  "symbolic-common",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -13381,7 +13389,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -13390,7 +13398,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -13518,11 +13526,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.23",
@@ -13780,9 +13789,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -14071,11 +14080,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -14084,7 +14093,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -14764,9 +14773,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -14779,6 +14788,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8220,7 +8220,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8312,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8526,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9221,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,11 +9461,12 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]
@@ -9473,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9482,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9496,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9554,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9579,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9602,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9617,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9631,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9648,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9672,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9740,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9795,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9833,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9881,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "bytes",
  "eyre",
@@ -9910,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9922,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9946,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9958,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9982,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10025,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10071,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10100,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10116,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10131,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10208,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10238,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10281,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10301,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10332,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10378,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10426,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10440,7 +10441,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10471,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10523,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10551,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10565,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10585,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10600,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10624,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10642,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10663,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10679,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10689,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "clap",
  "eyre",
@@ -10708,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "clap",
  "eyre",
@@ -10726,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10771,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10797,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10824,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10844,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10857,8 +10858,6 @@ dependencies = [
  "metrics",
  "rand 0.9.4",
  "rayon",
- "reth-chainspec",
- "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10875,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
+source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12350,6 +12349,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-etl",
+ "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
  "reth-node-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc4b83cb672156663e6094d098beb509965b7fe684bb3d6e44bb9ca2e9ae714"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -3702,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3899,8 +3899,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7999df38d0bd8f688212e1a4fae31fd2fea6d218649b9cd7c40bf3ec1318fc"
+source = "git+https://github.com/sigp/discv5?rev=7663c00#7663c00ee0837ea98547caaedede95d9d6736f4d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -8221,7 +8220,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8248,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8280,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8300,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8313,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8396,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8406,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8459,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8475,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8488,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8501,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8527,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8556,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8582,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8612,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8627,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8652,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8676,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8700,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8735,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8792,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8820,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8843,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8868,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8926,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8954,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8970,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8986,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9008,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9019,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9047,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9069,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9110,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "clap",
  "eyre",
@@ -9133,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9149,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9165,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9178,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9208,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9222,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9232,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9256,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9276,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9294,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9307,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9326,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9364,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9378,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "serde",
  "serde_json",
@@ -9388,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9416,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "bytes",
  "futures",
@@ -9436,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9453,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "bindgen",
  "cc",
@@ -9462,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "futures",
  "metrics",
@@ -9474,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9483,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9497,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9544,6 +9543,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9602,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9617,7 +9617,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9648,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9740,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "bytes",
  "eyre",
@@ -9910,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9922,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9946,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10100,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10131,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10208,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10281,7 +10281,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10301,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10440,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10551,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10642,7 +10642,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10663,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10679,7 +10679,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "clap",
  "eyre",
@@ -10708,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "clap",
  "eyre",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10797,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10857,6 +10857,8 @@ dependencies = [
  "metrics",
  "rand 0.9.4",
  "rayon",
+ "reth-chainspec",
+ "reth-ethereum-primitives",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10873,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=2c86c0b#2c86c0b876dbc7f580d4961970afbd689e4216f7"
+source = "git+https://github.com/paradigmxyz/reth?rev=b892885#b89288582b8920f31d79ef3acc5a7c00c6ef5328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8220,7 +8220,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8312,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8526,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9221,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "futures",
  "metrics",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9483,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9649,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9741,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-network",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9882,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "bytes",
  "eyre",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10209,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-genesis",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10282,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10441,7 +10441,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10552,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10566,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10601,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-primitives",
@@ -10643,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "clap",
  "eyre",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "clap",
  "eyre",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -10798,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10845,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=76e8865#76e886578b26dd18b14c21ef0e7f387284776566"
+source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-primitives-traits = { version = "0.3.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-primitives-traits = { version = "0.3.1", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2c86c0b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", features = [
   "std",
   "optional-checks",
 ] }
@@ -187,7 +187,7 @@ alloy = { version = "2.0.1", default-features = false }
 alloy-consensus = { version = "2.0.1", default-features = false }
 alloy-contract = { version = "2.0.1", default-features = false }
 alloy-eips = { version = "2.0.1", default-features = false }
-alloy-evm = { version = "0.33.0", default-features = false }
+alloy-evm = { version = "0.34.0", default-features = false }
 revm-inspectors = "0.39.0"
 alloy-genesis = { version = "2.0.1", default-features = false }
 alloy-hardforks = "0.4.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b892885" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b892885", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "76e8865", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -78,6 +78,7 @@ reth-db-api.workspace = true
 reth-etl.workspace = true
 reth-ethereum = { workspace = true, features = ["full", "cli", "network"] }
 reth-ethereum-cli.workspace = true
+reth-metrics.workspace = true
 reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -303,8 +303,6 @@ async fn run_p2p_network(
     config.sessions_config.session_event_buffer = cfg.max_concurrent_inbound;
 
     let (requests_tx, mut requests_rx) = tokio::sync::mpsc::channel(1024);
-    // 32 MiB memory budget for inbound transaction events; matches reth's default
-    // `tx_channel_memory_limit_bytes`.
     let (transactions_tx, mut transactions_rx) = reth_metrics::common::mpsc::memory_bounded_channel(
         config
             .transactions_manager_config

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -303,7 +303,10 @@ async fn run_p2p_network(
     config.sessions_config.session_event_buffer = cfg.max_concurrent_inbound;
 
     let (requests_tx, mut requests_rx) = tokio::sync::mpsc::channel(1024);
-    let (transactions_tx, mut transactions_rx) = tokio::sync::mpsc::unbounded_channel();
+    // 32 MiB memory budget for inbound transaction events; matches reth's default
+    // `tx_channel_memory_limit_bytes`.
+    let (transactions_tx, mut transactions_rx) =
+        reth_metrics::common::mpsc::memory_bounded_channel(32 * 1024 * 1024, "p2p-proxy.tx");
 
     let network = NetworkManager::new(config)
         .await

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -305,8 +305,12 @@ async fn run_p2p_network(
     let (requests_tx, mut requests_rx) = tokio::sync::mpsc::channel(1024);
     // 32 MiB memory budget for inbound transaction events; matches reth's default
     // `tx_channel_memory_limit_bytes`.
-    let (transactions_tx, mut transactions_rx) =
-        reth_metrics::common::mpsc::memory_bounded_channel(32 * 1024 * 1024, "p2p-proxy.tx");
+    let (transactions_tx, mut transactions_rx) = reth_metrics::common::mpsc::memory_bounded_channel(
+        config
+            .transactions_manager_config
+            .tx_channel_memory_limit_bytes,
+        "p2p-proxy.tx",
+    );
 
     let network = NetworkManager::new(config)
         .await

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -113,7 +113,7 @@ impl<H: Send + 'static> TxResult for TempoTxResult<H> {
 /// Block executor for Tempo.
 ///
 /// Wraps an inner [`EthBlockExecutor`] and layers Tempo-specific block execution
-/// logic on top: section-based transaction ordering ([`BlockSection`]), subblock
+/// logic on top: section-based transaction ordering (`BlockSection`), subblock
 /// validation, shared/non-shared gas accounting, and gas incentive tracking.
 pub struct TempoBlockExecutor<'a, DB: Database, I> {
     pub(crate) inner:

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -84,7 +84,7 @@ impl ReceiptBuilder for TempoReceiptBuilder {
 ///
 /// This is an extension of [`EthTxResult`] with context necessary for committing a Tempo transaction.
 #[derive(Debug)]
-pub(crate) struct TempoTxResult<H> {
+pub struct TempoTxResult<H> {
     /// Inner transaction execution result.
     inner: EthTxResult<H, TempoTxType>,
     /// Next section of the block.
@@ -98,7 +98,7 @@ pub(crate) struct TempoTxResult<H> {
     tx: Option<TempoTxEnvelope>,
 }
 
-impl<H> TxResult for TempoTxResult<H> {
+impl<H: Send + 'static> TxResult for TempoTxResult<H> {
     type HaltReason = H;
 
     fn result(&self) -> &ResultAndState<Self::HaltReason> {
@@ -115,7 +115,7 @@ impl<H> TxResult for TempoTxResult<H> {
 /// Wraps an inner [`EthBlockExecutor`] and layers Tempo-specific block execution
 /// logic on top: section-based transaction ordering ([`BlockSection`]), subblock
 /// validation, shared/non-shared gas accounting, and gas incentive tracking.
-pub(crate) struct TempoBlockExecutor<'a, DB: Database, I> {
+pub struct TempoBlockExecutor<'a, DB: Database, I> {
     pub(crate) inner:
         EthBlockExecutor<'a, TempoEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,
 
@@ -500,10 +500,7 @@ where
         })
     }
 
-    fn commit_transaction(
-        &mut self,
-        output: Self::Result,
-    ) -> Result<GasOutput, BlockExecutionError> {
+    fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
         let TempoTxResult {
             inner,
             next_section,
@@ -520,7 +517,7 @@ where
             inner.result.result.tx_gas_used()
         };
 
-        let gas_output = self.inner.commit_transaction(inner)?;
+        let gas_output = self.inner.commit_transaction(inner);
 
         self.section = next_section;
 
@@ -546,9 +543,9 @@ where
                     self.seen_subblocks.last_mut().unwrap()
                 };
 
-                last_subblock.1.push(tx.ok_or_else(|| {
-                    BlockExecutionError::msg("missing tx for subblock transaction")
-                })?);
+                last_subblock
+                    .1
+                    .push(tx.expect("missing tx for subblock transaction"));
             }
             BlockSection::GasIncentive => {
                 self.incentive_gas_used += gas_used;
@@ -558,7 +555,7 @@ where
             }
         }
 
-        Ok(gas_output)
+        gas_output
     }
 
     fn finish(
@@ -1203,7 +1200,7 @@ mod tests {
             tx: None,
         };
 
-        let gas_output = executor.commit_transaction(output).unwrap();
+        let gas_output = executor.commit_transaction(output);
 
         assert_eq!(gas_output.tx_gas_used(), 21000);
         assert_eq!(executor.section(), BlockSection::NonShared);
@@ -1250,7 +1247,7 @@ mod tests {
             tx: None,
         };
 
-        let gas_output = executor.commit_transaction(output).unwrap();
+        let gas_output = executor.commit_transaction(output);
 
         // With zero storage creation gas, execution gas equals total gas
         assert_eq!(gas_output.tx_gas_used(), 21000);
@@ -1287,7 +1284,7 @@ mod tests {
             is_payment: false,
             tx: None,
         };
-        executor.commit_transaction(output1).unwrap();
+        executor.commit_transaction(output1);
 
         // Commit second transaction (50000 gas)
         let tx2 = create_legacy_tx();
@@ -1309,7 +1306,7 @@ mod tests {
             is_payment: false,
             tx: None,
         };
-        executor.commit_transaction(output2).unwrap();
+        executor.commit_transaction(output2);
 
         // Receipts should have cumulative total gas (tracked by inner executor)
         let receipts = executor.receipts();
@@ -1370,7 +1367,7 @@ mod tests {
             is_payment: false,
             tx: None,
         };
-        executor.commit_transaction(output).unwrap();
+        executor.commit_transaction(output);
 
         assert_eq!(executor.non_shared_gas_left, initial_non_shared - 50_000);
     }
@@ -1413,7 +1410,7 @@ mod tests {
             is_payment: false,
             tx: None,
         };
-        executor.commit_transaction(output).unwrap();
+        executor.commit_transaction(output);
 
         // non_shared_gas_left should decrease by regular gas (200k), not total (300k)
         assert_eq!(
@@ -1459,7 +1456,7 @@ mod tests {
             is_payment: false,
             tx: None,
         };
-        executor.commit_transaction(output).unwrap();
+        executor.commit_transaction(output);
 
         assert_eq!(
             executor.incentive_gas_used, 200_000,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -9,7 +9,7 @@ use alloy_primitives::Address;
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
 mod block;
-pub use block::TempoReceiptBuilder;
+pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;
 pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
 #[cfg(feature = "engine")]
@@ -23,7 +23,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use alloy_evm::{
     self, EvmEnv,
-    block::{BlockExecutorFactory, BlockExecutorFor},
+    block::BlockExecutorFactory,
     eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
     revm::Inspector,
 };
@@ -36,7 +36,7 @@ use tempo_primitives::{
     subblock::PartialValidatorKey,
 };
 
-use crate::{block::TempoBlockExecutor, evm::TempoEvm};
+use crate::evm::TempoEvm;
 use reth_evm_ethereum::EthEvmConfig;
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params};
@@ -93,6 +93,9 @@ impl BlockExecutorFactory for TempoEvmConfig {
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
+    type TxExecutionResult = TempoTxResult<TempoHaltReason>;
+    type Executor<'a, DB: StateDB, I: Inspector<TempoContext<DB>>> =
+        TempoBlockExecutor<'a, DB, I>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         self.inner.executor_factory.evm_factory()
@@ -102,10 +105,10 @@ impl BlockExecutorFactory for TempoEvmConfig {
         &'a self,
         evm: TempoEvm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    ) -> Self::Executor<'a, DB, I>
     where
-        DB: StateDB + 'a,
-        I: Inspector<TempoContext<DB>> + 'a,
+        DB: StateDB,
+        I: Inspector<TempoContext<DB>>,
     {
         TempoBlockExecutor::new(evm, ctx, self.chain_spec())
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -94,8 +94,7 @@ impl BlockExecutorFactory for TempoEvmConfig {
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
     type TxExecutionResult = TempoTxResult<TempoHaltReason>;
-    type Executor<'a, DB: StateDB, I: Inspector<TempoContext<DB>>> =
-        TempoBlockExecutor<'a, DB, I>;
+    type Executor<'a, DB: StateDB, I: Inspector<TempoContext<DB>>> = TempoBlockExecutor<'a, DB, I>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         self.inner.executor_factory.evm_factory()

--- a/crates/primitives/src/reth_compat/header.rs
+++ b/crates/primitives/src/reth_compat/header.rs
@@ -1,5 +1,5 @@
 use crate::{TempoConsensusContext, TempoHeader};
-use alloy_primitives::{B256, BlockNumber, U256};
+use alloy_primitives::{B256, BlockNumber, Bytes, U256};
 
 impl reth_primitives_traits::InMemorySize for TempoConsensusContext {
     fn size(&self) -> usize {
@@ -45,6 +45,19 @@ impl reth_primitives_traits::header::HeaderMut for TempoHeader {
 
     fn set_difficulty(&mut self, difficulty: U256) {
         self.inner.set_difficulty(difficulty);
+    }
+
+    fn set_mix_hash(&mut self, mix_hash: B256) {
+        self.inner.set_mix_hash(mix_hash);
+    }
+
+    fn set_extra_data(&mut self, extra_data: Bytes) {
+        self.inner.set_extra_data(extra_data);
+    }
+
+    fn set_parent_beacon_block_root(&mut self, parent_beacon_block_root: Option<B256>) {
+        self.inner
+            .set_parent_beacon_block_root(parent_beacon_block_root);
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0098 rustls-webpki upgrade is pending
-  "RUSTSEC-2026-0098",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0099 rustls-webpki upgrade is pending
-  "RUSTSEC-2026-0099",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -88,13 +84,7 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
-  "https://github.com/alloy-rs/evm",
-  "https://github.com/bluealloy/revm.git",
   "https://github.com/commonwarexyz/monorepo",
-  "https://github.com/foundry-rs/foundry",
   "https://github.com/paradigmxyz/reth",
-  "https://github.com/paradigmxyz/reth-core",
-  "https://github.com/paradigmxyz/revm-inspectors",
   "https://github.com/sigp/discv5",
-  "https://github.com/DaniPopes/slotmap.git",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -95,5 +95,6 @@ allow-git = [
   "https://github.com/paradigmxyz/reth",
   "https://github.com/paradigmxyz/reth-core",
   "https://github.com/paradigmxyz/revm-inspectors",
+  "https://github.com/sigp/discv5",
   "https://github.com/DaniPopes/slotmap.git",
 ]


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`7839f3d...73ec2c9`](https://github.com/paradigmxyz/reth/compare/7839f3d...73ec2c9)

🔗 Amp thread: https://ampcode.com/threads/T-019dd89b-f659-75eb-a3f2-3e769d63297f
**Engine**
- Spawn BAL hashed state before storage prefetch ([#23761](https://github.com/paradigmxyz/reth/pull/23761)) and disable BAL parallel execution by default ([#23764](https://github.com/paradigmxyz/reth/pull/23764))
- Add CLI flag to disable BAL storage prefetch ([#23770](https://github.com/paradigmxyz/reth/pull/23770))
- Log transient invalid header cache skips ([#23711](https://github.com/paradigmxyz/reth/pull/23711))
- Add `DecodedBal` in `ExecutionEnv` ([#23675](https://github.com/paradigmxyz/reth/pull/23675))

**RPC**
- Clean up eth state cache reorg entries ([#23683](https://github.com/paradigmxyz/reth/pull/23683))
- Pass block timestamp to txn ([#23700](https://github.com/paradigmxyz/reth/pull/23700))
- Include block numbers in `BlockRangeExceedsHead` error ([#23720](https://github.com/paradigmxyz/reth/pull/23720))

**Network / P2P**
- Add Basic in-memory BAL store and BAL request to block access list requests ([#23682](https://github.com/paradigmxyz/reth/pull/23682), [#23710](https://github.com/paradigmxyz/reth/pull/23710))
- Enforce BAL response soft limit and apply count cap to handler ([#23725](https://github.com/paradigmxyz/reth/pull/23725), [#23754](https://github.com/paradigmxyz/reth/pull/23754))
- Avoid RLP-decoding `NewBlock` payloads ([#23712](https://github.com/paradigmxyz/reth/pull/23712)) and bound memory footprint of p2p messages ([#23718](https://github.com/paradigmxyz/reth/pull/23718))
- Memory-bound channel between network and tx manager ([#23802](https://github.com/paradigmxyz/reth/pull/23802))
- Track unknown tx types in announcement metrics ([#23688](https://github.com/paradigmxyz/reth/pull/23688))
- Retain active session buffer capacity ([#23702](https://github.com/paradigmxyz/reth/pull/23702)) and respect peer requirements for fetch followups ([#23706](https://github.com/paradigmxyz/reth/pull/23706))
- Support binding discv5 and discv4 to the same port ([#23613](https://github.com/paradigmxyz/reth/pull/23613)) and use Weak reference in discv5 kbuckets bg task to release port on shutdown ([#23282](https://github.com/paradigmxyz/reth/pull/23282))

**Trie**
- Skip DB seek on exact overlay hits ([#23559](https://github.com/paradigmxyz/reth/pull/23559))
- Account for heap-allocated blinded hashes in `SparseNode::memory_size` ([#23726](https://github.com/paradigmxyz/reth/pull/23726))

**DB / Storage**
- `reth db migrate-v2` for pruned nodes ([#23716](https://github.com/paradigmxyz/reth/pull/23716))
- Pass `ExecutedBlocks` to `OverlayBuilder`, reduce reverts queried ([#23657](https://github.com/paradigmxyz/reth/pull/23657))
- Add empty request check to storage values ([#23714](https://github.com/paradigmxyz/reth/pull/23714))
- Derive `Eq` for `IntegerList` ([#23709](https://github.com/paradigmxyz/reth/pull/23709)) and reorder unix deps after strum ([#23697](https://github.com/paradigmxyz/reth/pull/23697))

**Provider / EVM**
- Use overlay builders in historical state paths ([#23667](https://github.com/paradigmxyz/reth/pull/23667))
- Return gas output from block builder ([#23744](https://github.com/paradigmxyz/reth/pull/23744))
- Expose executor transaction result type ([#23759](https://github.com/paradigmxyz/reth/pull/23759))

**Perf**
- Configurable rocksdb block cache size and re-use of mdbx provider in re-execute ([#23701](https://github.com/paradigmxyz/reth/pull/23701))
- Enable revm `p256-aws-lc-rs` feature ([#23721](https://github.com/paradigmxyz/reth/pull/23721))
- Add platform-specific RUSTFLAGS to Dockerfile ([#23738](https://github.com/paradigmxyz/reth/pull/23738))

**Bench**
- Add reorg mode to `new-payload-fcu` ([#23666](https://github.com/paradigmxyz/reth/pull/23666))
- Enable `keccak-cache-global` in `reth-bb` ([#23723](https://github.com/paradigmxyz/reth/pull/23723)) and fix multi-executor support ([#23763](https://github.com/paradigmxyz/reth/pull/23763))
- Dedupe merged BAL storage reads ([#23758](https://github.com/paradigmxyz/reth/pull/23758))

**Re-execute**
- Verify reverts against changesets ([#23717](https://github.com/paradigmxyz/reth/pull/23717))

**Payload**
- Track Amsterdam block gas in builders ([#23743](https://github.com/paradigmxyz/reth/pull/23743))

**CLI**
- Use `TxTy`/`ReceiptTy` for static-file db get ([#23692](https://github.com/paradigmxyz/reth/pull/23692)) and node types in execution stage dump ([#23705](https://github.com/paradigmxyz/reth/pull/23705))
- Preserve `trusted_nodes_only` from config when `--trusted-only` is unset ([#23703](https://github.com/paradigmxyz/reth/pull/23703))
- Avoid u64 underflow in `setup_without_evm` for genesis header ([#23728](https://github.com/paradigmxyz/reth/pull/23728))

**Testing**
- Add BAL request e2e coverage ([#23727](https://github.com/paradigmxyz/reth/pull/23727))
- Cover admin node info discv5 port ([#23781](https://github.com/paradigmxyz/reth/pull/23781))

**Misc**
- Bump reth core to v0.3.1 ([#23707](https://github.com/paradigmxyz/reth/pull/23707)) and alloy-evm to 0.33.3 ([#23778](https://github.com/paradigmxyz/reth/pull/23778))
- Align ERA1 export with spec ([#23693](https://github.com/paradigmxyz/reth/pull/23693))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019dd89c-63d3-752f-ac22-7d4aef2ac3e3
- **Bumped reth git rev** from `7839f3d` to `73ec2c9` across all `reth-*` workspace dependencies in [Cargo.toml](file:///home/runner/work/tempo/tempo/Cargo.toml), and bumped `reth-primitives-traits` from `0.3.0` to `0.3.1` and `alloy-evm` from `0.33.0` to `0.34.0` to track upstream releases.
- **Switched p2p proxy transactions channel** from `tokio::sync::mpsc::unbounded_channel` to `reth_metrics::common::mpsc::memory_bounded_channel` with a 32 MiB budget in [bin/tempo/src/p2p_proxy.rs](file:///home/runner/work/tempo/tempo/bin/tempo/src/p2p_proxy.rs), matching reth's new default `tx_channel_memory_limit_bytes` to prevent unbounded memory growth; added `reth-metrics` to [bin/tempo/Cargo.toml](file:///home/runner/work/tempo/tempo/bin/tempo/Cargo.toml).
- **Changed `BlockExecutor::commit_transaction` signature** in [crates/evm/src/block.rs](file:///home/runner/work/tempo/tempo/crates/evm/src/block.rs) from returning `Result<GasOutput, BlockExecutionError>` to returning `GasOutput` directly (upstream removed the fallible return); replaced the missing-tx error with an `expect`, and updated all tests to drop `.unwrap()`.
- **Added `Send + 'static` bound to `TxResult` impl** for `TempoTxResult<H>` to satisfy the new upstream trait bounds on associated execution-result types.
- **Exposed `TempoBlockExecutor` and `TempoTxResult` as `pub`** (previously `pub(crate)`) and re-exported them from [crates/evm/src/lib.rs](file:///home/runner/work/tempo/tempo/crates/evm/src/lib.rs) so they can be named in the new associated types.
- **Added associated types `TxExecutionResult` and `Executor` to `BlockExecutorFactory` impl** for `TempoEvmConfig`, and changed `create_executor` to return the concrete `Self::Executor<'a, DB, I>` instead of `impl BlockExecutorFor<'a, Self, DB, I>`, tracking upstream's move from RPIT to named associated types; dropped the now-unused `BlockExecutorFor` import and the `'a` lifetime bounds on `DB`/`I`.
- **Implemented new `HeaderMut` methods** (`set_mix_hash`, `set_extra_data`, `set_parent_beacon_block_root`) for `TempoHeader` in [crates/primitives/src/reth_compat/header.rs](file:///home/runner/work/tempo/tempo/crates/primitives/src/reth_compat/header.rs) to satisfy the expanded upstream trait, delegating to the inner Ethereum header.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25101489247)
