### PR TITLE
fix(precompiles): fixed-size array packing

### DIFF
--- a/crates/precompiles-macros/src/storable_primitives.rs
+++ b/crates/precompiles-macros/src/storable_primitives.rs
@@ -347,12 +347,11 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
     } = config;
 
     // Calculate slot count at compile time
-    let slot_count = if *elem_is_packable {
-        // Packed: multiple elements per slot
-        (*array_size * elem_byte_count).div_ceil(32)
+    let slot_count_expr = if *elem_is_packable {
+        quote! { crate::storage::packing::calc_packed_slot_count(#array_size, #elem_byte_count) }
     } else {
         // Unpacked: each element uses full slots (assume 1 slot per element for primitives)
-        *array_size
+        quote! { #array_size }
     };
 
     let load_impl = if *elem_is_packable {
@@ -371,7 +370,7 @@ fn gen_array_impl(config: &ArrayConfig) -> TokenStream {
         // Implement StorableType
         impl crate::storage::StorableType for [#elem_type; #array_size] {
             // Arrays cannot be packed, so they must take full slots
-            const LAYOUT: crate::storage::Layout = crate::storage::Layout::Slots(#slot_count);
+            const LAYOUT: crate::storage::Layout = crate::storage::Layout::Slots(#slot_count_expr);
 
             type Handler = crate::storage::types::array::ArrayHandler<#elem_type, #array_size>;
 
@@ -432,7 +431,10 @@ fn gen_packed_array_load(array_size: &usize, elem_byte_count: &usize) -> TokenSt
 fn gen_packed_array_store(array_size: &usize, elem_byte_count: &usize) -> TokenStream {
     quote! {
         // Determine how many slots we need
-        let slot_count = (#array_size * #elem_byte_count).div_ceil(32);
+        let slot_count = crate::storage::packing::calc_packed_slot_count(
+            #array_size,
+            #elem_byte_count,
+        );
 
         // Build slots by packing elements
         for slot_idx in 0..slot_count {

--- a/crates/precompiles-macros/src/storable_primitives.rs
+++ b/crates/precompiles-macros/src/storable_primitives.rs
@@ -334,7 +334,7 @@ struct ArrayConfig {
 
 /// Whether a given amount of bytes (primitives only) should be packed, or not.
 fn is_packable(byte_count: usize) -> bool {
-    byte_count < 32 && 32 % byte_count == 0
+    byte_count < 32
 }
 
 /// Generate `StorableType`, `Storable`, and `StorageKey` for a fixed-size array.

--- a/crates/precompiles/src/storage/types/array.rs
+++ b/crates/precompiles/src/storage/types/array.rs
@@ -212,6 +212,7 @@ mod tests {
         storage::{Layout, LayoutCtx, PrecompileStorageProvider, StorageCtx},
         test_util::setup_storage,
     };
+    use alloy::primitives::aliases::U96;
     use proptest::prelude::*;
 
     // Strategy for generating random U256 slot values that won't overflow
@@ -354,6 +355,138 @@ mod tests {
             let loaded = slot.read().unwrap();
             assert_eq!(loaded, data, "[Address; 3] roundtrip failed");
         });
+    }
+    #[test]
+    fn u96_array_packed_layout_matches_solidity() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(450);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut handler = <[U96; 2]>::handle(base_slot, LayoutCtx::FULL, address);
+            handler.write([U96::from(1), U96::from(2)]).unwrap();
+        });
+
+        // Both elements packed in slot 0: low 12 bytes = elem 0, next 12 bytes = elem 1.
+        let expected = U256::from(1) | (U256::from(2) << 96);
+        assert_eq!(storage.sload(address, base_slot).unwrap(), expected);
+        assert_eq!(
+            storage.sload(address, base_slot + U256::ONE).unwrap(),
+            U256::ZERO
+        );
+
+        StorageCtx::enter(&mut storage, || {
+            let mut handler = <[U96; 2]>::handle(base_slot, LayoutCtx::FULL, address);
+            // Indexed read now agrees with bulk layout.
+            assert_eq!(handler.at(0).unwrap().read().unwrap(), U96::from(1));
+            assert_eq!(handler.at(1).unwrap().read().unwrap(), U96::from(2));
+
+            // Indexed write to elem 1 only modifies bytes 12..23 of slot 0.
+            handler[1].write(U96::from(3)).unwrap();
+        });
+
+        let after = U256::from(1) | (U256::from(3) << 96);
+        assert_eq!(storage.sload(address, base_slot).unwrap(), after);
+        assert_eq!(
+            storage.sload(address, base_slot + U256::ONE).unwrap(),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn u96_array_5_packed_layout_matches_solidity() {
+        let (mut storage, address) = setup_storage();
+        let base_slot = U256::from(550);
+
+        let data = [
+            U96::from(1u64),
+            U96::from(2u64),
+            U96::from(3u64),
+            U96::from(4u64),
+            U96::from(5u64),
+        ];
+
+        // LAYOUT must report 3 slots (Solidity: ceil(5/2) = 3).
+        assert_eq!(
+            <[U96; 5] as StorableType>::LAYOUT,
+            Layout::Slots(3),
+            "[U96; 5] must occupy 3 slots, not 2 (slot-count bug)"
+        );
+
+        StorageCtx::enter(&mut storage, || {
+            let mut handler = <[U96; 5]>::handle(base_slot, LayoutCtx::FULL, address);
+            handler.write(data).unwrap();
+        });
+
+        // Slot 0: elem0 in low 12 bytes, elem1 in next 12 bytes.
+        let expected_slot0 = U256::from(1) | (U256::from(2) << 96);
+        assert_eq!(
+            storage.sload(address, base_slot).unwrap(),
+            expected_slot0,
+            "slot 0 must hold packed (elem0, elem1)"
+        );
+
+        // Slot 1: elem2 + elem3 packed.
+        let expected_slot1 = U256::from(3) | (U256::from(4) << 96);
+        assert_eq!(
+            storage.sload(address, base_slot + U256::ONE).unwrap(),
+            expected_slot1,
+            "slot 1 must hold packed (elem2, elem3)"
+        );
+
+        // Slot 2: elem4 alone in low 12 bytes (this slot is missed entirely
+        // if the bulk-store loop uses the buggy `(5*12).div_ceil(32) = 2`
+        // slot-count formula).
+        assert_eq!(
+            storage
+                .sload(address, base_slot + U256::from(2u64))
+                .unwrap(),
+            U256::from(5),
+            "slot 2 must hold elem4 in low 12 bytes (slot-count formula must use \
+             ceil(N / itemsPerSlot), not (N*B).div_ceil(32))"
+        );
+
+        // Slot 3 must be untouched.
+        assert_eq!(
+            storage
+                .sload(address, base_slot + U256::from(3u64))
+                .unwrap(),
+            U256::ZERO,
+            "slot 3 must remain untouched"
+        );
+
+        // Whole-array roundtrip and per-index reads must agree with the
+        // packed layout established above.
+        StorageCtx::enter(&mut storage, || {
+            let mut handler = <[U96; 5]>::handle(base_slot, LayoutCtx::FULL, address);
+            assert_eq!(handler.read().unwrap(), data, "bulk read mismatch");
+            for (i, expected) in data.iter().enumerate() {
+                assert_eq!(
+                    handler.at(i).unwrap().read().unwrap(),
+                    *expected,
+                    "indexed read mismatch at i={i}"
+                );
+            }
+
+            // Indexed write to elem 4 must hit slot base+2 only.
+            handler[4].write(U96::from(99u64)).unwrap();
+        });
+        assert_eq!(
+            storage
+                .sload(address, base_slot + U256::from(2u64))
+                .unwrap(),
+            U256::from(99),
+            "indexed write to elem 4 must update slot base+2"
+        );
+        assert_eq!(
+            storage.sload(address, base_slot).unwrap(),
+            expected_slot0,
+            "indexed write to elem 4 must not disturb slot 0"
+        );
+        assert_eq!(
+            storage.sload(address, base_slot + U256::ONE).unwrap(),
+            expected_slot1,
+            "indexed write to elem 4 must not disturb slot 1"
+        );
     }
 
     #[test]

--- a/crates/precompiles/tests/storage_tests/solidity/primitives.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/primitives.rs
@@ -4,7 +4,10 @@
 //! storage patterns like primitive types, arrays, mappings, structs, and enums.
 
 use super::*;
-use alloy_primitives::{Address, FixedBytes};
+use alloy_primitives::{
+    Address, FixedBytes,
+    aliases::{I96, U96},
+};
 use tempo_precompiles::storage::Mapping;
 use tempo_precompiles_macros::{
     gen_test_fields_layout as layout_fields, gen_test_fields_struct as struct_fields,
@@ -60,6 +63,8 @@ fn test_arrays_layout() {
         field_b: U256,
         nested_array: [[u8; 4]; 8],
         another_nested_array: [[u16; 2]; 6],
+        u96_array5: [U96; 5],
+        i96_array5: [I96; 5],
     }
 
     let rust_layout = layout_fields!(
@@ -67,7 +72,9 @@ fn test_arrays_layout() {
         large_array,
         field_b,
         nested_array,
-        another_nested_array
+        another_nested_array,
+        u96_array5,
+        i96_array5
     );
 
     // Compare against expected layout from Solidity

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/arrays.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/arrays.layout.json
@@ -1,98 +1,136 @@
 {
-  "contracts": {
-    "tests/storage_tests/solidity/testdata/arrays.sol:Arrays": {
-      "storage-layout": {
-        "storage": [
-          {
-            "astId": 4,
-            "contract": "tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
-            "label": "fieldA",
-            "offset": 0,
-            "slot": "0",
-            "type": "t_uint256"
-          },
-          {
-            "astId": 8,
-            "contract": "tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
-            "label": "largeArray",
-            "offset": 0,
-            "slot": "1",
-            "type": "t_array(t_uint256)5_storage"
-          },
-          {
-            "astId": 10,
-            "contract": "tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
-            "label": "fieldB",
-            "offset": 0,
-            "slot": "6",
-            "type": "t_uint256"
-          },
-          {
-            "astId": 16,
-            "contract": "tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
-            "label": "nestedArray",
-            "offset": 0,
-            "slot": "7",
-            "type": "t_array(t_array(t_uint8)4_storage)8_storage"
-          },
-          {
-            "astId": 22,
-            "contract": "tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
-            "label": "anotherNestedArray",
-            "offset": 0,
-            "slot": "15",
-            "type": "t_array(t_array(t_uint16)2_storage)6_storage"
-          }
-        ],
-        "types": {
-          "t_array(t_array(t_uint16)2_storage)6_storage": {
-            "base": "t_array(t_uint16)2_storage",
-            "encoding": "inplace",
-            "label": "uint16[2][6]",
-            "numberOfBytes": "192"
-          },
-          "t_array(t_array(t_uint8)4_storage)8_storage": {
-            "base": "t_array(t_uint8)4_storage",
-            "encoding": "inplace",
-            "label": "uint8[4][8]",
-            "numberOfBytes": "256"
-          },
-          "t_array(t_uint16)2_storage": {
-            "base": "t_uint16",
-            "encoding": "inplace",
-            "label": "uint16[2]",
-            "numberOfBytes": "32"
-          },
-          "t_array(t_uint256)5_storage": {
-            "base": "t_uint256",
-            "encoding": "inplace",
-            "label": "uint256[5]",
-            "numberOfBytes": "160"
-          },
-          "t_array(t_uint8)4_storage": {
-            "base": "t_uint8",
-            "encoding": "inplace",
-            "label": "uint8[4]",
-            "numberOfBytes": "32"
-          },
-          "t_uint16": {
-            "encoding": "inplace",
-            "label": "uint16",
-            "numberOfBytes": "2"
-          },
-          "t_uint256": {
-            "encoding": "inplace",
-            "label": "uint256",
-            "numberOfBytes": "32"
-          },
-          "t_uint8": {
-            "encoding": "inplace",
-            "label": "uint8",
-            "numberOfBytes": "1"
-          }
+    "contracts": {
+        "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays": {
+            "storage-layout": {
+                "storage": [
+                    {
+                        "astId": 4,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "fieldA",
+                        "offset": 0,
+                        "slot": "0",
+                        "type": "t_uint256"
+                    },
+                    {
+                        "astId": 8,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "largeArray",
+                        "offset": 0,
+                        "slot": "1",
+                        "type": "t_array(t_uint256)5_storage"
+                    },
+                    {
+                        "astId": 10,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "fieldB",
+                        "offset": 0,
+                        "slot": "6",
+                        "type": "t_uint256"
+                    },
+                    {
+                        "astId": 16,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "nestedArray",
+                        "offset": 0,
+                        "slot": "7",
+                        "type": "t_array(t_array(t_uint8)4_storage)8_storage"
+                    },
+                    {
+                        "astId": 22,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "anotherNestedArray",
+                        "offset": 0,
+                        "slot": "15",
+                        "type": "t_array(t_array(t_uint16)2_storage)6_storage"
+                    },
+                    {
+                        "astId": 26,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "u96Array5",
+                        "offset": 0,
+                        "slot": "21",
+                        "type": "t_array(t_uint96)5_storage"
+                    },
+                    {
+                        "astId": 30,
+                        "contract": "crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol:Arrays",
+                        "label": "i96Array5",
+                        "offset": 0,
+                        "slot": "24",
+                        "type": "t_array(t_int96)5_storage"
+                    }
+                ],
+                "types": {
+                    "t_array(t_array(t_uint16)2_storage)6_storage": {
+                        "base": "t_array(t_uint16)2_storage",
+                        "encoding": "inplace",
+                        "label": "uint16[2][6]",
+                        "numberOfBytes": "192"
+                    },
+                    "t_array(t_array(t_uint8)4_storage)8_storage": {
+                        "base": "t_array(t_uint8)4_storage",
+                        "encoding": "inplace",
+                        "label": "uint8[4][8]",
+                        "numberOfBytes": "256"
+                    },
+                    "t_array(t_int96)5_storage": {
+                        "base": "t_int96",
+                        "encoding": "inplace",
+                        "label": "int96[5]",
+                        "numberOfBytes": "96"
+                    },
+                    "t_array(t_uint16)2_storage": {
+                        "base": "t_uint16",
+                        "encoding": "inplace",
+                        "label": "uint16[2]",
+                        "numberOfBytes": "32"
+                    },
+                    "t_array(t_uint256)5_storage": {
+                        "base": "t_uint256",
+                        "encoding": "inplace",
+                        "label": "uint256[5]",
+                        "numberOfBytes": "160"
+                    },
+                    "t_array(t_uint8)4_storage": {
+                        "base": "t_uint8",
+                        "encoding": "inplace",
+                        "label": "uint8[4]",
+                        "numberOfBytes": "32"
+                    },
+                    "t_array(t_uint96)5_storage": {
+                        "base": "t_uint96",
+                        "encoding": "inplace",
+                        "label": "uint96[5]",
+                        "numberOfBytes": "96"
+                    },
+                    "t_int96": {
+                        "encoding": "inplace",
+                        "label": "int96",
+                        "numberOfBytes": "12"
+                    },
+                    "t_uint16": {
+                        "encoding": "inplace",
+                        "label": "uint16",
+                        "numberOfBytes": "2"
+                    },
+                    "t_uint256": {
+                        "encoding": "inplace",
+                        "label": "uint256",
+                        "numberOfBytes": "32"
+                    },
+                    "t_uint8": {
+                        "encoding": "inplace",
+                        "label": "uint8",
+                        "numberOfBytes": "1"
+                    },
+                    "t_uint96": {
+                        "encoding": "inplace",
+                        "label": "uint96",
+                        "numberOfBytes": "12"
+                    }
+                }
+            }
         }
-      }
-    }
-  },
-  "version": "0.8.30+commit.73712a01.Darwin.appleclang"
+    },
+    "version": "0.8.34+commit.80d5c536.Darwin.appleclang"
 }

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/arrays.sol
@@ -8,4 +8,6 @@ contract Arrays {
     uint256 public fieldB; // slot 6
     uint8[4][8] public nestedArray; // slot 7-14 (8 slots)
     uint16[2][6] public anotherNestedArray; // slots 15-20 (6 slots)
+    uint96[5] public u96Array5; // slots 21-23
+    int96[5] public i96Array5; // slots 24-26
 }


### PR DESCRIPTION
## Summary

Two paired correctness bugs in `[T; N]` storage codegen for element types
where `T::BYTES <= 16` but `32 % T::BYTES != 0` (in practice: `[U96; N]`,
`[I96; N]`, and odd-sized `[FixedBytes<N>; M]`).

## The bugs

1. **Bulk and indexed paths use mismatched packing rules.**
   `storable_primitives::is_packable` required `32 % byte_count == 0`,
   excluding 12-byte types from the packed bulk path. `ArrayHandler::compute_handler`
   gates only on `T::BYTES <= 16` and uses the packed path. A bulk write
   followed by an indexed read on the same `[U96; N]` returns the wrong
   element; an indexed write mutates the wrong slot.

2. **Packed slot-count formula undercounts the trailing partial slot.**
   `(N * byte_count).div_ceil(32)` treats storage as contiguous and undercounts when
   `byte_count` does not divide 32. `[U96; 5]` reported 2 slots instead
   of 3, and the bulk-store loop dropped the final element.

Both bugs are currently dormant (no in-tree consumer of `[U96; N]` /
`[I96; N]`), but a future precompile schema using these types would hit
silent storage corruption.

## Changes

- `test`: regression tests for `[U96; 2]` (bulk-vs-indexed agreement)
  and `[U96; 5]` (slot-count formula).
- `fix`: relax `is_packable` to `byte_count < 32`, matching the trait-level
  `Layout::is_packable()` already used by indexed access.
- `fix`: route both array-codegen call sites through
  `packing::calc_packed_slot_count` (the same helper used by `Vec`/`Set`).
