### PR TITLE
feat(tip-1057): add allowance-based burnFrom TIP

### DIFF
--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -16,6 +16,8 @@ This TIP adds an allowance-based `burnFrom(address from, uint256 amount)` functi
 
 Unlike `burnAt`, `burnFrom` is allowance-based, and unlike `burnBlocked`, it is not restricted to blocked accounts. `burnFrom` still requires `ISSUER_ROLE`, applies TIP-403 authorization only to `from` in the sender role, and leaves `burnBlocked` unchanged as the existing privileged path for burning from sender-forbidden accounts.
 
+This still follows the standard `burnFrom` shape used by ERC-20 burnable tokens: it spends allowance, burns from `from`, and emits the standard `Transfer(from, address(0), amount)` burn signal. The differences are Tempo-specific additional checks for `ISSUER_ROLE`, sender-side TIP-403 authorization, and protected protocol addresses.
+
 ## Motivation
 
 TIP-20 already supports delegated transfers through `approve`, `permit`, and `transferFrom`, and it already supports administrative burns through `burn`, `burnBlocked`, and `burnAt`. What is missing is an allowance-based burn path that can express consent from the token holder while preserving TIP-20's existing issuer-controlled burn model.
@@ -67,7 +69,7 @@ On T6 and later, `burnFrom(from, amount)` MUST behave as follows:
 
 1. **Pause check**: Revert with `ContractPaused` if the token is paused.
 2. **Role check**: Revert with `Unauthorized` unless the caller has `ISSUER_ROLE`.
-3. **Protected addresses**: Revert with `ProtectedAddress` if `from` is:
+3. **Protected addresses**: Revert with `ProtectedAddress` if `from` is in the canonical TIP-20 protected-address set used by the existing arbitrary-source burn paths. At `T6`, this set is:
    - `TIP_FEE_MANAGER_ADDRESS` (`0xfeEC000000000000000000000000000000000000`)
    - `STABLECOIN_DEX_ADDRESS` (`0xDEc0000000000000000000000000000000000000`)
 4. **Sender authorization**: Revert with `PolicyForbids` unless `from` is authorized in the sender role under the token's active TIP-403 policy.
@@ -83,6 +85,13 @@ On T6 and later, `burnFrom(from, amount)` MUST behave as follows:
 9. **Events**:
    - Emit `Transfer(from, address(0), amount)`
    - Emit `BurnFrom(msg.sender, from, amount)`
+
+If `amount == 0`, `burnFrom(from, 0)` MUST be allowed if and only if `burn(0)` would be allowed under the same token state and caller role conditions. In particular:
+
+1. It still requires `ISSUER_ROLE`.
+2. It still enforces pause state, sender authorization, and protected-address checks.
+3. It leaves balances, total supply, allowance, and reward-accounting quantities unchanged.
+4. It emits the same zero-amount events that the corresponding nonzero-success path would emit.
 
 ## Policy semantics
 
@@ -122,9 +131,9 @@ This means an owner who approves a spender for `N` tokens authorizes that spende
 - if the spender also has `ISSUER_ROLE`, burn up to `N` tokens using `burnFrom`, or
 - use any combination of the two whose total allowance consumption does not exceed `N`
 
-`burnFrom` SHOULD follow the same allowance-spending behavior as `transferFrom`, including the convention that `type(uint256).max` acts as an infinite approval.
+`burnFrom` MUST follow the same allowance-spending behavior as `transferFrom`, including the convention that `type(uint256).max` acts as an infinite approval.
 
-`burnFrom` SHOULD NOT emit an `Approval` event when spending allowance. This matches modern ERC-20 allowance-spending conventions and matches TIP-20's current `transferFrom` behavior.
+`burnFrom` MUST NOT emit an `Approval` event when spending allowance. This matches modern ERC-20 allowance-spending conventions and matches TIP-20's current `transferFrom` behavior.
 
 ## Reward accounting
 
