### PR TITLE
feat: `StateAwareBestTransactions`

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -84,9 +84,9 @@ impl ReceiptBuilder for TempoReceiptBuilder {
 ///
 /// This is an extension of [`EthTxResult`] with context necessary for committing a Tempo transaction.
 #[derive(Debug)]
-pub struct TempoTxResult<H> {
+pub struct TempoTxResult {
     /// Inner transaction execution result.
-    inner: EthTxResult<H, TempoTxType>,
+    inner: EthTxResult<TempoHaltReason, TempoTxType>,
     /// Next section of the block.
     next_section: BlockSection,
     /// Whether the transaction is a payment transaction.
@@ -96,10 +96,24 @@ pub struct TempoTxResult<H> {
     /// This is only populated for subblock transactions for which we need to store
     /// the full transaction encoding for later validation of subblock hash.
     tx: Option<TempoTxEnvelope>,
+    /// Block gas consumed by this transaction. The block `gas_used` field will be incremented by this value.
+    block_gas_used: u64,
 }
 
-impl<H: Send + 'static> TxResult for TempoTxResult<H> {
-    type HaltReason = H;
+impl TempoTxResult {
+    /// Returns the block gas consumed by this transaction.
+    pub fn block_gas_used(&self) -> u64 {
+        self.block_gas_used
+    }
+
+    /// Returns the state gas consumed by this transaction.
+    pub fn state_gas_used(&self) -> u64 {
+        self.inner.result.result.gas().state_gas_spent()
+    }
+}
+
+impl TxResult for TempoTxResult {
+    type HaltReason = TempoHaltReason;
 
     fn result(&self) -> &ResultAndState<Self::HaltReason> {
         self.inner.result()
@@ -430,7 +444,7 @@ where
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
     type Evm = TempoEvm<DB, I>;
-    type Result = TempoTxResult<TempoHaltReason>;
+    type Result = TempoTxResult;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), alloy_evm::block::BlockExecutionError> {
         self.inner.apply_pre_execution_changes()?;
@@ -481,19 +495,19 @@ where
 
         let inner = result?;
 
+        // T4+: use block_regular_gas_used (excludes state gas) for section validation,
+        // matching block gas limit semantics. Pre-T4: use tx_gas_used.
+        let block_gas_used = if self.evm().cfg.spec.is_t4() {
+            inner.result.result.gas().block_regular_gas_used()
+        } else {
+            inner.result.result.tx_gas_used()
+        };
+
         let next_section = if let Some(next_section) = next_section {
             // If pre-execution validation returned a section to use, just use it.
             next_section
         } else {
-            // T4+: use block_regular_gas_used (excludes state gas) for section validation,
-            // matching block gas limit semantics. Pre-T4: use tx_gas_used.
-            let timestamp = self.evm().block().timestamp.to::<u64>();
-            let gas_used = if self.inner.spec.is_t4_active_at_timestamp(timestamp) {
-                inner.result.result.gas().block_regular_gas_used()
-            } else {
-                inner.result.result.tx_gas_used()
-            };
-            self.validate_tx(recovered.tx(), gas_used)?
+            self.validate_tx(recovered.tx(), block_gas_used)?
         };
         Ok(TempoTxResult {
             inner,
@@ -501,6 +515,7 @@ where
             is_payment: recovered.tx().is_payment_v1(),
             tx: matches!(next_section, BlockSection::SubBlock { .. })
                 .then(|| recovered.tx().clone()),
+            block_gas_used,
         })
     }
 
@@ -510,16 +525,8 @@ where
             next_section,
             is_payment,
             tx,
+            block_gas_used,
         } = output;
-
-        // T4+: use block_regular_gas_used (excludes state gas) for section validation,
-        // matching block gas limit semantics. Pre-T4: use tx_gas_used.
-        let timestamp = self.evm().block().timestamp.to::<u64>();
-        let gas_used = if self.inner.spec.is_t4_active_at_timestamp(timestamp) {
-            inner.result.result.gas().block_regular_gas_used()
-        } else {
-            inner.result.result.tx_gas_used()
-        };
 
         let gas_output = self.inner.commit_transaction(inner);
 
@@ -530,9 +537,9 @@ where
                 // no gas spending for start-of-block system transactions
             }
             BlockSection::NonShared => {
-                self.non_shared_gas_left -= gas_used;
+                self.non_shared_gas_left -= block_gas_used;
                 if !is_payment {
-                    self.non_payment_gas_left -= gas_used;
+                    self.non_payment_gas_left -= block_gas_used;
                 }
             }
             BlockSection::SubBlock { proposer } => {
@@ -552,7 +559,7 @@ where
                     .push(tx.expect("missing tx for subblock transaction"));
             }
             BlockSection::GasIncentive => {
-                self.incentive_gas_used += gas_used;
+                self.incentive_gas_used += block_gas_used;
             }
             BlockSection::System { .. } => {
                 // no gas spending for end-of-block system transactions
@@ -1236,6 +1243,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1317,6 +1325,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1355,6 +1364,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 21000,
         };
         executor.commit_transaction(output1);
 
@@ -1377,6 +1387,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 50000,
         };
         executor.commit_transaction(output2);
 
@@ -1438,6 +1449,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 50000,
         };
         executor.commit_transaction(output);
 
