### PR TITLE
chore(binary): remove fee recipient CLI arg

### DIFF
--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -467,15 +467,6 @@ fn main() -> eyre::Result<()> {
                     .wrap_err("failed to start Prometheus metrics exporter")?;
                 }
 
-                if args.consensus.fee_recipient.is_some() {
-                    warn!(
-                        "`--consensus.fee-recipient` is deprecated and will be \
-                         removed. It is only used pre-T2 hardfork, if validator \
-                         config v2 is not yet activated, or if the on-chain fee \
-                         recipient is set to the zero address",
-                    );
-                }
-
                 let consensus_stack =
                     run_consensus_stack(&ctx, args.consensus, node, cl_feed_state_clone);
                 tokio::pin!(consensus_stack);

--- a/crates/commonware-node/src/args.rs
+++ b/crates/commonware-node/src/args.rs
@@ -56,12 +56,6 @@ pub struct Args {
     #[arg(long = "consensus.deque-size", default_value_t = 10)]
     pub deque_size: usize,
 
-    /// Deprecated: the fee recipient is now read from the validator config v2
-    /// contract. This value is used as a fallback when the on-chain fee
-    /// recipient is `Address::ZERO` or when the v2 contract is not yet active.
-    #[arg(long = "consensus.fee-recipient")]
-    pub fee_recipient: Option<alloy_primitives::Address>,
-
     /// The amount of time to wait for a peer to respond to a consensus request.
     #[arg(long = "consensus.wait-for-peer-response", default_value = "2s")]
     pub wait_for_peer_response: PositiveDuration,

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -586,9 +586,6 @@ impl Inner<Init> {
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
         let attrs = TempoPayloadAttributes::new(
-            // The block beneficiary is overridden by the validator config v2
-            // contract; the suggested fee recipient here is just a placeholder.
-            alloy_primitives::Address::ZERO,
             Some(proposer_public_key),
             timestamp,
             timestamp_millis_part,

--- a/crates/commonware-node/src/consensus/application/actor.rs
+++ b/crates/commonware-node/src/consensus/application/actor.rs
@@ -97,7 +97,6 @@ where
 
             inner: Inner {
                 public_key: config.public_key,
-                fee_recipient: config.fee_recipient,
                 epoch_strategy: config.epoch_strategy,
 
                 payload_resolve_time: config.payload_resolve_time,
@@ -200,7 +199,6 @@ where
 #[derive(Clone)]
 struct Inner<TState> {
     public_key: PublicKey,
-    fee_recipient: Option<alloy_primitives::Address>,
     epoch_strategy: FixedEpocher,
     payload_resolve_time: Duration,
     payload_return_time: Duration,
@@ -588,7 +586,9 @@ impl Inner<Init> {
         let parent_hash = parent.block_hash();
         let proposer_public_key = crate::utils::public_key_to_b256(&self.public_key);
         let attrs = TempoPayloadAttributes::new(
-            self.fee_recipient.unwrap_or_default(),
+            // The block beneficiary is overridden by the validator config v2
+            // contract; the suggested fee recipient here is just a placeholder.
+            alloy_primitives::Address::ZERO,
             Some(proposer_public_key),
             timestamp,
             timestamp_millis_part,
@@ -805,7 +805,6 @@ impl Inner<Uninit> {
     ) -> eyre::Result<Inner<Init>> {
         let initialized = Inner {
             public_key: self.public_key,
-            fee_recipient: self.fee_recipient,
             epoch_strategy: self.epoch_strategy,
             payload_resolve_time: self.payload_resolve_time,
             payload_return_time: self.payload_return_time,

--- a/crates/commonware-node/src/consensus/application/mod.rs
+++ b/crates/commonware-node/src/consensus/application/mod.rs
@@ -42,10 +42,6 @@ pub(super) struct Config<TContext> {
     /// the validator config v2 contract.
     pub(super) public_key: PublicKey,
 
-    /// Deprecated CLI fallback for the fee recipient. Used when the on-chain
-    /// fee recipient is `Address::ZERO` or the V2 contract is not yet active.
-    pub(super) fee_recipient: Option<alloy_primitives::Address>,
-
     /// Number of messages from consensus to hold in our backlog
     /// before blocking.
     pub(super) mailbox_size: usize,

--- a/crates/commonware-node/src/consensus/engine.rs
+++ b/crates/commonware-node/src/consensus/engine.rs
@@ -69,8 +69,6 @@ const MAX_PENDING_ACKS: NonZeroUsize = NZUsize!(1);
 // because there doesn't really seem to be a point putting it into an extra initializer.
 #[derive(Clone)]
 pub struct Builder<TBlocker, TPeerManager> {
-    pub fee_recipient: Option<alloy_primitives::Address>,
-
     pub execution_node: Option<TempoFullNode>,
 
     pub blocker: TBlocker,
@@ -329,7 +327,10 @@ where
                 signer: self.signer.clone(),
                 scheme_provider: scheme_provider.clone(),
                 node: execution_node.clone(),
-                fee_recipient: self.fee_recipient.unwrap_or_default(),
+                // TODO: subblocks are currently dead; hardcode the recipient to
+                // zero until this is wired through V2 or the subblocks logic is
+                // replaced.
+                fee_recipient: alloy_primitives::Address::ZERO,
                 time_to_build_subblock: self.time_to_build_subblock,
                 subblock_broadcast_interval: self.subblock_broadcast_interval,
                 epoch_strategy: epoch_strategy.clone(),
@@ -347,7 +348,6 @@ where
         let (application, application_mailbox) = application::init(super::application::Config {
             context: context.with_label("application"),
             public_key: self.signer.public_key(),
-            fee_recipient: self.fee_recipient,
             mailbox_size: self.mailbox_size,
             marshal: marshal_mailbox.clone(),
             execution_node: execution_node.clone(),

--- a/crates/commonware-node/src/lib.rs
+++ b/crates/commonware-node/src/lib.rs
@@ -86,8 +86,6 @@ pub async fn run_consensus_stack(
     let subblocks = network.register(SUBBLOCKS_CHANNEL_IDENT, SUBBLOCKS_LIMIT, message_backlog);
 
     let consensus_engine = crate::consensus::engine::Builder {
-        fee_recipient: config.fee_recipient,
-
         execution_node: Some(execution_node),
         blocker: oracle.clone(),
         peer_manager: oracle.clone(),

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -302,7 +302,6 @@ pub async fn setup_validators(
         execution_config.feed_state = Some(feed_state.clone());
 
         let engine_config = consensus::Builder {
-            fee_recipient: None,
             execution_node: None,
             blocker: oracle.control(private_key.public_key()),
             peer_manager: oracle.socket_manager(),

--- a/crates/e2e/src/tests/fee_recipient.rs
+++ b/crates/e2e/src/tests/fee_recipient.rs
@@ -11,7 +11,6 @@ use crate::{Setup, setup_validators};
 
 const ORIGINAL_FEE_RECIPIENT: Address = Address::new([0xFE; 20]);
 const UPDATED_FEE_RECIPIENT: Address = Address::new([0xAB; 20]);
-const FALLBACK_FEE_RECIPIENT: Address = Address::new([0xCC; 20]);
 
 /// Verifies that the block beneficiary follows the on-chain V2 fee recipient
 /// across a `setFeeRecipient` update.
@@ -74,72 +73,6 @@ fn block_beneficiary_follows_v2_fee_recipient() {
         assert_eq!(
             block.header.inner.beneficiary, UPDATED_FEE_RECIPIENT,
             "block {target} beneficiary should be the updated fee recipient",
-        );
-    });
-}
-
-/// Verifies that when the on-chain fee recipient is set to `Address::ZERO`,
-/// the node falls back to the CLI-configured fee recipient.
-#[test_traced]
-fn falls_back_to_cli_fee_recipient_when_onchain_is_zero() {
-    let _ = tempo_eyre::install();
-
-    let setup = Setup::new()
-        .how_many_signers(1)
-        .epoch_length(100)
-        .fee_recipient(ORIGINAL_FEE_RECIPIENT)
-        .seed(0);
-
-    let cfg = deterministic::Config::default().with_seed(setup.seed);
-    let executor = deterministic::Runner::from(cfg);
-
-    executor.start(|mut context| async move {
-        let (mut nodes, execution_runtime) = setup_validators(&mut context, setup).await;
-        nodes[0].consensus_config_mut().fee_recipient = Some(FALLBACK_FEE_RECIPIENT);
-        join_all(nodes.iter_mut().map(|node| node.start(&context))).await;
-
-        let http_url = nodes[0]
-            .execution()
-            .rpc_server_handle()
-            .http_url()
-            .unwrap()
-            .parse()
-            .unwrap();
-
-        let receipt = execution_runtime
-            .set_fee_recipient_v2(http_url, 0, Address::ZERO)
-            .await
-            .unwrap();
-        let change_height = receipt.block_number.unwrap();
-
-        let mut canonical_events = nodes[0].execution().provider.canonical_state_stream();
-        let target = change_height + 1;
-        while let Some(event) = canonical_events.next().await {
-            if event.committed().tip().number() >= target {
-                break;
-            }
-        }
-
-        let provider = nodes[0].execution_provider();
-
-        for height in 1..=change_height {
-            let block = provider
-                .block_by_number(height)
-                .expect("provider error")
-                .unwrap_or_else(|| panic!("block {height} not found"));
-            assert_eq!(
-                block.header.inner.beneficiary, ORIGINAL_FEE_RECIPIENT,
-                "block {height} beneficiary should be the original fee recipient",
-            );
-        }
-
-        let block = provider
-            .block_by_number(target)
-            .expect("provider error")
-            .unwrap_or_else(|| panic!("block {target} not found"));
-        assert_eq!(
-            block.header.inner.beneficiary, FALLBACK_FEE_RECIPIENT,
-            "block {target} beneficiary should fall back to CLI fee recipient",
         );
     });
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use alloy_primitives::B256;
-use reth_evm::revm::primitives::Address;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
     PayloadAttributesBuilder, PayloadTypes,
@@ -320,7 +319,6 @@ impl PayloadAttributesBuilder<TempoPayloadAttributes, TempoHeader>
 
         let (timestamp, timestamp_millis_part) = (millis / 1000, millis % 1000);
         TempoPayloadAttributes::new(
-            Address::ZERO,
             None,
             timestamp,
             timestamp_millis_part,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1081,7 +1081,6 @@ mod tests {
         let extra_data = Bytes::from(vec![42, 43, 44, 45, 46]);
 
         let attrs = TempoPayloadAttributes::new(
-            Address::default(),
             None,
             1,
             0,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1080,14 +1080,7 @@ mod tests {
         // Test that extra_data in attributes can be accessed correctly
         let extra_data = Bytes::from(vec![42, 43, 44, 45, 46]);
 
-        let attrs = TempoPayloadAttributes::new(
-            None,
-            1,
-            0,
-            extra_data.clone(),
-            None,
-            Vec::new,
-        );
+        let attrs = TempoPayloadAttributes::new(None, 1, 0, extra_data.clone(), None, Vec::new);
 
         assert_eq!(attrs.extra_data(), &extra_data);
 

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -70,8 +70,11 @@ impl Default for TempoPayloadAttributes {
 
 impl TempoPayloadAttributes {
     /// Creates new `TempoPayloadAttributes` with `inner` attributes.
+    ///
+    /// The inner `suggested_fee_recipient` is always `Address::ZERO`; the
+    /// real beneficiary is resolved from the validator config v2 contract by
+    /// the payload builder.
     pub fn new(
-        suggested_fee_recipient: Address,
         proposer_public_key: Option<B256>,
         timestamp: u64,
         timestamp_millis_part: u64,
@@ -82,7 +85,7 @@ impl TempoPayloadAttributes {
         Self {
             inner: EthPayloadAttributes {
                 timestamp,
-                suggested_fee_recipient,
+                suggested_fee_recipient: Address::ZERO,
                 prev_randao: B256::ZERO,
                 withdrawals: Some(Default::default()),
                 parent_beacon_block_root: Some(B256::ZERO),
@@ -216,7 +219,6 @@ mod tests {
     impl TestExt for TempoPayloadAttributes {
         fn random() -> Self {
             Self::new(
-                Address::random(),
                 None,
                 1, // 1s
                 0,
@@ -271,12 +273,10 @@ mod tests {
     #[test]
     fn test_builder_attributes_construction() {
         let parent = B256::random();
-        let recipient = Address::random();
         let extra_data = Bytes::from(vec![1, 2, 3, 4, 5]);
 
         // With extra_data
         let attrs = TempoPayloadAttributes::new(
-            recipient,
             None,
             1,
             500, // 1.5s
@@ -285,7 +285,7 @@ mod tests {
             Vec::new,
         );
         assert_eq!(attrs.extra_data(), &extra_data);
-        assert_eq!(attrs.suggested_fee_recipient, recipient);
+        assert_eq!(attrs.suggested_fee_recipient, Address::ZERO);
         assert_eq!(
             attrs.payload_id(&parent),
             payload_id_from_block_hash(&parent)
@@ -300,7 +300,6 @@ mod tests {
 
         // Without extra_data
         let attrs2 = TempoPayloadAttributes::new(
-            recipient,
             None,
             2, // +500ms
             0,

--- a/xtask/src/generate_localnet.rs
+++ b/xtask/src/generate_localnet.rs
@@ -1,6 +1,5 @@
 use std::{net::SocketAddr, path::PathBuf};
 
-use alloy_primitives::Address;
 use eyre::{OptionExt as _, WrapErr as _, ensure};
 use rand_08::SeedableRng as _;
 use reth_network_peers::pk2id;
@@ -174,8 +173,7 @@ impl GenerateLocalnet {
                 \\\n--port {execution_p2p_port} \
                 \\\n--discovery.port {execution_p2p_port} \
                 \\\n--p2p-secret-key {execution_p2p_secret_key} \
-                \\\n--authrpc.port {authrpc_port} \
-                \\\n--consensus.fee-recipient {fee_recipient}",
+                \\\n--authrpc.port {authrpc_port}",
                 signing_key = signing_key_dst.display(),
                 signing_share = signing_share_dst.display(),
                 listen_port = config.consensus_p2p_port,
@@ -185,7 +183,6 @@ impl GenerateLocalnet {
                 trusted_peers = trusted_peers.join(","),
                 execution_p2p_port = config.execution_p2p_port,
                 execution_p2p_secret_key = enode_key_dst.display(),
-                fee_recipient = Address::ZERO,
                 authrpc_port = config.execution_p2p_port + 2,
             );
             println!("{cmd}\n\n");


### PR DESCRIPTION
Removes the `--consensus.fee-recipient` CLI argument. Fee recipients are now expected to be configured via the V2 smart contract only.

The `suggested_fee_recipient` argument was removed from `TempoPayloadAttributes` because it is never used.

The fee recipient plumbing is not connected to the subblocks smart contract. For the time being, all fee recipients will be set to `Address::ZERO` until the subblocks mechanism is reworked (currently disabled on mainnet).