### PR TITLE
ci(release-pr): use dedicated `release-pr` environment

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,7 +12,7 @@ jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
-    environment: release
+    environment: release-pr
     permissions: {}
     steps:
       - name: Mint scoped app token


### PR DESCRIPTION
ci(release-pr): use dedicated release-pr environment