### PR TITLE
chore: switch to crates.io OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -28,7 +29,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+        id: auth
+
       - name: Publish crates via sanitize pipeline
         run: ./scripts/publish-crates.sh --publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Replace `CARGO_REGISTRY_TOKEN` secret with OIDC trusted publishing via `rust-lang/crates-io-auth-action`.

After PR merged, delete the `CARGO_REGISTRY_TOKEN` repo secret.