### PR TITLE
refactor(consensus): rename `leader` to `proposer` and clarify sentinel-context comment

### DIFF
--- a/crates/commonware-node/src/consensus/block.rs
+++ b/crates/commonware-node/src/consensus/block.rs
@@ -151,8 +151,13 @@ impl commonware_consensus::CertifiableBlock for Block {
                 parent: (View::new(ctx.parent_view), self.parent_digest()),
             },
             None => {
-                // Pre-T4: Unused deterministic sentinel.
-                // Post-T4: This dummy context will fail verification with consensus values
+                // Returns a deterministic sentinel `Context`.
+                //
+                // Pre-T4: Unused; consensus does not consult this context.
+                // Post-T4: All blocks must carry a `consensus_context`, so reaching
+                // this branch indicates a malformed block. The sentinel intentionally
+                // does not match any real consensus values, so it will fail
+                // verification rather than panic.
                 let leader = PublicKey::from(PrivateKey::from_seed(0));
                 Context {
                     leader,

--- a/tips/tip-1031.md
+++ b/tips/tip-1031.md
@@ -35,11 +35,11 @@ pub struct Context {
   pub epoch: u64,
   pub view: u64,
   pub parent_view: u64,
-  pub leader: Ed25519PublicKey,
+  pub proposer: Ed25519PublicKey,
 }
 ```
 
-The `leader` field is typed as `Ed25519PublicKey` to encode the protocol-level invariant that the value must be a valid ed25519 public key. On the wire (and in the database), the field is represented as a `B256` — a fixed 32-byte value identical in size and layout to the raw key bytes. Encoding (RLP and `Compact`) is byte-equivalent to a `B256`, but decoding additionally enforces that the bytes form a valid ed25519 verification key; otherwise the header is rejected. This pushes the validity check to the type system rather than relying on downstream consumers to validate the bytes.
+The `proposer` field is typed as `Ed25519PublicKey` to encode the protocol-level invariant that the value must be a valid ed25519 public key. On the wire (and in the database), the field is represented as a `B256` — a fixed 32-byte value identical in size and layout to the raw key bytes. Encoding (RLP and `Compact`) is byte-equivalent to a `B256`, but decoding additionally enforces that the bytes form a valid ed25519 verification key; otherwise the header is rejected. This pushes the validity check to the type system rather than relying on downstream consumers to validate the bytes.
 
 The `Context` adds 4 fields: 3 `u64` values and 1 32-byte ed25519 public key, totaling 56 bytes raw. The field required to construct the [context required by simplex](https://github.com/commonwarexyz/monorepo/blob/main/consensus/src/simplex/types.rs#L22), not present in this struct can be computed using properties of the block, `parent_hash` -> `parent_digest`.
 


### PR DESCRIPTION
ref https://linear.app/tempoxyz/issue/SIGP-253

- Renames the `Context` field in TIP-1031 from `leader` to `proposer` so the spec matches the codebase, where `proposer` is the established term.
- Clarifies the `CertifiableBlock::context()` `None`-branch comment to state that it returns a deterministic sentinel (the prior comment incorrectly suggested a post-T4 panic).