### PR TITLE
feat(builder): enable suppress persistence during payload builds

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -217,6 +217,8 @@ fn init_engine_defaults() {
         //
         // This setting allows reth to process payload attributes even if `headBlockHash` is an ancestor of the canonical tip.
         .with_always_process_payload_attributes_on_canonical_head(true)
+        // Defer persistence I/O during active payload builds.
+        .with_suppress_persistence_during_build(true)
         .try_init()
         .expect("failed to initialize engine defaults");
 }

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -888,6 +888,8 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
             c.network.discovery.disable_discovery = true;
             c.network = c.network.with_unused_ports();
             c.network.p2p_secret_key_hex = Some(secret_key);
+            // Match Tempo's engine default for nodes launched by tests.
+            c.engine.suppress_persistence_during_build = true;
             c.engine.share_sparse_trie_with_payload_builder =
                 share_sparse_trie_with_payload_builder;
             c


### PR DESCRIPTION
Tempo now enables `suppress_persistence_during_build` in its engine defaults so payload construction defers persistence I/O by default.