@@ -164,10 +173,11 @@ Before `T6`, `burnFrom` and `BurnFrom` are unavailable and calls to the selector
 5. **Allowance conservation**: When the allowance is finite, a successful `burnFrom(from, amount)` decreases `allowance(from, operator)` by exactly `amount`.
 6. **Infinite allowance preservation**: When the allowance is `type(uint256).max`, a successful `burnFrom` leaves it unchanged.
 7. **Supply conservation**: After a successful `burnFrom(from, amount)`, `balanceOf[from]` and `totalSupply` each decrease by exactly `amount`.
-8. **Protected addresses**: `burnFrom` must never succeed for `TIP_FEE_MANAGER_ADDRESS` or `STABLECOIN_DEX_ADDRESS`.
-9. **Reward accounting**: If `from` is opted into rewards, the burn updates reward state exactly as other TIP-20 burn paths do.
-10. **Event correctness**: Every successful `burnFrom` emits exactly one `Transfer(from, address(0), amount)` event followed by exactly one `BurnFrom(operator, from, amount)` event.
-11. **No `burnBlocked` regression**: Existing `burnBlocked` behavior remains unchanged.
+8. **Protected addresses**: `burnFrom` must use the same protected-address rule/set as the existing arbitrary-source TIP-20 burn paths, and at `T6` must never succeed for `TIP_FEE_MANAGER_ADDRESS` or `STABLECOIN_DEX_ADDRESS`.
+9. **Zero-amount parity with `burn`**: `burnFrom(from, 0)` must be allowed if and only if `burn(0)` would be allowed under the same token state and caller role conditions, and when allowed it must leave state unchanged apart from emitting the standard zero-amount success events.
+10. **Reward accounting**: If `from` is opted into rewards, the burn updates reward state exactly as other TIP-20 burn paths do.
+11. **Event correctness**: Every successful `burnFrom` emits exactly one `Transfer(from, address(0), amount)` event followed by exactly one `BurnFrom(operator, from, amount)` event.
+12. **No `burnBlocked` regression**: Existing `burnBlocked` behavior remains unchanged.
 
 ### Test coverage
 
@@ -184,6 +194,8 @@ The test suite must verify at least the following cases:
 9. Success when `from` is sender-authorized under a compound TIP-1015 policy even if `from` is not recipient-authorized.
 10. Revert when attempting to burn from `TIP_FEE_MANAGER_ADDRESS`.
 11. Revert when attempting to burn from `STABLECOIN_DEX_ADDRESS`.
-12. Correct event order and event fields.
-13. Correct reward-accounting updates when `from` is opted into rewards.
-14. No change to `burnBlocked` behavior in existing tests.
+12. `burnFrom(from, 0)` succeeds exactly when `burn(0)` would succeed and otherwise fails for the same gating reasons.
+13. `burnFrom(from, 0)` leaves balances, supply, allowance, and reward-accounting quantities unchanged while still emitting the standard zero-amount success events.
+14. Correct event order and event fields.
+15. Correct reward-accounting updates when `from` is opted into rewards.
+16. No change to `burnBlocked` behavior in existing tests.

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1057
 title: Allowance-based burnFrom for TIP-20 tokens
-description: Adds an allowance-based burnFrom entrypoint to TIP-20 with sender-side TIP-403 authorization and a BurnFrom event.
+description: Adds an allowance-based burnFrom entrypoint to TIP-20 with ISSUER_ROLE, sender-side TIP-403 authorization, and a BurnFrom event.
 authors: Amp
 status: Draft
 related: TIP-20, TIP-403, TIP-1004, TIP-1006, TIP-1015
@@ -12,15 +12,17 @@ protocolVersion: T6
 
 ## Abstract
 
