### PR TITLE
fix(consensus): treat future timestamps as transient

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -207,6 +207,11 @@ impl Consensus<Block> for TempoConsensus {
 
         self.inner.validate_block_pre_execution(block)
     }
+
+    fn is_transient_error(&self, error: &ConsensusError) -> bool {
+        Consensus::<Block>::is_transient_error(&self.inner, error)
+            || matches!(error, ConsensusError::TimestampIsInFuture { .. })
+    }
 }
 
 impl FullConsensus<TempoPrimitives> for TempoConsensus {
@@ -912,6 +917,24 @@ mod tests {
             result.is_ok(),
             "Timestamp exactly at boundary should be accepted, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn test_timestamp_in_future_is_transient_error() {
+        let consensus = TempoConsensus::new(MODERATO.clone());
+        let err = ConsensusError::TimestampIsInFuture {
+            timestamp: 2,
+            present_timestamp: 1,
+        };
+
+        assert!(Consensus::<Block>::is_transient_error(&consensus, &err));
+
+        let err = ConsensusError::TimestampIsInPast {
+            parent_timestamp: 2,
+            timestamp: 1,
+        };
+
+        assert!(!Consensus::<Block>::is_transient_error(&consensus, &err));
     }
 
     #[test]

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -209,6 +209,7 @@ impl Consensus<Block> for TempoConsensus {
     }
 
     fn is_transient_error(&self, error: &ConsensusError) -> bool {
+        // Future timestamps can happen briefly when clocks drift between nodes.
         Consensus::<Block>::is_transient_error(&self.inner, error)
             || matches!(error, ConsensusError::TimestampIsInFuture { .. })
     }


### PR DESCRIPTION
Marks `ConsensusError::TimestampIsInFuture` as transient in Tempo consensus so future-dated blocks are retried after the local clock catches up. This can happen during brief clock drift between nodes.

Validated with `cargo test -p tempo-consensus`.