### PR TITLE
docs(tip-1055): stop storing order ID in order; add storage version number

### DIFF
--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -1,18 +1,20 @@
 ---
 id: TIP-1055
-title: Version Stablecoin DEX order storage and deprecate stored order IDs
-description: Adds a storage version byte to Stablecoin DEX orders and makes the mapping key the canonical order ID for newly created orders.
+title: Deprecate stored order IDs in Stablecoin DEX order storage
+description: Deprecates stored order IDs for newly created Stablecoin DEX orders and adds an internal storage version byte for compatibility and future layout changes.
 authors: Dan Robinson
 status: Draft
 related: N/A
 protocolVersion: T5
 ---
 
-# TIP-1055: Version Stablecoin DEX order storage and deprecate stored order IDs
+# TIP-1055: Deprecate stored order IDs in Stablecoin DEX order storage
 
 ## Abstract
 
-This TIP adds a `version` byte to Stablecoin DEX order storage using currently unused bytes in the existing layout. Existing orders are treated as version `0`. Newly created orders are version `1` and no longer store a meaningful `orderId` inside the order payload; instead, the mapping key is the canonical order ID.
+This TIP deprecates storing a meaningful `orderId` inside newly created Stablecoin DEX order records. Instead, the mapping key becomes the canonical order ID for all orders.
+
+To support that transition safely, it also adds an internal `version` byte to order storage using currently unused bytes in the existing layout. Existing orders are treated as version `0`, newly created orders are version `1`, and the `version` byte also creates a forward-compatible hook for future, potentially more disruptive, layout changes.
 
 This reduces order placement gas by removing a redundant zero-to-nonzero storage write for new orders. It does not require a migration and does not change the external `getOrder` return shape.
 

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -78,7 +78,8 @@ For version `1` orders:
 
 For version `0` orders:
 
-- the stored `orderId` field may remain populated
+- the stored `orderId` field MUST remain populated until the order is deleted
+- implementations MUST NOT modify slot `0` while a version `0` order remains live
 - implementations MUST NOT read it to recover order identity
 - implementations MUST use the mapping key instead
 
@@ -88,10 +89,10 @@ All orders created after this TIP is activated MUST be written as version `1` or
 
 Creating a version `1` order:
 
