### PR TITLE
chore(deny): remove RUSTSEC-2026-0118 ignore — hickory-proto 0.26.1 is unaffected

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-  # the fix, and no patched hickory-proto release exists
-  "RUSTSEC-2026-0118",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
The [RUSTSEC-2026-0118](https://rustsec.org/advisories/RUSTSEC-2026-0118) advisory marks `>=0.26.0-beta.1` as **unaffected**. Our pinned reth rev (`38c627c`) already resolves `hickory-proto 0.26.1` in `Cargo.lock`, so no reth bump is needed — the ignore entry can simply be removed.

Verified: `Cargo.lock` on main already has `hickory-proto 0.26.1`.