### PR TITLE
feat: add xtask to get enode without starting a full node

### DIFF
--- a/xtask/src/enode_from_secret.rs
+++ b/xtask/src/enode_from_secret.rs
@@ -1,0 +1,51 @@
+use std::net::SocketAddr;
+
+use eyre::{Context, ensure};
+use reth_network_peers::pk2id;
+
+/// Derive the enode URL from a 32-byte secp256k1 secret key.
+///
+/// The enode identifier is the uncompressed secp256k1 public key with the
+/// leading 0x04 tag stripped (64 bytes = 128 hex characters).
+#[derive(Debug, clap::Parser)]
+pub(crate) struct EnodeFromSecret {
+    /// 64-character hex string of the 32-byte secp256k1 secret key.
+    ///
+    /// May optionally start with "0x".
+    #[arg(long)]
+    secret_key: String,
+
+    /// Optional socket address (ip:port) to produce the full enode URL.
+    ///
+    /// If omitted only the public key is printed.
+    #[arg(long)]
+    address: Option<SocketAddr>,
+}
+
+impl EnodeFromSecret {
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        let mut hex = self.secret_key.trim();
+        hex = hex.strip_prefix("0x").unwrap_or(hex);
+        hex = hex.strip_prefix("0X").unwrap_or(hex);
+
+        ensure!(
+            hex.len() == 64,
+            "secret key must be exactly 64 hex characters (32 bytes), got {}",
+            hex.len()
+        );
+
+        let bytes = const_hex::decode(hex).wrap_err("invalid hex string")?;
+
+        let sk = secp256k1::SecretKey::from_slice(&bytes)
+            .wrap_err("invalid secp256k1 secret key")?;
+        let pk = sk.public_key(secp256k1::SECP256K1);
+        let peer_id = pk2id(&pk);
+
+        if let Some(addr) = self.address {
+            println!("enode://{peer_id:x}@{addr}");
+        } else {
+            println!("{peer_id:x}");
+        }
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,9 +2,9 @@
 use std::net::SocketAddr;
 
 use crate::{
-    check_abi::CheckAbi, generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
-    generate_localnet::GenerateLocalnet, generate_state_bloat::GenerateStateBloat,
-    get_dkg_outcome::GetDkgOutcome,
+    check_abi::CheckAbi, enode_from_secret::EnodeFromSecret, generate_devnet::GenerateDevnet,
+    generate_genesis::GenerateGenesis, generate_localnet::GenerateLocalnet,
+    generate_state_bloat::GenerateStateBloat, get_dkg_outcome::GetDkgOutcome,
 };
 
 use alloy::signers::{local::MnemonicBuilder, utils::secret_key_to_address};
@@ -13,6 +13,7 @@ use commonware_codec::DecodeExt;
 use eyre::Context;
 
 mod check_abi;
+mod enode_from_secret;
 mod generate_devnet;
 mod generate_genesis;
 mod generate_localnet;
@@ -36,6 +37,9 @@ async fn main() -> eyre::Result<()> {
             .await
             .wrap_err("failed to generate localnet configs"),
         Action::GenerateAddPeer(cfg) => generate_config_to_add_peer(cfg),
+        Action::EnodeFromSecret(args) => args
+            .run()
+            .wrap_err("failed to derive enode from secret key"),
         Action::GenerateStateBloat(args) => args
             .run()
             .await
@@ -61,6 +65,7 @@ enum Action {
     GenerateDevnet(GenerateDevnet),
     GenerateLocalnet(GenerateLocalnet),
     GenerateAddPeer(GenerateAddPeer),
+    EnodeFromSecret(EnodeFromSecret),
     GenerateStateBloat(GenerateStateBloat),
 }
 


### PR DESCRIPTION
enode is needed for validator configuration, currently generating it requires starting up the node. This adds small xtask to generate it given private key and address. 