### PR TITLE
deps: update reth from main (2026-04-30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8220,7 +8220,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8312,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8526,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9221,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "futures",
  "metrics",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9483,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9649,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9741,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9882,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "bytes",
  "eyre",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10209,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10282,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10441,7 +10441,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10552,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10566,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10601,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10643,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "clap",
  "eyre",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "clap",
  "eyre",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10798,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10845,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=077e5ee#077e5eecfef02e2fc32d35cd6f79ab5975b975a1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "077e5ee", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`077e5ee...fcfa828`](https://github.com/paradigmxyz/reth/compare/077e5ee...fcfa828)

🔗 Amp thread: https://ampcode.com/threads/T-019ddc9d-1d46-75e9-b9e8-644c7bd4c595
- **Engine**: Apply finalized state after syncing FCU head import ([#23838](https://github.com/paradigmxyz/reth/pull/23838))
- **Networking**: Customizable discovery defaults ([#23843](https://github.com/paradigmxyz/reth/pull/23843))
- **DB**: Replace deprecated `MDBX_NOTLS` with `MDBX_NOSTICKYTHREADS` ([#23378](https://github.com/paradigmxyz/reth/pull/23378))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019ddc9d-2d98-72cb-aac1-a4da293cbabf
- Bumped all `reth-*` git dependencies in `Cargo.toml` from rev `077e5ee` to `fcfa828` to pull in the latest upstream Reth SDK changes.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25147002830)
