### PR TITLE
refactor:  simplify types with `FeeRoute` enum

### DIFF
--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -86,128 +86,17 @@ impl PoolKey {
     }
 }
 
-/// Result of a per-pool liquidity check used to build a [`FeeSwapPlan`].
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SwapInfo {
-    /// Identifier of the `(user_token, validator_token)` AMM pool inspected.
-    pub pool_id: B256,
-    /// Validator-token reserve observed on this pool.
-    pub reserves: u128,
-    /// Validator-token amount this hop must produce `floor(amount_in · 9970 / 10000)`.
-    pub amount_out: u128,
-}
-
-impl SwapInfo {
-    /// `true` if `reserves` cover the required `amount_out` for this hop.
-    #[inline]
-    pub fn is_sufficient(&self) -> bool {
-        self.reserves >= self.amount_out
-    }
-}
-
-/// AMM path [`TipFeeManager`] will take to swap `user_token` into `validator_token` for fee collection.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FeeSwapPlan {
-    /// User and validator share the same fee token; no swap is performed.
-    SameToken,
-    /// Direct pool `(user_token, validator_token)` has enough liquidity for a single-hop swap.
-    Direct(SwapInfo),
-    /// Two-hop swap (T5+): routes through `intermediate = userToken.quoteToken()`.
+/// AMM path [`TipFeeManager`] will take to swap `user_token` into `validator_token`
+/// for fee collection. See [`TipFeeManager::plan_fee_swap`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeeRoute {
+    /// `user_token == validator_token`, or the direct pool has sufficient liquidity.
+    Direct,
+    /// T5+ fallback through `intermediate = userToken.quoteToken()` ([TIP-1033]).
     /// Each hop applies the standard `M = 9970/10000` rate sequentially.
