### PR TITLE
deps: update reth from main (2026-05-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,13 +2609,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -3271,6 +3282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4114,18 +4135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +4678,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4942,24 +4952,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "serde",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -4968,22 +4976,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5562,6 +5596,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -5667,6 +5704,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6588,6 +6655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7422,6 +7495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7830,6 +7914,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7867,6 +7962,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -8220,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8247,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8279,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8299,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8312,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8395,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8405,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8458,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8474,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8487,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8500,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8526,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8555,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8611,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8626,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8651,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8675,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8699,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8734,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8791,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8819,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8867,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8953,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8969,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9148,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9164,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9207,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9221,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9255,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9275,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9325,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9363,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9377,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "futures",
  "metrics",
@@ -9474,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9483,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9497,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9555,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9580,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9603,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9618,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9632,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9649,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9673,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9741,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9796,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9834,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9858,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9882,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "bytes",
  "eyre",
@@ -9911,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9923,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9947,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9959,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10026,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10072,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10101,7 +10202,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10117,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10132,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10209,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10239,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10282,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10302,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10333,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10379,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10427,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10441,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10472,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10524,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10552,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10566,7 +10667,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10586,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10601,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10625,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10643,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10664,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10680,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10690,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "clap",
  "eyre",
@@ -10709,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "clap",
  "eyre",
@@ -10727,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10772,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10798,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10825,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10845,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10874,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
+source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11412,9 +11513,9 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -11433,9 +11534,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -11664,7 +11765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -11982,6 +12083,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12262,6 +12379,27 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8220,7 +8220,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8279,7 +8279,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8312,7 +8312,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8458,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8474,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8487,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8500,7 +8500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8526,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8581,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8626,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9046,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "clap",
  "eyre",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9221,7 +9221,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9293,7 +9293,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9387,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9415,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "bytes",
  "futures",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "bindgen",
  "cc",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "futures",
  "metrics",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9483,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9649,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9741,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9858,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9882,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "bytes",
  "eyre",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10209,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10282,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10427,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10441,7 +10441,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10552,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10566,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10601,7 +10601,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10643,7 +10643,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "clap",
  "eyre",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "clap",
  "eyre",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10772,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10798,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10845,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcfa828#fcfa8287f69a3509fcfef95d1b4dc8948ec86665"
+source = "git+https://github.com/paradigmxyz/reth?rev=e98fb4a#e98fb4af981d84ff2c50f6f86d863060a77484e6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fcfa828", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e98fb4a", features = [
   "std",
   "optional-checks",
 ] }

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,10 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
+  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
+  # the fix, and no patched hickory-proto release exists
+  "RUSTSEC-2026-0118",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`fcfa828...38c627c`](https://github.com/paradigmxyz/reth/compare/fcfa828...38c627c)

🔗 Amp thread: https://ampcode.com/threads/T-019de481-7d1b-7477-8e1d-2a247b892090
- **Network**: prevent eth/68 tx request packing overflow ([#23848](https://github.com/paradigmxyz/reth/pull/23848)); add optional BAL fetching for block ranges ([#23779](https://github.com/paradigmxyz/reth/pull/23779))
- **Engine**: convert built payload to execution data ([#23859](https://github.com/paradigmxyz/reth/pull/23859))
- **CLI/Trie**: verify repaired trie state root before commit ([#23854](https://github.com/paradigmxyz/reth/pull/23854))
- **DB/Backup**: renumber `bal_index` space at segment boundaries in reth-bb ([#23868](https://github.com/paradigmxyz/reth/pull/23868))
- **Logging**: default to min-trace-logs ([#23851](https://github.com/paradigmxyz/reth/pull/23851))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019de481-9071-7231-9f1b-b020a2e3b474
- Bumped all `reth-*` git dependencies in `Cargo.toml` from rev `fcfa828` to `38c627c` to pick up the latest upstream Reth SDK changes.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25223888087)
