### PR TITLE
fix(p2p-proxy): cap header request expansion

### DIFF
--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -590,10 +590,11 @@ fn requested_header_numbers(
     mut current: u64,
     request: &reth_eth_wire_types::GetBlockHeaders,
 ) -> Vec<u64> {
-    let mut numbers = Vec::with_capacity(request.limit.min(HEADER_BATCH_SIZE as u64) as usize);
+    let limit = request.limit.min(HEADER_BATCH_SIZE as u64) as usize;
+    let mut numbers = Vec::with_capacity(limit);
     let step = u64::from(request.skip) + 1;
 
-    for _ in 0..request.limit {
+    for _ in 0..limit {
         numbers.push(current);
 
         match request.direction {


### PR DESCRIPTION
Caps `GetBlockHeaders` number expansion to `HEADER_BATCH_SIZE` before building the request vector, preventing peers from forcing unbounded memory growth with oversized limits.

Validated with `cargo check -p tempo --bin tempo`.