### PR TITLE
TIP-1057: T5 Hardfork Meta TIP

### DIFF
--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -1,10 +1,10 @@
 ---
 id: TIP-1057
 title: T5 Hardfork Meta TIP
-description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
-authors: Tempo
+description: Meta TIP collecting all features, bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
+authors: Federico Gimenez (@fgimenez), Marc Martinez (@0xrusowsky), Tanishk Goyal (@legion2002), Arsenii Kulikov (@klkvr), Kitsune (@0xKitsune)
 status: Draft
-related: TIP-1026, TIP-1030, TIP-1033, TIP-1035, TIP-1047, TIP-1056
+related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1047, TIP-1053, TIP-1056
 protocolVersion: T5
 ---
 
@@ -12,11 +12,11 @@ protocolVersion: T5
 
 ## Abstract
 
-This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1035, TIP-1047, TIP-1056) are intentionally excluded from this meta TIP.
+This meta TIP collects every protocol change that activates at T5: standalone-TIP feature work, bug fixes, and security hardening. Each item is small in isolation, but together they define the complete in-scope T5 bundle. Items that have a standalone TIP are summarized here with a pointer to the standalone TIP for full specification.
 
 ## Motivation
 
-Ongoing internal review and audit follow-ups uncovered correctness issues in precompile storage codegen that require hardfork gating. Additionally, cross-chain interoperability requirements necessitate deploying standard factory contracts at the T5 boundary. Because these changes alter state-function behavior or chain state at activation boundaries, they are grouped here as one coordinated rollout under T5.
+Ongoing internal review and audit follow-ups uncovered correctness issues in precompile storage codegen and dynamic-storage handling that require hardfork gating, and several feature TIPs target the same activation boundary. Because all of these changes alter state-function behavior or chain state at the activation boundary, they are grouped here as one coordinated rollout under T5.
 
 ---
 
