### PR TITLE
feat: make `TempoTxResult` more useful

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -84,9 +84,9 @@ impl ReceiptBuilder for TempoReceiptBuilder {
 ///
 /// This is an extension of [`EthTxResult`] with context necessary for committing a Tempo transaction.
 #[derive(Debug)]
-pub struct TempoTxResult<H> {
+pub struct TempoTxResult {
     /// Inner transaction execution result.
-    inner: EthTxResult<H, TempoTxType>,
+    inner: EthTxResult<TempoHaltReason, TempoTxType>,
     /// Next section of the block.
     next_section: BlockSection,
     /// Whether the transaction is a payment transaction.
@@ -96,10 +96,24 @@ pub struct TempoTxResult<H> {
     /// This is only populated for subblock transactions for which we need to store
     /// the full transaction encoding for later validation of subblock hash.
     tx: Option<TempoTxEnvelope>,
+    /// Block gas consumed by this transaction. The block `gas_used` field will be incremented by this value.
+    block_gas_used: u64,
 }
 
-impl<H: Send + 'static> TxResult for TempoTxResult<H> {
-    type HaltReason = H;
+impl TempoTxResult {
+    /// Returns the block gas consumed by this transaction.
+    pub fn block_gas_used(&self) -> u64 {
+        self.block_gas_used
+    }
+
+    /// Returns the state gas consumed by this transaction.
+    pub fn state_gas_used(&self) -> u64 {
+        self.inner.result.result.gas().state_gas_spent()
+    }
+}
+
+impl TxResult for TempoTxResult {
+    type HaltReason = TempoHaltReason;
 
     fn result(&self) -> &ResultAndState<Self::HaltReason> {
         self.inner.result()
@@ -430,7 +444,7 @@ where
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
     type Evm = TempoEvm<DB, I>;
-    type Result = TempoTxResult<TempoHaltReason>;
+    type Result = TempoTxResult;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), alloy_evm::block::BlockExecutionError> {
         self.inner.apply_pre_execution_changes()?;
@@ -481,19 +495,19 @@ where
 
         let inner = result?;
 
+        // T4+: use block_regular_gas_used (excludes state gas) for section validation,
+        // matching block gas limit semantics. Pre-T4: use tx_gas_used.
+        let block_gas_used = if self.evm().cfg.spec.is_t4() {
+            inner.result.result.gas().block_regular_gas_used()
+        } else {
+            inner.result.result.tx_gas_used()
+        };
+
         let next_section = if let Some(next_section) = next_section {
             // If pre-execution validation returned a section to use, just use it.
             next_section
         } else {
-            // T4+: use block_regular_gas_used (excludes state gas) for section validation,
-            // matching block gas limit semantics. Pre-T4: use tx_gas_used.
-            let timestamp = self.evm().block().timestamp.to::<u64>();
-            let gas_used = if self.inner.spec.is_t4_active_at_timestamp(timestamp) {
-                inner.result.result.gas().block_regular_gas_used()
-            } else {
-                inner.result.result.tx_gas_used()
-            };
-            self.validate_tx(recovered.tx(), gas_used)?
+            self.validate_tx(recovered.tx(), block_gas_used)?
         };
         Ok(TempoTxResult {
             inner,
@@ -501,6 +515,7 @@ where
             is_payment: recovered.tx().is_payment_v1(),
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
+            block_gas_used,
         })
     }
 
@@ -510,16 +525,8 @@ where
             next_section,
             is_payment,
             tx,
+            block_gas_used,
         } = output;
-
-        // T4+: use block_regular_gas_used (excludes state gas) for section validation,
-        // matching block gas limit semantics. Pre-T4: use tx_gas_used.
-        let timestamp = self.evm().block().timestamp.to::<u64>();
-        let gas_used = if self.inner.spec.is_t4_active_at_timestamp(timestamp) {
-            inner.result.result.gas().block_regular_gas_used()
-        } else {
-            inner.result.result.tx_gas_used()
-        };
 
         let gas_output = self.inner.commit_transaction(inner);
 
@@ -530,9 +537,9 @@ where
                 // no gas spending for start-of-block system transactions
             }
             BlockSection::NonShared => {
-                self.non_shared_gas_left -= gas_used;
+                self.non_shared_gas_left -= block_gas_used;
                 if !is_payment {
-                    self.non_payment_gas_left -= gas_used;
+                    self.non_payment_gas_left -= block_gas_used;
                 }
             }
             BlockSection::SubBlock { proposer } => {
@@ -552,7 +559,7 @@ where
                     .push(tx.expect("missing tx for subblock transaction"));
             }
             BlockSection::GasIncentive => {
-                self.incentive_gas_used += gas_used;
+                self.incentive_gas_used += block_gas_used;
             }
             BlockSection::System { .. } => {
                 // no gas spending for end-of-block system transactions
@@ -1236,6 +1243,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1317,6 +1325,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1355,6 +1364,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
         executor.commit_transaction(output1);
 
@@ -1377,6 +1387,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 50000,
         };
         executor.commit_transaction(output2);
 
@@ -1438,6 +1449,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 50000,
         };
         executor.commit_transaction(output);
 
@@ -1481,6 +1493,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 200_000,
         };
         executor.commit_transaction(output);
 
@@ -1527,6 +1540,7 @@ mod tests {
             next_section: BlockSection::GasIncentive,
             is_payment: false,
             tx: None,
+            block_gas_used: 200_000,
         };
         executor.commit_transaction(output);
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -93,7 +93,7 @@ impl BlockExecutorFactory for TempoEvmConfig {
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
-    type TxExecutionResult = TempoTxResult<TempoHaltReason>;
+    type TxExecutionResult = TempoTxResult;
     type Executor<'a, DB: StateDB, I: Inspector<TempoContext<DB>>> = TempoBlockExecutor<'a, DB, I>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -434,8 +434,6 @@ where
             .pool_fetch_duration_seconds
             .record(pool_fetch_start.elapsed());
 
-        let is_t4 = builder.evm().cfg.spec.is_t4();
-
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         loop {
@@ -528,17 +526,10 @@ where
             let tx_execution_start = Instant::now();
             if let Err(err) =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
-                    // Compute gas usage as either regular-only gas spending (T4+) or total gas spending (pre-T4)
-                    let gas_used = if is_t4 {
-                        result.result().result.gas().block_regular_gas_used()
-                    } else {
-                        result.result().result.tx_gas_used()
-                    };
-
-                    cumulative_gas_used += gas_used;
+                    cumulative_gas_used += result.block_gas_used();
                     cumulative_state_gas_used += result.result().result.gas().state_gas_spent();
                     if !is_payment {
-                        non_payment_gas_used += gas_used;
+                        non_payment_gas_used += result.block_gas_used();
                     }
 
                     // Score payload value by actual validator payout, applying the AMM

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -527,7 +527,7 @@ where
             if let Err(err) =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
                     cumulative_gas_used += result.block_gas_used();
-                    cumulative_state_gas_used += result.result().result.gas().state_gas_spent();
+                    cumulative_state_gas_used += result.state_gas_used();
                     if !is_payment {
                         non_payment_gas_used += result.block_gas_used();
                     }


### PR DESCRIPTION
With recent changes in alloy-evm custom tx result is now properly propagated to payload builder, allowing to avoid duplicating the `block_gas_used` calculation logic