### PR TITLE
deps: update reth from main (2026-05-11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
+source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fcc6530#fcc65301e96fa4e67886edc31793f0a951e0003c"
+source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "72bc95fd73591644f0022065bef3c027d1a5ed875a53cb19a898d71a00818c1d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -313,6 +313,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4187,7 +4188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8321,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,9 +8576,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8588,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9014,6 +9016,7 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "revm-primitives",
+ "revm-state",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -9024,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,9 +9682,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",
@@ -9702,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=194ece2#194ece23c3e9b03a26042ea887246d359e4fc47e"
+source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11466,7 +11470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11546,7 +11550,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12441,7 +12445,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14457,7 +14461,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,7 +8321,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8400,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8413,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8575,7 +8575,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8601,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8654,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9117,7 +9117,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "clap",
  "eyre",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9247,7 +9247,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9276,7 +9276,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9424,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "serde",
  "serde_json",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "bytes",
  "futures",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "bindgen",
  "cc",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "futures",
  "metrics",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9596,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "bytes",
  "eyre",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10022,7 +10022,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10124,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10201,7 +10201,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10402,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10527,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10624,7 +10624,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10666,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10686,7 +10686,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10791,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "clap",
  "eyre",
@@ -10810,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "clap",
  "eyre",
@@ -10828,7 +10828,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10899,7 +10899,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b3262d4#b3262d466fa204667835330af2744372ef646f81"
+source = "git+https://github.com/paradigmxyz/reth?rev=02d1776#02d1776786abc61721ae8876898ad19a702e0070"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8507,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "clap",
  "eyre",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "bytes",
  "futures",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "bindgen",
  "cc",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "futures",
  "metrics",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "bytes",
  "eyre",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10205,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10236,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10313,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10406,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10748,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "clap",
  "eyre",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "clap",
  "eyre",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=deb1526#deb1526d484a7dcea2a0529423fb2356ca1a9591"
+source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "194ece2", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "deb1526", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fcc6530", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b3262d4", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "02d1776", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -441,6 +441,9 @@ async fn run_p2p_network(
             IncomingEthRequest::GetBlockAccessLists { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
             }
+            IncomingEthRequest::GetCells { response, .. } => {
+                let _ = response.send(Ok(Default::default()));
+            }
         }
     }
 

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -25,7 +25,7 @@ use commonware_utils::ordered;
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::{StreamExt, future::BoxFuture};
 use reth_chainspec::EthChainSpec;
