### PR TITLE
ci: use foundry no-default build for specs

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -16,8 +16,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  # Pinned to mablr/alloy_bump_without_op (alloy 2.0.4 + OP support stripped)
-  FOUNDRY_SHA: "be874c9f6dacaa289b8c3b438f0e94e8d34e9fe0"
 
 jobs:
   check-specs-changes:
@@ -170,7 +168,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: ${{ env.FOUNDRY_SHA }}
+          ref: master
           path: foundry
           persist-credentials: false
 
@@ -194,7 +192,7 @@ jobs:
       - name: Build foundry forge with coverage instrumentation
         if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
-        run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release
+        run: RUSTFLAGS="-C instrument-coverage" cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles (with coverage)
         if: needs.check-precompiles.outputs.coverage == 'true'
@@ -207,7 +205,7 @@ jobs:
       - name: Build foundry forge
         if: needs.check-precompiles.outputs.coverage != 'true'
         working-directory: foundry
-        run: cargo build -p forge --profile release
+        run: cargo build -p forge --profile release --no-default-features
 
       - name: Run Forge tests with Rust precompiles
         if: needs.check-precompiles.outputs.coverage != 'true'

--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -82,7 +82,8 @@ sed -n '/^\[patch\./,$p' "$FOUNDRY_CARGO"
 # ── 4. Re-resolve the lockfile without upgrading unrelated crates ──────────
 # `cargo update` can pull newer upstream deps from Foundry's workspace, which is non-deterministic.
 # A normal resolver pass is enough to rewrite the lockfile entries for the tempo path overrides.
-(cd "$FOUNDRY_ROOT" && cargo metadata --format-version=1 >/dev/null)
+# Keep this aligned with the CI Forge build so Optimism-only dependencies do not re-enter resolution.
+(cd "$FOUNDRY_ROOT" && cargo metadata --format-version=1 --no-default-features >/dev/null)
 
 if grep -q '^source = "git+https://github.com/tempoxyz/tempo?rev=' "$FOUNDRY_ROOT/Cargo.lock"; then
   echo "ERROR: Tempo git sources still present in Cargo.lock after patching:" >&2


### PR DESCRIPTION
Unpins the specs workflow from the temporary no-OP Foundry SHA and checks out Foundry master again. Forge is now built with `--no-default-features`, matching the supported OP-disabled lane from foundry-rs/foundry#14612.

The patch script now resolves Foundry metadata with the same no-default feature set so OP-only dependencies do not enter the patched lockfile before the build.

Validation:
- `bash -n scripts/foundry-patch.sh`
- `shellcheck scripts/foundry-patch.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/specs.yml")'`
- fresh-worktree patch against Foundry master, then `cargo +1.94 tree -p forge --no-default-features` with no `op-*` / `alloy-op-*` matches
