### PR TITLE
perf(revm): enable `blst` and `c-kzg` features

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -83,6 +83,8 @@ std = [
 	"reth-ethereum-primitives?/std",
 	"reth-primitives-traits?/std",
 	"revm/std",
+	"revm/blst",
+	"revm/c-kzg",
 	"serde/std",
 	"serde_json/std",
 	"sha2/std",


### PR DESCRIPTION
- `blst` — BLS12-381 ([EIP-2537](https://eips.ethereum.org/EIPS/eip-2537))
- `c-kzg` — KZG point evaluation ([EIP-4844](https://eips.ethereum.org/EIPS/eip-4844))

`c-kzg` is less impactful since Tempo doesn't have blob transactions, so the point evaluation precompile is unlikely to be called in practice, but more of a nice-to-have.
