### PR TITLE
fix(consensus): trim whitespace when parsing hex signing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12522,6 +12522,7 @@ dependencies = [
  "commonware-utils",
  "const-hex",
  "rand 0.8.6",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/commonware-node-config/Cargo.toml
+++ b/crates/commonware-node-config/Cargo.toml
@@ -19,3 +19,4 @@ thiserror.workspace = true
 [dev-dependencies]
 commonware-utils.workspace = true
 rand_08.workspace = true
+tempfile.workspace = true

--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -27,11 +27,11 @@ impl SigningKey {
 
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, SigningKeyError> {
         let hex = std::fs::read_to_string(path).map_err(SigningKeyErrorKind::Read)?;
-        Self::try_from_hex(&hex)
+        Self::try_from_hex(hex.trim())
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningKeyError> {
-        let bytes = const_hex::decode(hex.trim()).map_err(SigningKeyErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex).map_err(SigningKeyErrorKind::Hex)?;
         let inner = PrivateKey::decode(&bytes[..]).map_err(SigningKeyErrorKind::Parse)?;
         Ok(Self { inner })
     }
@@ -92,11 +92,11 @@ impl SigningShare {
 
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, SigningShareError> {
         let hex = std::fs::read_to_string(path).map_err(SigningShareErrorKind::Read)?;
-        Self::try_from_hex(&hex)
+        Self::try_from_hex(hex.trim())
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningShareError> {
-        let bytes = const_hex::decode(hex.trim()).map_err(SigningShareErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex).map_err(SigningShareErrorKind::Hex)?;
         let inner = Share::decode(&bytes[..]).map_err(SigningShareErrorKind::Parse)?;
         Ok(Self { inner })
     }

--- a/crates/commonware-node-config/src/lib.rs
+++ b/crates/commonware-node-config/src/lib.rs
@@ -31,7 +31,7 @@ impl SigningKey {
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningKeyError> {
-        let bytes = const_hex::decode(hex).map_err(SigningKeyErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex.trim()).map_err(SigningKeyErrorKind::Hex)?;
         let inner = PrivateKey::decode(&bytes[..]).map_err(SigningKeyErrorKind::Parse)?;
         Ok(Self { inner })
     }
@@ -96,7 +96,7 @@ impl SigningShare {
     }
 
     pub fn try_from_hex(hex: &str) -> Result<Self, SigningShareError> {
-        let bytes = const_hex::decode(hex).map_err(SigningShareErrorKind::Hex)?;
+        let bytes = const_hex::decode(hex.trim()).map_err(SigningShareErrorKind::Hex)?;
         let inner = Share::decode(&bytes[..]).map_err(SigningShareErrorKind::Parse)?;
         Ok(Self { inner })
     }

--- a/crates/commonware-node-config/src/tests.rs
+++ b/crates/commonware-node-config/src/tests.rs
@@ -17,6 +17,12 @@ fn signing_key_snapshot() {
 }
 
 #[test]
+fn signing_key_trims_whitespace() {
+    SigningKey::try_from_hex(&format!("{SIGNING_KEY}\n")).unwrap();
+    SigningKey::try_from_hex(&format!("  {SIGNING_KEY}\r\n")).unwrap();
+}
+
+#[test]
 fn signing_key_roundtrip() {
     let signing_key: SigningKey = PrivateKey::from_seed(42).into();
     assert_eq!(
@@ -30,6 +36,12 @@ fn signing_key_roundtrip() {
 #[test]
 fn signing_share_snapshot() {
     SigningShare::try_from_hex(SIGNING_SHARE).unwrap();
+}
+
+#[test]
+fn signing_share_trims_whitespace() {
+    SigningShare::try_from_hex(&format!("{SIGNING_SHARE}\n")).unwrap();
+    SigningShare::try_from_hex(&format!("  {SIGNING_SHARE}\r\n")).unwrap();
 }
 
 #[test]

--- a/crates/commonware-node-config/src/tests.rs
+++ b/crates/commonware-node-config/src/tests.rs
@@ -1,3 +1,5 @@
+use std::io::Write as _;
+
 use commonware_cryptography::{
     Signer as _,
     bls12381::{dkg, primitives::variant::MinSig},
@@ -11,15 +13,23 @@ use crate::{SigningKey, SigningShare};
 const SIGNING_KEY: &str = "0x7848b5d711bc9883996317a3f9c90269d56771005d540a19184939c9e8d0db2a";
 const SIGNING_SHARE: &str = "0x00594108e8326f1a4f1dcfd0a473141bb95c54c9a591983922158f1f082c671e31";
 
+fn write_tempfile(contents: &str) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    file
+}
+
 #[test]
 fn signing_key_snapshot() {
     SigningKey::try_from_hex(SIGNING_KEY).unwrap();
 }
 
 #[test]
-fn signing_key_trims_whitespace() {
-    SigningKey::try_from_hex(&format!("{SIGNING_KEY}\n")).unwrap();
-    SigningKey::try_from_hex(&format!("  {SIGNING_KEY}\r\n")).unwrap();
+fn signing_key_read_from_file_trims_whitespace() {
+    let file = write_tempfile(&format!("{SIGNING_KEY}\n"));
+    SigningKey::read_from_file(file.path()).unwrap();
+    let file = write_tempfile(&format!("  {SIGNING_KEY}\r\n"));
+    SigningKey::read_from_file(file.path()).unwrap();
 }
 
 #[test]
@@ -39,9 +49,11 @@ fn signing_share_snapshot() {
 }
 
 #[test]
-fn signing_share_trims_whitespace() {
-    SigningShare::try_from_hex(&format!("{SIGNING_SHARE}\n")).unwrap();
-    SigningShare::try_from_hex(&format!("  {SIGNING_SHARE}\r\n")).unwrap();
+fn signing_share_read_from_file_trims_whitespace() {
+    let file = write_tempfile(&format!("{SIGNING_SHARE}\n"));
+    SigningShare::read_from_file(file.path()).unwrap();
+    let file = write_tempfile(&format!("  {SIGNING_SHARE}\r\n"));
+    SigningShare::read_from_file(file.path()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
SigningKey/SigningShare::try_from_hex now trim input before hex decoding so files with a trailing newline (the common case) no longer fail with "odd number of digits". Complements #3615 which only covered --wallet-key and --new-private-key.