### PR TITLE
feat(payload): derive payload ID from parent and consensus context

### DIFF
--- a/crates/payload/types/Cargo.toml
+++ b/crates/payload/types/Cargo.toml
@@ -27,4 +27,5 @@ derive_more.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
+tempo-primitives = { workspace = true, features = ["arbitrary", "reth-codec", "serde"] }
 serde_json.workspace = true

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes, Keccak256};
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
@@ -167,7 +167,12 @@ impl PayloadAttributes for TempoPayloadAttributes {
         // the consensus engine will kill the proposal task. Then eventually
         // consensus will circle back to an earlier node, which then
         // has the chance of picking up the old payload.
-        payload_id_from_block_hash(parent_hash)
+        //
+        // The consensus context (epoch, view, parent_view, proposer) is
+        // mixed into the ID so that distinct consensus rounds proposing on
+        // the same parent block produce distinct payload IDs and do not
+        // collide in the payload builder cache.
+        payload_id_from_parent_and_context(parent_hash, self.consensus_context.as_ref())
     }
 
     fn timestamp(&self) -> u64 {
@@ -195,6 +200,35 @@ fn payload_id_from_block_hash(block_hash: &B256) -> PayloadId {
     )
 }
 
+/// Constructs a [`PayloadId`] from the parent block hash and consensus context.
+///
+/// When `consensus_context` is `None`, this is equivalent to
+/// [`payload_id_from_block_hash`] for backwards compatibility with pre-fork
+/// blocks. Otherwise the parent hash and each field of the consensus context
+/// are streamed into a Keccak256 hasher and the first 8 bytes of the digest
+/// form the ID.
+fn payload_id_from_parent_and_context(
+    parent_hash: &B256,
+    consensus_context: Option<&TempoConsensusContext>,
+) -> PayloadId {
+    let Some(ctx) = consensus_context else {
+        return payload_id_from_block_hash(parent_hash);
+    };
+
+    let mut hasher = Keccak256::new();
+    hasher.update(parent_hash);
+    hasher.update(ctx.epoch.to_be_bytes());
+    hasher.update(ctx.view.to_be_bytes());
+    hasher.update(ctx.parent_view.to_be_bytes());
+    hasher.update(B256::from(&ctx.proposer));
+    let digest = hasher.finalize();
+
+    PayloadId::new(
+        <[u8; 8]>::try_from(&digest[0..8])
+            .expect("a 32 byte array always has more than 8 bytes"),
+    )
+}
+
 fn default_subblocks() -> Arc<dyn Fn() -> Vec<RecoveredSubBlock> + Send + Sync + 'static> {
     Arc::new(Vec::new)
 }
@@ -203,6 +237,7 @@ fn default_subblocks() -> Arc<dyn Fn() -> Vec<RecoveredSubBlock> + Send + Sync +
 mod tests {
     use super::*;
     use alloy_rpc_types_eth::Withdrawal;
+    use tempo_primitives::ed25519::PublicKey;
 
     trait TestExt: Sized {
         fn random() -> Self;
@@ -496,5 +531,75 @@ mod tests {
         };
         assert!(attrs_none.withdrawals().is_none());
         assert!(attrs_none.parent_beacon_block_root().is_none());
+    }
+
+    #[test]
+    fn payload_id_includes_consensus_context() {
+        let parent = B256::random();
+        let proposer = PublicKey::from_seed([0xab; 32]);
+
+        let mk = |ctx: Option<TempoConsensusContext>| -> PayloadId {
+            let mut attrs = TempoPayloadAttributes::random();
+            attrs.consensus_context = ctx;
+            attrs.payload_id(&parent)
+        };
+
+        let no_ctx = mk(None);
+        let ctx_a = mk(Some(TempoConsensusContext {
+            epoch: 1,
+            view: 1,
+            parent_view: 0,
+            proposer,
+        }));
+        let ctx_b = mk(Some(TempoConsensusContext {
+            epoch: 1,
+            view: 2,
+            parent_view: 1,
+            proposer,
+        }));
+        let ctx_c = mk(Some(TempoConsensusContext {
+            epoch: 2,
+            view: 1,
+            parent_view: 0,
+            proposer,
+        }));
+        let ctx_d = mk(Some(TempoConsensusContext {
+            epoch: 1,
+            view: 1,
+            parent_view: 0,
+            proposer: PublicKey::from_seed([0xcd; 32]),
+        }));
+
+        // Without context, falls back to parent-hash-only ID.
+        assert_eq!(no_ctx, payload_id_from_block_hash(&parent));
+
+        // Each distinct consensus context produces a distinct ID, and all
+        // differ from the no-context fallback.
+        let ids = [no_ctx, ctx_a, ctx_b, ctx_c, ctx_d];
+        for i in 0..ids.len() {
+            for j in (i + 1)..ids.len() {
+                assert_ne!(ids[i], ids[j], "payload ids {i} and {j} collide");
+            }
+        }
+
+        // Same context on the same parent is deterministic.
+        let ctx_a_again = mk(Some(TempoConsensusContext {
+            epoch: 1,
+            view: 1,
+            parent_view: 0,
+            proposer,
+        }));
+        assert_eq!(ctx_a, ctx_a_again);
+
+        // Different parent with the same context yields a different ID.
+        let other_parent = B256::random();
+        let mut attrs = TempoPayloadAttributes::random();
+        attrs.consensus_context = Some(TempoConsensusContext {
+            epoch: 1,
+            view: 1,
+            parent_view: 0,
+            proposer,
+        });
+        assert_ne!(attrs.payload_id(&parent), attrs.payload_id(&other_parent));
     }
 }

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -224,8 +224,7 @@ fn payload_id_from_parent_and_context(
     let digest = hasher.finalize();
 
     PayloadId::new(
-        <[u8; 8]>::try_from(&digest[0..8])
-            .expect("a 32 byte array always has more than 8 bytes"),
+        <[u8; 8]>::try_from(&digest[0..8]).expect("a 32 byte array always has more than 8 bytes"),
     )
 }
 


### PR DESCRIPTION
Considers consensus context when constructing a payload ID. Because reth is caching payloads by their IDs, ignoring consensus context would mean that the execution layer might return a payload with the wrong context, which would subsequently be ignored.

PR https://github.com/tempoxyz/tempo/pull/3751 proactively cancels ongoing payload builds when a view is cancelled. However, there is still a race between a new build request and cancellation of the old one, which can lead to conflicts.