### PR TITLE
fix(consensus): drain CL->EL backfill before sending newer FCUs

### DIFF
--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -132,7 +132,7 @@ pub(crate) struct Actor<TContext> {
     pending_backfill: OptionFuture<BoxFuture<'static, (u64, Option<Block>)>>,
 
     /// Blocks received from the marshal actor that are awaiting execution and
-    /// acknowedgement. FuturesOrdered because it is nicer to use as a stream
+    /// acknowledgement. FuturesOrdered because it is nicer to use as a stream
     /// in a select-loop.
     pending_finalizations: FuturesOrdered<Ready<(Span, Block, Exact)>>,
 

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -279,6 +279,10 @@ where
 
                 msg = self.mailbox.next() => {
                     let Some(msg) = msg else { break; };
+
+                    // CanonicalizeAndBuild will fail when the EL is in a syncing state during backfill.
+                    // CanonicalizeHead is safe to ignore for parents which will be forward finalized and
+                    // verification requests will also fail when the EL is syncing during backfill.
                     if let Command::Finalize(update) = msg.command {
                         pending_finalizations.push_back((msg.cause, update));
                     }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -195,40 +195,36 @@ where
                     let marshal = marshal.clone();
                     async move { (height, marshal.get_block(Height::new(height)).await) }
                 })
-                .fuse()
             )
         };
 