-This TIP adds a standard allowance-based `burnFrom(address from, uint256 amount)` function to TIP-20. The function allows a spender with sufficient allowance to burn tokens from `from`, emits the standard `Transfer(from, address(0), amount)` burn signal, and also emits a TIP-20-native `BurnFrom` event that records the operator.
+This TIP adds an allowance-based `burnFrom(address from, uint256 amount)` function to TIP-20. The function allows a caller with `ISSUER_ROLE` and sufficient allowance to burn tokens from `from`, emits the standard `Transfer(from, address(0), amount)` burn signal, and also emits a TIP-20-native `BurnFrom` event that records the operator.
 
-Unlike `burnAt`, `burnFrom` is not role-gated, and unlike `burnBlocked`, it is not restricted to blocked accounts. `burnFrom` applies TIP-403 authorization only to `from` in the sender role, leaving `burnBlocked` unchanged as the existing privileged path for burning from sender-forbidden accounts.
+Unlike `burnAt`, `burnFrom` is allowance-based, and unlike `burnBlocked`, it is not restricted to blocked accounts. `burnFrom` still requires `ISSUER_ROLE`, applies TIP-403 authorization only to `from` in the sender role, and leaves `burnBlocked` unchanged as the existing privileged path for burning from sender-forbidden accounts.
 
 ## Motivation
 
-TIP-20 already supports delegated transfers through `approve`, `permit`, and `transferFrom`, and it already supports administrative burns through `burn`, `burnBlocked`, and `burnAt`. What is missing is the standard delegated-burn primitive used in ERC-20 burnable tokens: a spender can burn from an owner up to the approved allowance.
+TIP-20 already supports delegated transfers through `approve`, `permit`, and `transferFrom`, and it already supports administrative burns through `burn`, `burnBlocked`, and `burnAt`. What is missing is an allowance-based burn path that can express consent from the token holder while preserving TIP-20's existing issuer-controlled burn model.
 
-Adding `burnFrom` makes TIP-20 more complete for wallets, integrations, and contracts that already model approvals as delegated token control. It also gives TIP-20 a non-admin burn path for sender-authorized accounts, while preserving the existing administrative `burnBlocked` path for sender-forbidden accounts.
+Adding `burnFrom` gives TIP-20 an allowance-based issuer burn path for sender-authorized accounts, while preserving the existing administrative `burnBlocked` path for sender-forbidden accounts.
+
+Requiring `ISSUER_ROLE` avoids turning `burnFrom` into a workaround around the existing `burn` authorization model. Without that role check, any holder could potentially route around the `burn` restriction by approving a spender, including self-approval patterns and issuer-operated helper contracts that are not meant to expand who may initiate burns.
 
 This TIP intentionally does not change `burnBlocked`. After this TIP:
 
@@ -29,7 +31,7 @@ This TIP intentionally does not change `burnBlocked`. After this TIP:
 
 ## Assumptions
 
-1. TIP-20 allowances authorize delegated token control, not delegated transfers only. A spender approved through `approve` or `permit` may use that allowance for either `transferFrom` or `burnFrom`.
+1. TIP-20 allowances authorize delegated token control, not delegated transfers only. A spender approved through `approve` or `permit` may use that allowance for either `transferFrom` or `burnFrom`, but `burnFrom` additionally requires `ISSUER_ROLE`.
 2. TIP-403 and TIP-1015 sender authorization is the correct policy axis for delegated burns. Burns have no recipient, so recipient and mint-recipient checks are not meaningful here.
 3. `burnBlocked` remains the administrative escape hatch for burning balances held by sender-forbidden accounts. This TIP does not weaken or replace that behavior.
 4. TIP-20 reward accounting on burns should remain consistent with existing burn paths. If this assumption is violated, `burnFrom` could desynchronize reward balances or opted-in supply.
@@ -51,8 +53,9 @@ The `ITIP20` interface is extended with:
 event BurnFrom(address indexed operator, address indexed from, uint256 amount);
 
 /// @notice Burns tokens from `from` using the caller's allowance.