@@ -1481,6 +1493,7 @@ mod tests {
             next_section: BlockSection::NonShared,
             is_payment: false,
             tx: None,
+            block_gas_used: 200_000,
         };
         executor.commit_transaction(output);
 
@@ -1527,6 +1540,7 @@ mod tests {
             next_section: BlockSection::GasIncentive,
             is_payment: false,
             tx: None,
+            block_gas_used: 200_000,
         };
         executor.commit_transaction(output);
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -93,7 +93,7 @@ impl BlockExecutorFactory for TempoEvmConfig {
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
-    type TxExecutionResult = TempoTxResult<TempoHaltReason>;
+    type TxExecutionResult = TempoTxResult;
     type Executor<'a, DB: StateDB, I: Inspector<TempoContext<DB>>> = TempoBlockExecutor<'a, DB, I>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -54,7 +54,7 @@ use tempo_primitives::{
     },
 };
 use tempo_transaction_pool::{
-    TempoTransactionPool,
+    StateAwareBestTransactions, TempoTransactionPool,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 use tracing::{Level, debug, debug_span, error, info, instrument, trace, warn};
@@ -422,14 +422,17 @@ where
         let base_fee = builder.evm_mut().block().basefee;
         let validator_fee_token = resolve_validator_fee_token(&mut builder)?;
         let pool_fetch_start = Instant::now();
-        let mut best_txs = best_txs(BestTransactionsAttributes::new(
-            base_fee,
-            builder
-                .evm_mut()
-                .block()
-                .blob_gasprice()
-                .map(|gasprice| gasprice as u64),
-        ));
+        // Wrap best transactions into state-aware wrapper to skip transactions that
+        // get invalidated by already-executed ones.
+        let mut best_txs =
+            StateAwareBestTransactions::new(best_txs(BestTransactionsAttributes::new(
+                base_fee,
+                builder
+                    .evm_mut()
+                    .block()
+                    .blob_gasprice()
+                    .map(|gasprice| gasprice as u64),
+            )));
         self.metrics
             .pool_fetch_duration_seconds
             .record(pool_fetch_start.elapsed());
@@ -553,6 +556,9 @@ where
                     } else {
                         warn!("no resolved fee token for a pool transaction")
                     }
