### PR TITLE
deps: update reth from main (2026-04-29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,21 +121,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a547705d5c1b42575a0542bae2ba45bc62a6154be86611afaef1c0ab5c38598e"
+checksum = "d8010fc7e9e8643ef4e758cdccf3eef26734594aedf88a9d5ed35e51837d42ef"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -188,24 +188,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
+checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
+checksum = "de3df0aadc569a8b277808a7d0ad0e421180654ea36a3c59e9ed2bb968c9a1cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
+checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -350,7 +350,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -371,7 +371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -386,13 +386,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
+checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "borsh",
  "serde",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
+checksum = "19e352478b756bad5d7203148e4b461861282ea2ded3da406ba24868b52cd098"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -442,19 +442,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
+checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -468,14 +468,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
+checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
@@ -512,13 +512,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
+checksum = "93a7c17472b55482d4734154c2f5ed13f72e03f6752cebb927f6a2d8b52e646c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
+checksum = "a8d86958b02bca85103d64fa60d7b364a8b017c6e40f2b02c3f50ca22964a738"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
+checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
+checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -639,15 +639,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670b3a8e0d1b32e9886b7a419b8efe6754ea00b9fdd4c0ea3c7411b6c30431f4"
+checksum = "e2144d5b2866e651796eac0a997d3b5a056449c12e0d91be3184129e0c722885"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -657,38 +657,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
+checksum = "df32156f085e74eac942b6103744be49b817c302341aaa8cb0c1c88dc29228d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
+checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5d68ddca890854fb78291cbde06115473ded00b2337d0f815e92c0c1f8003"
+checksum = "296450f5e76bece0116c939b9437b0421a5da9c5d40031bf4cf9b38d3d94e475"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
+checksum = "0ab075ac1c25bcf697f133b7cd92e2fb26afe213e872ef79fdf77f0d7bcb3793"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -717,15 +717,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f05338cfb4ee5508ff76f01c88142cab8a4579db74b7d9432936c26e4f11374"
+checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -737,17 +737,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
+checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -759,28 +759,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df223478aec91d8fb0f8643234764042fa432e6111aca126774802b2618a3a5"
+checksum = "7adc1243d55744a66b3a6cbbbba96436e8df5d248f2ee8186bef4238ef704ec7"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
+checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -788,13 +788,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fbf71892d4df9cae8d35dc96f15d522384bb93806205465e2c8c012b7f0a34"
+checksum = "f00b631c361e7c7baaf4f1f5a9877730f3507fed2acb9d4b34841b8184b2ec28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
+checksum = "a0eada2558e921b39dfcead33c487364df9b31374f5733c1c9d2c891c4529933"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
+checksum = "41eb29f7a8adcd8941fbb8e134022a133e6f8dfd345f2e3b7109599f8a7dca08"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19d1985804e9a46d3b1b4f0654a68210b44007ffdaddd0e0a35d2b8db6cc1f0"
+checksum = "1258987fbc82716b5153ec7bb95a8a295e7640871b8f03d8ec7c4000dc80c215"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ce972f2ade53477e8e9336773a417f731fc7c02f41b9cd3b8a2a273e06363e"
+checksum = "7ffc2a49bca5b73c6964711b57452f6c36a6bcb7f845ab7e9ad05b5a828d0161"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943c0105e0294b34cd06417129fadc591aed464d06f0614a7e998e585d27fbb1"
+checksum = "94e11ddaddfb98c1ddce737dc440225565b0ae0987ac9ad5e59a85db5904878c"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
+checksum = "bef839e7ce9b59aa60fa9a175e97986c6145c888d643b0f1fb0a3e7b8e56a2e2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe910cd3f56f7e4b26b8b7330b11c11c81286eaa8aa9fa6157e767a95e0f310"
+checksum = "44eb341d0013784da6a39e5bbdc11b95d6744993b12a1c3fd55df795a850dd42"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1004,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
+checksum = "3ac7a80c0bac3e44559d53d002e34c461dc2f23262b42cafec019bc70551abbe"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
+checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfad7aa9206fcb831ae401b6a1c893a402b8eed74f9c8ffbb7a7323afb0d9a4c"
+checksum = "1075d9d30fd4d71e50000fd4afb19ed2664ceab20c2a29f3889a6e988329e02d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
+checksum = "0e3bff84b2b2a46eb34cc522dc3f889a2867c70be90a377421429b662b3ec4ce"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
+checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8219,11 +8219,11 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -8246,11 +8246,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -8278,12 +8278,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8298,8 +8298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8311,12 +8311,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -8394,8 +8394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8404,10 +8404,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -8430,7 +8430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -8457,8 +8457,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8473,8 +8473,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8486,11 +8486,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8499,11 +8499,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8525,8 +8525,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8554,8 +8554,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8580,8 +8580,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8610,10 +8610,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8625,8 +8625,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8650,8 +8650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8674,8 +8674,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8698,11 +8698,11 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -8733,11 +8733,11 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8790,8 +8790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8818,8 +8818,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8841,11 +8841,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8866,12 +8866,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8924,8 +8924,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8952,11 +8952,11 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8968,8 +8968,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8984,8 +8984,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9006,8 +9006,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9017,8 +9017,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9045,13 +9045,13 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -9067,8 +9067,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9108,8 +9108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "clap",
  "eyre",
@@ -9131,11 +9131,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9147,10 +9147,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9163,8 +9163,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9176,11 +9176,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9206,11 +9206,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -9220,8 +9220,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9230,11 +9230,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -9254,11 +9254,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9274,8 +9274,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9292,8 +9292,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9305,11 +9305,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -9324,11 +9324,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -9362,10 +9362,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -9376,8 +9376,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9386,8 +9386,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9414,8 +9414,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "bytes",
  "futures",
@@ -9434,8 +9434,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9451,8 +9451,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "bindgen",
  "cc",
@@ -9460,8 +9460,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "futures",
  "metrics",
@@ -9473,8 +9473,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9482,8 +9482,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9496,11 +9496,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9554,8 +9554,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9579,11 +9579,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9602,8 +9602,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9617,8 +9617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9631,8 +9631,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9648,8 +9648,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9672,11 +9672,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9740,11 +9740,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9795,10 +9795,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9833,8 +9833,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,11 +9857,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9881,8 +9881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "bytes",
  "eyre",
@@ -9910,8 +9910,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9922,8 +9922,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9946,8 +9946,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9958,11 +9958,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9982,8 +9982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9997,7 +9997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10025,11 +10025,11 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10071,11 +10071,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -10100,8 +10100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10116,8 +10116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10131,12 +10131,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -10152,7 +10152,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -10208,10 +10208,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -10225,7 +10225,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -10238,8 +10238,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10281,8 +10281,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10301,10 +10301,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10332,13 +10332,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -10346,7 +10346,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -10378,11 +10378,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -10426,8 +10426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10440,10 +10440,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10471,11 +10471,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -10523,10 +10523,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -10551,8 +10551,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10565,8 +10565,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10585,8 +10585,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10600,11 +10600,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10624,10 +10624,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10642,8 +10642,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10663,11 +10663,11 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.6",
@@ -10679,8 +10679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10689,8 +10689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "clap",
  "eyre",
@@ -10708,8 +10708,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "clap",
  "eyre",
@@ -10726,11 +10726,11 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10771,11 +10771,11 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10797,14 +10797,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -10824,8 +10824,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10844,8 +10844,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10873,8 +10873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.1.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=73ec2c9#73ec2c9d5608e044d5018cd5d59f530f59ef3405"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=88505c7#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12392,12 +12392,12 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12454,7 +12454,7 @@ dependencies = [
 name = "tempo-chainspec"
 version = "1.5.3"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -12707,14 +12707,14 @@ name = "tempo-node"
 version = "1.6.0"
 dependencies = [
  "alloy",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "async-trait",
  "base64 0.22.1",
  "clap",
@@ -12808,7 +12808,7 @@ dependencies = [
 name = "tempo-payload-types"
 version = "1.6.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -12868,12 +12868,12 @@ name = "tempo-primitives"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -12906,7 +12906,7 @@ name = "tempo-revm"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -12974,7 +12974,7 @@ name = "tempo-transaction-pool"
 version = "1.6.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "73ec2c9", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,34 +183,34 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "88505c7", feat
 ] }
 revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
-alloy = { version = "2.0.1", default-features = false }
-alloy-consensus = { version = "2.0.1", default-features = false }
-alloy-contract = { version = "2.0.1", default-features = false }
-alloy-eips = { version = "2.0.1", default-features = false }
+alloy = { version = "2.0.4", default-features = false }
+alloy-consensus = { version = "2.0.4", default-features = false }
+alloy-contract = { version = "2.0.4", default-features = false }
+alloy-eips = { version = "2.0.4", default-features = false }
 alloy-evm = { version = "0.34.0", default-features = false }
 revm-inspectors = "0.39.0"
-alloy-genesis = { version = "2.0.1", default-features = false }
+alloy-genesis = { version = "2.0.4", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.5.7", default-features = false }
-alloy-network = { version = "2.0.1", default-features = false }
+alloy-network = { version = "2.0.4", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "2.0.1", default-features = false }
+alloy-provider = { version = "2.0.4", default-features = false }
 alloy-rlp = { version = "0.3.15", default-features = false }
-alloy-rpc-types-admin = "2.0.1"
-alloy-rpc-types-engine = "2.0.1"
-alloy-rpc-types-eth = { version = "2.0.1" }
-alloy-serde = { version = "2.0.1", default-features = false }
-alloy-signer = "2.0.1"
-alloy-signer-aws = "2.0.1"
-alloy-signer-gcp = "2.0.1"
-alloy-signer-ledger = "2.0.1"
-alloy-signer-local = "2.0.1"
-alloy-signer-trezor = "2.0.1"
+alloy-rpc-types-admin = "2.0.4"
+alloy-rpc-types-engine = "2.0.4"
+alloy-rpc-types-eth = { version = "2.0.4" }
+alloy-serde = { version = "2.0.4", default-features = false }
+alloy-signer = "2.0.4"
+alloy-signer-aws = "2.0.4"
+alloy-signer-gcp = "2.0.4"
+alloy-signer-ledger = "2.0.4"
+alloy-signer-local = "2.0.4"
+alloy-signer-trezor = "2.0.4"
 
 coins-bip32 = "0.12"
 zeroize = "1"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "2.0.1"
+alloy-transport = "2.0.4"
 
 commonware-broadcast = "2026.4.0"
 commonware-codec = "2026.4.0"

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1115,6 +1115,18 @@ where
         self.protocol_pool
             .get_blobs_for_versioned_hashes_v3(versioned_hashes)
     }
+
+    fn get_blobs_for_versioned_hashes_v4(
+        &self,
+        versioned_hashes: &[B256],
+        indices_bitarray: alloy_primitives::B128,
+    ) -> Result<
+        Vec<Option<alloy_eips::eip4844::BlobCellsAndProofsV1>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.protocol_pool
+            .get_blobs_for_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+    }
 }
 
 impl<Client> TransactionPoolExt for TempoTransactionPool<Client>


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`73ec2c9...88505c7`](https://github.com/paradigmxyz/reth/compare/73ec2c9...88505c7)

🔗 Amp thread: https://ampcode.com/threads/T-019dd952-f354-740f-8cb1-c6c03e1326f8
- **Engine**: Added `getBlobsV4` endpoint ([#23767](https://github.com/paradigmxyz/reth/pull/23767)).
- **RPC**: Narrowed `getLogs` retry range ([#23818](https://github.com/paradigmxyz/reth/pull/23818)).
- **DB**: Skipped `move_to_static_files` for `storage.v2` ([#23814](https://github.com/paradigmxyz/reth/pull/23814)).
- **Perf**: Prebound cursor operation metrics ([#23654](https://github.com/paradigmxyz/reth/pull/23654)).
- **Execution**: Properly handle selfdestructed storage slots in re-execute ([#23832](https://github.com/paradigmxyz/reth/pull/23832)).
- **Deps**: Bumped alloy to 2.0.4 ([#23828](https://github.com/paradigmxyz/reth/pull/23828)); released 2.2.0 ([#23831](https://github.com/paradigmxyz/reth/pull/23831)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019dd953-1036-7238-ad17-bc81e44fa2bd
- Bumped `reth` dependencies from rev `73ec2c9` to `88505c7` across all `reth-*` crates in [Cargo.toml](file:///home/runner/work/tempo/tempo/Cargo.toml) to track the latest upstream Reth SDK revision.
- Bumped `alloy` family crates (`alloy`, `alloy-consensus`, `alloy-contract`, `alloy-eips`, `alloy-genesis`, `alloy-network`, `alloy-provider`, `alloy-rpc-types-*`, `alloy-serde`, `alloy-signer*`, `alloy-transport`) from `2.0.1` to `2.0.4` to stay in sync with the new Reth revision.
- Implemented the new `get_blobs_for_versioned_hashes_v4` method on `TempoTransactionPool` in [tempo_pool.rs](file:///home/runner/work/tempo/tempo/crates/transaction-pool/src/tempo_pool.rs#L1118-L1128), delegating to the underlying `protocol_pool`, to satisfy the expanded `BlobStore`/pool trait introduced upstream (adds an `indices_bitarray: B128` parameter and returns `BlobCellsAndProofsV1` per hash).

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25109971223)