-/// @dev Applies TIP-403 sender authorization to `from`. Does not check recipient
-/// or mint-recipient authorization because the burn has no recipient.
+/// @dev Requires ISSUER_ROLE and applies TIP-403 sender authorization to `from`.
+/// Does not check recipient or mint-recipient authorization because the burn
+/// has no recipient.
 /// @param from The address to burn tokens from.
 /// @param amount The amount to burn.
 function burnFrom(address from, uint256 amount) external;
@@ -63,20 +66,21 @@ function burnFrom(address from, uint256 amount) external;
 On T6 and later, `burnFrom(from, amount)` MUST behave as follows:
 
 1. **Pause check**: Revert with `ContractPaused` if the token is paused.
-2. **Protected addresses**: Revert with `ProtectedAddress` if `from` is:
+2. **Role check**: Revert with `Unauthorized` unless the caller has `ISSUER_ROLE`.
+3. **Protected addresses**: Revert with `ProtectedAddress` if `from` is:
    - `TIP_FEE_MANAGER_ADDRESS` (`0xfeEC000000000000000000000000000000000000`)
    - `STABLECOIN_DEX_ADDRESS` (`0xDEc0000000000000000000000000000000000000`)
-3. **Sender authorization**: Revert with `PolicyForbids` unless `from` is authorized in the sender role under the token's active TIP-403 policy.
-4. **Allowance check**: Revert with `InsufficientAllowance` unless `allowance(from, msg.sender) >= amount`.
-5. **Allowance update**:
+4. **Sender authorization**: Revert with `PolicyForbids` unless `from` is authorized in the sender role under the token's active TIP-403 policy.
+5. **Allowance check**: Revert with `InsufficientAllowance` unless `allowance(from, msg.sender) >= amount`.
+6. **Allowance update**:
    - If the current allowance is `type(uint256).max`, leave it unchanged.
    - Otherwise decrement it by exactly `amount`.
-6. **Balance check**: Revert with `InsufficientBalance` if `from` has insufficient balance.
-7. **Burn execution**:
+7. **Balance check**: Revert with `InsufficientBalance` if `from` has insufficient balance.
+8. **Burn execution**:
    - Decrement `balanceOf[from]` by `amount`
    - Decrement `totalSupply` by `amount`
    - Apply the same reward-accounting updates as other TIP-20 burn paths
-8. **Events**:
+9. **Events**:
    - Emit `Transfer(from, address(0), amount)`
    - Emit `BurnFrom(msg.sender, from, amount)`
 
@@ -102,7 +106,7 @@ or the equivalent internal sender-role check in the node implementation.
 
 This TIP does not modify `burnBlocked`.
 
-- `burnFrom` is an allowance-based delegated burn path for sender-authorized accounts.
+- `burnFrom` is an allowance-based issuer burn path for sender-authorized accounts.
 - `burnBlocked` remains a privileged burn path for sender-forbidden accounts.
 - `burnAt` remains a privileged burn path that ignores transfer policy authorization.
 
@@ -115,7 +119,7 @@ These paths are intentionally distinct and are not aliases for one another.
 This means an owner who approves a spender for `N` tokens authorizes that spender to either:
 
 - transfer up to `N` tokens using `transferFrom`, or
-- burn up to `N` tokens using `burnFrom`, or
+- if the spender also has `ISSUER_ROLE`, burn up to `N` tokens using `burnFrom`, or
 - use any combination of the two whose total allowance consumption does not exceed `N`
 
 `burnFrom` SHOULD follow the same allowance-spending behavior as `transferFrom`, including the convention that `type(uint256).max` acts as an infinite approval.
@@ -153,31 +157,33 @@ Before `T6`, `burnFrom` and `BurnFrom` are unavailable and calls to the selector
 
 # Invariants
 