+        while let Some((height, block)) = backfill_on_start.next().await {
+            match block {
+                Some(block) => {
+                    let (ack, _wait) = Exact::handle();
+                    let span = info_span!("backfill_on_start", height);
+                    let _ = self.forward_finalized(span, block, ack).await;
+                }
+                None => {
+                    warn_span!("backfill_on_start", height).in_scope(|| {
+                        warn!(
+                            "marshal actor did not have block even though \
+                        it must have finalized it previously",
+                        )
+                    });
+                }
+            }
+        }
+
+        info_span!("backfill_on_start").in_scope(|| {
+            info!(
+                "no more blocks to backfill from consensus to \
+            execution layer"
+            )
+        });
+
         loop {
             select_biased! {
-                backfill = backfill_on_start.next() => {
-                    match backfill {
-                        Some((height, Some(block))) => {
-                            let (ack, _wait) = Exact::handle();
-                            let span = info_span!("backfill_on_start", height);
-                            let _ = self.forward_finalized(
-                                span,
-                                block,
-                                ack,
-                            ).await;
-                        }
-                        Some((height, None)) => {
-                            warn_span!("backfill_on_start", height)
-                            .in_scope(|| warn!(
-                                "marshal actor did not have block even though \
-                                it must have finalized it previously",
-                            ));
-                        }
-                        None => {
-                            info_span!("backfill_on_start")
-                            .in_scope(|| info!(
-                                "no more blocks to backfill from consensus to \
-                                execution layer")
-                            );
-                        }
-                    }
-                },
-
                 msg = self.mailbox.next() => {
                     let Some(msg) = msg else { break; };
                     // XXX: updating forkchoice and finalizing blocks must

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -13,7 +13,7 @@ use commonware_runtime::{
     Clock, ContextCell, FutureExt, Handle, Metrics, Pacer, Spawner, spawn_cell,
 };
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
-use eyre::{OptionExt as _, Report, WrapErr as _, ensure};
+use eyre::{Report, WrapErr as _, ensure};
 use futures::{
     FutureExt as _, StreamExt as _,
     channel::{
@@ -23,7 +23,8 @@ use futures::{
     future::{BoxFuture, Ready, ready},
     stream::FuturesOrdered,
 };
-use reth_provider::{BlockHashReader, BlockNumReader as _};
+use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
+use reth_provider::BlockNumReader as _;
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::TempoPayloadAttributes;
 use tokio::select;
@@ -157,14 +158,13 @@ where
             .provider
             .last_block_number()
             .wrap_err("unable to read latest block number from execution layer")?;
-        let last_finalized_block_hash = execution_node
-            .provider
-            .block_hash(last_execution_finalized_height)
-            .map_or_else(
-                |e| Err(Report::new(e)),
-                |hash| hash.ok_or_eyre("execution layer does not have the block hash"),
-            )
-            .wrap_err("failed to read the last finalized block hash")?;
+
+        let canonical_state = execution_node.provider.canonical_in_memory_state();
+        let finalized_num_hash = canonical_state
+            .get_finalized_num_hash()
+            .unwrap_or_else(|| BlockNumHash::new(0, execution_node.chain_spec().genesis_hash()));
+        let head_num_hash: BlockNumHash = canonical_state.chain_info().into();
+
         let fcu_heartbeat_timer = Box::pin(context.sleep(fcu_heartbeat_interval));
         let finalized_heights_to_backfill =
             (last_execution_finalized_height + 1)..=last_finalized_height.get();
@@ -178,12 +178,12 @@ where
             marshal,
             last_canonicalized: LastCanonicalized {
                 forkchoice: ForkchoiceState {
-                    head_block_hash: last_finalized_block_hash,
-                    safe_block_hash: last_finalized_block_hash,
-                    finalized_block_hash: last_finalized_block_hash,
+                    head_block_hash: head_num_hash.hash,
+                    safe_block_hash: finalized_num_hash.hash,
+                    finalized_block_hash: finalized_num_hash.hash,
                 },
-                head_height: last_execution_finalized_height,
-                finalized_height: last_execution_finalized_height,
+                head_height: Height::new(head_num_hash.number),
+                finalized_height: Height::new(finalized_num_hash.number),
             },
             fcu_heartbeat_interval,
             fcu_heartbeat_timer,
@@ -257,8 +257,13 @@ where
                 , if self.pending_backfill.is_none()
                 => {
                     // Error is emitted on function return.
-                    if self.forward_finalized( cause, block, ack).await.is_err()
+                    if let Err(error) = self.forward_finalized(cause, block, ack).await
                     {
+                        error_span!("shutdown").in_scope(|| error!(
+                            %error,
+                            "executor encountered fatal fork choice update error; \
+                            shutting down to prevent consensus-execution divergence"
+                        ));
                         break;
                     }
                 }
@@ -266,6 +271,7 @@ where
                 // Update the finalized tip if it has moved.
                 Some((height, digest)) = ready(self.latest_observed_finalized_tip)
                 , if finalized_tip_has_moved
+                && self.pending_backfill.is_none()
                 => {
                     let (response, _rx) = oneshot::channel();
                     self.canonicalize(

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -4,7 +4,7 @@
 //! execution layer and tracks the digest of the latest finalized block.
 //! It also advances the canonical chain by sending forkchoice-updates.
 
-use std::{collections::VecDeque, pin::Pin, sync::Arc, time::Duration};
+use std::{ops::RangeInclusive, pin::Pin, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
@@ -20,11 +20,13 @@ use futures::{
         mpsc::{self, UnboundedReceiver},
         oneshot,
     },
-    select_biased,
+    future::{BoxFuture, Ready, ready},
+    stream::FuturesOrdered,
 };
 use reth_provider::{BlockHashReader, BlockNumReader as _};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::TempoPayloadAttributes;
+use tokio::select;
 use tracing::{
     Level, Span, debug, error, error_span, info, info_span, instrument, warn, warn_span,
 };
@@ -36,6 +38,7 @@ use super::{
 use crate::{
     consensus::{Digest, block::Block},
     executor::ingress::CanonicalizeAndBuild,
+    utils::OptionFuture,
 };
 
 /// Tracks the last forkchoice state that the executor sent to the execution layer.
@@ -118,6 +121,21 @@ pub(crate) struct Actor<TContext> {
 
     /// The timer for the next FCU heartbeat. Reset whenever an FCU is sent.
     fcu_heartbeat_timer: Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
+
+    /// Gap between the last finalized block on the consensus and execution
+    /// layers. Needs to be handled on startup because the execution layer does
+    /// not reliably flush all blocks.
+    finalized_heights_to_backfill: RangeInclusive<u64>,
+
+    /// Backfills that are currently in-flight and are awaiting resolution.
+    pending_backfill: OptionFuture<BoxFuture<'static, (u64, Option<Block>)>>,
+
+    /// Blocks received from the marshal actor that are awaiting execution and
+    /// acknowedgement. FuturesOrdered because it is nicer to use as a stream
+    /// in a select-loop.
+    pending_finalizations: FuturesOrdered<Ready<(Span, Block, Exact)>>,
+
+    latest_observed_finalized_tip: Option<(Height, Digest)>,
 }
 
 impl<TContext> Actor<TContext>
@@ -147,8 +165,10 @@ where
                 |hash| hash.ok_or_eyre("execution layer does not have the block hash"),
             )
             .wrap_err("failed to read the last finalized block hash")?;
-        let last_execution_finalized_height = Height::new(last_execution_finalized_height);
         let fcu_heartbeat_timer = Box::pin(context.sleep(fcu_heartbeat_interval));
+        let finalized_heights_to_backfill =
+            (last_execution_finalized_height + 1)..=last_finalized_height.get();
+        let last_execution_finalized_height = Height::new(last_execution_finalized_height);
         Ok(Self {
             context: ContextCell::new(context),
             execution_node,
@@ -167,6 +187,12 @@ where
             },
             fcu_heartbeat_interval,
             fcu_heartbeat_timer,
+
+            finalized_heights_to_backfill,
+            pending_backfill: OptionFuture::none(),
+            pending_finalizations: FuturesOrdered::new(),
+
+            latest_observed_finalized_tip: None,
         })
     }
 
@@ -175,27 +201,84 @@ where
     }
 
     async fn run(mut self) {
-        let pending_finalizations = self.backfill_on_start().await;
-        for (cause, update) in pending_finalizations {
-            if let Err(error) = self
-                .finalize(cause, *update)
-                .await
-                .wrap_err("failed handling deferred finalization after backfill")
-            {
-                error_span!("shutdown").in_scope(|| {
-                    error!(
-                        %error,
-                        "executor encountered fatal fork choice update error; \
-                        shutting down to prevent consensus-execution divergence"
-                    )
-                });
-
-                return;
-            }
-        }
+        info_span!("start").in_scope(|| {
+            info!(
+                last_finalized_consensus_height = %self.last_consensus_finalized_height,
+                last_finalized_execution_height = %self.last_execution_finalized_height,
+                "consensus and execution layers reported last finalized heights; \
+                backfilling blocks from consensus to execution if necessary",
+            );
+        });
 
         loop {
-            select_biased! {
+            if self.pending_backfill.is_none()
+                && let Some(height) = self.finalized_heights_to_backfill.next()
+            {
+                self.pending_backfill.replace({
+                    let marshal = self.marshal.clone();
+                    async move { (height, marshal.get_block(Height::new(height)).await) }.boxed()
+                });
+            }
+
+            let finalized_tip_has_moved =
+                self.latest_observed_finalized_tip
+                    .is_some_and(|(height, digest)| {
+                        self.last_canonicalized
+                            != self.last_canonicalized.update_finalized(height, digest)
+                    });
+
+            select! {
+                biased;
+
+                // Complete all backfills first.
+                block = &mut self.pending_backfill => {
+                    match block {
+                        (height, Some(block)) => {
+                            let (ack, _wait) = Exact::handle();
+                            let span = info_span!("backfill_on_start", %height);
+                            let _ = self.forward_finalized(
+                                span,
+                                block,
+                                ack,
+                            ).await;
+                        }
+                        (height, None) => {
+                            warn_span!("backfill_on_start", %height)
+                            .in_scope(|| warn!(
+                                "marshal actor did not have block even though \
+                                it must have finalized it previously",
+                            ));
+                        }
+                    }
+                }
+
+                // Then forward all finalizations.
+                Some((cause, block, ack)) = self.pending_finalizations.next()
+                , if self.pending_backfill.is_none()
+                => {
+                    // Error is emitted on function return.
+                    if self.forward_finalized( cause, block, ack).await.is_err()
+                    {
+                        break;
+                    }
+                }
+
+                // Update the finalized tip if it has moved.
+                Some((height, digest)) = ready(self.latest_observed_finalized_tip)
+                , if finalized_tip_has_moved
+                => {
+                    let (response, _rx) = oneshot::channel();
+                    self.canonicalize(
+                        Span::current(),
+                        HeadOrFinalized::Finalized,
+                        height,
+                        digest,
+                        JustCanonicalizeOrAlsoBuild::JustCanonicalize { response },
+                    )
+                    .await;
+                }
+
+                // Serve requests lasts.
                 msg = self.mailbox.next() => {
                     let Some(msg) = msg else { break; };
                     // XXX: updating forkchoice and finalizing blocks must
@@ -220,77 +303,6 @@ where
                 },
             }
         }
-    }
-
-    // Backfills any necessary blocks from the consensus layer while buffering
-    // incoming finalization messages to flush after completion.
-    async fn backfill_on_start(&mut self) -> VecDeque<(Span, Box<Update<Block>>)> {
-        info_span!("start").in_scope(|| {
-            info!(
-                last_finalized_consensus_height = %self.last_consensus_finalized_height,
-                last_finalized_execution_height = %self.last_execution_finalized_height,
-                "consensus and execution layers reported last finalized heights; \
-                backfilling blocks from consensus to execution if necessary",
-            );
-        });
-
-        let mut backfill = {
-            let marshal = self.marshal.clone();
-            let heights = futures::stream::iter(
-                self.last_execution_finalized_height.get() + 1
-                    ..=self.last_consensus_finalized_height.get(),
-            );
-
-            let blocks = heights.then(move |h| {
-                let marshal = marshal.clone();
-                async move { (h, marshal.get_block(Height::new(h)).await) }
-            });
-
-            std::pin::pin!(blocks.fuse())
-        };
-
-        let mut pending_finalizations = VecDeque::new();
-        'backfill: loop {
-            select_biased! {
-                item = backfill.next() => {
-                    match item {
-                        None => {
-                            info_span!("backfill_on_start").in_scope(|| info!(
-                                "no more blocks to backfill from consensus to execution layer")
-                            );
-
-                            break 'backfill;
-                        }
-
-                        Some((height, Some(block))) => {
-                            let (ack, _wait) = Exact::handle();
-                            let span = info_span!("backfill_on_start", height);
-                            let _ = self.forward_finalized(span, block, ack).await;
-                        }
-
-                        Some((height, None)) => {
-                            warn_span!("backfill_on_start", height).in_scope(|| warn!(
-                                "marshal actor did not have block even though \
-                                it must have finalized it previously",
-                            ));
-                        }
-                    }
-                },
-
-                msg = self.mailbox.next() => {
-                    let Some(msg) = msg else { break; };
-
-                    // CanonicalizeAndBuild will fail when the EL is in a syncing state during backfill.
-                    // CanonicalizeHead is safe to ignore for parents which will be forward finalized and
-                    // verification requests will also fail when the EL is syncing during backfill.
-                    if let Command::Finalize(update) = msg.command {
-                        pending_finalizations.push_back((msg.cause, update));
-                    }
-                }
-            }
-        }
-
-        pending_finalizations
     }
 
     fn reset_fcu_heartbeat_timer(&mut self) {
@@ -339,7 +351,13 @@ where
 
     async fn handle_message(&mut self, message: Message) -> eyre::Result<()> {
         let cause = message.cause;
+        let is_backfilling =
+            self.pending_backfill.is_some() || !self.finalized_heights_to_backfill.is_empty();
         match message.command {
+            Command::CanonicalizeHead(..) | Command::CanonicalizeAndBuild(..) if is_backfilling => {
+                info_span!("handle_message")
+                    .in_scope(|| info!("request to canonicalize dropped while backfilling"));
+            }
             Command::CanonicalizeHead(CanonicalizeHead {
                 height,
                 digest,
@@ -372,11 +390,15 @@ where
                 )
                 .await;
             }
-            Command::Finalize(finalized) => {
-                self.finalize(cause, *finalized)
-                    .await
-                    .wrap_err("failed handling finalization")?;
-            }
+            Command::Finalize(finalized) => match *finalized {
+                Update::Tip(_, height, digest) => {
+                    self.latest_observed_finalized_tip.replace((height, digest));
+                }
+                Update::Block(block, acknowledgement) => {
+                    self.pending_finalizations
+                        .push_back(ready((cause, block, acknowledgement)));
+                }
+            },
         }
         Ok(())
     }
@@ -463,33 +485,6 @@ where
         }
         self.last_canonicalized = new_canonicalized;
         self.reset_fcu_heartbeat_timer();
-    }
-
-    #[instrument(parent = &cause, skip_all)]
-    /// Handles finalization events.
-    async fn finalize(&mut self, cause: Span, finalized: Update<Block>) -> eyre::Result<()> {
-        match finalized {
-            Update::Tip(_, height, digest) => {
-                let (response, rx) = oneshot::channel();
-                self.canonicalize(
-                    Span::current(),
-                    HeadOrFinalized::Finalized,
-                    height,
-                    digest,
-                    JustCanonicalizeOrAlsoBuild::JustCanonicalize { response },
-                )
-                .await;
-                rx.await
-                    .wrap_err("executor dropped channel")
-                    .and_then(|res| res)?;
-            }
-            Update::Block(block, acknowledgment) => {
-                self.forward_finalized(Span::current(), block, acknowledgment)
-                    .await
-                    .wrap_err("failed forwarding finalized block to execution layer")?;
-            }
-        }
-        Ok(())
     }
 
     /// Finalizes `block` by sending it to the execution layer.

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -4,7 +4,7 @@
 //! execution layer and tracks the digest of the latest finalized block.
 //! It also advances the canonical chain by sending forkchoice-updates.
 
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{collections::VecDeque, pin::Pin, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
@@ -175,53 +175,24 @@ where
     }
 
     async fn run(mut self) {
-        info_span!("start").in_scope(|| {
-            info!(
-                last_finalized_consensus_height = %self.last_consensus_finalized_height,
-                last_finalized_execution_height = %self.last_execution_finalized_height,
-                "consensus and execution layers reported last finalized heights; \
-                backfilling blocks from consensus to execution if necessary",
-            );
-        });
+        let pending_finalizations = self.backfill_on_start().await;
+        for (cause, update) in pending_finalizations {
+            if let Err(error) = self
+                .finalize(cause, *update)
+                .await
+                .wrap_err("failed handling deferred finalization after backfill")
+            {
+                error_span!("shutdown").in_scope(|| {
+                    error!(
+                        %error,
+                        "executor encountered fatal fork choice update error; \
+                        shutting down to prevent consensus-execution divergence"
+                    )
+                });
 
-        let mut backfill_on_start = {
-            let marshal = self.marshal.clone();
-            std::pin::pin!(
-                futures::stream::iter(
-                    self.last_execution_finalized_height.get() + 1
-                        ..=self.last_consensus_finalized_height.get(),
-                )
-                .then(move |height| {
-                    let marshal = marshal.clone();
-                    async move { (height, marshal.get_block(Height::new(height)).await) }
-                })
-            )
-        };
-
-        while let Some((height, block)) = backfill_on_start.next().await {
-            match block {
-                Some(block) => {
-                    let (ack, _wait) = Exact::handle();
-                    let span = info_span!("backfill_on_start", height);
-                    let _ = self.forward_finalized(span, block, ack).await;
-                }
-                None => {
-                    warn_span!("backfill_on_start", height).in_scope(|| {
-                        warn!(
-                            "marshal actor did not have block even though \
-                        it must have finalized it previously",
-                        )
-                    });
-                }
+                return;
             }
         }
-
-        info_span!("backfill_on_start").in_scope(|| {
-            info!(
-                "no more blocks to backfill from consensus to \
-            execution layer"
-            )
-        });
 
         loop {
             select_biased! {
@@ -249,6 +220,73 @@ where
                 },
             }
         }
+    }
+
+    // Backfills any necessary blocks from the consensus layer while buffering
+    // incoming finalization messages to flush after completion.
+    async fn backfill_on_start(&mut self) -> VecDeque<(Span, Box<Update<Block>>)> {
+        info_span!("start").in_scope(|| {
+            info!(
+                last_finalized_consensus_height = %self.last_consensus_finalized_height,
+                last_finalized_execution_height = %self.last_execution_finalized_height,
+                "consensus and execution layers reported last finalized heights; \
+                backfilling blocks from consensus to execution if necessary",
+            );
+        });
+
+        let mut backfill = {
+            let marshal = self.marshal.clone();
+            let heights = futures::stream::iter(
+                self.last_execution_finalized_height.get() + 1
+                    ..=self.last_consensus_finalized_height.get(),
+            );
+
+            let blocks = heights.then(move |h| {
+                let marshal = marshal.clone();
+                async move { (h, marshal.get_block(Height::new(h)).await) }
+            });
+
+            std::pin::pin!(blocks.fuse())
+        };
+
+        let mut pending_finalizations = VecDeque::new();
+        'backfill: loop {
+            select_biased! {
+                item = backfill.next() => {
+                    match item {
+                        None => {
+                            info_span!("backfill_on_start").in_scope(|| info!(
+                                "no more blocks to backfill from consensus to execution layer")
+                            );
+
+                            break 'backfill;
+                        }
+
+                        Some((height, Some(block))) => {
+                            let (ack, _wait) = Exact::handle();
+                            let span = info_span!("backfill_on_start", height);
+                            let _ = self.forward_finalized(span, block, ack).await;
+                        }
+
+                        Some((height, None)) => {
+                            warn_span!("backfill_on_start", height).in_scope(|| warn!(
+                                "marshal actor did not have block even though \
+                                it must have finalized it previously",
+                            ));
+                        }
+                    }
+                },
+
+                msg = self.mailbox.next() => {
+                    let Some(msg) = msg else { break; };
+                    if let Command::Finalize(update) = msg.command {
+                        pending_finalizations.push_back((msg.cause, update));
+                    }
+                }
+            }
+        }
+
+        pending_finalizations
     }
 
     fn reset_fcu_heartbeat_timer(&mut self) {

--- a/crates/commonware-node/src/utils.rs
+++ b/crates/commonware-node/src/utils.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     ops::{Deref, DerefMut},
     pin::Pin,
-    task::Poll,
+    task::{Poll, ready},
 };
 
 use alloy_primitives::B256;
@@ -34,9 +34,27 @@ pub(crate) fn public_key_to_tempo_primitive(
 #[pin_project]
 pub(crate) struct OptionFuture<F>(#[pin] Option<F>);
 
+impl<F> OptionFuture<F> {
+    pub(crate) fn new(fut: Option<F>) -> Self {
+        Self(fut)
+    }
+
+    pub(crate) fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+
+    pub(crate) fn none() -> Self {
+        Self::new(None)
+    }
+
+    pub(crate) fn replace(&mut self, fut: F) -> Option<F> {
+        self.0.replace(fut)
+    }
+}
+
 impl<F: Future> Default for OptionFuture<F> {
     fn default() -> Self {
-        Self(None)
+        Self::none()
     }
 }
 
@@ -63,12 +81,13 @@ impl<F: Future> DerefMut for OptionFuture<F> {
 impl<F: Future> Future for OptionFuture<F> {
     type Output = F::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        match this.0.as_pin_mut() {
-            Some(fut) => fut.poll(cx),
-            None => Poll::Pending,
-        }
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let output = match self.as_mut().project().0.as_pin_mut() {
+            Some(fut) => ready!(fut.poll(cx)),
+            None => return Poll::Pending,
+        };
+        self.as_mut().project().0.set(None);
+        Poll::Ready(output)
     }
 }
 

--- a/crates/e2e/src/tests/restart.rs
+++ b/crates/e2e/src/tests/restart.rs
@@ -617,11 +617,11 @@ fn backfill_on_start_after_crash() {
 /// The test asserts that **no** pipeline runs occur — the node should
 /// recover purely via backfill + live sync.
 #[test_traced]
-fn backfill_on_start_large_gap_triggers_pipeline() {
+fn backfill_on_start_large_gap_does_not_trigger_pipeline_sync() {
     let _ = tempo_eyre::install();
     let metrics_recorder = install_prometheus_recorder();
 
-    let setup = Setup::new().how_many_signers(3).epoch_length(100);
+    let setup = Setup::new().how_many_signers(4).epoch_length(100);
 
     let cfg = deterministic::Config::default().with_seed(setup.seed);
     Runner::from(cfg).start(|mut context| async move {
@@ -631,16 +631,16 @@ fn backfill_on_start_large_gap_triggers_pipeline() {
         join_all(validators.iter_mut().map(|v| v.start(&context))).await;
         connect_execution_peers(&validators).await;
 
-        // Let the network reach height 70.
-        wait_for_height(&context, 3, 70, false).await;
+        // Let the network reach height 40.
+        wait_for_height(&context, 4, 40, false).await;
 
-        // Stop validator[0] and unwind its EL by 50 blocks.
+        // Stop validator[0] and unwind its EL by 35 blocks (exceeds 32-block pipeline sync threshold).
         validators[0].stop().await;
-        let (el_before, el_after) = validators[0].unwind(50);
-        debug!(el_before, el_after, "unwound validator[0] by 50 blocks");
+        let (el_before, el_after) = validators[0].unwind(35);
+        debug!(el_before, el_after, "unwound validator[0] by 35 blocks");
 
-        // Let the remaining 2 validators advance 20 more blocks.
-        wait_for_height(&context, 2, 90, false).await;
+        // Let the remaining 3 validators advance 10 more blocks.
+        wait_for_height(&context, 3, 50, false).await;
 
         let pipeline_runs_before = get_pipeline_runs(metrics_recorder);
 
@@ -656,19 +656,16 @@ fn backfill_on_start_large_gap_triggers_pipeline() {
                 .execution_provider()
                 .last_block_number()
                 .unwrap();
+
             if current >= el_before + 5 {
                 recovered = true;
                 break;
             }
         }
-        assert!(recovered, "validator[0] did not recover within 60s");
 
-        let pipeline_runs_after = get_pipeline_runs(metrics_recorder);
-        assert_eq!(
-            pipeline_runs_after - pipeline_runs_before,
-            0,
-            "expected no pipeline runs, but got {}",
-            pipeline_runs_after - pipeline_runs_before,
-        );
+        assert!(recovered, "unwound validator did not recover");
+
+        let new_pipeline_runs = get_pipeline_runs(metrics_recorder) - pipeline_runs_before;
+        assert_eq!(new_pipeline_runs, 0);
     });
 }

--- a/crates/e2e/src/tests/restart.rs
+++ b/crates/e2e/src/tests/restart.rs
@@ -15,11 +15,12 @@ use commonware_utils::NZU64;
 use futures::future::join_all;
 use rand_08::Rng;
 use reth_ethereum::storage::BlockNumReader;
+use reth_node_metrics::recorder::install_prometheus_recorder;
 use tracing::debug;
 
 use crate::{
     CONSENSUS_NODE_PREFIX, Setup, connect_execution_peers, connect_execution_to_peers,
-    setup_validators,
+    get_pipeline_runs, setup_validators,
 };
 
 #[test_traced("WARN")]
@@ -599,6 +600,75 @@ fn backfill_on_start_after_crash() {
             el_recovered >= el_before,
             "EL should have recovered to at least {el_before} after backfill, \
             got {el_recovered}"
+        );
+    });
+}
+
+/// Reproduces the race where a large EL gap triggers a pipeline run on
+/// restart.
+///
+/// On restart with a 50-block gap, `select_biased!` in the consensus loop
+/// falls through to the mailbox while `marshal.get_block()` is still
+/// pending. A `Finalize` for `CL_tip + 1` arrives from live consensus;
+/// its FCU triggers a download from EL peers. The downloaded block is
+/// disconnected from the local chain and the gap exceeds 32, so reth
+/// triggers a pipeline run.
+///
+/// The test asserts that **no** pipeline runs occur — the node should
+/// recover purely via backfill + live sync.
+#[test_traced]
+fn backfill_on_start_large_gap_triggers_pipeline() {
+    let _ = tempo_eyre::install();
+    let metrics_recorder = install_prometheus_recorder();
+
+    let setup = Setup::new().how_many_signers(3).epoch_length(100);
+
+    let cfg = deterministic::Config::default().with_seed(setup.seed);
+    Runner::from(cfg).start(|mut context| async move {
+        let (mut validators, _execution_runtime) =
+            setup_validators(&mut context, setup.clone()).await;
+
+        join_all(validators.iter_mut().map(|v| v.start(&context))).await;
+        connect_execution_peers(&validators).await;
+
+        // Let the network reach height 70.
+        wait_for_height(&context, 3, 70, false).await;
+
+        // Stop validator[0] and unwind its EL by 50 blocks.
+        validators[0].stop().await;
+        let (el_before, el_after) = validators[0].unwind(50);
+        debug!(el_before, el_after, "unwound validator[0] by 50 blocks");
+
+        // Let the remaining 2 validators advance 20 more blocks.
+        wait_for_height(&context, 2, 90, false).await;
+
+        let pipeline_runs_before = get_pipeline_runs(metrics_recorder);
+
+        // Restart validator[0] with EL peers connected.
+        validators[0].start(&context).await;
+        connect_execution_to_peers(&validators[0], &validators).await;
+
+        // Wait up to 60s for the node to recover.
+        let mut recovered = false;
+        for _ in 0..60 {
+            context.sleep(Duration::from_secs(1)).await;
+            let current = validators[0]
+                .execution_provider()
+                .last_block_number()
+                .unwrap();
+            if current >= el_before + 5 {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "validator[0] did not recover within 60s");
+
+        let pipeline_runs_after = get_pipeline_runs(metrics_recorder);
+        assert_eq!(
+            pipeline_runs_after - pipeline_runs_before,
+            0,
+            "expected no pipeline runs, but got {}",
+            pipeline_runs_after - pipeline_runs_before,
         );
     });
 }


### PR DESCRIPTION
On restart with a CL/EL gap, `select_biased!` in the executor run loop
would fall through to the mailbox branch when `marshal.get_block()` was
momentarily pending between backfill blocks. A `Finalize` from live
consensus would get processed, its FCU would trigger a download from
EL peers, and the gap (>32 blocks) would cause reth to start pipeline
sync — breaking all subsequent backfill.

Moves the backfill stream drain into a dedicated `while let` loop that
completes fully before the main `select_biased!` loop starts.

Adds an e2e test that reproduces the bug with 4 validators, EL peers
connected, a 50-block unwind, and asserts `pipeline_runs == 0`.

CLOSES CHAIN-1115