-    TwoHop {
-        intermediate: Address,
-        swap1: SwapInfo,
-        swap2: SwapInfo,
-    },
-}
-
-impl FeeSwapPlan {
-    /// `true` iff this plan represents a viable fee-swap route.
-    pub fn is_sufficient(&self) -> bool {
-        match self {
-            Self::SameToken => true,
-            Self::Direct(swap) => swap.is_sufficient(),
-            Self::TwoHop { swap1, swap2, .. } => swap1.is_sufficient() && swap2.is_sufficient(),
-        }
-    }
-}
-
-/// Outcome of [`TipFeeManager::plan_fee_swap`]. Couples the chosen [`FeeSwapPlan`] with the
-/// planner's direct `(user_token, validator_token)` check, so the txpool can warm caches.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FeeSwapAttempt {
-    /// `Some` iff the planner produced a route, viable or not.
-    pub plan: Option<FeeSwapPlan>,
-    /// Direct probe held here only when not already exposed via `plan`.
-    direct: Option<SwapInfo>,
-}
-
-impl FeeSwapAttempt {
-    /// `user_token == validator_token` — no probe, no swap.
-    pub fn same_token() -> Self {
-        Self {
-            plan: Some(FeeSwapPlan::SameToken),
-            direct: None,
-        }
-    }
-
-    /// Direct pool is sufficient; `swap` is owned by the plan.
-    pub fn direct(swap: SwapInfo) -> Self {
-        debug_assert!(
-            swap.is_sufficient(),
-            "`Direct` plans must hold a sufficient probe",
-        );
-        Self {
-            plan: Some(FeeSwapPlan::Direct(swap)),
-            direct: None,
-        }
-    }
-
-    /// Direct pool was probed and found insufficient.
-    pub fn no_route(direct: SwapInfo) -> Self {
-        debug_assert!(
-            !direct.is_sufficient(),
-            "`no_route` only applies after the direct probe failed",
-        );
-        Self {
-            plan: None,
-            direct: Some(direct),
-        }
-    }
-
-    /// Two-hop fallback was checked end-to-end. `direct` is the insufficient path checked earlier.
-    pub fn two_hop(
-        intermediate: Address,
-        swap1: SwapInfo,
-        swap2: SwapInfo,
-        direct: SwapInfo,
-    ) -> Self {
-        debug_assert!(
-            !direct.is_sufficient(),
-            "two-hop fallback is only attempted after the direct probe fails",
-        );
-        Self {
-            plan: Some(FeeSwapPlan::TwoHop {
-                intermediate,
-                swap1,
-                swap2,
-            }),
-            direct: Some(direct),
-        }
-    }
-
-    /// Direct `(user_token, validator_token)` probe, regardless of where it is stored.
-    pub fn direct_check(&self) -> Option<&SwapInfo> {
-        match &self.plan {
-            Some(FeeSwapPlan::Direct(swap)) => Some(swap),
-            _ => self.direct.as_ref(),
-        }
-    }
-
-    /// `true` iff the chosen plan is a viable fee-swap route.
-    pub fn is_sufficient(&self) -> bool {
-        self.plan.as_ref().is_some_and(FeeSwapPlan::is_sufficient)
-    }
+    ///
+    /// [TIP-1033]: <https://docs.tempo.xyz/protocol/tips/tip-1033>
+    TwoHop(Address),
 }
 
 impl TipFeeManager {
@@ -221,25 +110,6 @@ impl TipFeeManager {
     pub fn get_pool(&self, call: ITIPFeeAMM::getPoolCall) -> Result<Pool> {
         let pool_id = self.pool_id(call.userToken, call.validatorToken);
         self.pools[pool_id].read()
-    }
-
-    /// Checks the pool identified by `pool_id` and returns a [`SwapInfo`] capturing the
-    /// validator-token reserve and the output amount that a fee swap of `max_amount` would
-    /// require. Sufficiency to perform the swap is reported via [`SwapInfo::is_sufficient`].
-    ///
-    /// # Errors
-    /// - `UnderOverflow` — output amount exceeds `u128`
-    pub fn check_sufficient_liquidity(&self, pool_id: B256, max_amount: U256) -> Result<SwapInfo> {
-        let amount_out_needed = compute_amount_out(max_amount)?;
-        let pool = self.pools[pool_id].read()?;
-
-        Ok(SwapInfo {
-            pool_id,
-            reserves: pool.reserve_validator_token,
-            amount_out: amount_out_needed
-                .try_into()
-                .map_err(|_| TempoPrecompileError::under_overflow())?,
-        })
     }
 
     /// Reserves pool liquidity in transient storage for a pending fee swap.
@@ -512,7 +382,7 @@ impl TipFeeManager {
             self.calculate_burn_amounts(&pool, pool_id, liquidity)?;
 
         // T1C+: Check that burn leaves enough liquidity for pending fee swaps
-        // Reservation is set by reserve_pool_liquidity() via check_sufficient_liquidity()
+        // Reservation is set by reserve_pool_liquidity() in collect_fee_pre_tx
         let validator_amount: u128 = amount_validator_token
             .try_into()
             .map_err(|_| TIPFeeAMMError::invalid_amount())?;
@@ -613,13 +483,10 @@ impl TipFeeManager {
     }
 
     /// Plans the AMM path needed to swap `max_amount` of `user_token` into `validator_token`
-    /// under the active hardfork. On T5+ falls back to a two-hop path through
-    /// `userToken.quoteToken()` as per [TIP-1033].
+    /// under the active hardfork. Read-only; does not reserve.
     ///
-    /// Returns a [`FeeSwapAttempt`] whose `plan` is `None` when no path has sufficient
-    /// liquidity. The direct `(user_token, validator_token)` probe is reported separately on
-    /// the attempt so callers can warm caches even when the chosen plan discards it (i.e.
-    /// when falling through to the two-hop fallback) or no viable plan exists.
+    /// On T5+ falls back to a two-hop path through `userToken.quoteToken()` as per [TIP-1033].
+    /// Returns `None` when no viable route exists.
     ///
     /// # Errors
     /// - `InvalidToken` — `user_token` does not have a valid TIP-20 prefix
@@ -631,41 +498,42 @@ impl TipFeeManager {
         user_token: Address,
         validator_token: Address,
         max_amount: U256,
-    ) -> Result<FeeSwapAttempt> {
+    ) -> Result<Option<FeeRoute>> {
         if user_token == validator_token {
-            return Ok(FeeSwapAttempt::same_token());
+            return Ok(Some(FeeRoute::Direct));
         }
 
-        // Direct (single-hop) path — always probed.
-        let direct_id = PoolKey::new(user_token, validator_token).get_id();
-        let direct = self.check_sufficient_liquidity(direct_id, max_amount)?;
-        if direct.is_sufficient() {
-            return Ok(FeeSwapAttempt::direct(direct));
+        let amount_out = compute_amount_out(max_amount)?;
+        let direct = self.pools[self.pool_id(user_token, validator_token)].read()?;
+        if amount_out <= U256::from(direct.reserve_validator_token) {
+            return Ok(Some(FeeRoute::Direct));
         }
 
         // T5+: two-hop fallback through `userToken.quoteToken()`.
         if !self.storage.spec().is_t5() {
-            return Ok(FeeSwapAttempt::no_route(direct));
+            return Ok(None);
         }
 
         // TIP-20 token graph forbids self-quoting, so `intermediate == user_token` is unreachable.
         let intermediate = TIP20Token::from_address(user_token)?.quote_token()?;
         if intermediate.is_zero() || intermediate == validator_token {
-            return Ok(FeeSwapAttempt::no_route(direct));
+            return Ok(None);
         }
 
         // First leg: user_token -> intermediate.
-        let leg1_id = PoolKey::new(user_token, intermediate).get_id();
-        let swap1 = self.check_sufficient_liquidity(leg1_id, max_amount)?;
-        if !swap1.is_sufficient() {
-            return Ok(FeeSwapAttempt::no_route(direct));
+        let leg1 = self.pools[self.pool_id(user_token, intermediate)].read()?;
+        if amount_out > U256::from(leg1.reserve_validator_token) {
+            return Ok(None);
         }
 
-        // Second leg: intermediate -> validator_token. Reported as `TwoHop` regardless of
-        // sufficiency so callers can warm caches with the observed reserves.
-        let leg2_id = PoolKey::new(intermediate, validator_token).get_id();
-        let swap2 = self.check_sufficient_liquidity(leg2_id, U256::from(swap1.amount_out))?;
-        Ok(FeeSwapAttempt::two_hop(intermediate, swap1, swap2, direct))
+        // Second leg: intermediate -> validator_token.
+        let amount_out2 = compute_amount_out(amount_out)?;
+        let leg2 = self.pools[self.pool_id(intermediate, validator_token)].read()?;
+        if amount_out2 > U256::from(leg2.reserve_validator_token) {
+            return Ok(None);
+        }
+
+        Ok(Some(FeeRoute::TwoHop(intermediate)))
     }
 
     /// Executes a fee swap, converting `user_token` to `validator_token` at a fixed rate m = 0.997
@@ -1213,9 +1081,19 @@ mod tests {
         })
     }
 
-    /// Test check_sufficient_liquidity boundary condition
+    /// Helper for tests: returns the validator-token reserve of a pool and the
+    /// validator-token output `compute_amount_out(max_amount)` would require.
+    fn pool_check(amm: &TipFeeManager, pool_id: B256, max_amount: U256) -> eyre::Result<(u128, u128)> {
+        let pool = amm.pools[pool_id].read()?;
+        let amount_out: u128 = compute_amount_out(max_amount)?
+            .try_into()
+            .map_err(|_| eyre::eyre!("amount_out exceeds u128"))?;
+        Ok((pool.reserve_validator_token, amount_out))
+    }
+
+    /// Test pool boundary condition
     #[test]
-    fn test_check_sufficient_liquidity_boundary() -> eyre::Result<()> {
+    fn test_pool_liquidity_boundary() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let admin = Address::random();
 
@@ -1239,17 +1117,13 @@ mod tests {
 
             // Exactly at boundary should succeed (100 * 0.997 = 99.7, which is < 100)
             let ok_amount = uint!(100_U256) * uint!(10_U256).pow(U256::from(6));
-            assert!(
-                amm.check_sufficient_liquidity(pool_id, ok_amount)?
-                    .is_sufficient()
-            );
+            let (reserve, amount_out) = pool_check(&amm, pool_id, ok_amount)?;
+            assert!(reserve >= amount_out);
 
             // Just over boundary should fail (101 * 0.997 = 100.697, which is > 100)
             let too_much = uint!(101_U256) * uint!(10_U256).pow(U256::from(6));
-            assert!(
-                !amm.check_sufficient_liquidity(pool_id, too_much)?
-                    .is_sufficient()
-            );
+            let (reserve, amount_out) = pool_check(&amm, pool_id, too_much)?;
+            assert!(reserve < amount_out);
 
             Ok(())
         })
@@ -1593,9 +1467,7 @@ mod tests {
             )?;
 
             let max_amount = uint!(10000_U256);
-            let amount_out = amm
-                .check_sufficient_liquidity(pool_id, max_amount)?
-                .amount_out;
+            let amount_out: u128 = compute_amount_out(max_amount)?.try_into().unwrap();
             amm.reserve_pool_liquidity(pool_id, amount_out)?;
 
             let reserved = amm.pending_fee_swap_reservation[pool_id].t_read()?;
@@ -1635,9 +1507,7 @@ mod tests {
 
             // Reserve most of the validator token liquidity
             let reserve_amount = U256::from(pool.reserve_validator_token) - uint!(100_U256);
-            let amount_out = amm
-                .check_sufficient_liquidity(pool_id, reserve_amount)?
-                .amount_out;
+            let amount_out: u128 = compute_amount_out(reserve_amount)?.try_into().unwrap();
             amm.reserve_pool_liquidity(pool_id, amount_out)?;
 
             let result = amm.burn(admin, user_token, validator_token, liquidity, recipient);
@@ -1678,9 +1548,7 @@ mod tests {
 
             let pool_id = amm.pool_id(user_token, validator_token);
             let small_reserve = uint!(1000_U256);
-            let amount_out = amm
-                .check_sufficient_liquidity(pool_id, small_reserve)?
-                .amount_out;
+            let amount_out: u128 = compute_amount_out(small_reserve)?.try_into().unwrap();
             amm.reserve_pool_liquidity(pool_id, amount_out)?;
 
             let small_burn = liquidity / uint!(10_U256);
@@ -1718,9 +1586,7 @@ mod tests {
             let pool_id =
                 setup_pool_with_liquidity(&mut amm, user_token, validator_token, liq, liq)?;
 
-            let amount_out = amm
-                .check_sufficient_liquidity(pool_id, uint!(50000_U256))?
-                .amount_out;
+            let amount_out: u128 = compute_amount_out(uint!(50000_U256))?.try_into().unwrap();
             amm.reserve_pool_liquidity(pool_id, amount_out)?;
 
             amm.rebalance_swap(admin, user_token, validator_token, uint!(5000_U256), to)?;
@@ -1755,9 +1621,7 @@ mod tests {
                 .address();
 
             let liq = uint!(100000_U256);
-            let pool_id =
-                setup_pool_with_liquidity(&mut amm, user_token, validator_token, liq, liq)?;
-            amm.check_sufficient_liquidity(pool_id, uint!(90000_U256))?;
+            setup_pool_with_liquidity(&mut amm, user_token, validator_token, liq, liq)?;
             assert!(
                 amm.rebalance_swap(admin, user_token, validator_token, uint!(5000_U256), to)
                     .is_ok()
@@ -1790,11 +1654,6 @@ mod tests {
 
             let deposit_amount = uint!(100000_U256);
             let liquidity = amm.mint(admin, user_token, validator_token, deposit_amount, admin)?;
-
-            let pool_id = amm.pool_id(user_token, validator_token);
-            let pool = amm.pools[pool_id].read()?;
-            let reserve_amount = U256::from(pool.reserve_validator_token) - uint!(100_U256);
-            amm.check_sufficient_liquidity(pool_id, reserve_amount)?;
 
             let result = amm.burn(admin, user_token, validator_token, liquidity, recipient);
             assert!(result.is_ok());

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -1081,16 +1081,6 @@ mod tests {
         })
     }
 
-    /// Helper for tests: returns the validator-token reserve of a pool and the
-    /// validator-token output `compute_amount_out(max_amount)` would require.
-    fn pool_check(amm: &TipFeeManager, pool_id: B256, max_amount: U256) -> eyre::Result<(u128, u128)> {
-        let pool = amm.pools[pool_id].read()?;
-        let amount_out: u128 = compute_amount_out(max_amount)?
-            .try_into()
-            .map_err(|_| eyre::eyre!("amount_out exceeds u128"))?;
-        Ok((pool.reserve_validator_token, amount_out))
-    }
-
     /// Test pool boundary condition
     #[test]
     fn test_pool_liquidity_boundary() -> eyre::Result<()> {
@@ -1114,16 +1104,15 @@ mod tests {
                 liquidity,
                 liquidity,
             )?;
+            let reserve = U256::from(amm.pools[pool_id].read()?.reserve_validator_token);
 
             // Exactly at boundary should succeed (100 * 0.997 = 99.7, which is < 100)
             let ok_amount = uint!(100_U256) * uint!(10_U256).pow(U256::from(6));
-            let (reserve, amount_out) = pool_check(&amm, pool_id, ok_amount)?;
-            assert!(reserve >= amount_out);
+            assert!(reserve >= compute_amount_out(ok_amount)?);
 
             // Just over boundary should fail (101 * 0.997 = 100.697, which is > 100)
             let too_much = uint!(101_U256) * uint!(10_U256).pow(U256::from(6));
-            let (reserve, amount_out) = pool_check(&amm, pool_id, too_much)?;
-            assert!(reserve < amount_out);
+            assert!(reserve < compute_amount_out(too_much)?);
 
             Ok(())
         })

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -87,7 +87,7 @@ impl PoolKey {
 }
 
 /// AMM path [`TipFeeManager`] will take to swap `user_token` into `validator_token`
-/// for fee collection. See [`TipFeeManager::plan_fee_swap`].
+/// for fee collection. See [`TipFeeManager::get_fee_route`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeeRoute {
     /// `user_token == validator_token`, or the direct pool has sufficient liquidity.
@@ -493,7 +493,7 @@ impl TipFeeManager {
     /// - `UnderOverflow` — fee-amount arithmetic overflows
     ///
     /// [TIP-1033]: <https://docs.tempo.xyz/protocol/tips/tip-1033>
-    pub fn plan_fee_swap(
+    pub fn get_fee_route(
         &self,
         user_token: Address,
         validator_token: Address,

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -186,7 +186,7 @@ impl TipFeeManager {
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
         if !skip_liquidity_check {
-            match self.plan_fee_swap(user_token, validator_token, max_amount)? {
+            match self.get_fee_route(user_token, validator_token, max_amount)? {
                 None => return Err(TIPFeeAMMError::insufficient_liquidity().into()),
                 Some(FeeRoute::Direct) => {
                     if user_token != validator_token && self.storage.spec().is_t1c() {

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -8,7 +8,7 @@ pub mod dispatch;
 use crate::{
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
-    tip_fee_manager::amm::{FeeSwapPlan, Pool, compute_amount_out},
+    tip_fee_manager::amm::{FeeRoute, Pool, compute_amount_out},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
     tip20_factory::TIP20Factory,
 };
@@ -186,33 +186,34 @@ impl TipFeeManager {
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
         if !skip_liquidity_check {
-            let attempt = self.plan_fee_swap(user_token, validator_token, max_amount)?;
-            if !attempt.is_sufficient() {
-                return Err(TIPFeeAMMError::insufficient_liquidity().into());
-            }
-
-            match attempt.plan {
-                Some(FeeSwapPlan::SameToken) => {}
-                Some(FeeSwapPlan::Direct(swap)) => {
-                    if self.storage.spec().is_t1c() {
-                        self.reserve_pool_liquidity(swap.pool_id, swap.amount_out)?;
+            match self.plan_fee_swap(user_token, validator_token, max_amount)? {
+                None => return Err(TIPFeeAMMError::insufficient_liquidity().into()),
+                Some(FeeRoute::Direct) => {
+                    if user_token != validator_token && self.storage.spec().is_t1c() {
+                        let amount_out: u128 = compute_amount_out(max_amount)?
+                            .try_into()
+                            .map_err(|_| TempoPrecompileError::under_overflow())?;
+                        self.reserve_pool_liquidity(
+                            self.pool_id(user_token, validator_token),
+                            amount_out,
+                        )?;
                     }
                 }
-                Some(FeeSwapPlan::TwoHop {
-                    intermediate,
-                    swap1,
-                    swap2,
-                }) => {
-                    debug_assert!(
-                        self.storage.spec().is_t1c(),
-                        "two-hop fallback is T5-gated and T5 implies T1C",
-                    );
-                    self.reserve_pool_liquidity(swap1.pool_id, swap1.amount_out)?;
-                    self.reserve_pool_liquidity(swap2.pool_id, swap2.amount_out)?;
+                Some(FeeRoute::TwoHop(intermediate)) => {
+                    // T5+ implies T1C+, so reservation is always required here.
+                    let out1: u128 = compute_amount_out(max_amount)?
+                        .try_into()
+                        .map_err(|_| TempoPrecompileError::under_overflow())?;
+                    let out2: u128 = compute_amount_out(U256::from(out1))?
+                        .try_into()
+                        .map_err(|_| TempoPrecompileError::under_overflow())?;
+                    self.reserve_pool_liquidity(self.pool_id(user_token, intermediate), out1)?;
+                    self.reserve_pool_liquidity(
+                        self.pool_id(intermediate, validator_token),
+                        out2,
+                    )?;
                     self.two_hop_intermediate.t_write(intermediate)?;
                 }
-                // Unreachable: `is_sufficient()` above rejects `None`.
-                None => unreachable!("guarded by is_sufficient()"),
             }
         }
 

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -208,10 +208,7 @@ impl TipFeeManager {
                         .try_into()
                         .map_err(|_| TempoPrecompileError::under_overflow())?;
                     self.reserve_pool_liquidity(self.pool_id(user_token, intermediate), out1)?;
-                    self.reserve_pool_liquidity(
-                        self.pool_id(intermediate, validator_token),
-                        out2,
-                    )?;
+                    self.reserve_pool_liquidity(self.pool_id(intermediate, validator_token), out2)?;
                     self.two_hop_intermediate.t_write(intermediate)?;
                 }
             }

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -59,7 +59,7 @@ impl AmmLiquidityCache {
     /// planner considers the two-hop fallback through `userToken.quoteToken()`.
     ///
     /// Hot path checks only the direct pool from the primitive cache; T5+ two-hop probes
-    /// always defer to the slow path (which calls [`TipFeeManager::plan_fee_swap`]).
+    /// always defer to the slow path (which calls [`TipFeeManager::get_fee_route`]).
     ///
     /// [TIP-1033]: <https://docs.tempo.xyz/protocol/tips/tip-1033>
     pub fn has_enough_liquidity(
@@ -101,7 +101,7 @@ impl AmmLiquidityCache {
             .with_read_only_storage_ctx(current_fork, || -> TempoResult<bool> {
                 let manager = TipFeeManager::new();
                 for validator_token in missing_in_cache {
-                    let route = manager.plan_fee_swap(user_token, validator_token, fee)?;
+                    let route = manager.get_fee_route(user_token, validator_token, fee)?;
 
                     // Warm the direct pool entry so future hot-path checks can short-circuit.
                     let direct_id = manager.pool_id(user_token, validator_token);

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -20,11 +20,11 @@ use tempo_evm::TempoStateAccess;
 use tempo_precompiles::{
     DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
     error::Result as TempoResult,
+    storage::Handler,
     tip_fee_manager::{
         TipFeeManager,
-        amm::{FeeSwapPlan, Pool, SwapInfo, compute_amount_out},
+        amm::{Pool, compute_amount_out},
     },
-    tip20,
 };
 use tempo_primitives::{TempoHeader, TempoReceipt};
 use tempo_revm::IntoAddress;
@@ -55,8 +55,11 @@ impl AmmLiquidityCache {
     }
 
     /// Checks whether there's enough liquidity in at least one of the AMM pools used by recent
-    /// validators for the given fee token and fee amount. On T5+, as per [TIP-1033], considers
-    /// the two-hop fallback through an intermediate `userToken.quoteToken()`.
+    /// validators for the given fee token and fee amount. On T5+, as per [TIP-1033], the
+    /// planner considers the two-hop fallback through `userToken.quoteToken()`.
+    ///
+    /// Hot path checks only the direct pool from the primitive cache; T5+ two-hop probes
+    /// always defer to the slow path (which calls [`TipFeeManager::plan_fee_swap`]).
     ///
     /// [TIP-1033]: <https://docs.tempo.xyz/protocol/tips/tip-1033>
     pub fn has_enough_liquidity(
@@ -67,10 +70,10 @@ impl AmmLiquidityCache {
     ) -> Result<bool, ProviderError> {
         let amount_out = compute_amount_out(fee).map_err(ProviderError::other)?;
 
-        let mut deferred = Vec::new();
+        let mut missing_in_cache = Vec::new();
         let current_fork;
 
-        // Hot path: decide each `(user, validator)` pair entirely from the primitive cache.
+        // Hot path: only the direct `(user, validator)` pool is consulted from the cache.
         {
             let inner = self.inner.read();
             current_fork = inner.current_fork;
@@ -80,85 +83,42 @@ impl AmmLiquidityCache {
                     return Ok(true);
                 }
 
-                let direct = inner
-                    .pool_cache
-                    .get(&(user_token, validator_token))
-                    .copied();
-                if matches!(direct, Some(r) if r >= amount_out) {
-                    return Ok(true);
-                }
-
-                if current_fork.is_t5() {
-                    match inner.quote_token_cache.get(&user_token).copied() {
-                        Some(h) if !h.is_zero() && h != validator_token => {
-                            let r1 = inner.pool_cache.get(&(user_token, h)).copied();
-                            let r2 = inner.pool_cache.get(&(h, validator_token)).copied();
-                            let out1 = amount_out;
-                            let out2 = compute_amount_out(out1).map_err(ProviderError::other)?;
-                            match (r1, r2) {
-                                (Some(r1), Some(r2)) if r1 >= out1 && r2 >= out2 => {
-                                    return Ok(true);
-                                }
-                                (Some(_), Some(_)) => {} // Both cached and not enough liquidity.
-                                _ => {
-                                    // A leg's reserve is missing: defer.
-                                    deferred.push(validator_token);
-                                    continue;
-                                }
-                            }
-                        }
-                        Some(_) => {} // Cached as zero / equal to validator: no two-hop path possible.
-                        None => {
-                            deferred.push(validator_token);
-                            continue;
-                        }
-                    }
-                }
-
-                // Direct unknown and (pre-T5 || two-hop ruled out): defer.
-                if direct.is_none() {
-                    deferred.push(validator_token);
+                match inner.pool_cache.get(&(user_token, validator_token)) {
+                    Some(reserve) if *reserve >= amount_out => return Ok(true),
+                    Some(_) if !current_fork.is_t5() => {} // direct insufficient, no fallback
+                    _ => missing_in_cache.push(validator_token),
                 }
             }
         }
 
-        if deferred.is_empty() {
+        if missing_in_cache.is_empty() {
             return Ok(false);
         }
 
-        // Slow path: check `plan_fee_swap` for deferred checks. This might race other fetches but we're OK with it.
+        // Slow path: ask the planner. Always warms the direct pool slot; T5+ two-hop pools
+        // are intentionally not cached (the hot path can never query them).
         state_provider
             .with_read_only_storage_ctx(current_fork, || -> TempoResult<bool> {
                 let manager = TipFeeManager::new();
-                for validator_token in deferred {
-                    let attempt = manager.plan_fee_swap(user_token, validator_token, fee)?;
+                for validator_token in missing_in_cache {
+                    let route = manager.plan_fee_swap(user_token, validator_token, fee)?;
+
+                    // Warm the direct pool entry so future hot-path checks can short-circuit.
+                    let direct_id = manager.pool_id(user_token, validator_token);
+                    let direct_pool = manager.pools[direct_id].read()?;
+                    let direct_slot = manager.pools[direct_id].base_slot();
                     {
                         let mut inner = self.inner.write();
-                        let cache_pool =
-                            |inner: &mut AmmLiquidityCacheInner,
-                             pair: (Address, Address),
-                             swap: &SwapInfo| {
-                                let slot = manager.pools[swap.pool_id].base_slot();
-                                inner.pool_cache.insert(pair, U256::from(swap.reserves));
-                                inner.slot_to_pool.insert(slot, pair);
-                            };
-
-                        if let Some(swap) = attempt.direct_check() {
-                            cache_pool(&mut inner, (user_token, validator_token), swap);
-                        }
-                        if let Some(FeeSwapPlan::TwoHop {
-                            intermediate,
-                            swap1,
-                            swap2,
-                        }) = &attempt.plan
-                        {
-                            inner.quote_token_cache.insert(user_token, *intermediate);
-                            cache_pool(&mut inner, (user_token, *intermediate), swap1);
-                            cache_pool(&mut inner, (*intermediate, validator_token), swap2);
-                        }
+                        inner.pool_cache.insert(
+                            (user_token, validator_token),
+                            U256::from(direct_pool.reserve_validator_token),
+                        );
+                        inner
+                            .slot_to_pool
+                            .insert(direct_slot, (user_token, validator_token));
                     }
-                    // If there is enough liquidity, short circuit and return `true`
-                    if attempt.is_sufficient() {
+
+                    if route.is_some() {
                         return Ok(true);
                     }
                 }
@@ -193,40 +153,30 @@ impl AmmLiquidityCache {
 
     /// Processes a new [`ExecutionOutcome`] and caches new validator
     /// fee token preferences and AMM pool liquidity changes.
-    ///
-    /// On T5+ also invalidates `AmmLiquidityCacheInner::quote_token_cache` entries for TIP-20
-    /// tokens whose `quoteToken` storage slot was written.
     pub fn on_new_state(&self, execution_outcome: &ExecutionOutcome<TempoReceipt>) {
-        let mut inner = self.inner.write();
-
-        // Process FeeManager slot changes: update pool reserves and validator preferences.
-        if let Some(storage) = execution_outcome
+        let Some(storage) = execution_outcome
             .account_state(&TIP_FEE_MANAGER_ADDRESS)
             .map(|acc| &acc.storage)
-        {
-            for (slot, value) in storage.iter() {
-                if let Some(pool) = inner.slot_to_pool.get(slot).copied() {
-                    // Update AMM pools
-                    let validator_reserve = U256::from(
-                        Pool::decode_from_slot(value.present_value).reserve_validator_token,
-                    );
-                    inner.pool_cache.insert(pool, validator_reserve);
-                } else if let Some(validator) = inner.slot_to_validator.get(slot).copied() {
-                    // Update validator fee token preferences
-                    inner
-                        .validator_preferences
-                        .insert(validator, value.present_value().into_address());
-                }
+        else {
+            return;
+        };
+
+        let mut inner = self.inner.write();
+
+        // Process all FeeManager slot changes and update the cache.
+        for (slot, value) in storage.iter() {
+            if let Some(pool) = inner.slot_to_pool.get(slot).copied() {
+                // Update AMM pools
+                let validator_reserve =
+                    U256::from(Pool::decode_from_slot(value.present_value).reserve_validator_token);
+                inner.pool_cache.insert(pool, validator_reserve);
+            } else if let Some(validator) = inner.slot_to_validator.get(slot).copied() {
+                // Update validator fee token preferences
+                inner
+                    .validator_preferences
+                    .insert(validator, value.present_value().into_address());
             }
         }
-
-        // Process TIP-20 quote token updates: invalidate stale entries.
-        inner.quote_token_cache.retain(|token, _| {
-            execution_outcome
-                .account_state(token)
-                .and_then(|acc| acc.storage.get(&tip20::slots::QUOTE_TOKEN))
-                .is_none()
-        });
     }
 
     /// Processes new blocks and records recent validators and their fee token preferences in the cache.
@@ -327,9 +277,6 @@ struct AmmLiquidityCacheInner {
 
     /// Cache for (user_token, validator_token) -> liquidity
     pool_cache: HashMap<(Address, Address), U256>,
-
-    /// Cached `userToken.quoteToken()` lookups.
-    quote_token_cache: AddressMap<Address>,
 
     /// Reverse index from a FeeManager pool slot to its `(user_token, validator_token)` key.
     slot_to_pool: U256Map<(Address, Address)>,
@@ -521,45 +468,6 @@ mod tests {
     }
 
     #[test]
-    fn test_has_enough_liquidity_two_hop_cached() {
-        let user = address!("1111111111111111111111111111111111111111");
-        let hop = address!("2222222222222222222222222222222222222222");
-        let validator = address!("3333333333333333333333333333333333333333");
-
-        let cache = AmmLiquidityCache {
-            inner: Arc::new(RwLock::new(AmmLiquidityCacheInner {
-                current_fork: TempoHardfork::T5,
-                unique_tokens: vec![validator],
-                pool_cache: {
-                    let mut m = HashMap::default();
-                    // Reserves easily cover floor(100*M) and floor(99*M) sequentially.
-                    m.insert((user, hop), U256::from(1_000_000));
-                    m.insert((hop, validator), U256::from(1_000_000));
-                    m
-                },
-                quote_token_cache: {
-                    let mut m = AddressMap::default();
-                    m.insert(user, hop);
-                    m
-                },
-                ..Default::default()
-            })),
-        };
-
-        // Provider would return zero for any storage read; if the slow path runs we'd see
-        // either a `false` result or a panic from the missing TIP-20 prefix on `user`.
-        let provider = create_mock_provider();
-        let mut state = provider.latest().unwrap();
-
-        let result = cache.has_enough_liquidity(user, U256::from(100), &mut state);
-        assert!(result.is_ok());
-        assert!(
-            result.unwrap(),
-            "two-hop primitives cached should resolve from hot path",
-        );
-    }
-
-    #[test]
     fn test_has_enough_liquidity_cache_miss_insufficient() {
         let user_token = address!("2222222222222222222222222222222222222222");
         let validator_token = address!("3333333333333333333333333333333333333333");
@@ -615,66 +523,7 @@ mod tests {
 
         let inner = cache.inner.read();
         assert!(inner.pool_cache.is_empty());
-        assert!(inner.quote_token_cache.is_empty());
         assert!(inner.validator_preferences.is_empty());
-    }
-
-    #[test]
-    fn test_on_new_state_invalidates_stale_quote_token_cache() {
-        use reth_provider::ExecutionOutcome;
-        use revm::database::{AccountStatus, BundleAccount, BundleState, states::StorageSlot};
-        use tempo_primitives::TempoReceipt;
-
-        // TIP-20-prefixed addresses so `from_address_unchecked`'s debug_assert holds.
-        let user_token = address!("20c0000000000000000000000000000000000001");
-        let hop_old = address!("20c0000000000000000000000000000000000002");
-        let hop_new = address!("20c0000000000000000000000000000000000003");
-        let other_user = address!("20c0000000000000000000000000000000000099");
-
-        let cache = AmmLiquidityCache {
-            inner: Arc::new(RwLock::new(AmmLiquidityCacheInner {
-                quote_token_cache: {
-                    let mut m = AddressMap::default();
-                    m.insert(user_token, hop_old);
-                    m.insert(other_user, hop_old);
-                    m
-                },
-                ..Default::default()
-            })),
-        };
-
-        // Build a bundle where `user_token`'s `quoteToken` slot was rewritten to `hop_new`.
-        let mut storage = HashMap::default();
-        storage.insert(
-            tip20::slots::QUOTE_TOKEN,
-            StorageSlot::new_changed(hop_old.into_word().into(), hop_new.into_word().into()),
-        );
-        let mut bundle_state = AddressMap::default();
-        bundle_state.insert(
-            user_token,
-            BundleAccount::new(None, None, storage, AccountStatus::Changed),
-        );
-        let bundle = BundleState {
-            state: bundle_state,
-            ..Default::default()
-        };
-        let execution_outcome: ExecutionOutcome<TempoReceipt> = ExecutionOutcome {
-            bundle,
-            ..Default::default()
-        };
-
-        cache.on_new_state(&execution_outcome);
-
-        let inner = cache.inner.read();
-        assert!(
-            !inner.quote_token_cache.contains_key(&user_token),
-            "stale quote_token_cache entry must be dropped on slot write",
-        );
-        assert_eq!(
-            inner.quote_token_cache.get(&other_user),
-            Some(&hop_old),
-            "untouched user tokens must keep their cached intermediate",
-        );
     }
 
     // ============================================
@@ -835,11 +684,6 @@ mod tests {
                     m.insert((user_token, validator_token), U256::from(1000));
                     m
                 },
-                quote_token_cache: {
-                    let mut m = AddressMap::default();
-                    m.insert(user_token, validator_token);
-                    m
-                },
                 slot_to_pool: {
                     let mut m = U256Map::default();
                     m.insert(U256::from(1), (user_token, validator_token));
@@ -869,10 +713,6 @@ mod tests {
         assert!(
             inner.pool_cache.is_empty(),
             "pools should be empty after clear"
-        );
-        assert!(
-            inner.quote_token_cache.is_empty(),
-            "quote_tokens should be empty after clear"
         );
         assert!(
             inner.slot_to_pool.is_empty(),


### PR DESCRIPTION
This PR consolidates the `SwapInfo`, `FeeSwapPlan`, and `FeeSwapAttempt` logic into a simplified two-variant `FeeRoute` enum. It also removes the txpool’s `quote_token_cache`.

On the hot path, we can determine whether a direct pool swap is sufficient using `pool_cache`. The slow path remains fast enough that re-running it for T5+ two-hop admissions should be negligible.

Additionally, `plan_fee_swap` has been refactored into a read-only `get_fee_route` function that returns `Result<Option<FeeRoute>>`.

Behavior is consistent with the implementation in `rus/tip-1033`. The trade-off is that the cold path now re-reads the direct pool slot to warm `pool_cache`, introducing one additional in-memory read (for the cold path only).