### PR TITLE
ci(bench): use replay token for bench comment handling

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -55,7 +55,7 @@ mkdir -p "$BENCH_WORK_DIR"
 # ============================================================================
 
 echo "Installing txgen-tempo and bench-cli..."
-cargo install --git "https://x-access-token:${DEREK_BENCH_REPLAY_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
+cargo install --git "https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
 
 # ============================================================================
 # Build baseline + feature binaries

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -215,7 +215,7 @@ on:
         type: string
         required: false
     secrets:
-      DEREK_BENCH_REPLAY_TOKEN:
+      DEREK_PAT:
         required: false
       TEMPO_TELEMETRY_URL:
         required: false
@@ -335,7 +335,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: tempoxyz/txgen
-          token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN || github.token }}
+          token: ${{ secrets.DEREK_PAT || github.token }}
           persist-credentials: false
           path: txgen
           fetch-depth: 0
@@ -354,7 +354,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -509,7 +509,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmark...'});
@@ -585,7 +585,7 @@ jobs:
         env:
           BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const fs = require('fs');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
@@ -719,7 +719,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -733,7 +733,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -215,7 +215,7 @@ on:
         type: string
         required: false
     secrets:
-      DEREK_PAT:
+      DEREK_BENCH_TOKEN:
         required: false
       TEMPO_TELEMETRY_URL:
         required: false
@@ -335,7 +335,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: tempoxyz/txgen
-          token: ${{ secrets.DEREK_PAT || github.token }}
+          token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
           persist-credentials: false
           path: txgen
           fetch-depth: 0
@@ -354,7 +354,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -509,7 +509,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmark...'});
@@ -585,7 +585,7 @@ jobs:
         env:
           BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const fs = require('fs');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
@@ -719,7 +719,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -733,7 +733,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -215,7 +215,7 @@ on:
         type: string
         required: false
     secrets:
-      DEREK_PAT:
+      DEREK_BENCH_REPLAY_TOKEN:
         required: false
       TEMPO_TELEMETRY_URL:
         required: false
@@ -335,7 +335,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: tempoxyz/txgen
-          token: ${{ secrets.DEREK_PAT || github.token }}
+          token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN || github.token }}
           persist-credentials: false
           path: txgen
           fetch-depth: 0
@@ -354,7 +354,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -509,7 +509,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmark...'});
@@ -585,7 +585,7 @@ jobs:
         env:
           BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             const fs = require('fs');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
@@ -719,7 +719,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -733,7 +733,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -86,7 +86,7 @@ on:
         type: string
         required: false
     secrets:
-      DEREK_BENCH_REPLAY_TOKEN:
+      DEREK_BENCH_TOKEN:
         required: false
       DEREK_TOKEN:
         required: false
@@ -120,7 +120,7 @@ jobs:
         id: checkout-ref
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             if (context.eventName === 'workflow_dispatch') {
               // Auto-discover PR for the current branch
@@ -183,7 +183,7 @@ jobs:
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -288,7 +288,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running replay benchmark...'});
@@ -298,7 +298,7 @@ jobs:
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
-          DEREK_BENCH_REPLAY_TOKEN: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
         run: bash .github/scripts/bench-tempo-replay.sh
 
       - name: Parse results
@@ -377,7 +377,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const fs = require('fs');
 
@@ -432,7 +432,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -446,7 +446,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           INPUT_REF_NAME: ${{ github.ref_name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             let pr, actor, mode, preset, duration, bloat, tps, baseline, feature, backend, txgenRef, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
 
@@ -356,7 +356,7 @@ jobs:
           ACK_BASELINE_HARDFORK: ${{ steps.args.outputs.baseline-hardfork }}
           ACK_FEATURE_HARDFORK: ${{ steps.args.outputs.feature-hardfork }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             if (context.eventName === 'issue_comment') {
               await github.rest.reactions.createForIssueComment({
@@ -437,7 +437,7 @@ jobs:
       feature-env: ${{ needs.tempo-bench-ack.outputs.feature-env }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
     secrets:
-      DEREK_PAT: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
@@ -465,5 +465,5 @@ jobs:
       warmup: ${{ needs.tempo-bench-ack.outputs.warmup }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
     secrets:
-      DEREK_BENCH_REPLAY_TOKEN: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -437,7 +437,7 @@ jobs:
       feature-env: ${{ needs.tempo-bench-ack.outputs.feature-env }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
     secrets:
-      DEREK_BENCH_REPLAY_TOKEN: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
+      DEREK_PAT: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           INPUT_REF_NAME: ${{ github.ref_name }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             let pr, actor, mode, preset, duration, bloat, tps, baseline, feature, backend, txgenRef, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, baselineHardfork, featureHardfork, runType, forceBloat, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
 
@@ -356,7 +356,7 @@ jobs:
           ACK_BASELINE_HARDFORK: ${{ steps.args.outputs.baseline-hardfork }}
           ACK_FEATURE_HARDFORK: ${{ steps.args.outputs.feature-hardfork }}
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
           script: |
             if (context.eventName === 'issue_comment') {
               await github.rest.reactions.createForIssueComment({
@@ -437,7 +437,7 @@ jobs:
       feature-env: ${{ needs.tempo-bench-ack.outputs.feature-env }}
       comment-id: ${{ needs.tempo-bench-ack.outputs.comment-id }}
     secrets:
-      DEREK_PAT: ${{ secrets.DEREK_PAT }}
+      DEREK_BENCH_REPLAY_TOKEN: ${{ secrets.DEREK_BENCH_REPLAY_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}


### PR DESCRIPTION
### Summary
- Switch the bench dispatch and e2e workflows to use `DEREK_BENCH_REPLAY_TOKEN` for PR lookup, comment reactions, status updates, and `txgen` checkout.
- Pass the replay token through the reusable workflow instead of the older `DEREK_PAT` secret so bench comment handling no longer depends on the broken shared PAT.

### Testing
- Not run (not requested)
- Verified the workflow diff and updated secret wiring across `bench.yml` and `bench-e2e.yml`