### PR TITLE
feat: allow omitting empty subblocks metadata system tx

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -254,7 +254,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tempo_chainspec::{
         hardfork::TempoHardfork,
-        spec::{MODERATO, TempoChainSpec},
+        spec::{DEV, MODERATO, TempoChainSpec},
     };
 
     fn current_timestamp_millis() -> u64 {
@@ -827,7 +827,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_block_pre_execution_no_system_tx() {
+    fn test_validate_block_pre_execution_pre_t4_missing_system_tx() {
         let consensus = TempoConsensus::new(MODERATO.clone());
         let chain_id = MODERATO.chain().id();
 
@@ -850,6 +850,23 @@ mod tests {
                 )),
             "Expected MissingEndOfBlockSystemTxs, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_validate_block_pre_execution_t4_allows_missing_system_tx() {
+        let consensus = TempoConsensus::new(DEV.clone());
+        let chain_id = DEV.chain().id();
+
+        let user_tx = create_tx(chain_id);
+
+        let header = TestHeaderBuilder::default()
+            .gas_limit(30_000_000)
+            .timestamp(0)
+            .build();
+        let block = create_valid_block(header, vec![user_tx]);
+        let sealed = SealedBlock::seal_slow(block);
+
+        assert!(consensus.validate_block_pre_execution(&sealed).is_ok());
     }
 
     #[test]

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -174,9 +174,19 @@ impl Consensus<Block> for TempoConsensus {
             .into());
         }
 
+        let expected_system_tx_count = if self
+            .inner
+            .chain_spec()
+            .is_t4_active_at_timestamp(block.header().timestamp())
+        {
+            0
+        } else {
+            SYSTEM_TX_COUNT
+        };
+
         // Get the last END_OF_BLOCK_SYSTEM_TX_COUNT transactions and validate they are end-of-block system txs
         let end_of_block_system_txs = transactions
-            .get(transactions.len().saturating_sub(SYSTEM_TX_COUNT)..)
+            .get(transactions.len().saturating_sub(expected_system_tx_count)..)
             .map(|slice| {
                 slice
                     .iter()
@@ -185,9 +195,9 @@ impl Consensus<Block> for TempoConsensus {
             })
             .unwrap_or_default();
 
-        if end_of_block_system_txs.len() != SYSTEM_TX_COUNT {
+        if end_of_block_system_txs.len() != expected_system_tx_count {
             return Err(TempoConsensusError::MissingEndOfBlockSystemTxs {
-                expected: SYSTEM_TX_COUNT,
+                expected: expected_system_tx_count,
                 actual: end_of_block_system_txs.len(),
             }
             .into());

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -214,6 +214,10 @@ where
                 ));
             }
 
+            if self.evm().cfg.spec.is_t4() {
+                return Err(BlockValidationError::msg("subblocks are disabled in T4+"));
+            }
+
             if tx.input().len() < U256::BYTES
                 || tx.input()[tx.input().len() - U256::BYTES..] != block_number
             {

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -564,6 +564,18 @@ where
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
+        let seen_subblock_signatures = match self.section {
+            BlockSection::System {
+                seen_subblocks_signatures,
+            } => seen_subblocks_signatures,
+            _ => false,
+        };
+
+        // If subblocks metadata transaction was not seen, imply empty metadata.
+        if !seen_subblock_signatures {
+            self.validate_shared_gas(&[])?;
+        }
+
         let timestamp = self.evm().block().timestamp.to::<u64>();
         let is_t4 = self.inner.spec.is_t4_active_at_timestamp(timestamp);
 

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -571,8 +571,8 @@ where
             _ => false,
         };
 
