### PR TITLE
feat: add T5 hardfork

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -28,6 +28,7 @@
     "t2Time": 0,
     "t3Time": 0,
     "t4Time": 0,
+    "t5Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -187,6 +187,8 @@ tempo_hardfork! (
         T3,
         /// T4 hardfork
         T4,
+        /// T5 hardfork
+        T5,
     }
 );
 
@@ -280,6 +282,7 @@ impl TempoHardfork {
             Self::T2 => Some(MAINNET_T2_BLOCK),
             Self::T3 => None, // not yet known
             Self::T4 => None,
+            Self::T5 => None,
         }
     }
 
@@ -296,6 +299,7 @@ impl TempoHardfork {
             Self::T2 => Some(MAINNET_T2_TIMESTAMP),
             Self::T3 => Some(MAINNET_T3_TIMESTAMP),
             Self::T4 => None,
+            Self::T5 => None,
         }
     }
 
@@ -312,6 +316,7 @@ impl TempoHardfork {
             Self::T2 => Some(MODERATO_T2_BLOCK),
             Self::T3 => None, // not yet known
             Self::T4 => None,
+            Self::T5 => None,
         }
     }
 
@@ -328,6 +333,7 @@ impl TempoHardfork {
             Self::T2 => Some(MODERATO_T2_TIMESTAMP),
             Self::T3 => Some(MODERATO_T3_TIMESTAMP),
             Self::T4 => None,
+            Self::T5 => None,
         }
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -57,6 +57,9 @@ pub struct TempoGenesisInfo {
     /// Activation timestamp for T4 hardfork.
     #[serde(skip_serializing_if = "Option::is_none")]
     t4_time: Option<u64>,
+    /// Activation timestamp for T5 hardfork.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    t5_time: Option<u64>,
 }
 
 impl TempoGenesisInfo {
@@ -85,6 +88,7 @@ impl TempoGenesisInfo {
             TempoHardfork::T2 => self.t2_time,
             TempoHardfork::T3 => self.t3_time,
             TempoHardfork::T4 => self.t4_time,
+            TempoHardfork::T5 => self.t5_time,
         }
     }
 }

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -28,6 +28,7 @@
     "t2Time": 0,
     "t3Time": 0,
     "t4Time": 0,
+    "t5Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -179,7 +179,7 @@ pub(crate) struct GenesisArgs {
     t4_time: u64,
 
     /// T5 hardfork activation time.
-    #[arg(long, default_value = "9223372036854775807")]
+    #[arg(long, default_value = "0")]
     t5_time: u64,
 }
 

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -177,6 +177,10 @@ pub(crate) struct GenesisArgs {
     /// T4 hardfork activation time.
     #[arg(long, default_value = "0")]
     t4_time: u64,
+
+    /// T5 hardfork activation time.
+    #[arg(long, default_value = "9223372036854775807")]
+    t5_time: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -541,6 +545,9 @@ impl GenesisArgs {
         chain_config
             .extra_fields
             .insert_value("t4Time".to_string(), self.t4_time)?;
+        chain_config
+            .extra_fields
+            .insert_value("t5Time".to_string(), self.t5_time)?;
         let mut extra_data = Bytes::from_static(b"tempo-genesis");
 
         if let Some(consensus_config) = &consensus_config {


### PR DESCRIPTION
Adds T5 hardfork variant to the Tempo chain. No activation timestamps set for mainnet/moderato yet.

Changes follow the documented `Adding a New Hardfork` guide in `hardfork.rs`:
- `TempoHardfork::T5` variant in `tempo_hardfork!` macro
- `t5_time` field in `TempoGenesisInfo`
- `fork_time()` match arm
- `dev.json` and `test-genesis.json` with `t5Time: i64::MAX` (disabled)
- CLI arg in `genesis_args.rs`

Linear: https://linear.app/tempoxyz/issue/CHAIN-1139/t5-hardfork-meta-tip
