### PR TITLE
docs(tip-1026): scheme allowlist, non-breaking shape, storage layout, expanded security notes

### DIFF
--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -12,13 +12,17 @@ protocolVersion: TBD
 
 ## Abstract
 
-Adds a `logoURI` field to TIP-20 tokens — a string capped at 256 bytes, mutable by the token admin. This allows wallets and explorers to read a token's icon URI directly from the contract without depending on an external token list registry.
+Adds a `logoURI` field to TIP-20 tokens — a string capped at 256 bytes, mutable by the token admin and validated against a small allowlist of URI schemes. This allows wallets and explorers to read a token's icon URI directly from the contract for *metadata distribution*; curation/verification of trusted tokens remains an off-chain concern (see [Out of Scope](#out-of-scope)).
 
 ## Motivation
 
-Token icons are currently maintained in an off-chain token list registry ([tokenlist.tempo.xyz](https://tokenlist.tempo.xyz)). Wallets, explorers, and other apps must query this external service to display token icons, and issuers must submit a PR to a separate repository after deploying their token.
+Token icons are currently distributed through an off-chain token list registry ([tokenlist.tempo.xyz](https://tokenlist.tempo.xyz)). Wallets, explorers, and other apps must query this external service to display token icons, and issuers must submit a PR to a separate repository after deploying their token.
 
-Adding `logoURI` as a first-class on-chain field makes token metadata self-describing. The 256-byte cap prevents abuse (e.g., storing excessively large strings that could degrade indexer or explorer performance).
+Adding `logoURI` as a first-class on-chain field makes token metadata self-describing: any token deployed with TIP-1026 metadata gets discoverability without an off-chain registry round-trip. The 256-byte cap prevents abuse (e.g., storing excessively large strings that could degrade indexer or explorer performance).
+
+### Out of Scope
+
+This TIP only covers *metadata distribution*. It does **not** address curation or verification of trusted tokens — i.e. the curated subset of tokens that integrators (wallets choosing default gas tokens, DEXes choosing swappable assets, explorers choosing default-listed tokens) need a trust signal for. That curated list remains off-chain (e.g. continuing to be served from the existing tokenlist) and is expected to be addressed in a follow-up TIP.
 
 ---
 
@@ -34,8 +38,11 @@ The following functions are added to `ITIP20`:
 function logoURI() external view returns (string memory);
 
 /// @notice Sets the logo URI for this token (requires DEFAULT_ADMIN_ROLE)
-/// @param newLogoURI The new logo URI (must be <= 256 bytes)
+/// @param newLogoURI The new logo URI (must be <= 256 bytes and, if non-empty,
+///                   a valid URI with an allowed scheme — see Behavior).
 /// @dev Reverts with LogoURITooLong if the URI exceeds 256 bytes.
+///      Reverts with InvalidLogoURI if the URI is non-empty and either not
+///      syntactically a URI or its scheme is not in the allowlist.
 ///      An empty string is valid and clears the logo URI.
 function setLogoURI(string calldata newLogoURI) external;
 ```
@@ -54,42 +61,82 @@ event LogoURIUpdated(address indexed updater, string newLogoURI);
 ```solidity
 /// @notice The provided logo URI exceeds the maximum length of 256 bytes
 error LogoURITooLong();
+
+/// @notice The provided logo URI is non-empty and is either not a syntactically
+///         valid URI or its scheme is not in the allowlist (see Behavior).
+error InvalidLogoURI();
 ```
 
 ## Behavior
 
 - `logoURI()` returns the current logo URI. Returns an empty string if not set.
-- `setLogoURI(string)` updates the logo URI. Restricted to `DEFAULT_ADMIN_ROLE`. Reverts with `LogoURITooLong` if `bytes(newLogoURI).length > 256`.
+- `setLogoURI(string)` updates the logo URI. Restricted to `DEFAULT_ADMIN_ROLE`.
+  - Reverts with `LogoURITooLong` if `bytes(newLogoURI).length > 256`.
+  - Reverts with `InvalidLogoURI` if `newLogoURI` is non-empty and either does not have a scheme parseable per RFC 3986 §3.1 (`scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` followed by `:`) or the scheme is not in the **allowlist**:
+
+    | Scheme   | Notes                                                            |
+    |----------|------------------------------------------------------------------|
+    | `https`  | Recommended for general web-hosted assets.                       |
+    | `http`   | Allowed for completeness; integrators should prefer `https`.     |
+    | `ipfs`   | Recommended for content-addressed assets.                        |
+    | `data`   | Useful for small inline images; subject to the 256-byte cap.     |
+
+    Scheme matching is ASCII-case-insensitive (e.g. `HTTPS` and `https` are equivalent).
+  - Empty strings (`""`) are explicitly valid and clear the logo URI; no scheme check is performed in that case.
 
 ### Factory Support
 
-`TIP20Factory.createToken` accepts an optional `logoURI` parameter. Passing an empty string omits it. This avoids a separate `setLogoURI` transaction for new deployments while remaining backward-compatible with existing flows that don't pass the argument.
-
-The `TokenCreated` event is extended to include the logo URI:
+A new Solidity overload of `TIP20Factory.createToken` is added that accepts an additional `logoURI` argument:
 
 ```solidity
-event TokenCreated(
-    address indexed token,
-    string name,
-    string symbol,
-    string currency,
-    ITIP20 quoteToken,
+function createToken(
+    string memory name,
+    string memory symbol,
+    string memory currency,
+    address quoteToken,
     address admin,
     bytes32 salt,
-    string logoURI
-);
+    string memory logoURI
+) external returns (address);
 ```
+
+The new overload validates `logoURI` with the same rules as `setLogoURI` *before* deploying the token (so a rejected URI does not leave a partially-created token in storage), then, if `logoURI` is non-empty, writes it and emits `LogoURIUpdated` from the **new token's address** with `updater = msg.sender`. An empty `logoURI` skips both the slot write and the event.
+
+#### Backwards compatibility
+
+This TIP is **non-breaking**:
+
+- The legacy 6-argument `createToken(name, symbol, currency, quoteToken, admin, salt)` selector (`0x68130445`) is unchanged.
+- The `TokenCreated` event signature (and therefore `topic0`) is **unchanged**. The new overload does **not** extend `TokenCreated`; the logo information is conveyed via the token-level `LogoURIUpdated` event described above.
+- All new selectors (`logoURI()`, `setLogoURI(string)`, the 7-argument `createToken` overload) are gated behind the activating hardfork; before activation they revert as unknown selectors.
+
+Existing integrations that call the 6-argument `createToken` and decode `TokenCreated` continue to work unchanged.
+
+#### Storage layout
+
+`TIP20Token` storage is **append-only**: each `TIP20Token` instance has a fixed slot layout that existing tokens already commit to, so any new persistent field introduced by this TIP MUST be appended at the end of the existing layout. The new `logoURI` slot is therefore placed **after** the last pre-existing field (the rewards block, ending at `userRewardInfo`). Implementations must not interleave the new slot among existing ones; doing so would re-interpret existing storage on already-deployed tokens and break consensus on state.
+
+A token deployed before activation reads `logoURI()` as the empty string (the default for an unwritten string slot), which is the same value `logoURI()` returns immediately after `setLogoURI("")`. No state migration is required at the activation boundary.
 
 ## Recommended Formats
 
-- HTTPS: `https://example.com/icon.svg` (~40–120 bytes)
-- IPFS: `ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM` (~53 bytes)
+- HTTPS: `https://example.com/icon.png` (~40–120 bytes)
+- IPFS:  `ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM` (~53 bytes)
 
-SVG or PNG at a square aspect ratio is recommended.
+Square aspect ratio is recommended. **Rasterized formats (PNG / WebP / static, single-frame) are recommended over SVG**; integrators that accept SVG must follow the SVG-handling guidance in [Security Considerations](#security-considerations).
 
 ## Security Considerations
 
-The contract performs **no validation** on the contents of `logoURI`. Any string up to 256 bytes is accepted, including non-URL strings, `javascript:` URIs, or malformed data. Wallets and explorers that display token logos **must** sanitize and validate the URI before rendering — for example, by restricting to `https://` and `ipfs://` schemes and rejecting unknown or dangerous schemes.
+The protocol enforces only structural checks: a 256-byte length cap and a scheme allowlist (`https`, `http`, `ipfs`, `data`). Beyond that, the resolved endpoint and its content **must be treated as untrusted** by every consumer. Apps that load logos from `logoURI` should treat it the same way they would treat any user-supplied URL — standard web2 application-security practices apply.
+
+Specific risks integrators should plan for:
+
+- **Tracking / deanonymization.** Any wallet, explorer, or backend that fetches the logo directly leaks the user's IP address (and `User-Agent`, etc.) to whoever controls the endpoint. Integrators that want to avoid this should fetch through a content proxy, cache through a centrally-fetched image CDN, or only fetch on user opt-in.
+- **SVG-based XSS.** SVG is an executable format. Embedded `<script>`/event handlers run in the origin of whoever renders them inline. Integrators **must not** render SVG via `innerHTML`, `<iframe srcdoc>`, or `<object>`; instead, either disallow SVG, sanitize it (e.g. with DOMPurify in `SVG` mode and an explicit allowlist), or rasterize it server-side before serving.
+- **Image-parser exploits.** Native renderers and backend image pipelines have a history of decoder vulnerabilities (e.g. CVE-2023-4863, CVE-2022-44268). Treat images fetched from `logoURI` as untrusted input to whichever decoder will see them.
+- **Impersonation.** Nothing prevents a token from claiming the logo, name, and symbol of another token. The protocol does not solve this; consumers who care about distinguishing legitimate tokens must rely on an out-of-band trust signal (see [Out of Scope](#out-of-scope)).
+
+The scheme allowlist eliminates obviously dangerous values (`javascript:`, `file:`, `vbscript:`, etc.) at the protocol level. It does **not** vouch for the content reachable through the URI.
 
 # Invariants
 
@@ -97,3 +144,5 @@ The contract performs **no validation** on the contents of `logoURI`. Any string
 - Only accounts with `DEFAULT_ADMIN_ROLE` can call `setLogoURI`.
 - `setLogoURI` must emit `LogoURIUpdated` on success.
 - `setLogoURI` must revert with `LogoURITooLong` if `bytes(newLogoURI).length > 256`.
+- `setLogoURI` must revert with `InvalidLogoURI` if `newLogoURI` is non-empty and either has no parseable scheme or its scheme is not in the allowlist.
+- The legacy 6-argument `createToken` selector and the `TokenCreated` event signature are unchanged by this TIP.

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -90,13 +90,13 @@ A new Solidity overload of `TIP20Factory.createToken` is added that accepts an a
 
 ```solidity
 function createToken(
-    string memory name,
-    string memory symbol,
-    string memory currency,
+    string calldata name,
+    string calldata symbol,
+    string calldata currency,
     address quoteToken,
     address admin,
     bytes32 salt,
-    string memory logoURI
+    string calldata logoURI
 ) external returns (address);
 ```
 

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -102,15 +102,7 @@ function createToken(
 
 The new overload validates `logoURI` with the same rules as `setLogoURI` *before* deploying the token (so a rejected URI does not leave a partially-created token in storage), then, if `logoURI` is non-empty, writes it and emits `LogoURIUpdated` from the **new token's address** with `updater = msg.sender`. An empty `logoURI` skips both the slot write and the event.
 
-#### Backwards compatibility
-
-This TIP is **non-breaking**:
-
-- The legacy 6-argument `createToken(name, symbol, currency, quoteToken, admin, salt)` selector (`0x68130445`) is unchanged.
-- The `TokenCreated` event signature (and therefore `topic0`) is **unchanged**. The new overload does **not** extend `TokenCreated`; the logo information is conveyed via the token-level `LogoURIUpdated` event described above.
-- All new selectors (`logoURI()`, `setLogoURI(string)`, the 7-argument `createToken` overload) are gated behind the activating hardfork; before activation they revert as unknown selectors.
-
-Existing integrations that call the 6-argument `createToken` and decode `TokenCreated` continue to work unchanged.
+This TIP is non-breaking. The existing `createToken` selector and `TokenCreated` event remain unchanged, new functionality is additive and gated behind the activating hardfork, and existing integrations continue to work without modification.
 
 #### Storage layout
 

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -120,8 +120,4 @@ The protocol only validates URI structure. Integrators are responsible for accou
 # Invariants
 
 - `bytes(logoURI()).length <= 256` must always hold.
-- Only accounts with `DEFAULT_ADMIN_ROLE` can call `setLogoURI`.
-- `setLogoURI` must emit `LogoURIUpdated` on success.
-- `setLogoURI` must revert with `LogoURITooLong` if `bytes(newLogoURI).length > 256`.
-- `setLogoURI` must revert with `InvalidLogoURI` if `newLogoURI` is non-empty and either has no parseable scheme or its scheme is not in the allowlist.
 - The legacy 6-argument `createToken` selector and the `TokenCreated` event signature are unchanged by this TIP.

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -119,16 +119,9 @@ Square aspect ratio is recommended. **Rasterized formats (PNG / WebP / static, s
 
 ## Security Considerations
 
-The protocol enforces only structural checks: a 256-byte length cap and a scheme allowlist (`https`, `http`, `ipfs`, `data`). Beyond that, the resolved endpoint and its content **must be treated as untrusted** by every consumer. Apps that load logos from `logoURI` should treat it the same way they would treat any user-supplied URL — standard web2 application-security practices apply.
+The protocol enforces only structural checks: a 256-byte length cap and a scheme allowlist (https, http, ipfs, data). The resolved endpoint and its content must be treated as untrusted by all consumers.
 
-Specific risks integrators should plan for:
-
-- **Tracking / deanonymization.** Any wallet, explorer, or backend that fetches the logo directly leaks the user's IP address (and `User-Agent`, etc.) to whoever controls the endpoint. Integrators that want to avoid this should fetch through a content proxy, cache through a centrally-fetched image CDN, or only fetch on user opt-in.
-- **SVG-based XSS.** SVG is an executable format. Embedded `<script>`/event handlers run in the origin of whoever renders them inline. Integrators **must not** render SVG via `innerHTML`, `<iframe srcdoc>`, or `<object>`; instead, either disallow SVG, sanitize it (e.g. with DOMPurify in `SVG` mode and an explicit allowlist), or rasterize it server-side before serving.
-- **Image-parser exploits.** Native renderers and backend image pipelines have a history of decoder vulnerabilities (e.g. CVE-2023-4863, CVE-2022-44268). Treat images fetched from `logoURI` as untrusted input to whichever decoder will see them.
-- **Impersonation.** Nothing prevents a token from claiming the logo, name, and symbol of another token. The protocol does not solve this; consumers who care about distinguishing legitimate tokens must rely on an out-of-band trust signal (see [Out of Scope](#out-of-scope)).
-
-The scheme allowlist eliminates obviously dangerous values (`javascript:`, `file:`, `vbscript:`, etc.) at the protocol level. It does **not** vouch for the content reachable through the URI.
+The protocol only validates URI structure. Integrators are responsible for accounting for tracking, as direct logo fetches expose user metadata such as IP address to the endpoint operator, for executable SVG content which should not be rendered inline, for image decoder vulnerabilities since all fetched images are untrusted input, and for impersonation since tokens may claim arbitrary branding and trust must come from offchain curation.
 
 # Invariants
 

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -22,7 +22,7 @@ Adding `logoURI` as a first-class on-chain field makes token metadata self-descr
 
 ### Out of Scope
 
-This TIP only covers *metadata distribution*. It does **not** address curation or verification of trusted tokens — i.e. the curated subset of tokens that integrators (wallets choosing default gas tokens, DEXes choosing swappable assets, explorers choosing default-listed tokens) need a trust signal for. That curated list remains off-chain (e.g. continuing to be served from the existing tokenlist) and is expected to be addressed in a follow-up TIP.
+This TIP is limited to metadata distribution. It does not define which tokens are trusted, verified, or suitable for integration by wallets, DEXes, or explorers. Decisions around trust and curation, such as gas tokens or swappable assets remain offchain and at the discretion of integrators.
 
 ---
 

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -100,7 +100,7 @@ function createToken(
 ) external returns (address);
 ```
 
-The new overload validates `logoURI` with the same rules as `setLogoURI` *before* deploying the token (so a rejected URI does not leave a partially-created token in storage), then, if `logoURI` is non-empty, writes it and emits `LogoURIUpdated` from the **new token's address** with `updater = msg.sender`. An empty `logoURI` skips both the slot write and the event.
+The new overload validates `logoURI` with the same rules as `setLogoURI`. Validation MAY occur before or after deployment, but a rejected URI MUST cause the entire transaction to revert so no partially-created token is observable. If `logoURI` is non-empty, the overload writes it and emits `LogoURIUpdated` from the **new token's address** with `updater = msg.sender`. An empty `logoURI` skips both the slot write and the event.
 
 This TIP is non-breaking. The existing `createToken` selector and `TokenCreated` event remain unchanged, new functionality is additive and gated behind the activating hardfork, and existing integrations continue to work without modification.
 

--- a/tips/tip-1026.md
+++ b/tips/tip-1026.md
@@ -104,12 +104,6 @@ The new overload validates `logoURI` with the same rules as `setLogoURI`. Valida
 
 This TIP is non-breaking. The existing `createToken` selector and `TokenCreated` event remain unchanged, new functionality is additive and gated behind the activating hardfork, and existing integrations continue to work without modification.
 
-#### Storage layout
-
-`TIP20Token` storage is **append-only**: each `TIP20Token` instance has a fixed slot layout that existing tokens already commit to, so any new persistent field introduced by this TIP MUST be appended at the end of the existing layout. The new `logoURI` slot is therefore placed **after** the last pre-existing field (the rewards block, ending at `userRewardInfo`). Implementations must not interleave the new slot among existing ones; doing so would re-interpret existing storage on already-deployed tokens and break consensus on state.
-
-A token deployed before activation reads `logoURI()` as the empty string (the default for an unwritten string slot), which is the same value `logoURI()` returns immediately after `setLogoURI("")`. No state migration is required at the activation boundary.
-
 ## Recommended Formats
 
 - HTTPS: `https://example.com/icon.png` (~40–120 bytes)


### PR DESCRIPTION
ref #2996 

- Replaces "no validation" with a protocol-level URI scheme allowlist (`https`, `http`, `ipfs`, `data`, case-insensitive per RFC 3986 §3.1) and adds the `InvalidLogoURI` error.
- Documents the non-breaking shape: legacy 6-arg `createToken` selector (`0x68130445`) and `TokenCreated` topic0 are unchanged; the new `createToken` is a Solidity overload, and logo info is carried by the token-level `LogoURIUpdated` event.
- Documents the append-only `TIP20Token` storage-layout constraint and the no-migration semantics at activation.
- Expands Security Considerations (tracking/deanonymization, SVG XSS, image-parser exploits, impersonation) and adds an "Out of Scope" subsection clarifying that curation/verification stays off-chain (follow-up TIP).