+
+                    // Notify transactions iterator about the new state.
+                    best_txs.on_new_result(result);
                 })
             {
                 if let BlockExecutionError::Validation(BlockValidationError::InvalidTx {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -434,8 +434,6 @@ where
             .pool_fetch_duration_seconds
             .record(pool_fetch_start.elapsed());
 
-        let is_t4 = builder.evm().cfg.spec.is_t4();
-
         let execution_start = Instant::now();
         let _block_fill_span = debug_span!(target: "payload_builder", "block_fill").entered();
         loop {
@@ -528,17 +526,10 @@ where
             let tx_execution_start = Instant::now();
             if let Err(err) =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
-                    // Compute gas usage as either regular-only gas spending (T4+) or total gas spending (pre-T4)
-                    let gas_used = if is_t4 {
-                        result.result().result.gas().block_regular_gas_used()
-                    } else {
-                        result.result().result.tx_gas_used()
-                    };
-
-                    cumulative_gas_used += gas_used;
+                    cumulative_gas_used += result.block_gas_used();
                     cumulative_state_gas_used += result.result().result.gas().state_gas_spent();
                     if !is_payment {
-                        non_payment_gas_used += gas_used;
+                        non_payment_gas_used += result.block_gas_used();
                     }
 
                     // Score payload value by actual validator payout, applying the AMM

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -527,7 +527,7 @@ where
             if let Err(err) =
                 builder.execute_transaction_with_result_closure(tx_with_env, |result| {
                     cumulative_gas_used += result.block_gas_used();
-                    cumulative_state_gas_used += result.result().result.gas().state_gas_spent();
+                    cumulative_state_gas_used += result.state_gas_used();
                     if !is_payment {
                         non_payment_gas_used += result.block_gas_used();
                     }

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -163,12 +163,8 @@ where
 }
 
 /// A [`BestTransactions`] wrapper that tracks execution state changes and skips
-/// transactions that would obviously fail due to state mutations from previously
+/// transactions that would fail due to state mutations from previously
 /// included transactions.
-///
-/// Currently tracks fee payer balance changes: when a transaction is executed and
-/// modifies a TIP20 balance slot, subsequent transactions sharing the same
-/// `(fee_token, fee_payer)` pair are skipped since they may no longer be solvent.
 pub struct StateAwareBestTransactions<I> {
     inner: I,
     /// Tracks decreased TIP20 balance slots: `(token_address, slot) -> new_balance`.

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -1,10 +1,15 @@
 //! An iterator over the best transactions in the tempo pool.
 
 use crate::transaction::TempoPooledTransaction;
+use alloy_primitives::{Address, U256, map::HashMap};
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_transaction_pool::{
-    BestTransactions, CoinbaseTipOrdering, Priority, TransactionOrdering,
+    BestTransactions, CoinbaseTipOrdering, Priority, TransactionOrdering, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
 };
+use revm::state::EvmState;
+use std::sync::Arc;
+use tempo_precompiles::tip20::is_tip20_prefix;
 
 /// An extension trait for [`BestTransactions`] that in addition to the transaction also yields the priority value.
 pub trait BestPriorityTransactions<T: TransactionOrdering>: BestTransactions {
@@ -153,6 +158,106 @@ where
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         self.left.set_skip_blobs(skip_blobs);
         self.right.set_skip_blobs(skip_blobs);
+    }
+}
+
+/// A [`BestTransactions`] wrapper that tracks execution state changes and skips
+/// transactions that would obviously fail due to state mutations from previously
+/// included transactions.
+///
+/// Currently tracks fee payer balance changes: when a transaction is executed and
+/// modifies a TIP20 balance slot, subsequent transactions sharing the same
+/// `(fee_token, fee_payer)` pair are skipped since they may no longer be solvent.
+pub struct StateAwareBestTransactions<I> {
+    inner: I,
+    /// Tracks decreased TIP20 balance slots: `(token_address, slot) -> new_balance`.
+    /// Updated after each executed transaction. Used to check if a candidate
+    /// transaction's fee payer can still cover its fee cost.
+    decreased_balances: HashMap<(Address, U256), U256>,
+}
+
+impl<I> StateAwareBestTransactions<I>
+where
+    I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+{
+    /// Wraps an existing [`BestTransactions`] iterator.
+    pub fn new(inner: I) -> Self {
+        Self {
+            inner,
+            decreased_balances: HashMap::default(),
+        }
+    }
+
+    /// Ingests execution state changes from a committed transaction.
+    ///
+    /// Scans the [`EvmState`] for TIP20 balance decreases and records the new
+    /// balance so that candidate transactions whose fee payer can no longer
+    /// cover their fee cost are skipped.
+    pub fn on_new_state(&mut self, state: &EvmState) {
+        for (&address, account) in state {
+            if !is_tip20_prefix(address) {
+                continue;
+            }
+
+            for (&slot, storage_slot) in &account.storage {
+                if storage_slot.present_value < storage_slot.original_value {
+                    self.decreased_balances
+                        .insert((address, slot), storage_slot.present_value);
+                }
+            }
+        }
+    }
+
+}
+
+impl<I> Iterator for StateAwareBestTransactions<I>
+where
+    I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+{
+    type Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let tx = self.inner.next()?;
+
+            let Some(key) = tx.transaction.fee_balance_slot() else {
+                debug_assert!(false, "pool transaction must have cached fee_balance_slot");
+                continue;
+            };
+
+            if let Some(&balance) = self.decreased_balances.get(&key) {
+                if balance < tx.transaction.fee_token_cost() {
+                    self.inner.mark_invalid(
+                        &tx,
+                        &InvalidPoolTransactionError::Consensus(
+                            InvalidTransactionError::InsufficientFunds(
+                                (balance, tx.transaction.fee_token_cost()).into(),
+                            ),
+                        ),
+                    );
+                    continue;
+                }
+            }
+
+            return Some(tx);
+        }
+    }
+}
+
+impl<I> BestTransactions for StateAwareBestTransactions<I>
+where
+    I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>> + Send,
+{
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: &InvalidPoolTransactionError) {
+        self.inner.mark_invalid(transaction, kind);
+    }
+
+    fn no_updates(&mut self) {
+        self.inner.no_updates();
+    }
+
+    fn set_skip_blobs(&mut self, skip_blobs: bool) {
+        self.inner.set_skip_blobs(skip_blobs);
     }
 }
 

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -207,7 +207,6 @@ where
             }
         }
     }