@@ -39,4 +39,50 @@ T5+ fixes: relax `is_packable` to `byte_count < 32` (matching the trait-level `L
 
 Overwriting a dynamic storable (`Vec<T>`, `String`, `Bytes`) with a shorter value left stale tail slots populated, so subsequent reads observed garbage past the new length. T5+ ensures that shrinking writes on dynamic types clear their stale tails. Additionally introduces a `LayoutCtx::INIT` sentinel for hot paths that know the destination is virgin (`Vec::push`), letting them skip the extra SLOAD + cleanup.
 
+## 3. TIP-1026: optional `logoURI` and `createToken` overload
 
+**PRs**: [#3745](https://github.com/tempoxyz/tempo/pull/3745), [#3867](https://github.com/tempoxyz/tempo/pull/3867) · **Authors**: @fgimenez
+
+Adds an optional `logoURI` field to the TIP-20 token metadata and exposes a new `createToken` overload that accepts it, gated to T5+. See [TIP-1026](./tip-1026) for the full specification. The follow-up PR rounds out invariant-test coverage to reach the admin-side branches and the spec invariants exercised by the new overload.
+
+## 4. TIP-1030: allow same-tick flip orders
+
+**PR**: [#3724](https://github.com/tempoxyz/tempo/pull/3724) · **Author**: @fgimenez
+
+Relaxes `placeFlip` validation to allow `flipTick == tick`, gated behind T5. See [TIP-1030](./tip-1030) for the motivation and full specification.
+
+## 5. TIP-1033: multi-hop FeeAMM routing
+
+**PRs**: [#3739](https://github.com/tempoxyz/tempo/pull/3739), [#3809](https://github.com/tempoxyz/tempo/pull/3809), [#3856](https://github.com/tempoxyz/tempo/pull/3856) · **Authors**: @0xrusowsky, @0xKitsune
+
+Implements the TIP-1033 `FeeManager` precompile and integrates it with the transaction pool, including two-hop fee settlement when the direct FeeAMM pool is missing or insufficient. Follow-ups extract fee-liquidity reservation from `collect_fee_pre_tx`, simplify the txpool AMM cache hot path, add node e2e coverage, and round out invariant tests. See [TIP-1033](./tip-1033) for the full specification.
+
+## 6. TIP-1034: TIP-20 channel escrow precompile
+
+**PRs**: [#3704](https://github.com/tempoxyz/tempo/pull/3704), [#3734](https://github.com/tempoxyz/tempo/pull/3734) · **Authors**: @legion2002
+
+Enshrines the native TIP-20 channel escrow precompile, with packed channel state, approve-less funding via system transfers, and voucher settlement, close, and withdraw flows. Gated behind T5 end-to-end: the precompile is only registered and deployed once T5 is active. The dependency PR adds a reusable `U96` storage primitive (Alloy `Uint<96, 2>` conversions, storage/packing trait impls, roundtrip tests) used by the packed channel state. See [TIP-1034](./tip-1034) for the full specification.
+
+## 7. TIP-1035: stablecoin DEX implicit approval
+
+**PR**: [#3828](https://github.com/tempoxyz/tempo/pull/3828) · **Author**: @klkvr
+
+Adds an `isImplicitlyApproved` method to `AddressRegistry` and switches the stablecoin DEX to use `system_transfer_from` post-T5, removing the need for explicit approvals from registry-managed addresses. See [TIP-1035](./tip-1035) for the full specification.
+
+## 8. TIP-1045: enshrine `is_payment_v2`
+
+**PR**: [#3844](https://github.com/tempoxyz/tempo/pull/3844) · **Author**: @0xrusowsky
+
+Enshrines `is_payment_v2` into the protocol so payment-lane classification follows the consensus-level allow-list of call targets/selectors and bounded auxiliary payloads. See [TIP-1045](./tip-1045) for the full specification.
+
+## 9. TIP-1053: witness digest in key authorizations
+
+**PR**: [#3838](https://github.com/tempoxyz/tempo/pull/3838) · **Author**: @legion2002
+
+Implements TIP-1053 key-authorization nonces behind T5 using the simplified nonce-presence semantics from the spec. Present nonce fields are included in the signed key authorization and consumed per account on successful authorization; absent nonce fields preserve legacy byte-equivalent encodings. Adds T5-gated `AccountKeychain` selectors to authorize with a nonce, burn a nonce, and query nonce consumption. See [TIP-1053](./tip-1053) for the full specification.
+
+## 10. TIP-1056: persistent order IDs across flips
+
+**PR**: [#3776](https://github.com/tempoxyz/tempo/pull/3776) · **Author**: @klkvr
+
+Keeps order IDs stable across flip operations on the stablecoin DEX so downstream consumers can track an order through its full lifecycle. See [TIP-1056](./tip-1056) for the full specification.

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -1,0 +1,42 @@
+---
+id: TIP-1057
+title: T5 Hardfork Meta TIP
+description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
+authors: Tempo
+status: Draft
+related: TIP-1026, TIP-1030, TIP-1033, TIP-1035, TIP-1047, TIP-1056
+protocolVersion: T5
+---
+
+# TIP-1057: T5 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1035, TIP-1047, TIP-1056) are intentionally excluded from this meta TIP.
+
+## Motivation
+
+Ongoing internal review and audit follow-ups uncovered correctness issues in precompile storage codegen that require hardfork gating. Additionally, cross-chain interoperability requirements necessitate deploying standard factory contracts at the T5 boundary. Because these changes alter state-function behavior or chain state at activation boundaries, they are grouped here as one coordinated rollout under T5.
+
+---
+
+# Changes
+
+## 1. Fix fixed-size array packing in precompile storage codegen
+
+**PR**: [#3811](https://github.com/tempoxyz/tempo/pull/3811) · **Author**: @0xrusowsky
+
+Two paired correctness bugs in `[T; N]` storage codegen for element types where `T::BYTES <= 16` but `32 % T::BYTES != 0` (in practice: `[U96; N]`, `[I96; N]`, and odd-sized `[FixedBytes<N>; M]`).
+
+- **Bulk and indexed paths used mismatched packing rules.** `storable_primitives::is_packable` required `32 % byte_count == 0`, excluding 12-byte types from the packed bulk path. `ArrayHandler::compute_handler` gates only on `T::BYTES <= 16` and uses the packed path. A bulk write followed by an indexed read on the same `[U96; N]` returns the wrong element; an indexed write mutates the wrong slot.
+- **Packed slot-count formula undercounted the trailing partial slot.** `(N * byte_count).div_ceil(32)` treats storage as contiguous and undercounts when `byte_count` does not divide 32. `[U96; 5]` reported 2 slots instead of 3, and the bulk-store loop dropped the final element.
+
+T5+ fixes: relax `is_packable` to `byte_count < 32` (matching the trait-level `Layout::is_packable()` already used by indexed access) and route both array-codegen call sites through `packing::calc_packed_slot_count`.
+
+## 2. Clean up stale tail slots in dynamic storage types
+
+**PR**: [#3840](https://github.com/tempoxyz/tempo/pull/3840) · **Author**: @0xrusowsky
+
+Overwriting a dynamic storable (`Vec<T>`, `String`, `Bytes`) with a shorter value left stale tail slots populated, so subsequent reads observed garbage past the new length. T5+ ensures that shrinking writes on dynamic types clear their stale tails. Additionally introduces a `LayoutCtx::INIT` sentinel for hot paths that know the destination is virgin (`Vec::push`), letting them skip the extra SLOAD + cleanup.
+
+

--- a/tips/tip-1057.md
+++ b/tips/tip-1057.md
@@ -1,8 +1,8 @@
 ---
 id: TIP-1057
 title: T5 Hardfork Meta TIP
-description: Meta TIP collecting all features, bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
-authors: Federico Gimenez (@fgimenez), Marc Martinez (@0xrusowsky), Tanishk Goyal (@legion2002), Arsenii Kulikov (@klkvr), Kitsune (@0xKitsune)
+description: Meta TIP collecting bug fixes, security hardening, and infrastructure changes gated behind the T5 hardfork.
+authors: Marc Martinez (@0xrusowsky)
 status: Draft
 related: TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1047, TIP-1053, TIP-1056
 protocolVersion: T5
@@ -12,11 +12,11 @@ protocolVersion: T5
 
 ## Abstract
 
-This meta TIP collects every protocol change that activates at T5: standalone-TIP feature work, bug fixes, and security hardening. Each item is small in isolation, but together they define the complete in-scope T5 bundle. Items that have a standalone TIP are summarized here with a pointer to the standalone TIP for full specification.
+This meta TIP collects bug fixes, security hardening, and infrastructure changes that activate at T5. Each item is small in isolation, but together they define the complete in-scope T5 bug-fix and infrastructure bundle. Feature changes already specified by standalone TIPs (TIP-1026, TIP-1030, TIP-1033, TIP-1034, TIP-1035, TIP-1045, TIP-1047, TIP-1053, TIP-1056) are intentionally excluded from this meta TIP.
 
 ## Motivation
 
-Ongoing internal review and audit follow-ups uncovered correctness issues in precompile storage codegen and dynamic-storage handling that require hardfork gating, and several feature TIPs target the same activation boundary. Because all of these changes alter state-function behavior or chain state at the activation boundary, they are grouped here as one coordinated rollout under T5.
+Ongoing internal review and audit follow-ups uncovered correctness issues in precompile storage codegen that require hardfork gating. Additionally, cross-chain interoperability requirements necessitate deploying standard factory contracts at the T5 boundary. Because these changes alter state-function behavior or chain state at activation boundaries, they are grouped here as one coordinated rollout under T5.
 
 ---
 
@@ -38,51 +38,3 @@ T5+ fixes: relax `is_packable` to `byte_count < 32` (matching the trait-level `L
 **PR**: [#3840](https://github.com/tempoxyz/tempo/pull/3840) · **Author**: @0xrusowsky
 
 Overwriting a dynamic storable (`Vec<T>`, `String`, `Bytes`) with a shorter value left stale tail slots populated, so subsequent reads observed garbage past the new length. T5+ ensures that shrinking writes on dynamic types clear their stale tails. Additionally introduces a `LayoutCtx::INIT` sentinel for hot paths that know the destination is virgin (`Vec::push`), letting them skip the extra SLOAD + cleanup.
-
-## 3. TIP-1026: optional `logoURI` and `createToken` overload
-
-**PRs**: [#3745](https://github.com/tempoxyz/tempo/pull/3745), [#3867](https://github.com/tempoxyz/tempo/pull/3867) · **Authors**: @fgimenez
-
-Adds an optional `logoURI` field to the TIP-20 token metadata and exposes a new `createToken` overload that accepts it, gated to T5+. See [TIP-1026](./tip-1026) for the full specification. The follow-up PR rounds out invariant-test coverage to reach the admin-side branches and the spec invariants exercised by the new overload.
-
-## 4. TIP-1030: allow same-tick flip orders
-
-**PR**: [#3724](https://github.com/tempoxyz/tempo/pull/3724) · **Author**: @fgimenez
-
-Relaxes `placeFlip` validation to allow `flipTick == tick`, gated behind T5. See [TIP-1030](./tip-1030) for the motivation and full specification.
-
-## 5. TIP-1033: multi-hop FeeAMM routing
-
-**PRs**: [#3739](https://github.com/tempoxyz/tempo/pull/3739), [#3809](https://github.com/tempoxyz/tempo/pull/3809), [#3856](https://github.com/tempoxyz/tempo/pull/3856) · **Authors**: @0xrusowsky, @0xKitsune
-
-Implements the TIP-1033 `FeeManager` precompile and integrates it with the transaction pool, including two-hop fee settlement when the direct FeeAMM pool is missing or insufficient. Follow-ups extract fee-liquidity reservation from `collect_fee_pre_tx`, simplify the txpool AMM cache hot path, add node e2e coverage, and round out invariant tests. See [TIP-1033](./tip-1033) for the full specification.
-
-## 6. TIP-1034: TIP-20 channel escrow precompile
-
-**PRs**: [#3704](https://github.com/tempoxyz/tempo/pull/3704), [#3734](https://github.com/tempoxyz/tempo/pull/3734) · **Authors**: @legion2002
-
-Enshrines the native TIP-20 channel escrow precompile, with packed channel state, approve-less funding via system transfers, and voucher settlement, close, and withdraw flows. Gated behind T5 end-to-end: the precompile is only registered and deployed once T5 is active. The dependency PR adds a reusable `U96` storage primitive (Alloy `Uint<96, 2>` conversions, storage/packing trait impls, roundtrip tests) used by the packed channel state. See [TIP-1034](./tip-1034) for the full specification.
-
-## 7. TIP-1035: stablecoin DEX implicit approval
-
-**PR**: [#3828](https://github.com/tempoxyz/tempo/pull/3828) · **Author**: @klkvr
-
-Adds an `isImplicitlyApproved` method to `AddressRegistry` and switches the stablecoin DEX to use `system_transfer_from` post-T5, removing the need for explicit approvals from registry-managed addresses. See [TIP-1035](./tip-1035) for the full specification.
-
-## 8. TIP-1045: enshrine `is_payment_v2`
-
-**PR**: [#3844](https://github.com/tempoxyz/tempo/pull/3844) · **Author**: @0xrusowsky
-
-Enshrines `is_payment_v2` into the protocol so payment-lane classification follows the consensus-level allow-list of call targets/selectors and bounded auxiliary payloads. See [TIP-1045](./tip-1045) for the full specification.
-
-## 9. TIP-1053: witness digest in key authorizations
-
-**PR**: [#3838](https://github.com/tempoxyz/tempo/pull/3838) · **Author**: @legion2002
-
-Implements TIP-1053 key-authorization nonces behind T5 using the simplified nonce-presence semantics from the spec. Present nonce fields are included in the signed key authorization and consumed per account on successful authorization; absent nonce fields preserve legacy byte-equivalent encodings. Adds T5-gated `AccountKeychain` selectors to authorize with a nonce, burn a nonce, and query nonce consumption. See [TIP-1053](./tip-1053) for the full specification.
-
-## 10. TIP-1056: persistent order IDs across flips
-
-**PR**: [#3776](https://github.com/tempoxyz/tempo/pull/3776) · **Author**: @klkvr
-
-Keeps order IDs stable across flip operations on the stablecoin DEX so downstream consumers can track an order through its full lifecycle. See [TIP-1056](./tip-1056) for the full specification.


### PR DESCRIPTION
Meta TIP collecting all protocol changes included in the T5 network upgrade.

| PR | Title |
|----|-------|
| [#3811](https://github.com/tempoxyz/tempo/pull/3811) | Fix fixed-size array packing in precompile storage codegen |
| [#3840](https://github.com/tempoxyz/tempo/pull/3840) | Clean up stale tail slots in dynamic storage types |
