### PR TITLE
fix(ci): unblock cargo deny on hickory advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,12 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0118 hickory-proto DNSSEC loop
+  # requires dnssec-ring or dnssec-aws-lc-rs, but reth-dns-discovery only enables tokio.
+  "RUSTSEC-2026-0118",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto name compression DoS
+  # comes from the reth-pinned hickory 0.25 resolver stack; ignore until reth can move to 0.26.x.
+  "RUSTSEC-2026-0119",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cargo deny started failing on two new hickory advisories pulled in through the reth DNS discovery resolver stack.

This ignores the DNSSEC-only advisory because that feature is not enabled in our build, and it ignores the remaining hickory advisory until the pinned reth revision can move to hickory 0.26.x.

Verified with cargo deny check.
