### PR TITLE
chore: remove --consensus.fee-recipient from tempo.nu

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -1394,7 +1394,6 @@ def build-consensus-args [node_dir: string, trusted_peers: string, port: int] {
         "--discovery.v5.port" $"($discv5_port)"
         "--p2p-secret-key" $enode_key
         "--authrpc.port" $"($authrpc_port)"
-        "--consensus.fee-recipient" "0x0000000000000000000000000000000000000000"
         "--consensus.use-local-defaults"
         "--consensus.bypass-ip-check"
     ]


### PR DESCRIPTION
Follow-up to #3817 — the CLI arg was removed from the binary, so drop it from the localnet helper script as well.