### PR TITLE
chore(ci): point back to foundry's `master`

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: tempo-tip1016
+          ref: master
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
this PR updates the CI tests that rely on foundry, to point back to its `master` branch