-1. **Sender-only policy check**: `burnFrom` must depend only on sender authorization for `from`; it must not depend on recipient or mint-recipient authorization.
-2. **Forbidden senders cannot be burned via allowance**: If `from` is sender-forbidden under the active policy, `burnFrom` must revert with `PolicyForbids` even when sufficient allowance exists.
-3. **Authorized senders can be burned via allowance**: If `from` is sender-authorized, policy alone must not block `burnFrom`.
-4. **Allowance conservation**: When the allowance is finite, a successful `burnFrom(from, amount)` decreases `allowance(from, operator)` by exactly `amount`.
-5. **Infinite allowance preservation**: When the allowance is `type(uint256).max`, a successful `burnFrom` leaves it unchanged.
-6. **Supply conservation**: After a successful `burnFrom(from, amount)`, `balanceOf[from]` and `totalSupply` each decrease by exactly `amount`.
-7. **Protected addresses**: `burnFrom` must never succeed for `TIP_FEE_MANAGER_ADDRESS` or `STABLECOIN_DEX_ADDRESS`.
-8. **Reward accounting**: If `from` is opted into rewards, the burn updates reward state exactly as other TIP-20 burn paths do.
-9. **Event correctness**: Every successful `burnFrom` emits exactly one `Transfer(from, address(0), amount)` event followed by exactly one `BurnFrom(operator, from, amount)` event.
-10. **No `burnBlocked` regression**: Existing `burnBlocked` behavior remains unchanged.
+1. **Issuer role required**: `burnFrom` must always revert if the caller lacks `ISSUER_ROLE`.
+2. **Sender-only policy check**: `burnFrom` must depend only on sender authorization for `from`; it must not depend on recipient or mint-recipient authorization.
+3. **Forbidden senders cannot be burned via allowance**: If `from` is sender-forbidden under the active policy, `burnFrom` must revert with `PolicyForbids` even when sufficient allowance exists and the caller has `ISSUER_ROLE`.
+4. **Authorized senders can be burned via allowance**: If `from` is sender-authorized, policy alone must not block `burnFrom`.
+5. **Allowance conservation**: When the allowance is finite, a successful `burnFrom(from, amount)` decreases `allowance(from, operator)` by exactly `amount`.
+6. **Infinite allowance preservation**: When the allowance is `type(uint256).max`, a successful `burnFrom` leaves it unchanged.
+7. **Supply conservation**: After a successful `burnFrom(from, amount)`, `balanceOf[from]` and `totalSupply` each decrease by exactly `amount`.
+8. **Protected addresses**: `burnFrom` must never succeed for `TIP_FEE_MANAGER_ADDRESS` or `STABLECOIN_DEX_ADDRESS`.
+9. **Reward accounting**: If `from` is opted into rewards, the burn updates reward state exactly as other TIP-20 burn paths do.
+10. **Event correctness**: Every successful `burnFrom` emits exactly one `Transfer(from, address(0), amount)` event followed by exactly one `BurnFrom(operator, from, amount)` event.
+11. **No `burnBlocked` regression**: Existing `burnBlocked` behavior remains unchanged.
 
 ### Test coverage
 
 The test suite must verify at least the following cases:
 
