### PR TITLE
TIP-1035: clarify StablecoinDEX switches from transfer_from to system_transfer_from

### DIFF
--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -72,7 +72,9 @@ This function returns `true` if and only if `addr` is on the Implicit Approval L
 | Address | Contract | Rationale |
 |---------|----------|-----------|
 | `0xfeEC000000000000000000000000000000000000` | TipFeeManager (FeeAMM) | Already relies on `system_transfer_from` for fee collection and liquidity operations |
-| `0xDEc0000000000000000000000000000000000000` | StablecoinDEX | Switches from `transfer_from` to `system_transfer_from`, removing redundant approvals for DEX order placement and swap flows |
+| `0xDEc0000000000000000000000000000000000000` | StablecoinDEX | Removes redundant approvals for DEX order placement and swap flows |
+
+With this TIP activation, `StablecoinDEX` MUST switch from using `transfer_from` to `system_transfer_from`.
 
 ## Security Model
 

--- a/tips/tip-1035.md
+++ b/tips/tip-1035.md
@@ -72,7 +72,7 @@ This function returns `true` if and only if `addr` is on the Implicit Approval L
 | Address | Contract | Rationale |
 |---------|----------|-----------|
 | `0xfeEC000000000000000000000000000000000000` | TipFeeManager (FeeAMM) | Already relies on `system_transfer_from` for fee collection and liquidity operations |
-| `0xDEc0000000000000000000000000000000000000` | StablecoinDEX | Removes redundant approvals for DEX order placement and swap flows |
+| `0xDEc0000000000000000000000000000000000000` | StablecoinDEX | Switches from `transfer_from` to `system_transfer_from`, removing redundant approvals for DEX order placement and swap flows |
 
 ## Security Model
 


### PR DESCRIPTION
Clarifies in the Initial List table that StablecoinDEX switches from `transfer_from` to `system_transfer_from` as part of TIP-1035.