### PR TITLE
perf(revm): enable `p256-aws-lc-rs` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11074,6 +11074,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "38.0.0", features = ["optional_fee_charge", "p256-aws-lc-rs"], default-features = false }
+revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
 alloy = { version = "2.0.1", default-features = false }
 alloy-consensus = { version = "2.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7839f3d", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "38.0.0", features = ["optional_fee_charge", "p256-aws-lc-rs"], default-features = false }
 
 alloy = { version = "2.0.1", default-features = false }
 alloy-consensus = { version = "2.0.1", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -83,6 +83,7 @@ std = [
 	"reth-ethereum-primitives?/std",
 	"reth-primitives-traits?/std",
 	"revm/std",
+	"revm/p256-aws-lc-rs",
 	"serde/std",
 	"serde_json/std",
 	"sha2/std",


### PR DESCRIPTION
Same as https://github.com/paradigmxyz/reth/pull/23721

This is not as impactful for Tempo, because we have native p256 signature support, and we already use aws-lc-rs backend there. But still nice to have.