### PR TITLE
refactor(tip-1033): clean up fee routing and add e2e coverage

### DIFF
--- a/crates/node/tests/it/tip_fee_amm.rs
+++ b/crates/node/tests/it/tip_fee_amm.rs
@@ -1,21 +1,62 @@
 use crate::utils::{TestNodeBuilder, await_receipts, setup_test_token};
 use alloy::{
-    primitives::U256,
+    primitives::{B256, U256},
     providers::{Provider, ProviderBuilder},
     signers::local::MnemonicBuilder,
+    sol_types::SolEvent,
 };
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, uint};
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{
-    IFeeManager,
+    IFeeManager, IRolesAuth,
     ITIP20::{self, ITIP20Instance},
-    ITIPFeeAMM,
+    ITIP20Factory, ITIPFeeAMM,
 };
 use tempo_precompiles::{
-    DEFAULT_FEE_TOKEN, PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    tip_fee_manager::amm::{MIN_LIQUIDITY, PoolKey},
+    DEFAULT_FEE_TOKEN, PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
+    tip_fee_manager::amm::{MIN_LIQUIDITY, PoolKey, compute_amount_out},
+    tip20::ISSUER_ROLE,
 };
+use tempo_primitives::transaction::calc_gas_balance_spending;
+use test_case::test_case;
+
+async fn setup_test_token_with_quote<P>(
+    provider: P,
+    caller: Address,
+    quote_token: Address,
+) -> eyre::Result<ITIP20Instance<impl Clone + Provider>>
+where
+    P: Provider + Clone,
+{
+    let factory = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, provider.clone());
+    let receipt = factory
+        .createToken(
+            "Test".to_string(),
+            "TEST".to_string(),
+            "USD".to_string(),
+            quote_token,
+            caller,
+            B256::random(),
+        )
+        .gas(5_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let event = ITIP20Factory::TokenCreated::decode_log(&receipt.logs()[1].inner).unwrap();
+    let token = ITIP20::new(event.token, provider.clone());
+
+    IRolesAuth::new(*token.address(), provider)
+        .grantRole(*ISSUER_ROLE, caller)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    Ok(token)
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mint_liquidity() -> eyre::Result<()> {
@@ -376,6 +417,167 @@ async fn test_transact_different_fee_tokens() -> eyre::Result<()> {
 
     assert!(pool_before.reserveUserToken < pool_after.reserveUserToken);
     assert!(pool_before.reserveValidatorToken > pool_after.reserveValidatorToken);
+
+    Ok(())
+}
+
+#[test_case(false ; "no_direct_pool")]
+#[test_case(true ; "insufficient_direct_pool")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transact_two_hop_fee_route(direct_pool_exists: bool) -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let http_url = setup.http_url;
+
+    let user_wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC)
+        .index(1)?
+        .build()?;
+    let user_address = user_wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(user_wallet)
+        .connect_http(http_url);
+
+    let validator_address = provider
+        .get_block(BlockId::latest())
+        .await?
+        .expect("Could not get block")
+        .header
+        .beneficiary;
+
+    let fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let validator_token = ITIP20Instance::new(PATH_USD_ADDRESS, provider.clone());
+
+    let hop_token = setup_test_token(provider.clone(), user_address).await?;
+    let user_token =
+        setup_test_token_with_quote(provider.clone(), user_address, *hop_token.address()).await?;
+
+    let liquidity = uint!(1_000_000_000_000_000_000_U256);
+    let mut pending = vec![];
+    pending.push(user_token.mint(user_address, liquidity).send().await?);
+    pending.push(hop_token.mint(user_address, liquidity).send().await?);
+    await_receipts(&mut pending).await?;
+
+    fee_amm
+        .mint(
+            *user_token.address(),
+            *hop_token.address(),
+            liquidity,
+            user_address,
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    fee_amm
+        .mint(
+            *hop_token.address(),
+            *validator_token.address(),
+            liquidity,
+            user_address,
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    if direct_pool_exists {
+        // Present but far below any real tx fee, forcing the T5 two-hop fallback.
+        fee_amm
+            .mint(
+                *user_token.address(),
+                *validator_token.address(),
+                U256::from(3_000),
+                user_address,
+            )
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+    }
+
+    fee_manager
+        .setUserToken(*user_token.address())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let direct_before = fee_amm
+        .getPool(*user_token.address(), *validator_token.address())
+        .call()
+        .await?;
+    let first_hop_before = fee_amm
+        .getPool(*user_token.address(), *hop_token.address())
+        .call()
+        .await?;
+    let second_hop_before = fee_amm
+        .getPool(*hop_token.address(), *validator_token.address())
+        .call()
+        .await?;
+    let collected_before = fee_manager
+        .collectedFees(validator_address, *validator_token.address())
+        .call()
+        .await?;
+
+    let transfer_token = ITIP20::new(DEFAULT_FEE_TOKEN, provider.clone());
+    let receipt = transfer_token
+        .transfer(Address::random(), U256::from(1))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status());
+
+    let actual_spending = calc_gas_balance_spending(receipt.gas_used, receipt.effective_gas_price);
+    let out1 = compute_amount_out(actual_spending)?;
+    let out2 = compute_amount_out(out1)?;
+
+    let collected_after = fee_manager
+        .collectedFees(validator_address, *validator_token.address())
+        .call()
+        .await?;
+    assert_eq!(collected_after - collected_before, out2);
+
+    let direct_after = fee_amm
+        .getPool(*user_token.address(), *validator_token.address())
+        .call()
+        .await?;
+    assert_eq!(
+        direct_after.reserveUserToken,
+        direct_before.reserveUserToken
+    );
+    assert_eq!(
+        direct_after.reserveValidatorToken,
+        direct_before.reserveValidatorToken
+    );
+
+    let first_hop_after = fee_amm
+        .getPool(*user_token.address(), *hop_token.address())
+        .call()
+        .await?;
+    assert_eq!(
+        first_hop_after.reserveUserToken,
+        first_hop_before.reserveUserToken + actual_spending.to::<u128>()
+    );
+    assert_eq!(
+        first_hop_after.reserveValidatorToken,
+        first_hop_before.reserveValidatorToken - out1.to::<u128>()
+    );
+
+    let second_hop_after = fee_amm
+        .getPool(*hop_token.address(), *validator_token.address())
+        .call()
+        .await?;
+    assert_eq!(
+        second_hop_after.reserveUserToken,
+        second_hop_before.reserveUserToken + out1.to::<u128>()
+    );
+    assert_eq!(
+        second_hop_after.reserveValidatorToken,
+        second_hop_before.reserveValidatorToken - out2.to::<u128>()
+    );
 
     Ok(())
 }

--- a/crates/precompiles/src/tip_fee_manager/amm.rs
+++ b/crates/precompiles/src/tip_fee_manager/amm.rs
@@ -99,7 +99,7 @@ pub enum FeeRoute {
 }
 
 /// Pools read during planning, paired with their observed validator-token reserve.
-type PoolData = ((Address, Address), u128);
+pub type PoolData = ((Address, Address), u128);
 
 impl TipFeeManager {
     /// Returns the deterministic pool ID for a directional token pair. Note that the pool id is

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -180,37 +180,47 @@ impl TipFeeManager {
         tip20_token.transfer_fee_pre_tx(fee_payer, max_amount)?;
 
         if !skip_liquidity_check {
-            match self.plan_fee_route(user_token, validator_token, max_amount)? {
-                (None, _) => return Err(TIPFeeAMMError::insufficient_liquidity().into()),
-                (Some(FeeRoute::SameToken), _) => {}
-                (Some(FeeRoute::Direct), _) => {
-                    if self.storage.spec().is_t1c() {
-                        let amount_out: u128 = compute_amount_out(max_amount)?
-                            .try_into()
-                            .map_err(|_| TempoPrecompileError::under_overflow())?;
-                        self.reserve_pool_liquidity(
-                            self.pool_id(user_token, validator_token),
-                            amount_out,
-                        )?;
-                    }
-                }
-                (Some(FeeRoute::TwoHop(intermediate)), _) => {
-                    // T5+ implies T1C+, so reservation is always required here.
-                    let out1: u128 = compute_amount_out(max_amount)?
-                        .try_into()
-                        .map_err(|_| TempoPrecompileError::under_overflow())?;
-                    let out2: u128 = compute_amount_out(U256::from(out1))?
-                        .try_into()
-                        .map_err(|_| TempoPrecompileError::under_overflow())?;
-                    self.reserve_pool_liquidity(self.pool_id(user_token, intermediate), out1)?;
-                    self.reserve_pool_liquidity(self.pool_id(intermediate, validator_token), out2)?;
-                    self.two_hop_intermediate.t_write(intermediate)?;
-                }
-            }
+            let (route, _) = self.plan_fee_route(user_token, validator_token, max_amount)?;
+            let route = route.ok_or_else(TIPFeeAMMError::insufficient_liquidity)?;
+            self.reserve_fee_liquidity(user_token, validator_token, max_amount, route)?;
         }
 
         // Return the user's token preference
         Ok(user_token)
+    }
+
+    /// Reserves AMM liquidity needed to settle the selected fee route after transaction execution.
+    fn reserve_fee_liquidity(
+        &mut self,
+        user_token: Address,
+        validator_token: Address,
+        max_amount: U256,
+        route: FeeRoute,
+    ) -> Result<()> {
+        match route {
+            FeeRoute::SameToken => {}
+            FeeRoute::Direct if self.storage.spec().is_t1c() => {
+                let amount_out: u128 = compute_amount_out(max_amount)?
+                    .try_into()
+                    .map_err(|_| TempoPrecompileError::under_overflow())?;
+                self.reserve_pool_liquidity(self.pool_id(user_token, validator_token), amount_out)?;
+            }
+            FeeRoute::Direct => {}
+            FeeRoute::TwoHop(intermediate) => {
+                // T5+ implies T1C+, so reservation is always required here.
+                let out1: u128 = compute_amount_out(max_amount)?
+                    .try_into()
+                    .map_err(|_| TempoPrecompileError::under_overflow())?;
+                let out2: u128 = compute_amount_out(U256::from(out1))?
+                    .try_into()
+                    .map_err(|_| TempoPrecompileError::under_overflow())?;
+                self.reserve_pool_liquidity(self.pool_id(user_token, intermediate), out1)?;
+                self.reserve_pool_liquidity(self.pool_id(intermediate, validator_token), out2)?;
+                self.two_hop_intermediate.t_write(intermediate)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Finalizes fee collection after transaction execution.

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -74,11 +74,10 @@ impl AmmLiquidityCache {
         {
             let inner = self.inner.read();
             hardfork = inner.hardfork;
-            let two_hop_out = if hardfork.is_t5() {
-                Some(compute_amount_out(amount_out).map_err(ProviderError::other)?)
-            } else {
-                None
-            };
+            let two_hop_out = hardfork
+                .is_t5()
+                .then(|| compute_amount_out(amount_out).map_err(ProviderError::other))
+                .transpose()?;
 
             for &validator_token in &inner.unique_tokens {
                 // Validators always accept fees in their own token.

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -68,13 +68,13 @@ impl AmmLiquidityCache {
         let amount_out = compute_amount_out(fee).map_err(ProviderError::other)?;
 
         let mut missing_in_cache = Vec::new();
-        let current_fork;
+        let hardfork;
 
         // Hot path: decide each `(user, validator)` pair entirely from the primitive cache.
         {
             let inner = self.inner.read();
-            current_fork = inner.current_fork;
-            let two_hop_out = if current_fork.is_t5() {
+            hardfork = inner.hardfork;
+            let two_hop_out = if hardfork.is_t5() {
                 Some(compute_amount_out(amount_out).map_err(ProviderError::other)?)
             } else {
                 None
@@ -131,7 +131,7 @@ impl AmmLiquidityCache {
         // Slow path: ask the planner. Unconditionally warm all its reported `data.pools`.
         // This might race other fetches but we're OK with it.
         state_provider
-            .with_read_only_storage_ctx(current_fork, || -> TempoResult<bool> {
+            .with_read_only_storage_ctx(hardfork, || -> TempoResult<bool> {
                 let manager = TipFeeManager::new();
                 for validator_token in missing_in_cache {
                     let (route, pools) =
@@ -305,7 +305,7 @@ impl AmmLiquidityCache {
         }
 
         // Refresh the cached active hardfork from the latest seen header.
-        self.inner.write().current_fork = client.chain_spec().tempo_hardfork_at(latest_timestamp);
+        self.inner.write().hardfork = client.chain_spec().tempo_hardfork_at(latest_timestamp);
 
         Ok(())
     }
@@ -314,7 +314,7 @@ impl AmmLiquidityCache {
 #[derive(Debug, Default)]
 struct AmmLiquidityCacheInner {
     /// Hardfork active at the most recently observed canonical header.
-    current_fork: TempoHardfork,
+    hardfork: TempoHardfork,
 
     /// Cache for (user_token, validator_token) -> liquidity
     pool_cache: HashMap<(Address, Address), U256>,
@@ -519,7 +519,7 @@ mod tests {
 
         let cache = AmmLiquidityCache {
             inner: Arc::new(RwLock::new(AmmLiquidityCacheInner {
-                current_fork: TempoHardfork::T5,
+                hardfork: TempoHardfork::T5,
                 unique_tokens: vec![validator],
                 pool_cache: {
                     let mut m = HashMap::default();

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -74,6 +74,12 @@ impl AmmLiquidityCache {
         {
             let inner = self.inner.read();
             current_fork = inner.current_fork;
+            let two_hop_out = if current_fork.is_t5() {
+                Some(compute_amount_out(amount_out).map_err(ProviderError::other)?)
+            } else {
+                None
+            };
+
             for &validator_token in &inner.unique_tokens {
                 // Validators always accept fees in their own token.
                 if validator_token == user_token {
@@ -88,29 +94,25 @@ impl AmmLiquidityCache {
                     return Ok(true);
                 }
 
-                if current_fork.is_t5() {
-                    match inner.quote_token_cache.get(&user_token).copied() {
-                        Some(h) if !h.is_zero() && h != validator_token => {
-                            let r1 = inner.pool_cache.get(&(user_token, h)).copied();
-                            let r2 = inner.pool_cache.get(&(h, validator_token)).copied();
-                            let out1 = amount_out;
-                            let out2 = compute_amount_out(out1).map_err(ProviderError::other)?;
-                            match (r1, r2) {
-                                (Some(r1), Some(r2)) if r1 >= out1 && r2 >= out2 => {
-                                    return Ok(true);
-                                }
-                                (Some(_), Some(_)) => {} // Both cached and not enough liquidity.
-                                _ => {
-                                    // A leg's reserve is missing: defer.
-                                    missing_in_cache.push(validator_token);
-                                    continue;
-                                }
+                if let Some(out2) = two_hop_out {
+                    let Some(hop) = inner.quote_token_cache.get(&user_token).copied() else {
+                        missing_in_cache.push(validator_token);
+                        continue;
+                    };
+
+                    if !hop.is_zero() && hop != validator_token {
+                        let r1 = inner.pool_cache.get(&(user_token, hop)).copied();
+                        let r2 = inner.pool_cache.get(&(hop, validator_token)).copied();
+                        match (r1, r2) {
+                            (Some(r1), Some(r2)) if r1 >= amount_out && r2 >= out2 => {
+                                return Ok(true);
                             }
-                        }
-                        Some(_) => {} // Cached as zero / equal to validator: no two-hop path possible.
-                        None => {
-                            missing_in_cache.push(validator_token);
-                            continue;
+                            (Some(_), Some(_)) => {} // Both cached and not enough liquidity.
+                            _ => {
+                                // A leg's reserve is missing: defer.
+                                missing_in_cache.push(validator_token);
+                                continue;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR  extracts fee-liquidity reservation from `collect_fee_pre_tx` and simplifies the txpool AMM cache hot path. It also adds node e2e coverage for TIP-1033 two-hop settlement when the direct FeeAMM pool is missing or insufficient.

Linear: https://linear.app/tempoxyz/issue/CHAIN-1143/tip-1033-multihop-feeamm-routing