-        // If subblocks metadata transaction was not seen, imply empty metadata.
-        if !seen_subblock_signatures {
+        // Post T4, if subblocks metadata transaction was not seen, imply empty metadata.
+        if !seen_subblock_signatures && self.evm().cfg.spec.is_t4() {
             self.validate_shared_gas(&[])?;
         }
 

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -852,6 +852,28 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_system_tx_rejects_metadata_tx_in_t4() {
+        let chainspec = DEV.clone();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default().build(&mut db, &chainspec);
+
+        // TestExecutorBuilder seeds the default runtime spec, so force the T4 path explicitly.
+        executor.inner.evm.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T4;
+
+        let signer = PrivateKey::from_seed(0);
+        let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
+        let input = create_system_tx_input(metadata, 1);
+        let system_tx = create_system_tx(chainspec.chain().id(), input);
+
+        let result = executor.validate_system_tx(&system_tx);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "subblocks are disabled in T4+"
+        );
+    }
+
+    #[test]
     fn test_validate_shared_gas() {
         let chainspec = test_chainspec();
         let mut db = State::builder().with_bundle_update().build();
@@ -1230,6 +1252,40 @@ mod tests {
 
         let result = executor.finish();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_finish_t4_without_metadata_passes_when_incentive_gas_is_zero() {
+        let chainspec = DEV.clone();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .with_validator_set(vec![B256::repeat_byte(0x01)])
+            .build(&mut db, &chainspec);
+
+        executor.inner.evm.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T4;
+        executor.apply_pre_execution_changes().unwrap();
+
+        assert!(executor.finish().is_ok());
+    }
+
+    #[test]
+    fn test_finish_t4_without_metadata_rejects_incentive_gas() {
+        let chainspec = DEV.clone();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .with_validator_set(vec![B256::repeat_byte(0x01)])
+            .with_incentive_gas_used(1)
+            .build(&mut db, &chainspec);
+
+        executor.inner.evm.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T4;
+        executor.apply_pre_execution_changes().unwrap();
+
+        match executor.finish() {
+            Err(err) => assert_eq!(err.to_string(), "incentive gas limit exceeded"),
+            Ok(_) => panic!("finish should fail when T4 block has incentive gas without metadata"),
+        }
     }
 
     #[test]

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -12,8 +12,4 @@ pub enum TempoEvmError {
     /// Invalid EVM configuration.
     #[error("invalid EVM configuration: {0}")]
     InvalidEvmConfig(String),
-
-    /// No subblock metadata system transaction is found in the block.
-    #[error("couldn't find subblock metadata transaction in block")]
-    NoSubblockMetadataFound,
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -514,7 +514,7 @@ mod tests {
         use tempo_chainspec::spec::DEV;
 
         let chainspec = DEV.clone();
-        let evm_config = TempoEvmConfig::new(chainspec.clone());
+        let evm_config = TempoEvmConfig::new(chainspec);
 
         let header = TempoHeader {
             inner: alloy_consensus::Header {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -283,7 +283,7 @@ mod tests {
     use super::*;
     use crate::test_utils::test_chainspec;
     use alloy_consensus::{BlockHeader, Signed, TxLegacy};
-    use alloy_primitives::{B256, Bytes, Signature, TxKind, U256};
+    use alloy_primitives::{B256, Bytes, TxKind, U256};
     use alloy_rlp::{Encodable, bytes::BytesMut};
     use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
     use std::collections::HashMap;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -510,6 +510,40 @@ mod tests {
     }
 
     #[test]
+    fn test_context_for_block_t4_without_metadata_has_empty_fee_recipients() {
+        use tempo_chainspec::spec::DEV;
+
+        let chainspec = DEV.clone();
+        let evm_config = TempoEvmConfig::new(chainspec.clone());
+
+        let header = TempoHeader {
+            inner: alloy_consensus::Header {
+                number: 1,
+                timestamp: 1000,
+                gas_limit: 30_000_000,
+                parent_beacon_block_root: Some(B256::ZERO),
+                ..Default::default()
+            },
+            general_gas_limit: 10_000_000,
+            timestamp_millis_part: 500,
+            shared_gas_limit: 3_000_000,
+            ..Default::default()
+        };
+
+        let body = BlockBody {
+            transactions: vec![],
+            ommers: vec![],
+            withdrawals: None,
+        };
+
+        let block = Block { header, body };
+        let sealed_block = SealedBlock::seal_slow(block);
+
+        let context = evm_config.context_for_block(&sealed_block).unwrap();
+        assert!(context.subblock_fee_recipients.is_empty());
+    }
+
+    #[test]
     fn test_context_for_next_block() {
         let evm_config = TempoEvmConfig::new(test_chainspec());
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -214,7 +214,7 @@ impl ConfigureEvm for TempoEvmConfig {
             .rev()
             .filter(|tx| (*tx).to() == Some(Address::ZERO))
             .find_map(|tx| Vec::<SubBlockMetadata>::decode(&mut tx.input().as_ref()).ok())
-            .ok_or(TempoEvmError::NoSubblockMetadataFound)?
+            .unwrap_or_default()
             .into_iter()
             .map(|metadata| {
                 (

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -508,56 +508,6 @@ mod tests {
     }
 
     #[test]
-    fn test_context_for_block_no_subblock_metadata() {
-        let evm_config = TempoEvmConfig::new(test_chainspec());
-
-        // Create a block without subblock metadata system tx
-        let regular_tx = TempoTxEnvelope::Legacy(Signed::new_unhashed(
-            TxLegacy {
-                chain_id: Some(1),
-                nonce: 0,
-                gas_price: 1,
-                gas_limit: 21000,
-                to: TxKind::Call(alloy_primitives::Address::repeat_byte(0x01)),
-                value: U256::ZERO,
-                input: Bytes::new(),
-            },
-            Signature::test_signature(),
-        ));
-
-        let header = TempoHeader {
-            inner: alloy_consensus::Header {
-                number: 1,
-                timestamp: 1000,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            },
-            general_gas_limit: 10_000_000,
-            timestamp_millis_part: 500,
-            shared_gas_limit: 3_000_000,
-            ..Default::default()
-        };
-
-        let body = BlockBody {
-            transactions: vec![regular_tx],
-            ommers: vec![],
-            withdrawals: None,
-        };
-
-        let block = Block { header, body };
-        let sealed_block = SealedBlock::seal_slow(block);
-
-        let result = evm_config.context_for_block(&sealed_block);
-
-        // Should fail because no subblock metadata tx was found
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            TempoEvmError::NoSubblockMetadataFound
-        ));
-    }
-
-    #[test]
     fn test_context_for_next_block() {
         let evm_config = TempoEvmConfig::new(test_chainspec());
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -27,11 +27,7 @@ use reth_execution_types::BlockExecutionOutput;
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_payload_primitives::{BuiltPayload, BuiltPayloadExecutedBlock};
 use reth_primitives_traits::{Recovered, transaction::error::InvalidTransactionError};
-use reth_revm::{
-    State,
-    context::{Block, BlockEnv},
-    database::StateProviderDatabase,
-};
+use reth_revm::{State, context::Block, database::StateProviderDatabase};
 use reth_storage_api::{StateProvider, StateProviderFactory};
 use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool, ValidPoolTransaction,
@@ -127,9 +123,14 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
     /// - Subblocks signatures - validates subblock signatures
     fn build_seal_block_txs(
         &self,
-        block_env: &BlockEnv,
+        evm: &TempoEvm<impl Database>,
         subblocks: &[RecoveredSubBlock],
     ) -> Vec<Recovered<TempoTxEnvelope>> {
+        if subblocks.is_empty() && evm.cfg.spec.is_t4() {
+            // Post-T4, omit the subblocks metadata transaction if there are no subblocks
+            return vec![];
+        }
+
         let chain_spec = self.provider.chain_spec();
         let chain_id = Some(chain_spec.chain().id());
 
@@ -140,7 +141,7 @@ impl<Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>> TempoPayloadBuilde
             .collect::<Vec<SubBlockMetadata>>();
         let subblocks_input = alloy_rlp::encode(&subblocks_metadata)
             .into_iter()
-            .chain(block_env.number.to_be_bytes_vec())
+            .chain(evm.block.number.to_be_bytes_vec())
             .collect();
 
         let subblocks_signatures_tx = Recovered::new_unchecked(
@@ -409,7 +410,7 @@ where
 
         // Prepare system transactions before actual block building and account for their size.
         let prepare_system_txs_start = Instant::now();
-        let system_txs = self.build_seal_block_txs(builder.evm().block(), &subblocks);
+        let system_txs = self.build_seal_block_txs(builder.evm(), &subblocks);
         for tx in &system_txs {
             block_size_used += tx.inner().length();
         }


### PR DESCRIPTION
Right now all blocks include an empty subblocks metadata tx which is somewhat redundant. This PR changes building and validation logic to allow omitting subblocks metadata transaction if there are no subblocks included