### PR TITLE
fix: mitigate race condition in payload cancellation

### DIFF
--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -32,14 +32,16 @@ use commonware_runtime::{
 };
 use prometheus_client::metrics::counter::Counter;
 
-use commonware_utils::{SystemTimeExt, channel::oneshot};
+use commonware_utils::SystemTimeExt;
 use eyre::{OptionExt as _, WrapErr as _, bail, ensure, eyre};
-use futures::{StreamExt as _, TryFutureExt as _, channel::mpsc, future::try_join};
+use futures::{
+    StreamExt as _, TryFutureExt as _,
+    channel::{mpsc, oneshot},
+    future::try_join,
+};
 use rand_08::{CryptoRng, Rng};
 use reth_ethereum::chainspec::EthChainSpec as _;
-use reth_node_builder::{
-    Block as _, BuiltPayload, ConsensusEngineHandle, PayloadAttributes, PayloadKind,
-};
+use reth_node_builder::{Block as _, BuiltPayload, ConsensusEngineHandle, PayloadKind};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks as _};
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::{TempoExecutionData, TempoFullNode, TempoPayloadTypes};
@@ -311,17 +313,26 @@ impl Inner<Init> {
             leader,
         } = request;
 
-        let (payload_id_tx, mut payload_id_rx) = oneshot::channel();
+        let mut payload_id_rx: Option<oneshot::Receiver<eyre::Result<PayloadId>>> = None;
+        let mut payload_id: Option<PayloadId> = None;
 
         let proposal_digest = select!(
             () = response.closed() => {
-                // If we got interrupted, fetch payload resolve future and drop it
-                // to make sure that payload building is canceled.
-                if let Ok(payload_id) = payload_id_rx.try_recv() {
+                let id = if let Some(id) = payload_id {
+                    Some(id)
+                } else if let Some(rx) = payload_id_rx.as_mut() {
+                    Some(rx
+                        .await
+                        .wrap_err("executor dropped response")?
+                        .wrap_err("failed requesting a new payload build")?)
+                } else {
+                    None
+                };
+                if let Some(id) = id {
                     let fut = self
                         .execution_node
                         .payload_builder_handle
-                        .resolve_kind_fut(payload_id, PayloadKind::WaitForPending)
+                        .resolve_kind_fut(id, PayloadKind::WaitForPending)
                         .await
                         .wrap_err("failed resolving payload")?;
                     drop(fut);
@@ -338,7 +349,8 @@ impl Inner<Init> {
                 parent_view,
                 parent_digest,
                 round,
-                payload_id_tx,
+                &mut payload_id_rx,
+                &mut payload_id,
                 leader,
             ) => {
                 res.wrap_err("failed creating a proposal")
@@ -414,13 +426,15 @@ impl Inner<Init> {
         Ok(())
     }
 
+    #[expect(clippy::too_many_arguments, reason = "internal helper used in one place")]
     async fn propose<TContext: Pacer>(
         self,
         context: TContext,
         parent_view: View,
         parent_digest: Digest,
         round: Round,
-        payload_id_tx: oneshot::Sender<PayloadId>,
+        payload_id_rx_slot: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
+        payload_id_slot: &mut Option<PayloadId>,
         leader: PublicKey,
     ) -> eyre::Result<Digest> {
         let propose_start = Instant::now();
@@ -598,17 +612,28 @@ impl Inner<Init> {
             },
         );
 
-        let payload_id = attrs.payload_id(&parent.digest().0);
-        payload_id_tx.send(payload_id).map_err(|_| {
-            eyre!("caller went away before payload job ID could be returned; aborting proposal")
-        })?;
         let interrupt_handle = attrs.interrupt_handle().clone();
 
-        self.state
-            .executor
-            .canonicalize_and_build(parent.height(), parent.digest(), attrs)
+        // Share the dispatch receiver with the cancel branch so that, if cancellation
+        // hits between dispatch send and receiving `payload_id`, the cancel branch can
+        // still drain the rx, learn `payload_id`, and cancel the now-registered job.
+        *payload_id_rx_slot = Some(
+            self.state
+                .executor
+                .canonicalize_and_build(parent.height(), parent.digest(), attrs)?,
+        );
+
+        let payload_id = payload_id_rx_slot
+            .as_mut()
+            .expect("just set")
             .await
+            .wrap_err("executor dropped response")?
             .wrap_err("failed requesting a new payload build")?;
+
+        // Once we hold `payload_id`, the cancel branch no longer needs the rx;
+        // it can cancel directly by id.
+        *payload_id_rx_slot = None;
+        *payload_id_slot = Some(payload_id);
 
         let elapsed = propose_start.elapsed();
         let remaining_resolve = self.payload_resolve_time.saturating_sub(elapsed);

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -426,7 +426,10 @@ impl Inner<Init> {
         Ok(())
     }
 
-    #[expect(clippy::too_many_arguments, reason = "internal helper used in one place")]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "internal helper used in one place"
+    )]
     async fn propose<TContext: Pacer>(
         self,
         context: TContext,
@@ -617,11 +620,11 @@ impl Inner<Init> {
         // Share the dispatch receiver with the cancel branch so that, if cancellation
         // hits between dispatch send and receiving `payload_id`, the cancel branch can
         // still drain the rx, learn `payload_id`, and cancel the now-registered job.
-        *payload_id_rx_slot = Some(
-            self.state
-                .executor
-                .canonicalize_and_build(parent.height(), parent.digest(), attrs)?,
-        );
+        *payload_id_rx_slot = Some(self.state.executor.canonicalize_and_build(
+            parent.height(),
+            parent.digest(),
+            attrs,
+        )?);
 
         let payload_id = payload_id_rx_slot
             .as_mut()

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -314,21 +314,14 @@ impl Inner<Init> {
         } = request;
 
         let mut payload_id_rx: Option<oneshot::Receiver<eyre::Result<PayloadId>>> = None;
-        let mut payload_id: Option<PayloadId> = None;
 
         let proposal_digest = select!(
             () = response.closed() => {
-                let id = if let Some(id) = payload_id {
-                    Some(id)
-                } else if let Some(rx) = payload_id_rx.as_mut() {
-                    Some(rx
+                if let Some(rx) = payload_id_rx.as_mut() {
+                    let id = rx
                         .await
                         .wrap_err("executor dropped response")?
-                        .wrap_err("failed requesting a new payload build")?)
-                } else {
-                    None
-                };
-                if let Some(id) = id {
+                        .wrap_err("failed requesting a new payload build")?;
                     let fut = self
                         .execution_node
                         .payload_builder_handle
@@ -350,7 +343,6 @@ impl Inner<Init> {
                 parent_digest,
                 round,
                 &mut payload_id_rx,
-                &mut payload_id,
                 leader,
             ) => {
                 res.wrap_err("failed creating a proposal")
@@ -426,10 +418,6 @@ impl Inner<Init> {
         Ok(())
     }
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "internal helper used in one place"
-    )]
     async fn propose<TContext: Pacer>(
         self,
         context: TContext,
@@ -437,7 +425,6 @@ impl Inner<Init> {
         parent_digest: Digest,
         round: Round,
         payload_id_rx: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
-        payload_id_slot: &mut Option<PayloadId>,
         leader: PublicKey,
     ) -> eyre::Result<Digest> {
         let propose_start = Instant::now();
@@ -633,10 +620,11 @@ impl Inner<Init> {
             .wrap_err("executor dropped response")?
             .wrap_err("failed requesting a new payload build")?;
 
-        // Once we hold `payload_id`, the cancel branch no longer needs the rx;
-        // it can cancel directly by id.
-        *payload_id_rx = None;
-        *payload_id_slot = Some(payload_id);
+        // Replace the slot with a pre-filled oneshot so the cancel branch can keep
+        // unconditionally awaiting `payload_id_rx` and immediately get back `payload_id`.
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(payload_id));
+        *payload_id_rx = Some(rx);
 
         let elapsed = propose_start.elapsed();
         let remaining_resolve = self.payload_resolve_time.saturating_sub(elapsed);

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -436,7 +436,7 @@ impl Inner<Init> {
         parent_view: View,
         parent_digest: Digest,
         round: Round,
-        payload_id_rx_slot: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
+        payload_id_rx: &mut Option<oneshot::Receiver<eyre::Result<PayloadId>>>,
         payload_id_slot: &mut Option<PayloadId>,
         leader: PublicKey,
     ) -> eyre::Result<Digest> {
@@ -620,13 +620,13 @@ impl Inner<Init> {
         // Share the dispatch receiver with the cancel branch so that, if cancellation
         // hits between dispatch send and receiving `payload_id`, the cancel branch can
         // still drain the rx, learn `payload_id`, and cancel the now-registered job.
-        *payload_id_rx_slot = Some(self.state.executor.canonicalize_and_build(
+        *payload_id_rx = Some(self.state.executor.canonicalize_and_build(
             parent.height(),
             parent.digest(),
             attrs,
         )?);
 
-        let payload_id = payload_id_rx_slot
+        let payload_id = payload_id_rx
             .as_mut()
             .expect("just set")
             .await
@@ -635,7 +635,7 @@ impl Inner<Init> {
 
         // Once we hold `payload_id`, the cancel branch no longer needs the rx;
         // it can cancel directly by id.
-        *payload_id_rx_slot = None;
+        *payload_id_rx = None;
         *payload_id_slot = Some(payload_id);
 
         let elapsed = propose_start.elapsed();

--- a/crates/commonware-node/src/executor/ingress.rs
+++ b/crates/commonware-node/src/executor/ingress.rs
@@ -36,12 +36,12 @@ impl Mailbox {
     }
 
     /// Canonicalizes the given head and requests a new payload to be built.
-    pub(crate) async fn canonicalize_and_build(
+    pub(crate) fn canonicalize_and_build(
         &self,
         height: Height,
         digest: Digest,
         attributes: TempoPayloadAttributes,
-    ) -> eyre::Result<PayloadId> {
+    ) -> eyre::Result<oneshot::Receiver<eyre::Result<PayloadId>>> {
         let (response, rx) = oneshot::channel();
         self.inner
             .unbounded_send(Message::in_current_span(CanonicalizeAndBuild {
@@ -53,9 +53,7 @@ impl Mailbox {
             .wrap_err(
                 "failed sending canonicalize and build request to agent, this means it exited",
             )?;
-        rx.await
-            .wrap_err("executor dropped response")
-            .and_then(|res| res)
+        Ok(rx)
     }
 }
 


### PR DESCRIPTION
https://github.com/tempoxyz/tempo/issues/3451 added logic to resolve/cancel payload job upon cancellation. however, the current implementation is a subject to a race condition in cases when proposal is interrupted after dispatching FCU but before the FCU completes (and starts the payload build). In that case `resolve_kind_fut` would return `None` because the payload build did not yet begin, and the payload job would still get spawned and will run until deadline.

This PR fixes it by maintaining shared state between `handle_propose` and `propose` that is used to properly await the FCU response if cancellation happens while it's still in-flight