-1. writes `version = 1`
-2. uses the mapping key as the order's canonical identity
-3. does not rely on a meaningful stored `orderId`
-4. leaves slot `0` untouched
+1. MUST write `version = 1`
+2. MUST use the mapping key as the order's canonical identity
+3. MUST NOT rely on a meaningful stored `orderId`
+4. MUST leave slot `0` untouched
 
 This applies equally to regular orders and flip orders.
 

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -1,0 +1,106 @@
+---
+id: TIP-1055
+title: Version Stablecoin DEX order storage and deprecate stored order IDs
+description: Adds a storage version byte to Stablecoin DEX orders and makes the mapping key the canonical order ID for newly created orders.
+authors: Dan Robinson
+status: Draft
+related: N/A
+protocolVersion: T5
+---
+
+# TIP-1055: Version Stablecoin DEX order storage and deprecate stored order IDs
+
+## Abstract
+
+This TIP adds a `version` byte to Stablecoin DEX order storage using currently unused bytes in the existing layout. Existing orders are treated as version `0`. Newly created orders are version `1` and no longer store a meaningful `orderId` inside the order payload; instead, the mapping key is the canonical order ID.
+
+This reduces order placement gas by removing a redundant zero-to-nonzero storage write for new orders. It does not require a migration and does not change the external `getOrder` return shape.
+
+## Motivation
+
+Stablecoin DEX orders are currently stored in `mapping(uint128 => Order)`, but the stored `Order` payload also includes `orderId`. That duplicates identity already provided by the mapping key and strands half of a storage slot on every order. New orders pay to initialize that slot even though the order ID is already known from context.
+
+The smallest safe fix is to introduce a storage version byte and stop relying on stored `orderId` for newly created orders. Existing orders remain valid without rewriting state, and the external API can keep returning the same `Order` struct by filling `orderId` from the lookup key.
+
+## Assumptions
+
+- Stablecoin DEX order identity is already provided by the `orders` mapping key.
+- Internal orderbook logic can thread the mapping key explicitly anywhere it currently relies on `order.orderId` for writes, deletes, linked-list updates, or events.
+- Existing orders may remain active indefinitely, so the change must not require migrating or rewriting legacy state.
+- The added `version` byte fits in currently unused bytes of the existing storage layout, so existing field offsets and slot count remain unchanged.
+- Deleting an order continues to clear the full stored record, regardless of version.
+
+---
+
+# Specification
+
+## Order storage version
+
+Stablecoin DEX order storage gains a `uint8 version` field packed into currently unused bytes of the existing final storage slot.
+
+- `version = 0`: legacy order
+- `version = 1`: new-format order
+
+Existing orders are implicitly version `0` because their newly introduced `version` byte reads as zero.
+
+## Canonical order identity
+
+For all orders, the canonical `orderId` is the key in `mapping(uint128 => Order) orders`.
+
+For version `1` orders:
+
+- the stored `orderId` field is deprecated
+- implementations SHOULD write it as zero
+- implementations MUST NOT rely on it to recover order identity
+
+For version `0` orders:
+
+- the stored `orderId` field may remain populated
+- implementations MAY ignore it and use the mapping key instead
+
+## New order creation
+
+All orders created after this TIP is activated MUST be written as version `1` orders.
+
+Creating a version `1` order:
+
+1. writes `version = 1`
+2. uses the mapping key as the order's canonical identity
+3. does not rely on a meaningful stored `orderId`
+
+This applies equally to regular orders and flip orders.
+
+## Getter behavior
+
+The external `getOrder(orderId)` interface is unchanged.
+
+When `getOrder(orderId)` returns an `Order`, the returned `orderId` field MUST be populated from the lookup key, not from stored order payload state. This applies to both version `0` and version `1` orders.
+
+No new getter is required by this TIP.
+
+## Internal behavior
+
+Internal Stablecoin DEX logic MUST treat the mapping key as the order identity when:
+
+- writing partial fills back to storage
+- deleting filled or cancelled orders
+- updating linked-list pointers and level head/tail references
+- emitting events that include `orderId`
+
+Version `1` orders MUST remain fully interoperable with version `0` orders in matching, cancellation, and flip handling.
+
+## Deletion
+
+Order deletion behavior is unchanged.
+
+When an order is removed, the implementation clears the stored order record as it does today. No version-specific deletion path is introduced.
+
+---
+
+# Invariants
+
+- Version `0` orders remain readable and executable without migration.
+- Version `1` orders do not require a meaningful stored `orderId` to support matching, cancellation, or event emission.
+- `getOrder(orderId)` continues to return the same external struct shape for both version `0` and version `1` orders.
+- Adding `version` does not increase the Stablecoin DEX order storage slot count.
+- Deleting an order clears the full stored record regardless of version.

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -76,14 +76,17 @@ For version `1` orders:
 
 - the stored `orderId` field is deprecated
 - implementations MUST NOT rely on it to recover order identity
-- implementations MUST NOT perform an `SSTORE` to slot `0` when creating, updating, or flipping a live version `1` order
+- implementations MUST NOT perform an `SSTORE` to slot `0` when creating or updating a live version `1` order
+- after a version `0` order is upgraded to version `1`, implementations MUST NOT perform any further `SSTORE` to slot `0` until the order is deleted
 
 For version `0` orders:
 
-- the stored `orderId` field MUST remain populated until the order is deleted
-- implementations MUST NOT modify slot `0` while a version `0` order remains live
+- the stored `orderId` field MUST remain populated until the order is deleted or upgraded to version `1`
+- implementations MUST NOT modify slot `0` while a version `0` order remains live, except to clear it during an upgrade to version `1`
 - implementations MUST NOT read it to recover order identity
 - implementations MUST use the mapping key instead
+
+When a live version `0` order is upgraded to version `1`, implementations MUST clear slot `0` as part of that upgrade.
 
 ## New order creation
 
@@ -131,4 +134,5 @@ When an order is removed, the implementation clears the stored order record as i
 - Version `1` orders do not require a meaningful stored `orderId` to support matching, cancellation, or event emission.
 - `getOrder(orderId)` continues to return the same external struct shape for both version `0` and version `1` orders.
 - Adding `version` does not increase the Stablecoin DEX order storage slot count.
+- A version `0` order that is upgraded to version `1` clears slot `0` exactly once as part of that upgrade.
 - Deleting an order clears the full stored record regardless of version.

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -16,7 +16,7 @@ This TIP deprecates storing a meaningful `orderId` inside newly created Stableco
 
 To support that transition safely, it also adds an internal `version` byte to order storage using currently unused bytes in the existing layout. Existing orders are treated as version `0`, newly created orders are version `1`, and the `version` byte also creates a forward-compatible hook for future, potentially more disruptive, layout changes.
 