-1. Successful `burnFrom` from a sender-authorized account with finite allowance.
-2. Successful `burnFrom` from a sender-authorized account with infinite allowance.
-3. Revert on insufficient allowance.
-4. Revert on insufficient balance.
-5. Revert while paused.
-6. Revert when `from` is sender-forbidden under a simple TIP-403 policy.
-7. Revert when `from` is sender-forbidden under a compound TIP-1015 policy.
-8. Success when `from` is sender-authorized under a compound TIP-1015 policy even if `from` is not recipient-authorized.
-9. Revert when attempting to burn from `TIP_FEE_MANAGER_ADDRESS`.
-10. Revert when attempting to burn from `STABLECOIN_DEX_ADDRESS`.
-11. Correct event order and event fields.
-12. Correct reward-accounting updates when `from` is opted into rewards.
-13. No change to `burnBlocked` behavior in existing tests.
+1. Successful `burnFrom` from a sender-authorized account with finite allowance when the caller has `ISSUER_ROLE`.
+2. Successful `burnFrom` from a sender-authorized account with infinite allowance when the caller has `ISSUER_ROLE`.
+3. Revert when the caller lacks `ISSUER_ROLE`.
+4. Revert on insufficient allowance.
+5. Revert on insufficient balance.
+6. Revert while paused.
+7. Revert when `from` is sender-forbidden under a simple TIP-403 policy.
+8. Revert when `from` is sender-forbidden under a compound TIP-1015 policy.
+9. Success when `from` is sender-authorized under a compound TIP-1015 policy even if `from` is not recipient-authorized.
+10. Revert when attempting to burn from `TIP_FEE_MANAGER_ADDRESS`.
+11. Revert when attempting to burn from `STABLECOIN_DEX_ADDRESS`.
+12. Correct event order and event fields.
+13. Correct reward-accounting updates when `from` is opted into rewards.
+14. No change to `burnBlocked` behavior in existing tests.

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -1,0 +1,183 @@
+---
+id: TIP-1057
+title: Allowance-based burnFrom for TIP-20 tokens
+description: Adds an allowance-based burnFrom entrypoint to TIP-20 with sender-side TIP-403 authorization and a BurnFrom event.
+authors: Amp
+status: Draft
+related: TIP-20, TIP-403, TIP-1004, TIP-1006, TIP-1015
+protocolVersion: T6
+---
+
+# TIP-1057: Allowance-based burnFrom for TIP-20 tokens
+
+## Abstract
+
+This TIP adds a standard allowance-based `burnFrom(address from, uint256 amount)` function to TIP-20. The function allows a spender with sufficient allowance to burn tokens from `from`, emits the standard `Transfer(from, address(0), amount)` burn signal, and also emits a TIP-20-native `BurnFrom` event that records the operator.
+
+Unlike `burnAt`, `burnFrom` is not role-gated, and unlike `burnBlocked`, it is not restricted to blocked accounts. `burnFrom` applies TIP-403 authorization only to `from` in the sender role, leaving `burnBlocked` unchanged as the existing privileged path for burning from sender-forbidden accounts.
+
+## Motivation
+
+TIP-20 already supports delegated transfers through `approve`, `permit`, and `transferFrom`, and it already supports administrative burns through `burn`, `burnBlocked`, and `burnAt`. What is missing is the standard delegated-burn primitive used in ERC-20 burnable tokens: a spender can burn from an owner up to the approved allowance.
+
+Adding `burnFrom` makes TIP-20 more complete for wallets, integrations, and contracts that already model approvals as delegated token control. It also gives TIP-20 a non-admin burn path for sender-authorized accounts, while preserving the existing administrative `burnBlocked` path for sender-forbidden accounts.
+
+This TIP intentionally does not change `burnBlocked`. After this TIP:
+
+- `burnFrom` covers the sender-authorized side of the policy space
+- `burnBlocked` continues to cover the sender-forbidden side of the policy space
+
+## Assumptions
+
+1. TIP-20 allowances authorize delegated token control, not delegated transfers only. A spender approved through `approve` or `permit` may use that allowance for either `transferFrom` or `burnFrom`.
+2. TIP-403 and TIP-1015 sender authorization is the correct policy axis for delegated burns. Burns have no recipient, so recipient and mint-recipient checks are not meaningful here.
+3. `burnBlocked` remains the administrative escape hatch for burning balances held by sender-forbidden accounts. This TIP does not weaken or replace that behavior.
+4. TIP-20 reward accounting on burns should remain consistent with existing burn paths. If this assumption is violated, `burnFrom` could desynchronize reward balances or opted-in supply.
+5. Protected system addresses such as `TIP_FEE_MANAGER_ADDRESS` and `STABLECOIN_DEX_ADDRESS` must remain non-burnable through userland delegated flows to preserve protocol accounting invariants.
+
+---
+
+# Specification
+
+## Interface additions
+
+The `ITIP20` interface is extended with:
+
+```solidity
+/// @notice Emitted when tokens are burned from an account via allowance.
+/// @param operator The spender that exercised the allowance.
+/// @param from The address whose tokens were burned.
+/// @param amount The amount burned.
+event BurnFrom(address indexed operator, address indexed from, uint256 amount);
+
+/// @notice Burns tokens from `from` using the caller's allowance.
+/// @dev Applies TIP-403 sender authorization to `from`. Does not check recipient
+/// or mint-recipient authorization because the burn has no recipient.
+/// @param from The address to burn tokens from.
+/// @param amount The amount to burn.
+function burnFrom(address from, uint256 amount) external;
+```
+
+## Behavior
+
+On T6 and later, `burnFrom(from, amount)` MUST behave as follows:
+
+1. **Pause check**: Revert with `ContractPaused` if the token is paused.
+2. **Protected addresses**: Revert with `ProtectedAddress` if `from` is:
+   - `TIP_FEE_MANAGER_ADDRESS` (`0xfeEC000000000000000000000000000000000000`)
+   - `STABLECOIN_DEX_ADDRESS` (`0xDEc0000000000000000000000000000000000000`)
+3. **Sender authorization**: Revert with `PolicyForbids` unless `from` is authorized in the sender role under the token's active TIP-403 policy.
+4. **Allowance check**: Revert with `InsufficientAllowance` unless `allowance(from, msg.sender) >= amount`.
+5. **Allowance update**:
+   - If the current allowance is `type(uint256).max`, leave it unchanged.
+   - Otherwise decrement it by exactly `amount`.
+6. **Balance check**: Revert with `InsufficientBalance` if `from` has insufficient balance.
+7. **Burn execution**:
+   - Decrement `balanceOf[from]` by `amount`
+   - Decrement `totalSupply` by `amount`
+   - Apply the same reward-accounting updates as other TIP-20 burn paths
+8. **Events**:
+   - Emit `Transfer(from, address(0), amount)`
+   - Emit `BurnFrom(msg.sender, from, amount)`
+
+## Policy semantics
+
+`burnFrom` MUST apply TIP-403 authorization only to `from` in the sender role.
+
+For simple TIP-403 policies, this is equivalent to checking whether `from` is authorized to send.
+
+For compound TIP-1015 policies, `burnFrom` MUST check sender authorization using the sender policy component only. It MUST NOT check recipient authorization, and it MUST NOT check mint-recipient authorization.
+
+Concretely, the authorization rule is:
+
+```solidity
+TIP403_REGISTRY.isAuthorizedSender(transferPolicyId, from)
+```
+
+or the equivalent internal sender-role check in the node implementation.
+
+`burnFrom` MUST NOT use the generic `isAuthorized(policyId, user)` path for compound policies, because that path combines sender and recipient authorization and would incorrectly reject burns for users who are authorized to send but not authorized to receive.
+
+## Interaction with existing burn paths
+
+This TIP does not modify `burnBlocked`.
+
+- `burnFrom` is an allowance-based delegated burn path for sender-authorized accounts.
+- `burnBlocked` remains a privileged burn path for sender-forbidden accounts.
+- `burnAt` remains a privileged burn path that ignores transfer policy authorization.
+
+These paths are intentionally distinct and are not aliases for one another.
+
+## Allowance semantics
+
+`burnFrom` uses the same allowance bucket as `transferFrom`.
+
+This means an owner who approves a spender for `N` tokens authorizes that spender to either:
+
+- transfer up to `N` tokens using `transferFrom`, or
+- burn up to `N` tokens using `burnFrom`, or
+- use any combination of the two whose total allowance consumption does not exceed `N`
+
+`burnFrom` SHOULD follow the same allowance-spending behavior as `transferFrom`, including the convention that `type(uint256).max` acts as an infinite approval.
+
+`burnFrom` SHOULD NOT emit an `Approval` event when spending allowance. This matches modern ERC-20 allowance-spending conventions and matches TIP-20's current `transferFrom` behavior.
+
+## Reward accounting
+
+If `from` is opted into rewards, `burnFrom` MUST preserve the same reward-accounting invariants as the other TIP-20 burn paths:
+
+1. Pending rewards accrued before the burn remain claimable.
+2. `from`'s reward-per-token snapshot is updated before the balance reduction takes effect.
+3. `optedInSupply` decreases by exactly `amount` when `from` is opted in.
+
+## Event semantics
+
+`Transfer(from, address(0), amount)` remains the canonical burn event for ERC-20 compatibility.
+
+The additional `BurnFrom(operator, from, amount)` event is TIP-20-native indexing metadata. It records who exercised the allowance and distinguishes delegated burns from:
+
+- self-burns via `burn`
+- administrative burns via `burnBlocked`
+- administrative burns via `burnAt`
+
+The events MUST be emitted in this order:
+
+1. `Transfer(from, address(0), amount)`
+2. `BurnFrom(operator, from, amount)`
+
+## Activation
+
+This TIP is scheduled for protocol version `T6`.
+
+Before `T6`, `burnFrom` and `BurnFrom` are unavailable and calls to the selector MUST revert as unknown function selectors.
+
+# Invariants
+
+1. **Sender-only policy check**: `burnFrom` must depend only on sender authorization for `from`; it must not depend on recipient or mint-recipient authorization.
+2. **Forbidden senders cannot be burned via allowance**: If `from` is sender-forbidden under the active policy, `burnFrom` must revert with `PolicyForbids` even when sufficient allowance exists.
+3. **Authorized senders can be burned via allowance**: If `from` is sender-authorized, policy alone must not block `burnFrom`.
+4. **Allowance conservation**: When the allowance is finite, a successful `burnFrom(from, amount)` decreases `allowance(from, operator)` by exactly `amount`.
+5. **Infinite allowance preservation**: When the allowance is `type(uint256).max`, a successful `burnFrom` leaves it unchanged.
+6. **Supply conservation**: After a successful `burnFrom(from, amount)`, `balanceOf[from]` and `totalSupply` each decrease by exactly `amount`.
+7. **Protected addresses**: `burnFrom` must never succeed for `TIP_FEE_MANAGER_ADDRESS` or `STABLECOIN_DEX_ADDRESS`.
+8. **Reward accounting**: If `from` is opted into rewards, the burn updates reward state exactly as other TIP-20 burn paths do.
+9. **Event correctness**: Every successful `burnFrom` emits exactly one `Transfer(from, address(0), amount)` event followed by exactly one `BurnFrom(operator, from, amount)` event.
+10. **No `burnBlocked` regression**: Existing `burnBlocked` behavior remains unchanged.
+
+### Test coverage
+
+The test suite must verify at least the following cases:
+
+1. Successful `burnFrom` from a sender-authorized account with finite allowance.
+2. Successful `burnFrom` from a sender-authorized account with infinite allowance.
+3. Revert on insufficient allowance.
+4. Revert on insufficient balance.
+5. Revert while paused.
+6. Revert when `from` is sender-forbidden under a simple TIP-403 policy.
+7. Revert when `from` is sender-forbidden under a compound TIP-1015 policy.
+8. Success when `from` is sender-authorized under a compound TIP-1015 policy even if `from` is not recipient-authorized.
+9. Revert when attempting to burn from `TIP_FEE_MANAGER_ADDRESS`.
+10. Revert when attempting to burn from `STABLECOIN_DEX_ADDRESS`.
+11. Correct event order and event fields.
+12. Correct reward-accounting updates when `from` is opted into rewards.
+13. No change to `burnBlocked` behavior in existing tests.


### PR DESCRIPTION
Adds TIP-1057 for an allowance-based `burnFrom` on TIP-20.

The draft targets T6, requires `ISSUER_ROLE`, applies TIP-403 sender auth to `from`, adds a `BurnFrom(operator, from, amount)` event, and leaves `burnBlocked` unchanged.