### PR TITLE
ci: pin foundry SHA for invariant tests

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -16,6 +16,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
+  # Pinned to mablr/alloy_bump_without_op (alloy 2.0.4 + OP support stripped)
+  FOUNDRY_SHA: "be874c9f6dacaa289b8c3b438f0e94e8d34e9fe0"
 
 jobs:
   check-specs-changes:
@@ -168,7 +170,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: ${{ env.FOUNDRY_SHA }}
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
Pins the foundry checkout in `specs.yml` to [`be874c9f`](https://github.com/foundry-rs/foundry/tree/mablr/alloy_bump_without_op) instead of tracking `master`.

The branch (`mablr/alloy_bump_without_op`) ships an alloy 2.0.4 bump with OP stack support stripped, which unblocks the invariant-test build after #3761 moved tempo to alloy 2.0.4 / alloy-evm 0.34.

Verified locally: `forge test` against `tips/verify` runs clean — 482 passed, 0 failed, 6 skipped.