### PR TITLE
fix(tip-1028): impl bugs and nits

### DIFF
--- a/crates/precompiles/src/tip1028_escrow/mod.rs
+++ b/crates/precompiles/src/tip1028_escrow/mod.rs
@@ -406,6 +406,68 @@ mod tests {
     }
 
     #[test]
+    fn test_claim_blocked_rejects_when_token_paused() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let blocked_at = 1_728_000u64;
+        storage.set_timestamp(U256::from(blocked_at));
+
+        let admin = Address::random();
+        let originator = Address::random();
+        let receiver = Address::random();
+        let amount = U256::from(100u64);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("T", "T", admin)
+                .with_issuer(admin)
+                .with_role(admin, TIP20Token::pause_role())
+                .with_mint(originator, amount)
+                .apply()?;
+            block_all_senders(receiver, Address::ZERO)?;
+
+            token.transfer(
+                originator,
+                ITIP20::transferCall {
+                    to: receiver,
+                    amount,
+                },
+            )?;
+            token.pause(admin, ITIP20::pauseCall {})?;
+
+            let receipt = receipt_v1(
+                originator,
+                receiver,
+                blocked_at,
+                1,
+                BlockedReason::RECEIVE_POLICY,
+                InboundKind::TRANSFER,
+                B256::ZERO,
+            );
+            let mut escrow = TIP1028Escrow::new();
+            let result = escrow.claim_blocked(
+                receiver,
+                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::contract_paused().into());
+            assert_eq!(
+                receipt_balance(&escrow, token.address(), Address::ZERO, &receipt)?,
+                amount
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: ESCROW_ADDRESS
+                })?,
+                amount
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: receiver })?,
+                U256::ZERO
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_escrow_balance_matches_open_receipts() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         storage.set_timestamp(U256::from(1_728_001u64));

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -400,9 +400,9 @@ impl TIP20Token {
     /// - `PolicyForbids` — TIP-403 policy rejects the mint recipient
     /// - `SupplyCapExceeded` — minting would push total supply above the cap
     pub fn mint(&mut self, msg_sender: Address, call: ITIP20::mintCall) -> Result<()> {
-        let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
+        let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             Address::ZERO,
             &to,
             call.amount,
@@ -430,9 +430,9 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::mintWithMemoCall,
     ) -> Result<()> {
-        let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
+        let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             Address::ZERO,
             &to,
             call.amount,
@@ -725,7 +725,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             msg_sender,
             &to,
             call.amount,
@@ -761,7 +761,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             call.from,
             &to,
             call.amount,
@@ -788,7 +788,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             call.from,
             &to,
             call.amount,
@@ -831,7 +831,7 @@ impl TIP20Token {
         self.validate_transfer(from, &to)?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
+        if self.validate_or_escrow_funds(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
             return Ok(true);
         }
 
@@ -869,7 +869,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_inbound_or_escrow(
+        if self.validate_or_escrow_funds(
             msg_sender,
             &to,
             call.amount,
@@ -984,9 +984,25 @@ impl TIP20Token {
         self.ensure_transfer_authorized(from, to.target)
     }
 
-    /// Ensures that the recipient is authorized to receive mints.
-    /// Additionally (+T3) checks pause state, validates the effective recipient.
-    fn validate_mint(&self, to: &Recipient) -> Result<()> {
+    /// Resolves the effective recipient, checks that `msg_sender` has the issuer role, preserves
+    /// the pre-T6 `total_supply` read position, validates that the token is not paused, and the
+    /// recipient can receive mints. On T6+, the `total_supply` read is deferred to `_mint`.
+    ///
+    /// Returns the resolved recipient and, pre-T6, the total supply.
+    fn validate_mint(
+        &self,
+        msg_sender: Address,
+        to: Address,
+    ) -> Result<(Recipient, Option<U256>)> {
+        let to = Recipient::resolve(to)?;
+        self.check_role(msg_sender, *ISSUER_ROLE)?;
+
+        let total_supply = if self.storage.spec().is_t6() {
+            None
+        } else {
+            Some(self.total_supply()?)
+        };
+
         if self.storage.spec().is_t3() {
             self.check_not_paused()?;
             to.validate()?;
@@ -1001,29 +1017,6 @@ impl TIP20Token {
             return Err(TIP20Error::policy_forbids().into());
         }
 
-        Ok(())
-    }
-
-    /// Resolves the effective recipient, checks that `msg_sender` has the issuer role, preserves
-    /// the pre-T6 `total_supply` read position, validates that the token is not paused, and the
-    /// recipient can receive mints. On T6+, the `total_supply` read is deferred to `_mint`.
-    ///
-    /// Returns the resolved recipient and, pre-T6, the total supply.
-    fn preflight_mint(
-        &self,
-        msg_sender: Address,
-        to: Address,
-    ) -> Result<(Recipient, Option<U256>)> {
-        let to = Recipient::resolve(to)?;
-        self.check_role(msg_sender, *ISSUER_ROLE)?;
-
-        let total_supply = if self.storage.spec().is_t6() {
-            None
-        } else {
-            Some(self.total_supply()?)
-        };
-
-        self.validate_mint(&to)?;
         Ok((to, total_supply))
     }
 
@@ -1097,11 +1090,12 @@ impl TIP20Token {
         self.emit_event(to.build_transfer_event(from, amount))
     }
 
-    /// Validates inbound TIP-1028 receive policy for `to`.
+    /// Validates the TIP-1028 receive-policy check for the destination address. If the receive
+    /// policy prohibits the action, the funds are escrowed.
     ///
     /// Returns `true` when receive-policies block the inbound and this function escrows the funds.
     /// Callers must ONLY move funds when `false` is returned.
-    fn validate_inbound_or_escrow(
+    fn validate_or_escrow_funds(
         &mut self,
         originator: Address,
         to: &Recipient,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -402,7 +402,7 @@ impl TIP20Token {
     pub fn mint(&mut self, msg_sender: Address, call: ITIP20::mintCall) -> Result<()> {
         let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             Address::ZERO,
             &to,
             call.amount,
@@ -432,7 +432,7 @@ impl TIP20Token {
     ) -> Result<()> {
         let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             Address::ZERO,
             &to,
             call.amount,
@@ -725,7 +725,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             msg_sender,
             &to,
             call.amount,
@@ -761,7 +761,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             call.from,
             &to,
             call.amount,
@@ -788,7 +788,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             call.from,
             &to,
             call.amount,
@@ -831,7 +831,7 @@ impl TIP20Token {
         self.validate_transfer(from, &to)?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.validate_or_escrow_funds(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
+        if self.validate_inbound_or_escrow(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
             return Ok(true);
         }
 
@@ -869,7 +869,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_inbound_or_escrow(
             msg_sender,
             &to,
             call.amount,
@@ -1097,9 +1097,11 @@ impl TIP20Token {
         self.emit_event(to.build_transfer_event(from, amount))
     }
 
-    /// Validates the TIP-1028 receive-policy check for the destination address. If the receive
-    /// policy prohibits the action, the funds are escrowed.
-    fn validate_or_escrow_funds(
+    /// Validates inbound TIP-1028 receive policy for `to`.
+    ///
+    /// Returns `true` when receive-policies block the inbound and this function escrows the funds.
+    /// Callers must ONLY move funds when `false` is returned.
+    fn validate_inbound_or_escrow(
         &mut self,
         originator: Address,
         to: &Recipient,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -394,9 +394,7 @@ impl TIP20Token {
     /// - `PolicyForbids` — TIP-403 policy rejects the mint recipient
     /// - `SupplyCapExceeded` — minting would push total supply above the cap
     pub fn mint(&mut self, msg_sender: Address, call: ITIP20::mintCall) -> Result<()> {
-        let to = Recipient::resolve(call.to)?;
-        self.check_role(msg_sender, *ISSUER_ROLE)?;
-        self.validate_mint(&to)?;
+        let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
 
         if self.validate_or_escrow_funds(
             Address::ZERO,
@@ -408,7 +406,7 @@ impl TIP20Token {
             return Ok(());
         }
 
-        self._mint(&to, call.amount)?;
+        self._mint(&to, call.amount, total_supply)?;
         self.emit_event(TIP20Event::Mint(ITIP20::Mint {
             to: call.to,
             amount: call.amount,
@@ -426,9 +424,7 @@ impl TIP20Token {
         msg_sender: Address,
         call: ITIP20::mintWithMemoCall,
     ) -> Result<()> {
-        let to = Recipient::resolve(call.to)?;
-        self.check_role(msg_sender, *ISSUER_ROLE)?;
-        self.validate_mint(&to)?;
+        let (to, total_supply) = self.preflight_mint(msg_sender, call.to)?;
 
         if self.validate_or_escrow_funds(
             Address::ZERO,
@@ -440,7 +436,7 @@ impl TIP20Token {
             return Ok(());
         }
 
-        self._mint(&to, call.amount)?;
+        self._mint(&to, call.amount, total_supply)?;
         self.emit_event(TIP20Event::TransferWithMemo(ITIP20::TransferWithMemo {
             from: Address::ZERO,
             to: call.to,
@@ -458,9 +454,13 @@ impl TIP20Token {
     }
 
     /// Internal helper to mint new tokens and update balances.
-    fn _mint(&mut self, to: &Recipient, amount: U256) -> Result<()> {
-        let total_supply = self.total_supply()?;
+    ///
+    /// Accepts an optional pre-fetched `total_supply` to preserve re-execution behavior (pre-T6).
+    /// If `None`, reads from storage.
+    fn _mint(&mut self, to: &Recipient, amount: U256, total_supply: Option<U256>) -> Result<()> {
         let new_supply = total_supply
+            .map(Ok)
+            .unwrap_or_else(|| self.total_supply())?
             .checked_add(amount)
             .ok_or(TempoPrecompileError::under_overflow())?;
 
@@ -998,6 +998,29 @@ impl TIP20Token {
         Ok(())
     }
 
+    /// Resolves the effective recipient, checks that `msg_sender` has the issuer role, preserves
+    /// the pre-T6 `total_supply` read position, validates that the token is not paused, and the
+    /// recipient can receive mints. On T6+, the `total_supply` read is deferred to `_mint`.
+    ///
+    /// Returns the resolved recipient and, pre-T6, the total supply.
+    fn preflight_mint(
+        &self,
+        msg_sender: Address,
+        to: Address,
+    ) -> Result<(Recipient, Option<U256>)> {
+        let to = Recipient::resolve(to)?;
+        self.check_role(msg_sender, *ISSUER_ROLE)?;
+
+        let total_supply = if self.storage.spec().is_t6() {
+            None
+        } else {
+            Some(self.total_supply()?)
+        };
+
+        self.validate_mint(&to)?;
+        Ok((to, total_supply))
+    }
+
     /// Check whether a transfer is authorized by the token's [`TIP403Registry`] policy.
     /// [TIP-1015]: For T2+, uses directional sender/recipient checks.
     ///
@@ -1097,7 +1120,7 @@ impl TIP20Token {
             InboundKind::TRANSFER => {
                 self._transfer(originator, &Recipient::direct(ESCROW_ADDRESS), amount)?
             }
-            InboundKind::MINT => self._mint(&Recipient::direct(ESCROW_ADDRESS), amount)?,
+            InboundKind::MINT => self._mint(&Recipient::direct(ESCROW_ADDRESS), amount, None)?,
             InboundKind::__Invalid => {
                 return Err(TIP1028EscrowError::invalid_receipt_claim().into());
             }
@@ -4061,6 +4084,33 @@ pub(crate) mod tests {
 
             Ok(())
         }
+    }
+
+    #[test]
+    fn test_mint_paused_pre_t6_preserves_sload_count() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T5);
+        let (admin, amount) = (Address::random(), U256::random());
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("Test", "TST", admin)
+                .with_issuer(admin)
+                .with_role(admin, *PAUSE_ROLE)
+                .apply()?;
+            token.pause(admin, ITIP20::pauseCall {})?;
+
+            token.storage.reset_counters();
+            let result = token.mint(admin, ITIP20::mintCall { to: admin, amount });
+
+            assert_eq!(
+                result,
+                Err(TempoPrecompileError::TIP20(TIP20Error::contract_paused()))
+            );
+            assert_eq!(token.storage.counter_sload(), 3);
+
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -989,11 +989,7 @@ impl TIP20Token {
     /// recipient can receive mints. On T6+, the `total_supply` read is deferred to `_mint`.
     ///
     /// Returns the resolved recipient and, pre-T6, the total supply.
-    fn validate_mint(
-        &self,
-        msg_sender: Address,
-        to: Address,
-    ) -> Result<(Recipient, Option<U256>)> {
+    fn validate_mint(&self, msg_sender: Address, to: Address) -> Result<(Recipient, Option<U256>)> {
         let to = Recipient::resolve(to)?;
         self.check_role(msg_sender, *ISSUER_ROLE)?;
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -124,6 +124,12 @@ pub static UNPAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"UNPAUSE_R
 pub static ISSUER_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"ISSUER_ROLE"));
 /// Role hash that authorizes burning tokens from blocked accounts.
 pub static BURN_BLOCKED_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"BURN_BLOCKED_ROLE"));
+/// System custody addresses protected from burn-blocked operations, to protect accounting invariants.
+pub const PROTECTED: &[Address] = &[
+    TIP_FEE_MANAGER_ADDRESS,
+    STABLECOIN_DEX_ADDRESS,
+    ESCROW_ADDRESS,
+];
 
 impl TIP20Token {
     /// Returns the token name.
@@ -521,7 +527,7 @@ impl TIP20Token {
     /// - `ContractPaused` — (+T3) token is paused
     /// - `Unauthorized` — caller does not hold `BURN_BLOCKED_ROLE`
     /// - `PolicyForbids` — target address is not blocked by policy
-    /// - `ProtectedAddress` — cannot burn from fee manager or stablecoin DEX addresses
+    /// - `ProtectedAddress` — cannot burn from the system custody addresses
     pub fn burn_blocked(
         &mut self,
         msg_sender: Address,
@@ -533,8 +539,8 @@ impl TIP20Token {
         }
         self.check_role(msg_sender, *BURN_BLOCKED_ROLE)?;
 
-        // Prevent burning from `FeeManager` and `StablecoinDEX` to protect accounting invariants
-        if matches!(call.from, TIP_FEE_MANAGER_ADDRESS | STABLECOIN_DEX_ADDRESS) {
+        // Prevent burning from system custody addresses to protect accounting invariants.
+        if PROTECTED.contains(&call.from) {
             return Err(TIP20Error::protected_address().into());
         }
 
@@ -2937,47 +2943,26 @@ pub(crate) mod tests {
                 .with_mint(TIP_FEE_MANAGER_ADDRESS, amount)
                 // Mint tokens to StablecoinDEX
                 .with_mint(STABLECOIN_DEX_ADDRESS, amount)
+                // Simulate funds backing blocked TIP-1028 receipts
+                .with_mint(ESCROW_ADDRESS, amount)
                 .apply()?;
 
-            // Attempt to burn from FeeManager
-            let result = token.burn_blocked(
-                burner,
-                ITIP20::burnBlockedCall {
-                    from: TIP_FEE_MANAGER_ADDRESS,
-                    amount: amount / U256::from(2),
-                },
-            );
+            for protected in PROTECTED {
+                let result = token.burn_blocked(
+                    burner,
+                    ITIP20::burnBlockedCall {
+                        from: *protected,
+                        amount: amount / U256::from(2),
+                    },
+                );
+                assert_eq!(result.unwrap_err(), TIP20Error::protected_address().into());
 
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::ProtectedAddress(_)))
-            ));
-
-            // Verify FeeManager balance is unchanged
-            let balance = token.balance_of(ITIP20::balanceOfCall {
-                account: TIP_FEE_MANAGER_ADDRESS,
-            })?;
-            assert_eq!(balance, amount);
-
-            // Attempt to burn from StablecoinDEX
-            let result = token.burn_blocked(
-                burner,
-                ITIP20::burnBlockedCall {
-                    from: STABLECOIN_DEX_ADDRESS,
-                    amount: amount / U256::from(2),
-                },
-            );
-
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::ProtectedAddress(_)))
-            ));
-
-            // Verify StablecoinDEX balance is unchanged
-            let balance = token.balance_of(ITIP20::balanceOfCall {
-                account: STABLECOIN_DEX_ADDRESS,
-            })?;
-            assert_eq!(balance, amount);
+                // Verify balance is unchanged
+                let balance = token.balance_of(ITIP20::balanceOfCall {
+                    account: *protected,
+                })?;
+                assert_eq!(balance, amount);
+            }
 
             Ok(())
         })

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -402,7 +402,7 @@ impl TIP20Token {
     pub fn mint(&mut self, msg_sender: Address, call: ITIP20::mintCall) -> Result<()> {
         let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             Address::ZERO,
             &to,
             call.amount,
@@ -432,7 +432,7 @@ impl TIP20Token {
     ) -> Result<()> {
         let (to, total_supply) = self.validate_mint(msg_sender, call.to)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             Address::ZERO,
             &to,
             call.amount,
@@ -725,7 +725,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             msg_sender,
             &to,
             call.amount,
@@ -761,7 +761,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             call.from,
             &to,
             call.amount,
@@ -788,7 +788,7 @@ impl TIP20Token {
         self.validate_transfer(call.from, &to)?;
         self.consume_allowance(call.from, msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             call.from,
             &to,
             call.amount,
@@ -831,7 +831,7 @@ impl TIP20Token {
         self.validate_transfer(from, &to)?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.validate_or_escrow_funds(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
+        if self.validate_or_escrow(from, &to, amount, InboundKind::TRANSFER, B256::ZERO)? {
             return Ok(true);
         }
 
@@ -869,7 +869,7 @@ impl TIP20Token {
         self.validate_transfer(msg_sender, &to)?;
         self.check_and_update_spending_limit(msg_sender, call.amount)?;
 
-        if self.validate_or_escrow_funds(
+        if self.validate_or_escrow(
             msg_sender,
             &to,
             call.amount,
@@ -1095,7 +1095,7 @@ impl TIP20Token {
     ///
     /// Returns `true` when receive-policies block the inbound and this function escrows the funds.
     /// Callers must ONLY move funds when `false` is returned.
-    fn validate_or_escrow_funds(
+    fn validate_or_escrow(
         &mut self,
         originator: Address,
         to: &Recipient,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1150,6 +1150,8 @@ impl TIP20Token {
         amount: U256,
         meter_spending_limit: bool,
     ) -> Result<()> {
+        self.check_not_paused()?;
+
         if to == ESCROW_ADDRESS {
             return Err(TIP1028EscrowError::escrow_address_reserved().into());
         }

--- a/crates/precompiles/src/tip403_registry/dispatch.rs
+++ b/crates/precompiles/src/tip403_registry/dispatch.rs
@@ -62,7 +62,9 @@ impl Precompile for TIP403Registry {
                 ITIP403RegistryCalls::compoundPolicyData(call) => {
                     view(call, |c| self.compound_policy_data(c))
                 }
-                ITIP403RegistryCalls::receivePolicy(call) => view(call, |c| self.receive_policy(c)),
+                ITIP403RegistryCalls::receivePolicy(call) => {
+                    view(call, |c| self.receive_policy(c.account))
+                }
                 ITIP403RegistryCalls::validateReceivePolicy(call) => view(call, |c| {
                     let blocked_reason = self
                         .validate_receive_policy(c.token, c.sender, c.receiver)?

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -345,6 +345,15 @@ impl TIP403Registry {
             return Err(TIP403RegistryError::virtual_address_not_allowed().into());
         }
 
+        let recovery_address = call.recoveryAddress;
+        if recovery_address == ESCROW_ADDRESS
+            || recovery_address == msg_sender
+            || recovery_address.is_tip20()
+            || recovery_address.is_virtual()
+        {
+            return Err(TIP403RegistryError::invalid_receive_policy_address().into());
+        }
+
         self.validate_receive_policy_id(call.senderPolicyId)?;
         self.validate_receive_policy_id(call.tokenFilterId)?;
 
@@ -352,7 +361,7 @@ impl TIP403Registry {
             has_receive_policy: true,
             sender_policy_id: call.senderPolicyId,
             token_filter_id: call.tokenFilterId,
-            recovery_address: call.recoveryAddress,
+            recovery_address,
         })?;
 
         self.emit_event(TIP403RegistryEvent::ReceivePolicyUpdated(
@@ -360,7 +369,7 @@ impl TIP403Registry {
                 account: msg_sender,
                 senderPolicyId: call.senderPolicyId,
                 tokenFilterId: call.tokenFilterId,
-                recoveryAddress: call.recoveryAddress,
+                recoveryAddress: recovery_address,
             },
         ))
     }
@@ -866,7 +875,7 @@ mod tests {
     };
     use rand_08::Rng;
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
+    use tempo_contracts::precompiles::{PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS};
     use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
 
     #[test]
@@ -1154,6 +1163,44 @@ mod tests {
                     TIP403RegistryError::VirtualAddressNotAllowed(_)
                 ))
             ));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_set_receive_policy_rejects_invalid_recovery_address() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        let account = Address::random();
+        let virtual_addr = Address::new_virtual(MasterId::random(), UserTag::random());
+
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = TIP403Registry::new();
+
+            for recovery_address in [ESCROW_ADDRESS, PATH_USD_ADDRESS, virtual_addr, account] {
+                let result = registry.set_receive_policy(
+                    account,
+                    ITIP403Registry::setReceivePolicyCall {
+                        senderPolicyId: REJECT_ALL_POLICY_ID,
+                        tokenFilterId: ALLOW_ALL_POLICY_ID,
+                        recoveryAddress: recovery_address,
+                    },
+                );
+                assert_eq!(
+                    result.unwrap_err(),
+                    TIP403RegistryError::invalid_receive_policy_address().into()
+                );
+            }
+
+            // Zero remains the self-recovery sentinel.
+            registry.set_receive_policy(
+                account,
+                ITIP403Registry::setReceivePolicyCall {
+                    senderPolicyId: REJECT_ALL_POLICY_ID,
+                    tokenFilterId: ALLOW_ALL_POLICY_ID,
+                    recoveryAddress: Address::ZERO,
+                },
+            )?;
 
             Ok(())
         })

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -49,7 +49,7 @@ pub struct TIP403Registry {
     /// address is restricted.
     policy_set: Mapping<u64, Mapping<Address, bool>>,
     /// Account receive policy configuration.
-    address_receive_config: Mapping<Address, ReceivePolicyConfig>,
+    receive_policy_config: Mapping<Address, ReceivePolicyConfig>,
 }
 
 #[derive(Debug, Clone, Default, Storable)]
@@ -240,11 +240,8 @@ impl TIP403Registry {
     }
 
     /// Returns `account`'s receive-policy configuration.
-    pub fn receive_policy(
-        &self,
-        call: ITIP403Registry::receivePolicyCall,
-    ) -> Result<ITIP403Registry::receivePolicyReturn> {
-        let config = self.address_receive_config[call.account].read()?;
+    pub fn receive_policy(&self, account: Address) -> Result<ITIP403Registry::receivePolicyReturn> {
+        let config = self.receive_policy_config[account].read()?;
         Ok(ITIP403Registry::receivePolicyReturn {
             hasReceivePolicy: config.has_receive_policy,
             senderPolicyId: config.sender_policy_id,
@@ -263,7 +260,7 @@ impl TIP403Registry {
         sender: Address,
         receiver: Address,
     ) -> Result<Option<ITIP403Registry::BlockedReason>> {
-        let config = self.address_receive_config[receiver].read()?;
+        let config = self.receive_policy_config[receiver].read()?;
         if !config.has_receive_policy {
             return Ok(None);
         }
@@ -281,7 +278,7 @@ impl TIP403Registry {
 
     /// Returns `receiver`'s configured recovery address, or zero if no receive policy is set.
     pub fn receive_policy_recovery(&self, receiver: Address) -> Result<Address> {
-        Ok(self.address_receive_config[receiver]
+        Ok(self.receive_policy_config[receiver]
             .read()?
             .recovery_address)
     }
@@ -357,7 +354,7 @@ impl TIP403Registry {
         self.validate_receive_policy_id(call.senderPolicyId)?;
         self.validate_receive_policy_id(call.tokenFilterId)?;
 
-        self.address_receive_config[msg_sender].write(ReceivePolicyConfig {
+        self.receive_policy_config[msg_sender].write(ReceivePolicyConfig {
             has_receive_policy: true,
             sender_policy_id: call.senderPolicyId,
             token_filter_id: call.tokenFilterId,
@@ -1059,7 +1056,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let registry = TIP403Registry::new();
 
-            let policy = registry.receive_policy(ITIP403Registry::receivePolicyCall { account })?;
+            let policy = registry.receive_policy(account)?;
             assert!(!policy.hasReceivePolicy);
             assert_eq!(policy.senderPolicyId, REJECT_ALL_POLICY_ID);
             assert_eq!(
@@ -1100,7 +1097,7 @@ mod tests {
                 },
             )?;
 
-            let policy = registry.receive_policy(ITIP403Registry::receivePolicyCall { account })?;
+            let policy = registry.receive_policy(account)?;
             assert!(policy.hasReceivePolicy);
             assert_eq!(policy.senderPolicyId, REJECT_ALL_POLICY_ID);
             assert_eq!(


### PR DESCRIPTION
this PR fixes:
- re-execution in `mint` paths
- validate recovery address when setting receive policies
- block claims when token is paused
- add escrow to the list of protected addresses

additionally it performs some formatting and documentation nits