### PR TITLE
ci: isolate bench metrics labels per run

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -88,6 +88,27 @@ def find-tempo-pids [] {
     ps | where name =~ "tempo" | where name !~ "tempo-bench" | get pid
 }
 
+# Signal a process, retrying through sudo for stale runner-owned processes.
+def signal-process [pid: int, signal: int] {
+    try {
+        kill -s $signal $pid
+    } catch { |e|
+        print $"  Warning: kill -s ($signal) ($pid) failed: ($e.msg). Retrying with sudo..."
+        sudo kill -s $signal $pid
+    }
+}
+
+def remove-reth-ipc [] {
+    if ("/tmp/reth.ipc" | path exists) {
+        try {
+            rm --force /tmp/reth.ipc
+        } catch { |e|
+            print $"  Warning: removing /tmp/reth.ipc failed: ($e.msg). Retrying with sudo..."
+            sudo rm -f /tmp/reth.ipc
+        }
+    }
+}
+
 # Initialize node with state bloat
 # 1. Run `tempo init` to create the database
 # 2. Generate state bloat binary file
@@ -642,7 +663,7 @@ def run-bench-single [
     print "  Stopping node..."
     let pids = (find-tempo-pids)
     for pid in $pids {
-        kill -s 2 $pid
+        signal-process $pid 2
     }
     # Wait for tempo processes to fully exit
     for pid in $pids {
@@ -654,7 +675,7 @@ def run-bench-single [
         }
         if $wait >= 30 {
             print $"  Warning: PID ($pid) did not exit, sending SIGKILL"
-            kill -s 9 $pid
+            signal-process $pid 9
             sleep 1sec
         }
     }
@@ -682,9 +703,7 @@ def run-bench-single [
     }
 
     # Remove stale IPC socket
-    if ("/tmp/reth.ipc" | path exists) {
-        rm --force /tmp/reth.ipc
-    }
+    remove-reth-ipc
 
     print $"=== Run ($run_label) complete ==="
 }
@@ -1086,13 +1105,13 @@ def "main kill" [
     if ($pids | length) > 0 {
         print $"Sending SIGINT to ($pids | length) tempo processes..."
         for pid in $pids {
-            kill -s 2 $pid
+            signal-process $pid 2
         }
     }
 
     # Remove stale IPC socket
     if $has_stale_ipc {
-        rm --force /tmp/reth.ipc
+        remove-reth-ipc
         print "Removed /tmp/reth.ipc"
     }
     print "Done."
@@ -2681,7 +2700,7 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
             print "Stopping instrumented node (SIGINT for profraw flush)..."
             let pids = (find-tempo-pids)
             for pid in $pids {
-                kill -s 2 $pid
+                signal-process $pid 2
             }
             sleep 3sec
             print "Node stopped."

--- a/tempo.nu
+++ b/tempo.nu
@@ -12,7 +12,6 @@ const BENCH_WORKTREES_DIR = ".bench-worktrees"
 const BENCH_RESULTS_DIR = "bench-results"
 const BLOAT_MNEMONIC = "test test test test test test test test test test test junk"
 const METRICS_PROXY_SCRIPT = "contrib/bench/bench-metrics-proxy.py"
-const METRICS_LABELS_FILE = "/tmp/bench-metrics-labels.json"
 const MINIO_BUCKET = "minio/tempo-binaries"
 const BENCH_META_SUBDIR = ".bench-meta"
 
@@ -503,11 +502,12 @@ def run-bench-single [
         run_start_epoch: $"($run_start_epoch)"
         reference_epoch: $"($reference_epoch)"
     }
-    $labels | to json | save -f $METRICS_LABELS_FILE
+    let labels_file = $"($results_dir)/metrics-labels-($run_label).json"
+    $labels | to json | save -f $labels_file
 
     let proxy_pid = if ($METRICS_PROXY_SCRIPT | path exists) {
         let proxy_job = (job spawn {
-            python3 $METRICS_PROXY_SCRIPT --upstream "http://127.0.0.1:9001/" --port 9090
+            python3 $METRICS_PROXY_SCRIPT --upstream "http://127.0.0.1:9001/" --port 9090 --labels $labels_file
         })
         sleep 500ms
         $proxy_job

--- a/tempo.nu
+++ b/tempo.nu
@@ -88,27 +88,6 @@ def find-tempo-pids [] {
     ps | where name =~ "tempo" | where name !~ "tempo-bench" | get pid
 }
 
-# Signal a process, retrying through sudo for stale runner-owned processes.
-def signal-process [pid: int, signal: int] {
-    try {
-        kill -s $signal $pid
-    } catch { |e|
-        print $"  Warning: kill -s ($signal) ($pid) failed: ($e.msg). Retrying with sudo..."
-        sudo kill -s $signal $pid
-    }
-}
-
-def remove-reth-ipc [] {
-    if ("/tmp/reth.ipc" | path exists) {
-        try {
-            rm --force /tmp/reth.ipc
-        } catch { |e|
-            print $"  Warning: removing /tmp/reth.ipc failed: ($e.msg). Retrying with sudo..."
-            sudo rm -f /tmp/reth.ipc
-        }
-    }
-}
-
 # Initialize node with state bloat
 # 1. Run `tempo init` to create the database
 # 2. Generate state bloat binary file
@@ -663,7 +642,7 @@ def run-bench-single [
     print "  Stopping node..."
     let pids = (find-tempo-pids)
     for pid in $pids {
-        signal-process $pid 2
+        kill -s 2 $pid
     }
     # Wait for tempo processes to fully exit
     for pid in $pids {
@@ -675,7 +654,7 @@ def run-bench-single [
         }
         if $wait >= 30 {
             print $"  Warning: PID ($pid) did not exit, sending SIGKILL"
-            signal-process $pid 9
+            kill -s 9 $pid
             sleep 1sec
         }
     }
@@ -703,7 +682,9 @@ def run-bench-single [
     }
 
     # Remove stale IPC socket
-    remove-reth-ipc
+    if ("/tmp/reth.ipc" | path exists) {
+        rm --force /tmp/reth.ipc
+    }
 
     print $"=== Run ($run_label) complete ==="
 }
@@ -1105,13 +1086,13 @@ def "main kill" [
     if ($pids | length) > 0 {
         print $"Sending SIGINT to ($pids | length) tempo processes..."
         for pid in $pids {
-            signal-process $pid 2
+            kill -s 2 $pid
         }
     }
 
     # Remove stale IPC socket
     if $has_stale_ipc {
-        remove-reth-ipc
+        rm --force /tmp/reth.ipc
         print "Removed /tmp/reth.ipc"
     }
     print "Done."
@@ -2700,7 +2681,7 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
             print "Stopping instrumented node (SIGINT for profraw flush)..."
             let pids = (find-tempo-pids)
             for pid in $pids {
-                signal-process $pid 2
+                kill -s 2 $pid
             }
             sleep 3sec
             print "Node stopped."


### PR DESCRIPTION
Adds per-run metrics label files for `tempo.nu` benchmark executions instead of writing a shared `/tmp/bench-metrics-labels.json` path. The benchmark proxy now receives the run-specific labels file, which avoids collisions and the permission failure seen in the e2e bench job.

Testing:
- `git diff --check`
- `nu --ide-check 5 tempo.nu`