-This reduces order placement gas by removing a redundant zero-to-nonzero storage write for new orders. It does not require a migration and does not change the external `getOrder` return shape.
+This reduces order placement gas by removing a redundant zero-to-nonzero storage write for new orders. It does not require a migration, though it does require a protocol upgrade, and it does not change the external `getOrder` return shape.
 
 The storage `version` is an internal implementation detail. It is not returned by `getOrder`, not emitted in events, and not otherwise exposed through the external Stablecoin DEX interface.
 

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -16,6 +16,8 @@ This TIP adds a `version` byte to Stablecoin DEX order storage using currently u
 
 This reduces order placement gas by removing a redundant zero-to-nonzero storage write for new orders. It does not require a migration and does not change the external `getOrder` return shape.
 
+The storage `version` is an internal implementation detail. It is not returned by `getOrder`, not emitted in events, and not otherwise exposed through the external Stablecoin DEX interface.
+
 ## Motivation
 
 Stablecoin DEX orders are currently stored in `mapping(uint128 => Order)`, but the stored `Order` payload also includes `orderId`. That duplicates identity already provided by the mapping key and strands half of a storage slot on every order. New orders pay to initialize that slot even though the order ID is already known from context.
@@ -63,8 +65,8 @@ For all orders, the canonical `orderId` is the key in `mapping(uint128 => Order)
 For version `1` orders:
 
 - the stored `orderId` field is deprecated
-- implementations SHOULD write it as zero
 - implementations MUST NOT rely on it to recover order identity
+- implementations need not perform a dedicated write to zero the deprecated bytes
 
 For version `0` orders:
 
@@ -89,7 +91,7 @@ The external `getOrder(orderId)` interface is unchanged.
 
 When `getOrder(orderId)` returns an `Order`, the returned `orderId` field MUST be populated from the lookup key, not from stored order payload state. This applies to both version `0` and version `1` orders.
 
-No new getter is required by this TIP.
+No new getter is required by this TIP. The storage `version` is never exposed to users.
 
 ## Internal behavior
 

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -62,16 +62,25 @@ Existing orders are implicitly version `0` because their newly introduced `versi
 
 For all orders, the canonical `orderId` is the key in `mapping(uint128 => Order) orders`.
 
+The deprecated stored `orderId` occupies the first slot of the stored `Order` record (slot `0` in the current zero-indexed layout):
+
+```text
+slot 0
+- bytes 0..15:  orderId   (uint128)  <-- deprecated for version 1 orders
+- bytes 16..31: unused
+```
+
 For version `1` orders:
 
 - the stored `orderId` field is deprecated
 - implementations MUST NOT rely on it to recover order identity
-- implementations need not perform a dedicated write to zero the deprecated bytes
+- implementations MUST NOT perform an `SSTORE` to slot `0` when creating, updating, or flipping a live version `1` order
 
 For version `0` orders:
 
 - the stored `orderId` field may remain populated
-- implementations MAY ignore it and use the mapping key instead
+- implementations MUST NOT read it to recover order identity
+- implementations MUST use the mapping key instead
 
 ## New order creation
 
@@ -82,6 +91,7 @@ Creating a version `1` order:
 1. writes `version = 1`
 2. uses the mapping key as the order's canonical identity
 3. does not rely on a meaningful stored `orderId`
+4. leaves slot `0` untouched
 
 This applies equally to regular orders and flip orders.
 

--- a/tips/tip-1055.md
+++ b/tips/tip-1055.md
@@ -38,6 +38,19 @@ The smallest safe fix is to introduce a storage version byte and stop relying on
 
 Stablecoin DEX order storage gains a `uint8 version` field packed into currently unused bytes of the existing final storage slot.
 
+The changed slot is the final slot of the stored `Order` record (slot `5` in the current zero-indexed layout). Its layout becomes:
+
+```text
+slot 5
+- bytes 0..15:  next      (uint128)
+- byte  16:     isFlip    (bool)
+- bytes 17..18: flipTick  (int16)
+- byte  19:     version   (uint8)   <-- newly assigned by this TIP
+- bytes 20..31: unused
+```
+
+Before this TIP, bytes `19..31` of that slot were unused. This TIP assigns byte `19` to `version` and leaves the rest unchanged, so the order storage slot count does not increase.
+
 - `version = 0`: legacy order
 - `version = 1`: new-format order
 


### PR DESCRIPTION
Drafts TIP-1055 for versioned Stablecoin DEX order storage.

It adds a storage version byte for mixed legacy/new orders and deprecates storing `orderId` for newly created orders. The goal is to save a redundant storage write without changing the external `getOrder` shape or requiring a migration.