### PR TITLE
docs(tip-1053): witness digest in key authorizations

### DIFF
--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -1,0 +1,129 @@
+---
+id: TIP-1053
+title: Witness Digest in Key Authorizations
+description: Add an optional opaque 32-byte witness digest to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context.
+authors: Jake Moxey (@jxom)
+status: Draft
+related: TIP-1011, TIP-1020, TIP-1049
+---
+
+# TIP-1053: Witness Digest in Key Authorizations
+
+## Abstract
+
+This TIP extends the `key_authorization` payload with an optional opaque `witness_digest: bytes32` field. The protocol includes the digest in the signing hash but otherwise treats it as opaque: it is not interpreted, validated, stored, or emitted. Applications use the field to bind a single signature to an arbitrary context — most commonly a server-issued sign-in challenge — so a user can authorize an access key and prove identity to an application in one signature.
+
+## Motivation
+
+A common UX pattern requires two signatures from the user:
+
+1. **Authenticate to an application server.** The server issues a random challenge; the user signs it with their account key to prove possession.
+2. **Authorize a new access key.** The user signs a `key_authorization` so the application can act on their behalf going forward (subject to limits/scopes/expiry).
+
+On WebAuthn keys, each signature is a separate biometric prompt. Doing this twice for what users perceive as a single "log in" action is awkward and erodes trust.
+
+Adding an opaque `witness_digest` to `key_authorization` lets the user sign **once**: the signature simultaneously authorizes the access key and binds to the server's challenge. A consuming verifier (most commonly an application server, but possibly a smart contract, indexer, or any other party that wants to validate the user's intent) checks the binding by recomputing the expected digest from the challenge it issued and comparing it to the digest committed to in the signed authorization.
+
+The protocol stays minimal: it does not learn about sign-in semantics, application schemas, or challenge formats. Apps and wallets standardize on the digest preimage.
+
+## Assumptions
+
+- The consuming verifier is responsible for replay protection of its own flow (e.g. a server-side nonce store for an application server). The protocol does not track used `witness_digest` values; it does not know which digests are tied to live sessions.
+- The `witness_digest` preimage is application-defined. The protocol does not validate its structure. Misuse (e.g. signing a digest the user did not understand) is a wallet/app UX concern, addressable via standardized preimage formats and typed-data rendering.
+- A user signing a `key_authorization` with a non-zero `witness_digest` is asserting consent to whatever application context the digest commits to. Wallets MUST display, or hash from typed data the wallet renders, the preimage so the user can review it before signing.
+- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. The field defaults to absent / zero, in which case the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization.
+- Replay protection for the access-key registration itself is unchanged: the existing `keys[account][keyId]` permanence prevents reuse of a given `key_id` after it has been authorized.
+
+---
+
+# Specification
+
+## Encoding
+
+`key_authorization` gains an optional trailing `witness_digest: bytes32` field:
+
+```
+key_authorization = rlp([
+  chain_id,
+  key_type,
+  key_id,
+  expiry?,
+  limits?,
+  allowed_calls?,
+  admin?,          
+  witness_digest?,  // NEW — opaque 32 bytes, default zero/absent
+])
+```
+
+- Encoding is RLP, identical to the existing payload format with one optional trailing item.
+- `witness_digest` MUST be exactly 32 bytes when present.
+- When absent (or encoded as `0x80` / empty), it is treated as `bytes32(0)`. The signing hash MUST treat absent and `bytes32(0)` as encoding-equivalent so older clients producing the original encoding still produce valid hashes.
+
+## Signing
+
+The signing hash is the keccak256 of the canonical RLP encoding:
+
+```
+digest = keccak256(rlp(key_authorization))
+```
+
+No additional domain separation is introduced. RLP boundaries already disambiguate the trailing field. The protocol verifies signatures exactly as it does today; the only change is that the encoded payload may now contain the additional field.
+
+## Protocol Behavior
+
+The protocol:
+
+- MUST include `witness_digest` in the signing hash whenever it is present in the encoded `key_authorization`.
+- MUST NOT interpret the `witness_digest` value.
+- MUST NOT enforce uniqueness, freshness, or any structural constraint on `witness_digest`.
+- MUST NOT store `witness_digest` in account or precompile state.
+- MUST NOT emit `witness_digest` in any event by default.
+
+The field is invisible to all existing precompile read paths (`getKey`, `KeyInfo`, etc.). It exists solely to commit the signature to an off-protocol context.
+
+## Verification
+
+A consuming verifier (most commonly an application server, but the same flow applies to any party validating the signed authorization — smart contract, indexer, off-chain attester, etc.) verifies a witness digest entirely offchain. The client sends the verifier a single byte string:
+
+```
+payload             = key_authorization ‖ signature
+
+key_authorization   = rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls, admin, witness_digest])
+signature           = admin key signature over keccak256(key_authorization)
+```
+
+The verifier:
+
+1. Splits `payload` into `key_authorization` and `signature` (signature length is fixed per signature type).
+2. RLP-decodes `key_authorization` to access its fields.
+3. Recomputes `expected_digest` from the challenge / typed-data message it issued.
+4. Asserts the decoded `witness_digest == expected_digest`.
+5. Hashes `key_authorization` with keccak256, recovers the signer from `signature`.
+6. Asserts the recovered signer equals the expected account.
+7. Validates the remaining decoded fields against the verifier's policy (key_id matches the passkey being registered, expiry is within bounds, limits/scopes/admin flag match the verifier's expectations).
+
+No node, RPC, or chain state is required for verification when the signer is the root key. Admin-key signed authorizations ([TIP-1049](https://tips.sh/1049)) require a chain lookup to confirm admin status; verifiers wishing to accept those should call `AccountKeychain.verifySignature` or query `isAdminKey` directly.
+
+## Preimage
+
+The `witness_digest` preimage is application-defined. The protocol treats any 32-byte value identically and does not prescribe a format. Wallet and application standardization (e.g., a "Sign-In with Tempo" typed-data convention) is left to a separate document so it can evolve without protocol changes.
+
+## Backward Compatibility
+
+- Existing key authorizations without the field continue to validate. The encoder MUST omit the trailing field when `witness_digest == bytes32(0)`, producing a byte-equivalent encoding to pre-TIP-1053 payloads.
+- Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a non-zero digest, which is the correct fail-safe.
+- [TIP-1049](https://tips.sh/1049)'s `admin` field placement is unchanged. `witness_digest` is appended after it.
+
+# Invariants
+
+1. **Hash inclusion.** When `witness_digest` is present in the encoded `key_authorization`, it MUST be part of the signing hash. Validators MUST reject any signature computed over a hash that omits a present digest.
+
+2. **Encoding determinism.** For a given logical `key_authorization` (including `witness_digest == bytes32(0)`), the canonical RLP encoding is unique: the trailing zero digest MUST be omitted, never encoded as 32 zero bytes. This guarantees byte-identical encoding to legacy authorizations and prevents two distinct hashes for the same logical payload.
+
+3. **Protocol blindness.** The protocol MUST NOT branch on, validate, store, or emit the `witness_digest` value. Any precompile, event, or state field that exposes it is out of scope for this TIP and would require its own.
+
+4. **Replay protection unchanged.** Replay protection for the access-key registration itself is unchanged from pre-TIP-1053 semantics: the existing `keys[account][keyId]` permanence (revoked or active) prevents re-registration of the same `key_id`. The `witness_digest` is not a replay-protection mechanism for the auth.
+
+5. **Backward compatibility.** Authorizations with `witness_digest == bytes32(0)` (or absent) MUST produce signatures byte-identical to those produced under pre-TIP-1053 rules. Existing wallets, indexers, and tooling that do not know about this field continue to function for the legacy case.
+
+6. **No cross-protocol leakage.** [TIP-1020](https://tips.sh/1020) (`recover`/`verify`) and `AccountKeychain.verifySignature` ([TIP-1049](https://tips.sh/1049)) MUST NOT learn about `witness_digest`. The field exists only on the signed `key_authorization` payload, not on arbitrary signatures.

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -50,7 +50,6 @@ key_authorization = rlp([
   expiry?,
   limits?,
   allowed_calls?,
-  admin?,          
   witness_digest?,  // NEW — opaque 32 bytes, default zero/absent
 ])
 ```
@@ -88,8 +87,8 @@ A consuming verifier (most commonly an application server, but the same flow app
 ```
 payload             = key_authorization ‖ signature
 
-key_authorization   = rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls, admin, witness_digest])
-signature           = admin key signature over keccak256(key_authorization)
+key_authorization   = rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls, witness_digest])
+signature           = root or admin key signature over keccak256(key_authorization)
 ```
 
 The verifier:
@@ -100,9 +99,9 @@ The verifier:
 4. Asserts the decoded `witness_digest == expected_digest`.
 5. Hashes `key_authorization` with keccak256, recovers the signer from `signature`.
 6. Asserts the recovered signer equals the expected account.
-7. Validates the remaining decoded fields against the verifier's policy (key_id matches the passkey being registered, expiry is within bounds, limits/scopes/admin flag match the verifier's expectations).
+7. Validates the remaining decoded fields against the verifier's policy (key_id matches the passkey being registered, expiry is within bounds, limits/scopes match the verifier's expectations).
 
-No node, RPC, or chain state is required for verification when the signer is the root key. Admin-key signed authorizations ([TIP-1049](https://tips.sh/1049)) require a chain lookup to confirm admin status; verifiers wishing to accept those should call `AccountKeychain.verifySignature` or query `isAdminKey` directly.
+No node, RPC, or chain state is required for verification when the signer is the root key. Admin-key signed authorizations ([TIP-1049](https://tips.sh/1049)) require a chain lookup to confirm admin status; verifiers wishing to accept those should call `SignatureVerifier.verifyAdmin` (TIP-1020) or query `AccountKeychain.isAdminKey` directly.
 
 ## Preimage
 
@@ -112,7 +111,6 @@ The `witness_digest` preimage is application-defined. The protocol treats any 32
 
 - Existing key authorizations without the field continue to validate. The encoder MUST omit the trailing field when `witness_digest == bytes32(0)`, producing a byte-equivalent encoding to pre-TIP-1053 payloads.
 - Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a non-zero digest, which is the correct fail-safe.
-- [TIP-1049](https://tips.sh/1049)'s `admin` field placement is unchanged. `witness_digest` is appended after it.
 
 # Invariants
 

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -116,14 +116,8 @@ The `witness_digest` preimage is application-defined. The protocol treats any 32
 
 # Invariants
 
-1. **Hash inclusion.** When `witness_digest` is present in the encoded `key_authorization`, it MUST be part of the signing hash. Validators MUST reject any signature computed over a hash that omits a present digest.
+1. **Hash inclusion.** When `witness_digest` is present in the encoded `key_authorization`, it MUST be part of the signing hash.
 
-2. **Encoding determinism.** For a given logical `key_authorization` (including `witness_digest == bytes32(0)`), the canonical RLP encoding is unique: the trailing zero digest MUST be omitted, never encoded as 32 zero bytes. This guarantees byte-identical encoding to legacy authorizations and prevents two distinct hashes for the same logical payload.
+2. **Encoding determinism.** A `witness_digest` of `bytes32(0)` MUST be omitted from the RLP encoding, never encoded as 32 zero bytes.
 
-3. **Protocol blindness.** The protocol MUST NOT branch on, validate, store, or emit the `witness_digest` value. Any precompile, event, or state field that exposes it is out of scope for this TIP and would require its own.
-
-4. **Replay protection unchanged.** Replay protection for the access-key registration itself is unchanged from pre-TIP-1053 semantics: the existing `keys[account][keyId]` permanence (revoked or active) prevents re-registration of the same `key_id`. The `witness_digest` is not a replay-protection mechanism for the auth.
-
-5. **Backward compatibility.** Authorizations with `witness_digest == bytes32(0)` (or absent) MUST produce signatures byte-identical to those produced under pre-TIP-1053 rules. Existing wallets, indexers, and tooling that do not know about this field continue to function for the legacy case.
-
-6. **No cross-protocol leakage.** [TIP-1020](https://tips.sh/1020) (`recover`/`verify`) and `AccountKeychain.verifySignature` ([TIP-1049](https://tips.sh/1049)) MUST NOT learn about `witness_digest`. The field exists only on the signed `key_authorization` payload, not on arbitrary signatures.
+3. **Protocol blindness.** The protocol MUST NOT branch on, validate, store, or emit the `witness_digest` value.

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -5,6 +5,7 @@ description: Add an optional 32-byte nonce to key authorizations so a single sig
 authors: Jake Moxey (@jxom)
 status: Draft
 related: TIP-1011, TIP-1020
+protocolVersion: T5
 ---
 
 # TIP-1053: Nonce in Key Authorizations

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -3,7 +3,7 @@ id: TIP-1053
 title: Nonce in Key Authorizations
 description: Add an optional 32-byte nonce to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context, with protocol-enforced uniqueness enabling revocation.
 authors: Jake Moxey (@jxom)
-status: Draft
+status: Approved
 related: TIP-1011, TIP-1020
 protocolVersion: T5
 ---

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -134,5 +134,3 @@ The `nonce` format is application-defined when used as a challenge digest. The p
 2. **Encoding determinism.** A `nonce` of `bytes32(0)` MUST be omitted from the RLP encoding, never encoded as 32 zero bytes.
 
 3. **Single-use.** For any account `A` and any non-zero `nonce` value `n`, the protocol MUST accept at most one successful `key_authorization` registration or burn for `(A, n)`.
-
-4. **Protocol opacity beyond uniqueness.** The protocol MUST NOT branch on the structure of `nonce` beyond enforcing uniqueness; it MUST NOT interpret, parse, or validate the value's content.

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -1,17 +1,17 @@
 ---
 id: TIP-1053
-title: Witness Digest in Key Authorizations
-description: Add an optional opaque 32-byte witness digest to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context.
+title: Nonce in Key Authorizations
+description: Add an optional 32-byte nonce to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context, with protocol-enforced uniqueness enabling revocation.
 authors: Jake Moxey (@jxom)
 status: Draft
 related: TIP-1011, TIP-1020, TIP-1049
 ---
 
-# TIP-1053: Witness Digest in Key Authorizations
+# TIP-1053: Nonce in Key Authorizations
 
 ## Abstract
 
-This TIP extends the `key_authorization` payload with an optional opaque `witness_digest: bytes32` field. The protocol includes the digest in the signing hash but otherwise treats it as opaque: it is not interpreted, validated, stored, or emitted. Applications use the field to bind a single signature to an arbitrary context — most commonly a server-issued sign-in challenge — so a user can authorize an access key and prove identity to an application in one signature.
+This TIP extends the `key_authorization` payload with an optional `nonce: bytes32` field. The protocol includes the nonce in the signing hash and enforces per-account uniqueness so a nonce can be consumed at most once. The nonce value itself is otherwise opaque to the protocol. Applications use the field to bind a single signature to an arbitrary context — most commonly a server-issued  challenge — so a user can authorize an access key and prove identity to an application in one signature. The same field doubles as a revocation handle for previously signed but not-yet-submitted authorizations.
 
 ## Motivation
 
@@ -22,17 +22,18 @@ A common UX pattern requires two signatures from the user:
 
 On WebAuthn keys, each signature is a separate biometric prompt. Doing this twice for what users perceive as a single "log in" action is awkward and erodes trust.
 
-Adding an opaque `witness_digest` to `key_authorization` lets the user sign **once**: the signature simultaneously authorizes the access key and binds to the server's challenge. A consuming verifier (most commonly an application server, but possibly a smart contract, indexer, or any other party that wants to validate the user's intent) checks the binding by recomputing the expected digest from the challenge it issued and comparing it to the digest committed to in the signed authorization.
+Adding a `nonce` to `key_authorization` lets the user sign **once**: the signature simultaneously authorizes the access key and binds to the offchain verifier's challenge. An offchain verifier (most commonly an application server or any other party that wants to validate the user's intent) checks the binding by recomputing the expected nonce from the challenge it issued and comparing it to the value committed to in the signed authorization.
 
-The protocol stays minimal: it does not learn about sign-in semantics, application schemas, or challenge formats. Apps and wallets standardize on the digest preimage.
+A `nonce` field also gives accounts a first-class revocation primitive: an account can burn a nonce onchain (via a no-op consumption) to invalidate any previously signed but unsubmitted `key_authorization` that uses that same nonce. This is particularly useful when a user signs a key authorization that is then lost, leaked, or superseded before it lands on chain.
+
+The protocol stays minimal: it does not learn about sign-in semantics, application schemas, or challenge formats. Apps and wallets standardize on the nonce format. The protocol's only added responsibility is uniqueness tracking.
 
 ## Assumptions
 
-- The consuming verifier is responsible for replay protection of its own flow (e.g. a server-side nonce store for an application server). The protocol does not track used `witness_digest` values; it does not know which digests are tied to live sessions.
-- The `witness_digest` preimage is application-defined. The protocol does not validate its structure. Misuse (e.g. signing a digest the user did not understand) is a wallet/app UX concern, addressable via standardized preimage formats and typed-data rendering.
-- A user signing a `key_authorization` with a non-zero `witness_digest` is asserting consent to whatever application context the digest commits to. Wallets MUST display, or hash from typed data the wallet renders, the preimage so the user can review it before signing.
-- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. The field defaults to absent / zero, in which case the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization.
-- Replay protection for the access-key registration itself is unchanged: the existing `keys[account][keyId]` permanence prevents reuse of a given `key_id` after it has been authorized.
+- The offchain verifier (e.g. app server) is responsible for replay protection of its own session flow. The protocol's nonce uniqueness check protects the onchain registration of the **key authorization**; an offchain verifier still needs to bind its session to the specific nonce it issued.
+- The `nonce` format is application-defined when used as a challenge digest. The protocol does not validate its structure.
+- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. The field defaults to absent / zero, in which case the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization and no nonce tracking is performed.
+- Nonce-bearing authorizations gain an additional uniqueness guarantee at the `(account, nonce)` granularity.
 
 ---
 
@@ -40,7 +41,7 @@ The protocol stays minimal: it does not learn about sign-in semantics, applicati
 
 ## Encoding
 
-`key_authorization` gains an optional trailing `witness_digest: bytes32` field:
+`key_authorization` gains an optional trailing `nonce: bytes32` field:
 
 ```
 key_authorization = rlp([
@@ -50,13 +51,13 @@ key_authorization = rlp([
   expiry?,
   limits?,
   allowed_calls?,
-  witness_digest?,  // NEW — opaque 32 bytes, default zero/absent
+  nonce?,  // NEW — 32 bytes, default zero/absent
 ])
 ```
 
 - Encoding is RLP, identical to the existing payload format with one optional trailing item.
-- `witness_digest` MUST be exactly 32 bytes when present.
-- When absent (or encoded as `0x80` / empty), it is treated as `bytes32(0)`. The signing hash MUST treat absent and `bytes32(0)` as encoding-equivalent so older clients producing the original encoding still produce valid hashes.
+- `nonce` MUST be exactly 32 bytes when present.
+- A `nonce` of `bytes32(0)` is reserved to mean "no nonce" and MUST be omitted from the RLP encoding rather than encoded as 32 zero bytes. This guarantees byte-equivalence with pre-TIP-1053 encoding for nonce-less authorizations.
 
 ## Signing
 
@@ -72,22 +73,36 @@ No additional domain separation is introduced. RLP boundaries already disambigua
 
 The protocol:
 
-- MUST include `witness_digest` in the signing hash whenever it is present in the encoded `key_authorization`.
-- MUST NOT interpret the `witness_digest` value.
-- MUST NOT enforce uniqueness, freshness, or any structural constraint on `witness_digest`.
-- MUST NOT store `witness_digest` in account or precompile state.
-- MUST NOT emit `witness_digest` in any event by default.
+- MUST include `nonce` in the signing hash whenever it is present in the encoded `key_authorization`.
+- MUST enforce that, for any account `A`, a given non-zero `nonce` is consumed at most once. An attempt to register a `key_authorization` whose `(account, nonce)` pair has already been consumed MUST revert.
+- MUST mark `(account, nonce)` as consumed atomically with the successful registration of the authorization.
+- MUST NOT enforce ordering, monotonicity, or any other structural constraint on `nonce`. Nonces may be arbitrary 32-byte values chosen by the application.
+- MUST NOT interpret the `nonce` value beyond uniqueness tracking.
+- MUST NOT emit `nonce` in any event by default beyond what is needed to expose consumption.
 
-The field is invisible to all existing precompile read paths (`getKey`, `KeyInfo`, etc.). It exists solely to commit the signature to an off-protocol context.
+A nonce-less authorization (field absent / `bytes32(0)`) is processed exactly as in pre-TIP-1053 behavior: no uniqueness check is performed, no state is written for nonce tracking, and the existing `keys[account][key_id]` permanence is the sole replay guard.
+
+The field is invisible to existing precompile read paths that surface `KeyInfo`. A new read path MAY be added to query consumption status of a given `(account, nonce)` pair.
+
+## Revocation
+
+An account holder can pre-emptively invalidate a signed-but-unsubmitted `key_authorization` by burning its nonce onchain. Burning is a no-op consumption: the protocol exposes a path that marks `(account, nonce)` as consumed without registering any key. Once the nonce is consumed, any later attempt to submit the original authorization with the same nonce reverts.
+
+This gives users and wallets a clean recovery primitive when:
+
+- A signed authorization is lost or leaked before submission.
+- A user wants to supersede an outstanding authorization with a new one for the same `key_id`.
+
+Burning is restricted to the account itself (or any key authorized to act on its behalf, subject to that key's scope rules).
 
 ## Verification
 
-A consuming verifier (most commonly an application server, but the same flow applies to any party validating the signed authorization — smart contract, indexer, off-chain attester, etc.) verifies a witness digest entirely offchain. The client sends the verifier a single byte string:
+A offchain verifier (most commonly an application server, but the same flow applies to any party validating the signed authorization) verifies a nonce-bearing authorization entirely offchain. The client sends the verifier a single byte string:
 
 ```
 payload             = key_authorization ‖ signature
 
-key_authorization   = rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls, witness_digest])
+key_authorization   = rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls, nonce])
 signature           = root or admin key signature over keccak256(key_authorization)
 ```
 
@@ -95,27 +110,28 @@ The verifier:
 
 1. Splits `payload` into `key_authorization` and `signature` (signature length is fixed per signature type).
 2. RLP-decodes `key_authorization` to access its fields.
-3. Recomputes `expected_digest` from the challenge / typed-data message it issued.
-4. Asserts the decoded `witness_digest == expected_digest`.
+3. Recomputes `expected_nonce` from the challenge / typed-data message it issued.
+4. Asserts the decoded `nonce == expected_nonce`.
 5. Hashes `key_authorization` with keccak256, recovers the signer from `signature`.
 6. Asserts the recovered signer equals the expected account.
 7. Validates the remaining decoded fields against the verifier's policy (key_id matches the passkey being registered, expiry is within bounds, limits/scopes match the verifier's expectations).
 
-No node, RPC, or chain state is required for verification when the signer is the root key. Admin-key signed authorizations ([TIP-1049](https://tips.sh/1049)) require a chain lookup to confirm admin status; verifiers wishing to accept those should call `SignatureVerifier.verifyAdmin` (TIP-1020) or query `AccountKeychain.isAdminKey` directly.
+## Format
 
-## Preimage
-
-The `witness_digest` preimage is application-defined. The protocol treats any 32-byte value identically and does not prescribe a format. Wallet and application standardization (e.g., a "Sign-In with Tempo" typed-data convention) is left to a separate document so it can evolve without protocol changes.
+The `nonce` format is application-defined when used as a challenge digest. The protocol treats any 32-byte value identically and does not prescribe a format. Wallet and application standardization (e.g., a "Sign-In with Tempo" convention) is left to a separate document so it can evolve without protocol changes.
 
 ## Backward Compatibility
 
-- Existing key authorizations without the field continue to validate. The encoder MUST omit the trailing field when `witness_digest == bytes32(0)`, producing a byte-equivalent encoding to pre-TIP-1053 payloads.
-- Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a non-zero digest, which is the correct fail-safe.
+- Existing key authorizations without the field continue to validate. The encoder MUST omit the trailing field when `nonce == bytes32(0)`, producing a byte-equivalent encoding to pre-TIP-1053 payloads.
+- Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a non-zero nonce, which is the correct fail-safe.
+- Nonce uniqueness tracking is only engaged for non-zero nonces; legacy nonce-less authorizations incur no additional state.
 
 # Invariants
 
-1. **Hash inclusion.** When `witness_digest` is present in the encoded `key_authorization`, it MUST be part of the signing hash.
+1. **Hash inclusion.** When `nonce` is present in the encoded `key_authorization`, it MUST be part of the signing hash.
 
-2. **Encoding determinism.** A `witness_digest` of `bytes32(0)` MUST be omitted from the RLP encoding, never encoded as 32 zero bytes.
+2. **Encoding determinism.** A `nonce` of `bytes32(0)` MUST be omitted from the RLP encoding, never encoded as 32 zero bytes.
 
-3. **Protocol blindness.** The protocol MUST NOT branch on, validate, store, or emit the `witness_digest` value.
+3. **Single-use.** For any account `A` and any non-zero `nonce` value `n`, the protocol MUST accept at most one successful `key_authorization` registration or burn for `(A, n)`.
+
+4. **Protocol opacity beyond uniqueness.** The protocol MUST NOT branch on the structure of `nonce` beyond enforcing uniqueness; it MUST NOT interpret, parse, or validate the value's content.

--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -4,7 +4,7 @@ title: Nonce in Key Authorizations
 description: Add an optional 32-byte nonce to key authorizations so a single signature can both authorize an access key and bind to an arbitrary application context, with protocol-enforced uniqueness enabling revocation.
 authors: Jake Moxey (@jxom)
 status: Draft
-related: TIP-1011, TIP-1020, TIP-1049
+related: TIP-1011, TIP-1020
 ---
 
 # TIP-1053: Nonce in Key Authorizations


### PR DESCRIPTION
Adds an optional opaque \`witness_digest: bytes32\` to \`key_authorization\` so a single signature can both authorize an access key and bind to an arbitrary application context (e.g. a sign-in challenge), enabling one-signature flows.

The protocol includes the digest in the signing hash but otherwise treats it as opaque — not interpreted, stored, or emitted. Verifiers (typically application servers) check the binding offchain by recomputing the expected digest. Preimage standardization (e.g. Sign-In with Tempo) is left to a separate document.