### PR TITLE
feat(consensus): track finalized blocks proposed by node

### DIFF
--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -181,6 +181,7 @@ where
                 last_finalized_height,
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
+                public_key: self.signer.public_key(),
             },
         )
         .wrap_err("failed initialization executor actor")?;

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -181,7 +181,7 @@ where
                 last_finalized_height,
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
-                public_key: self.signer.public_key(),
+                public_key: Some(self.signer.public_key()),
             },
         )
         .wrap_err("failed initialization executor actor")?;

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -8,9 +8,9 @@ use std::{ops::RangeInclusive, pin::Pin, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
-
+use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{
-    Clock, ContextCell, FutureExt, Handle, Metrics, Pacer, Spawner, spawn_cell,
+    Clock, ContextCell, FutureExt, Handle, Pacer, Spawner, spawn_cell,
 };
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
 use eyre::{Report, WrapErr as _, ensure};
@@ -23,6 +23,7 @@ use futures::{
     future::{BoxFuture, Ready, ready},
     stream::FuturesOrdered,
 };
+use prometheus_client::metrics::counter::Counter;
 use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
 use reth_provider::BlockNumReader as _;
 use tempo_node::{TempoExecutionData, TempoFullNode};
@@ -137,11 +138,39 @@ pub(crate) struct Actor<TContext> {
     pending_finalizations: FuturesOrdered<Ready<(Span, Block, Exact)>>,
 
     latest_observed_finalized_tip: Option<(Height, Digest)>,
+
+    /// The node's ed25519 public key.
+    public_key: PublicKey,
+
+    metrics: Metrics,
+}
+
+#[derive(Clone)]
+struct Metrics {
+    /// Number of finalized blocks whose proposer matches this node's public key.
+    finalized_blocks_proposed_by_self: Counter,
+}
+
+impl Metrics {
+    fn init<TContext>(context: &TContext) -> Self
+    where
+        TContext: commonware_runtime::Metrics,
+    {
+        let finalized_blocks_proposed_by_self = Counter::default();
+        context.register(
+            "finalized_blocks_proposed_by_self",
+            "number of finalized blocks whose proposer matches this node's public key",
+            finalized_blocks_proposed_by_self.clone(),
+        );
+        Self {
+            finalized_blocks_proposed_by_self,
+        }
+    }
 }
 
 impl<TContext> Actor<TContext>
 where
-    TContext: Clock + Metrics + Pacer + Spawner,
+    TContext: Clock + commonware_runtime::Metrics + Pacer + Spawner,
 {
     pub(super) fn init(
         context: TContext,
@@ -153,7 +182,9 @@ where
             last_finalized_height,
             marshal,
             fcu_heartbeat_interval,
+            public_key,
         } = config;
+        let metrics = Metrics::init(&context);
         let last_execution_finalized_height = execution_node
             .provider
             .last_block_number()
@@ -193,6 +224,9 @@ where
             pending_finalizations: FuturesOrdered::new(),
 
             latest_observed_finalized_tip: None,
+
+            public_key,
+            metrics,
         })
     }
 
@@ -542,6 +576,7 @@ where
             .and_then(|res| res)?;
 
         let block = block.into_inner();
+        let consensus_context = block.header().consensus_context;
         let payload_status = self
             .execution_node
             .add_ons_handle
@@ -563,6 +598,13 @@ where
             "this is a problem: payload status of block-to-be-finalized was \
             neither valid nor syncing: `{payload_status}`"
         );
+
+        if let Some(ctx) = consensus_context {
+            let proposer: PublicKey = ctx.proposer.get().into();
+            if proposer == self.public_key {
+                self.metrics.finalized_blocks_proposed_by_self.inc();
+            }
+        }
 
         acknowledgment.acknowledge();
 

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -137,8 +137,9 @@ pub(crate) struct Actor<TContext> {
 
     latest_observed_finalized_tip: Option<(Height, Digest)>,
 
-    /// The node's ed25519 public key.
-    public_key: PublicKey,
+    /// The node's ed25519 public key if the node is participating in
+    /// consensus. Not set if not, for example for followers.
+    public_key: Option<PublicKey>,
 
     metrics: Metrics,
 }
@@ -597,11 +598,11 @@ where
             neither valid nor syncing: `{payload_status}`"
         );
 
-        if let Some(ctx) = consensus_context {
-            let proposer: PublicKey = ctx.proposer.get().into();
-            if proposer == self.public_key {
-                self.metrics.finalized_blocks_proposed_by_self.inc();
-            }
+        if let Some(public_key) = self.public_key.as_ref()
+            && consensus_context
+                .is_some_and(|context| &PublicKey::from(context.proposer.get()) == public_key)
+        {
+            self.metrics.finalized_blocks_proposed_by_self.inc();
         }
 
         acknowledgment.acknowledge();

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -9,9 +9,7 @@ use std::{ops::RangeInclusive, pin::Pin, sync::Arc, time::Duration};
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
 use commonware_cryptography::ed25519::PublicKey;
-use commonware_runtime::{
-    Clock, ContextCell, FutureExt, Handle, Pacer, Spawner, spawn_cell,
-};
+use commonware_runtime::{Clock, ContextCell, FutureExt, Handle, Pacer, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
 use eyre::{Report, WrapErr as _, ensure};
 use futures::{

--- a/crates/commonware-node/src/executor/mod.rs
+++ b/crates/commonware-node/src/executor/mod.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use commonware_consensus::types::Height;
+use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{Clock, Metrics, Pacer, Spawner};
 
 mod actor;
@@ -43,4 +44,8 @@ pub(crate) struct Config {
     /// The interval at which to send a forkchoice update heartbeat to the
     /// execution layer.
     pub(crate) fcu_heartbeat_interval: std::time::Duration,
+
+    /// The node's ed25519 public key. Used to track how many finalized blocks
+    /// were proposed by this node.
+    pub(crate) public_key: PublicKey,
 }

--- a/crates/commonware-node/src/executor/mod.rs
+++ b/crates/commonware-node/src/executor/mod.rs
@@ -45,7 +45,7 @@ pub(crate) struct Config {
     /// execution layer.
     pub(crate) fcu_heartbeat_interval: std::time::Duration,
 
-    /// The node's ed25519 public key. Used to track how many finalized blocks
-    /// were proposed by this node.
-    pub(crate) public_key: PublicKey,
+    /// The node's ed25519 public key if the node is participating in
+    /// consensus. Not set if not, for example for followers.
+    pub(crate) public_key: Option<PublicKey>,
 }

--- a/crates/commonware-node/src/follow/engine.rs
+++ b/crates/commonware-node/src/follow/engine.rs
@@ -168,6 +168,7 @@ impl<TUpstream> Config<TUpstream> {
                 last_finalized_height,
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
+                public_key: None,
             },
         )
         .wrap_err("failed to initialize executor")?;


### PR DESCRIPTION
Adds a new metric `consensus_engine_executor_finalized_blocks_proposed_by_self`, which is counting how many finalized blocks were proposed by this node (and subsequently processed).