-use reth_db::mdbx::{DatabaseEnv, GIGABYTE};
+use reth_db::mdbx::DatabaseEnv;
 use reth_ethereum::{
     evm::{
         primitives::EvmEnv,
@@ -843,12 +843,14 @@ pub fn genesis() -> Genesis {
     serde_json::from_str(include_str!("../../node/tests/assets/test-genesis.json")).unwrap()
 }
 
-/// Returns MDBX DB args sized for tests (1 GB max instead of 8 TB).
+/// Returns MDBX DB args sized for tests (64 MB max with 4 MB growth step).
 ///
-/// The default 8 TB geometry exhausts process virtual-address space when
-/// many databases are open concurrently across parallel test threads.
+/// The default 8 TB geometry with 4 GB growth step both exhausts process
+/// virtual-address space when many databases are open concurrently across
+/// parallel test threads, and pre-allocates multi-GB files on disk that
+/// can fill the CI runner's disk.
 pub fn test_db_args() -> reth_db::mdbx::DatabaseArguments {
-    reth_db::mdbx::DatabaseArguments::default().with_geometry_max_size(Some(GIGABYTE))
+    reth_db::mdbx::DatabaseArguments::test()
 }
 
 /// Launches a tempo execution node.

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -1,6 +1,8 @@
 //! A testing node that can start and stop both consensus and execution layers.
 
-use crate::execution_runtime::{self, ExecutionNode, ExecutionNodeConfig, ExecutionRuntimeHandle};
+use crate::execution_runtime::{
+    self, ExecutionNode, ExecutionNodeConfig, ExecutionRuntimeHandle, test_db_args,
+};
 use alloy_primitives::{Address, B256};
 use commonware_cryptography::{
     Signer as _,
@@ -9,7 +11,7 @@ use commonware_cryptography::{
 use commonware_p2p::simulated::{Control, Oracle, SocketManager};
 use commonware_runtime::{Handle, Metrics as _, deterministic::Context};
 use reth_config::config::StageConfig;
-use reth_db::{Database, DatabaseEnv, mdbx::DatabaseArguments, open_db_read_only};
+use reth_db::{Database, DatabaseEnv, open_db_read_only};
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_ethereum::{
     consensus::noop::NoopConsensus,
@@ -225,7 +227,7 @@ where
         if self.execution_database.is_none() {
             let db_path = self.execution_node_datadir.join("db");
             self.execution_database = Some(
-                reth_db::init_db(db_path, DatabaseArguments::default())
+                reth_db::init_db(db_path, test_db_args())
                     .expect("failed to init database")
                     .with_metrics(),
             );
@@ -473,12 +475,9 @@ where
         // Open a read-only provider to the database
         // Note: MDBX allows multiple readers, so this is safe even if another process
         // has the database open for reading
-        let database = open_db_read_only(
-            self.execution_node_datadir.join("db"),
-            DatabaseArguments::default(),
-        )
-        .expect("failed to open execution node database")
-        .with_metrics();
+        let database = open_db_read_only(self.execution_node_datadir.join("db"), test_db_args())
+            .expect("failed to open execution node database")
+            .with_metrics();
 
         let static_file_provider =
             StaticFileProvider::read_only(self.execution_node_datadir.join("static_files"))

--- a/crates/e2e/src/tests/mod.rs
+++ b/crates/e2e/src/tests/mod.rs
@@ -1,7 +1,10 @@
 use commonware_macros::test_traced;
 use reth_ethereum::{rpc::types::engine::ForkchoiceState, storage::BlockReader as _};
 
-use crate::{ExecutionRuntime, execution_runtime::chainspec};
+use crate::{
+    ExecutionRuntime,
+    execution_runtime::{chainspec, test_db_args},
+};
 
 mod backfill;
 mod consensus_rpc;
@@ -46,7 +49,7 @@ fn spawning_execution_node_works() {
         let config = crate::ExecutionNodeConfig::generate();
         let db_path = handle.nodes_dir().join("node-1").join("db");
         std::fs::create_dir_all(&db_path).expect("failed to create database directory");
-        let database = reth_db::init_db(db_path, reth_db::mdbx::DatabaseArguments::default())
+        let database = reth_db::init_db(db_path, test_db_args())
             .expect("failed to init database")
             .with_metrics();
         let node = handle

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -47,6 +47,7 @@ impl BlockAssembler<TempoEvmConfig> for TempoBlockAssembler {
             bundle_state,
             state_provider,
             state_root,
+            block_access_list_hash,
             ..
         } = input;
 
@@ -66,6 +67,7 @@ impl BlockAssembler<TempoEvmConfig> for TempoBlockAssembler {
             bundle_state,
             state_provider,
             state_root,
+            block_access_list_hash,
         ))?;
 
         Ok(block.map_header(|inner| TempoHeader {
@@ -200,6 +202,7 @@ mod tests {
             &bundle_state,
             &state_provider,
             state_root,
+            None,
         );
 
         let block = assembler
@@ -306,6 +309,7 @@ mod tests {
             &bundle_state,
             &state_provider,
             B256::ZERO,
+            None,
         );
 
         let block = assembler

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -714,6 +714,7 @@ where
             block,
             hashed_state,
             trie_updates,
+            ..
         } = if let Some(mut handle) = trie_handle {
             // Dropping the hook signals that execution is complete and the sparse trie task can
             // finalize the state root it has been updating incrementally.


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`8328732...f9c39fc`](https://github.com/paradigmxyz/reth/compare/8328732...f9c39fc)

🔗 Amp thread: https://ampcode.com/threads/T-019e154c-c02f-7184-8c73-1ab595245482
**RPC**
- Relax forkchoice update error match ([#23941](https://github.com/paradigmxyz/reth/pull/23941))
- Support block overrides in `estimateGas` ([#23990](https://github.com/paradigmxyz/reth/pull/23990))
- Cache revm BAL in eth state cache and cache decoded revm BALs ([#24037](https://github.com/paradigmxyz/reth/pull/24037), [#24079](https://github.com/paradigmxyz/reth/pull/24079))
- Implement `eth_baseFee` and add `eth_getBlockAccessList` method ([#24050](https://github.com/paradigmxyz/reth/pull/24050), [#24080](https://github.com/paradigmxyz/reth/pull/24080))

**Engine / Payload**
- Include rejection reason in `InvalidBlock` event ([#23945](https://github.com/paradigmxyz/reth/pull/23945))
- Add validation output type ([#24089](https://github.com/paradigmxyz/reth/pull/24089))
- Prune BAL store from persistence task ([#24084](https://github.com/paradigmxyz/reth/pull/24084))
- Run payload builder on a named OS thread ([#24038](https://github.com/paradigmxyz/reth/pull/24038))
- Avoid tx pool for empty payloads ([#24103](https://github.com/paradigmxyz/reth/pull/24103))
- Extract `spawn_receipt_root_task` ([#24031](https://github.com/paradigmxyz/reth/pull/24031))

**Storage / DB**
- Bump libmdbx to v0.13.12 ([#24007](https://github.com/paradigmxyz/reth/pull/24007))
- Add decoded BAL lookup, BAL store pruning, flush hook, and `insert_many` ([#23998](https://github.com/paradigmxyz/reth/pull/23998), [#24023](https://github.com/paradigmxyz/reth/pull/24023), [#24071](https://github.com/paradigmxyz/reth/pull/24071), [#24066](https://github.com/paradigmxyz/reth/pull/24066))
- Add balstore cache size arg ([#24002](https://github.com/paradigmxyz/reth/pull/24002))
- Add default rocksdb write buffer manager ([#24001](https://github.com/paradigmxyz/reth/pull/24001))

**Execution / Perf**
- Parallel execution ([#23924](https://github.com/paradigmxyz/reth/pull/23924))
- Use crossbeam receiver for tx recovery ([#24032](https://github.com/paradigmxyz/reth/pull/24032))
- Avoid clone ([#23940](https://github.com/paradigmxyz/reth/pull/23940))

**Networking**
- Advertise configured NAT IP in ENR for discv5 ([#24013](https://github.com/paradigmxyz/reth/pull/24013))
- Make full block BAL lookup optional ([#24074](https://github.com/paradigmxyz/reth/pull/24074))
- Add `eth/72` version, `NewPooledTransactionHashes72`, `GetCells`/`Cells` messages, and `get_cell` in `BlobStore` trait ([#24012](https://github.com/paradigmxyz/reth/pull/24012), [#24101](https://github.com/paradigmxyz/reth/pull/24101), [#24041](https://github.com/paradigmxyz/reth/pull/24041), [#24098](https://github.com/paradigmxyz/reth/pull/24098))
- Add structs for EIP-8070 ([#24024](https://github.com/paradigmxyz/reth/pull/24024))

**Node / CLI**
- Add `--debug.skip-genesis-validation` ([#23919](https://github.com/paradigmxyz/reth/pull/23919))

**Metrics**
- Add storage settings metric ([#24018](https://github.com/paradigmxyz/reth/pull/24018))

**Bench**
- Route PR benchmarks through txgen ([#23869](https://github.com/paradigmxyz/reth/pull/23869))
- Support big blocks in `reth-bench new-payload-fcu`, generate big blocks in flight, and skip big-block snapshot downloads ([#24028](https://github.com/paradigmxyz/reth/pull/24028), [#24048](https://github.com/paradigmxyz/reth/pull/24048), [#23992](https://github.com/paradigmxyz/reth/pull/23992))
- `generate-big-blocks`: don't fetch receipts and further simplify ([#24011](https://github.com/paradigmxyz/reth/pull/24011), [#24025](https://github.com/paradigmxyz/reth/pull/24025))
- Use per-run bench metrics labels file ([#24005](https://github.com/paradigmxyz/reth/pull/24005))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e154d-0339-710d-a727-a0c64c3f5a35
- Bumped reth git dependency rev from `8328732` to `f9c39fc` across all `reth-*` crates in `Cargo.toml`.
- Handled new `IncomingEthRequest::GetCells` variant in [p2p_proxy.rs](file:///home/runner/work/tempo/tempo/bin/tempo/src/p2p_proxy.rs) by responding with `Default::default()`, matching the existing pattern for `GetBlockAccessLists` (upstream added a new eth wire request type).
- Updated [TempoBlockAssembler](file:///home/runner/work/tempo/tempo/crates/evm/src/assemble.rs) to destructure and forward the new `block_access_list_hash` field from `BlockAssemblerInput` into the block builder, and updated test call sites to pass `None` for the new argument (upstream `BlockAssemblerInput` gained a `block_access_list_hash` field).
- Added `..` rest pattern when destructuring the trie task result in [payload/builder/src/lib.rs](file:///home/runner/work/tempo/tempo/crates/payload/builder/src/lib.rs) to ignore newly added field(s) on the upstream struct.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25650212538)
