### PR TITLE
deps: update reth from main (2026-05-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
+checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1163,7 +1163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4187,7 +4187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4627,7 +4627,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6763,7 +6763,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9026,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "clap",
  "eyre",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9394,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "serde",
  "serde_json",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "bytes",
  "futures",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "bindgen",
  "cc",
@@ -9562,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "futures",
  "metrics",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9897,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "bytes",
  "eyre",
@@ -10012,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10127,9 +10127,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
@@ -10173,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10202,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10218,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10233,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10310,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10340,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10383,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10403,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10434,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10480,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10528,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10542,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10573,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10625,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10653,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10667,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10687,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10702,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10766,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10829,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10947,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10976,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
+source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11466,7 +11467,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11546,7 +11547,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12175,7 +12176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12441,7 +12442,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14453,7 +14454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9026,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "clap",
  "eyre",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9394,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "serde",
  "serde_json",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "bytes",
  "futures",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "bindgen",
  "cc",
@@ -9562,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "futures",
  "metrics",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9897,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "bytes",
  "eyre",
@@ -10012,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10127,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10173,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10202,7 +10202,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10233,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10340,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10480,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10528,7 +10528,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10542,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10667,7 +10667,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=38c627c#38c627ce8f1a3bb82bed8a6beb3016f62c50016d"
+source = "git+https://github.com/paradigmxyz/reth?rev=30fe86d#30fe86d25568399bd2b64ff93562b440a5000ca4"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9026,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "clap",
  "eyre",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9394,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "serde",
  "serde_json",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "bytes",
  "futures",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "bindgen",
  "cc",
@@ -9562,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "futures",
  "metrics",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9897,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "bytes",
  "eyre",
@@ -10012,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10069,7 +10069,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-execution-types",
@@ -10084,7 +10083,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10127,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10161,6 +10160,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tasks",
+ "reth-tokio-util",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
@@ -10174,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10219,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10404,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10435,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10529,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10543,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10668,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10719,6 +10719,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
+ "reth-tokio-util",
  "reth-trie-common",
  "revm-database",
  "serde_json",
@@ -10727,7 +10728,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10745,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10766,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10782,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10792,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "clap",
  "eyre",
@@ -10811,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "clap",
  "eyre",
@@ -10829,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10874,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10900,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10927,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10947,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10976,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=ddb3819#ddb3819ec945958ca01032390b8c7a1c83e8df2f"
+source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12916,7 +12917,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "either",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9026,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9070,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "clap",
  "eyre",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9394,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9478,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "serde",
  "serde_json",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "bytes",
  "futures",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "bindgen",
  "cc",
@@ -9562,7 +9562,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "futures",
  "metrics",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9656,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9733,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9897,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "bytes",
  "eyre",
@@ -10012,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10060,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10083,7 +10083,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10126,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10174,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10219,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10404,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10435,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10529,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10543,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10668,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10728,7 +10728,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10793,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "clap",
  "eyre",
@@ -10812,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "clap",
  "eyre",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10928,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10948,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=d5c5b0b#d5c5b0b63308eb6ff3e3391a79ef4dbcfc4f8b52"
+source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,9 +8601,8 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
- "alloy-consensus",
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -8616,7 +8615,6 @@ dependencies = [
  "futures",
  "reqwest 0.13.2",
  "reth-node-api",
- "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -8627,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9026,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9054,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9070,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9086,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9108,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9119,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9147,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9210,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "clap",
  "eyre",
@@ -9233,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9249,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9265,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9278,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9308,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9322,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9332,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9356,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9376,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9394,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9407,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9426,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9464,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9478,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "serde",
  "serde_json",
@@ -9488,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9516,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "bytes",
  "futures",
@@ -9536,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9553,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "bindgen",
  "cc",
@@ -9562,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "futures",
  "metrics",
@@ -9575,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9584,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9598,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9656,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9704,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9719,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9733,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9750,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9774,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9842,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9897,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9935,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9983,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "bytes",
  "eyre",
@@ -10012,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10024,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10048,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10060,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10083,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10126,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10174,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10203,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10219,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10234,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10311,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10341,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10384,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10404,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10435,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10481,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10529,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10543,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10574,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10626,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10654,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10668,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10688,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10703,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10728,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10746,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10767,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10783,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10793,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "clap",
  "eyre",
@@ -10812,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "clap",
  "eyre",
@@ -10830,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10875,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10901,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10928,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10948,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10977,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=a60c3ee#a60c3ee3404cbb11be79f3fb250d354eccf7b489"
+source = "git+https://github.com/paradigmxyz/reth?rev=12ec7c5#12ec7c57281c611355a02a2032ea7330ed9d3c68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "38c627c", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "30fe86d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ddb3819", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "12ec7c5", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,64 +120,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d5c5b0b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a60c3ee", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -231,12 +231,14 @@ impl FullConsensus<TempoPrimitives> for TempoConsensus {
         block: &RecoveredBlock<Block>,
         result: &BlockExecutionResult<TempoReceipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        block_access_list_hash: Option<alloy_primitives::B256>,
     ) -> Result<(), ConsensusError> {
         FullConsensus::<TempoPrimitives>::validate_block_post_execution(
             &self.inner,
             block,
             result,
             receipt_root_bloom,
+            block_access_list_hash,
         )
     }
 }
@@ -922,7 +924,7 @@ mod tests {
         };
 
         let err = consensus
-            .validate_block_post_execution(&recovered, &result, None)
+            .validate_block_post_execution(&recovered, &result, None, None)
             .unwrap_err();
         assert!(
             matches!(err, ConsensusError::BodyReceiptRootDiff(_)),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -26,7 +26,7 @@ use reth_node_builder::{
     },
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
-use reth_primitives_traits::SealedHeader;
+use reth_primitives_traits::{SealedBlock, SealedHeader};
 use reth_provider::{EthStorage, providers::ProviderFactoryBuilder};
 use reth_rpc_builder::{Identity, RethRpcModule};
 use reth_rpc_eth_api::{
@@ -35,12 +35,12 @@ use reth_rpc_eth_api::{
 };
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore};
-use std::default::Default;
+use std::{default::Default, sync::Arc};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::TempoConsensus;
 use tempo_evm::TempoEvmConfig;
 use tempo_payload_builder::TempoPayloadBuilder;
-use tempo_payload_types::TempoPayloadAttributes;
+use tempo_payload_types::{TempoExecutionData, TempoPayloadAttributes};
 use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
 use tempo_transaction_pool::{
     AA2dPool, AA2dPoolConfig, TempoTransactionPool,
@@ -283,10 +283,14 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for TempoNode {
     type RpcBlock =
         alloy_rpc_types_eth::Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeader>;
 
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> tempo_primitives::Block {
-        rpc_block
+    fn rpc_to_execution_data(rpc_block: Self::RpcBlock) -> TempoExecutionData {
+        let block = rpc_block
             .into_consensus_block()
-            .map_transactions(|tx| tx.into_inner())
+            .map_transactions(|tx| tx.into_inner());
+        TempoExecutionData {
+            block: Arc::new(SealedBlock::seal_slow(block)),
+            validator_set: None,
+        }
     }
 
     fn local_payload_attributes_builder(

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -39,7 +39,6 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 
-either.workspace = true
 metrics.workspace = true
 tracing.workspace = true
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -9,7 +9,6 @@ use crate::metrics::{InstrumentedFinishProvider, TempoPayloadBuilderMetrics};
 use alloy_consensus::{BlockHeader as _, Signed, Transaction, TxLegacy};
 use alloy_primitives::{Address, U256};
 use alloy_rlp::{Decodable, Encodable};
-use either::Either;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
     is_better_payload,
@@ -839,8 +838,8 @@ where
         let executed_block = BuiltPayloadExecutedBlock {
             recovered_block: Arc::new(block),
             execution_output: Arc::new(execution_output),
-            hashed_state: Either::Left(Arc::new(hashed_state)),
-            trie_updates: Either::Left(Arc::new(trie_updates)),
+            hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_updates),
         };
 
         let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`38c627c...8328732`](https://github.com/paradigmxyz/reth/compare/38c627c...8328732)

🔗 Amp thread: https://ampcode.com/threads/T-019df89b-7bd5-7546-abc8-f81cb9bbbab9
- **Engine**
  - Add shared block accessor to `EthBuiltPayload`, expose built payload block access list, and require built payload conversion ([#23862](https://github.com/paradigmxyz/reth/pull/23862), [#23860](https://github.com/paradigmxyz/reth/pull/23860), [#23928](https://github.com/paradigmxyz/reth/pull/23928))
  - Spawn deferred trie work for directly inserted payloads and skip already-known executed blocks ([#23935](https://github.com/paradigmxyz/reth/pull/23935), [#23987](https://github.com/paradigmxyz/reth/pull/23987))
  - Acknowledge `save_blocks` before prune ([#23904](https://github.com/paradigmxyz/reth/pull/23904))
  - Increase state root task timeout to 4s ([#23949](https://github.com/paradigmxyz/reth/pull/23949))

- **Storage / BAL**
  - Add in-memory BAL retention and BAL notification stream ([#23873](https://github.com/paradigmxyz/reth/pull/23873), [#23918](https://github.com/paradigmxyz/reth/pull/23918))
  - Add BAL validation in post-execution ([#23496](https://github.com/paradigmxyz/reth/pull/23496))

- **Networking**
  - Add capability message id helpers in `eth-wire` ([#23908](https://github.com/paradigmxyz/reth/pull/23908))
  - Validate EIP-1459 hash labels before caching entries ([#22582](https://github.com/paradigmxyz/reth/pull/22582))

- **RPC**
  - Fill `maxUsedGas` in `simulate` results ([#23983](https://github.com/paradigmxyz/reth/pull/23983))

- **Debug Client**
  - Pass execution data from providers ([#23969](https://github.com/paradigmxyz/reth/pull/23969))

- **Perf / Tooling**
  - Skip recomputing receipts root in `generate-big-blocks` ([#23930](https://github.com/paradigmxyz/reth/pull/23930))

- **Chore**
  - Fix nightly clippy warnings ([#23923](https://github.com/paradigmxyz/reth/pull/23923))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019df89b-9c72-705e-9e62-ef9d142f32be
- Bumped `reth` git dependency revision from `38c627c` to `8328732` for all `reth-*` crates in `Cargo.toml`.
- Updated `FullConsensus::validate_block_post_execution` to accept a new `block_access_list_hash: Option<B256>` parameter (forwarded to inner consensus); test call site updated accordingly.
- Migrated `DebugNode` impl from `rpc_to_primitive_block` → `rpc_to_execution_data`, now returning a `TempoExecutionData` wrapping an `Arc<SealedBlock>` plus `validator_set: None` to match the new trait signature.
- Replaced `either::Either::Left(Arc::new(...))` wrappers for `hashed_state` and `trie_updates` in `BuiltPayloadExecutedBlock` with plain `Arc::new(...)`, since the upstream fields are no longer `Either`-typed.
- Dropped the now-unused `either` dependency from `crates/payload/builder/Cargo.toml` and its import.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25383044680)
