### PR TITLE
fix: sync foundry.lock forge-std rev with submodule

### DIFF
--- a/tips/verify/foundry.lock
+++ b/tips/verify/foundry.lock
@@ -1,6 +1,6 @@
 {
   "lib/forge-std": {
-    "rev": "f61e4dd133379a4536a54ee57a808c9c00019b60"
+    "rev": "e72518ef87be67df939a70b0ff1cb349e92b6dde"
   },
   "lib/solady": {
     "rev": "90db92ce173856605d24a554969f2c67cadbc7e9"


### PR DESCRIPTION
## Problem

The Argo `invariant-tests` workflow has been failing with exit code 1 (compile error) since ~Apr 28. The workflow clones without `--recursive`, so `lib/forge-std/` is empty and forge auto-installs from `foundry.lock`.

`foundry.lock` pinned `forge-std` to `f61e4dd1` which **lacks `signEd25519`**, while the git submodule already points to `e72518ef` which **has it**. This causes:

```
Error (9582): Member "signEd25519" not found or not visible after argument-dependent lookup in contract Vm.
```

in `ValidatorConfigV2.t.sol`.

GHA `specs.yml` passes because it clones with `submodules: recursive` (uses the submodule version directly).

## Fix

Update `tips/verify/foundry.lock` to pin `forge-std` to `e72518ef87be67df939a70b0ff1cb349e92b6dde`, matching the submodule.

## Context

- The foundry-branch pin fix (PR #3768 / workflows #419) resolved the earlier revm mismatch (exit 101) but did not address this second issue.
- Slack thread: https://tempoxyz.slack.com/archives/C0A6PD3BQ3F/p1777601759314299