### PR TITLE
tip-1046: add #3793 (pre-validate call scopes before writing)

### DIFF
--- a/tips/tip-1046.md
+++ b/tips/tip-1046.md
@@ -75,3 +75,9 @@ When storing a struct with packed fields, the generated code reads the first pac
 **PR**: [#3746](https://github.com/tempoxyz/tempo/pull/3746) · **Author**: @klkvr 
 
 Blocks currently always include a subblocks metadata system transaction, even when no subblocks are present. T4+ allows blocks to omit that empty metadata transaction, treats missing metadata as an empty subblocks list during execution, and rejects explicit subblock metadata or subblocks after activation so the post-T4 path consistently operates without subblocks.
+
+## 10. Pre-validate call scopes before writing
+
+**PR**: [#3793](https://github.com/tempoxyz/tempo/pull/3793) · **Author**: @klkvr
+
+Key authorization logic previously wrote call scopes to storage one by one and validated each after insertion. A malicious batch could force the node to insert a large set of scopes where only the last entry fails validation, wasting storage writes and creating a DOS vector. T4+ also relaxes selector scope validation to check the target address without requiring TIP-20 initialization, matching the intended authorization semantics.


### PR DESCRIPTION
Adds [#3793](https://github.com/tempoxyz/tempo/pull/3793) (*fix: validate call scopes before writing* by @klkvr) as item 10 in the T4 Hardfork Meta TIP.

Pre-validates all call scopes before writing them to storage, closing a DOS vector where a large batch with a failing final entry wastes storage writes. Also relaxes selector scope validation to check the target address without requiring TIP-20 initialization.