-
 }
 
 impl<I> Iterator for StateAwareBestTransactions<I>

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -2,13 +2,14 @@
 
 use crate::transaction::TempoPooledTransaction;
 use alloy_primitives::{Address, U256, map::HashMap};
+use reth_evm::block::TxResult;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_transaction_pool::{
     BestTransactions, CoinbaseTipOrdering, Priority, TransactionOrdering, ValidPoolTransaction,
     error::InvalidPoolTransactionError,
 };
-use revm::state::EvmState;
 use std::sync::Arc;
+use tempo_evm::TempoTxResult;
 use tempo_precompiles::tip20::is_tip20_prefix;
 
 /// An extension trait for [`BestTransactions`] that in addition to the transaction also yields the priority value.
@@ -188,13 +189,10 @@ where
         }
     }
 
-    /// Ingests execution state changes from a committed transaction.
-    ///
-    /// Scans the [`EvmState`] for TIP20 balance decreases and records the new
-    /// balance so that candidate transactions whose fee payer can no longer
-    /// cover their fee cost are skipped.
-    pub fn on_new_state(&mut self, state: &EvmState) {
-        for (&address, account) in state {
+    /// Processes a new transaction execution result and collects any relevant
+    /// state changes that might affect other transactions validity.
+    pub fn on_new_result(&mut self, result: &TempoTxResult) {
+        for (&address, account) in &result.result().state {
             if !is_tip20_prefix(address) {
                 continue;
             }
@@ -224,18 +222,18 @@ where
                 continue;
             };
 
-            if let Some(&balance) = self.decreased_balances.get(&key) {
-                if balance < tx.transaction.fee_token_cost() {
-                    self.inner.mark_invalid(
-                        &tx,
-                        &InvalidPoolTransactionError::Consensus(
-                            InvalidTransactionError::InsufficientFunds(
-                                (balance, tx.transaction.fee_token_cost()).into(),
-                            ),
+            if let Some(&balance) = self.decreased_balances.get(&key)
+                && balance < tx.transaction.fee_token_cost()
+            {
+                self.inner.mark_invalid(
+                    &tx,
+                    &InvalidPoolTransactionError::Consensus(
+                        InvalidTransactionError::InsufficientFunds(
+                            (balance, tx.transaction.fee_token_cost()).into(),
                         ),
-                    );
-                    continue;
-                }
+                    ),
+                );
+                continue;
             }
 
             return Some(tx);

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -21,6 +21,7 @@ pub mod metrics;
 pub mod paused;
 pub mod tt_2d_pool;
 
+pub use best::StateAwareBestTransactions;
 pub use maintain::TempoPoolUpdates;
 
 pub use metrics::{AA2dPoolMetrics, TempoPoolMaintenanceMetrics};

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -20,7 +20,7 @@ use std::{
     fmt::Debug,
     sync::{Arc, OnceLock},
 };
-use tempo_precompiles::{DEFAULT_FEE_TOKEN, nonce::NonceManager};
+use tempo_precompiles::{DEFAULT_FEE_TOKEN, nonce::NonceManager, tip20::TIP20Token};
 use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use thiserror::Error;
@@ -51,6 +51,11 @@ pub struct TempoPooledTransaction {
     /// Used by `keychain_subject()` so pool maintenance matches against the same token
     /// that was validated without requiring state access.
     resolved_fee_token: OnceLock<Address>,
+    /// Cached TIP20 balance storage slot for the fee payer.
+    ///
+    /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
+    /// can check if the fee payer's balance was modified without recomputing the keccak.
+    fee_balance_slot: OnceLock<Option<(Address, U256)>>,
 }
 
 impl TempoPooledTransaction {
@@ -79,6 +84,7 @@ impl TempoPooledTransaction {
             tx_env: OnceLock::new(),
             key_expiry: OnceLock::new(),
             resolved_fee_token: OnceLock::new(),
+            fee_balance_slot: OnceLock::new(),
         }
     }
 
@@ -221,6 +227,19 @@ impl TempoPooledTransaction {
     /// Returns the resolved fee token cached during validation, if available.
     pub fn resolved_fee_token(&self) -> Option<Address> {
         self.resolved_fee_token.get().copied()
+    }
+
+    /// Returns the `(fee_token, balance_slot)` pair for this transaction's fee payer,
+    /// lazily computed and cached on first access.
+    pub fn fee_balance_slot(&self) -> Option<(Address, U256)> {
+        *self.fee_balance_slot.get_or_init(|| {
+            let fee_token = self.resolved_fee_token().unwrap_or_else(|| {
+                self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN)
+            });
+            let fee_payer = self.inner().fee_payer(self.sender()).ok()?;
+            let slot = TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].slot();
+            Some((fee_token, slot))
+        })
     }
 
     /// Returns the expiring nonce hash for AA expiring nonce transactions.

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -233,9 +233,9 @@ impl TempoPooledTransaction {
     /// lazily computed and cached on first access.
     pub fn fee_balance_slot(&self) -> Option<(Address, U256)> {
         *self.fee_balance_slot.get_or_init(|| {
-            let fee_token = self.resolved_fee_token().unwrap_or_else(|| {
-                self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN)
-            });
+            let fee_token = self
+                .resolved_fee_token()
+                .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
             let fee_payer = self.inner().fee_payer(self.sender()).ok()?;
             let slot = TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].slot();
             Some((fee_token, slot))


### PR DESCRIPTION
Depends on https://github.com/tempoxyz/tempo/pull/3780

Introduces `StateAwareBestTransactions` wrapper around best transactions iterator that is aware of previously executed transactions and their state changes that can affect transactions emitted later.

The motivation is that even though we do our best to ensure that all transactions in the txpool are valid on top of latest block's state we can't control cross-transaction dependencies and thus it is possible to have a situation when after executing a single transaction entire pool is invalidated forcing builder to iterate over every single transaction performing stateful checks.

For now `StateAwareBestTransactions` only performs a single but very obvious check of the sender's balance being decreased by previos transactions, making the next ones invalid