### PR TITLE
docs(tip-1053): simplify nonce presence semantics

### DIFF
--- a/tips/tip-1053.md
+++ b/tips/tip-1053.md
@@ -33,7 +33,7 @@ The protocol stays minimal: it does not learn about sign-in semantics, applicati
 
 - The offchain verifier (e.g. app server) is responsible for replay protection of its own session flow. The protocol's nonce uniqueness check protects the onchain registration of the **key authorization**; an offchain verifier still needs to bind its session to the specific nonce it issued.
 - The `nonce` format is application-defined when used as a challenge digest. The protocol does not validate its structure.
-- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. The field defaults to absent / zero, in which case the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization and no nonce tracking is performed.
+- This TIP is purely additive to `key_authorization`. Existing authorizations (without the field) continue to validate identically. When the field is absent, the resulting hash is byte-equivalent to pre-TIP-1053 encoding for that authorization and no nonce tracking is performed.
 - Nonce-bearing authorizations gain an additional uniqueness guarantee at the `(account, nonce)` granularity.
 
 ---
@@ -52,13 +52,13 @@ key_authorization = rlp([
   expiry?,
   limits?,
   allowed_calls?,
-  nonce?,  // NEW — 32 bytes, default zero/absent
+  nonce?,  // NEW — 32 bytes
 ])
 ```
 
 - Encoding is RLP, identical to the existing payload format with one optional trailing item.
 - `nonce` MUST be exactly 32 bytes when present.
-- A `nonce` of `bytes32(0)` is reserved to mean "no nonce" and MUST be omitted from the RLP encoding rather than encoded as 32 zero bytes. This guarantees byte-equivalence with pre-TIP-1053 encoding for nonce-less authorizations.
+- Absence of the trailing field means "no nonce". If the field is present, its exact `bytes32` value is the nonce, including `bytes32(0)`.
 
 ## Signing
 
@@ -75,13 +75,13 @@ No additional domain separation is introduced. RLP boundaries already disambigua
 The protocol:
 
 - MUST include `nonce` in the signing hash whenever it is present in the encoded `key_authorization`.
-- MUST enforce that, for any account `A`, a given non-zero `nonce` is consumed at most once. An attempt to register a `key_authorization` whose `(account, nonce)` pair has already been consumed MUST revert.
+- MUST enforce that, for any account `A`, a present `nonce` is consumed at most once. An attempt to register a `key_authorization` whose `(account, nonce)` pair has already been consumed MUST revert.
 - MUST mark `(account, nonce)` as consumed atomically with the successful registration of the authorization.
 - MUST NOT enforce ordering, monotonicity, or any other structural constraint on `nonce`. Nonces may be arbitrary 32-byte values chosen by the application.
 - MUST NOT interpret the `nonce` value beyond uniqueness tracking.
 - MUST NOT emit `nonce` in any event by default beyond what is needed to expose consumption.
 
-A nonce-less authorization (field absent / `bytes32(0)`) is processed exactly as in pre-TIP-1053 behavior: no uniqueness check is performed, no state is written for nonce tracking, and the existing `keys[account][key_id]` permanence is the sole replay guard.
+A nonce-less authorization (field absent) is processed exactly as in pre-TIP-1053 behavior: no uniqueness check is performed, no state is written for nonce tracking, and the existing `keys[account][key_id]` permanence is the sole replay guard.
 
 The field is invisible to existing precompile read paths that surface `KeyInfo`. A new read path MAY be added to query consumption status of a given `(account, nonce)` pair.
 
@@ -123,14 +123,14 @@ The `nonce` format is application-defined when used as a challenge digest. The p
 
 ## Backward Compatibility
 
-- Existing key authorizations without the field continue to validate. The encoder MUST omit the trailing field when `nonce == bytes32(0)`, producing a byte-equivalent encoding to pre-TIP-1053 payloads.
-- Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a non-zero nonce, which is the correct fail-safe.
-- Nonce uniqueness tracking is only engaged for non-zero nonces; legacy nonce-less authorizations incur no additional state.
+- Existing key authorizations without the field continue to validate and produce byte-equivalent encodings to pre-TIP-1053 payloads.
+- Legacy verifiers that don't understand the field will compute the same hash for legacy-shaped authorizations and will reject (signature mismatch) for authorizations with a present nonce, which is the correct fail-safe.
+- Nonce uniqueness tracking is only engaged when the nonce field is present; legacy nonce-less authorizations incur no additional state.
 
 # Invariants
 
 1. **Hash inclusion.** When `nonce` is present in the encoded `key_authorization`, it MUST be part of the signing hash.
 
-2. **Encoding determinism.** A `nonce` of `bytes32(0)` MUST be omitted from the RLP encoding, never encoded as 32 zero bytes.
+2. **Encoding determinism.** An absent `nonce` field MUST be omitted from the RLP encoding. A present `nonce` field MUST encode its exact 32-byte value.
 
-3. **Single-use.** For any account `A` and any non-zero `nonce` value `n`, the protocol MUST accept at most one successful `key_authorization` registration or burn for `(A, n)`.
+3. **Single-use.** For any account `A` and any present `nonce` value `n`, the protocol MUST accept at most one successful `key_authorization` registration or burn for `(A, n)`.


### PR DESCRIPTION
Updates TIP-1053 so nonce presence, not nonce value, determines whether replay tracking is enabled: an absent trailing field means no nonce, while any present `bytes32` value is a nonce, including `bytes32(0)`.

This keeps backward compatibility for legacy authorizations because absent trailing fields are still omitted and therefore produce byte-equivalent RLP/signing hashes. It also removes a wire-level footgun: RLP already distinguishes an absent trailing field from an explicit empty field (`0x80`) and from a present `bytes32(0)` field (`0xa0` plus 32 zero bytes), so reserving zero as a no-nonce sentinel adds special-case implementation logic without buying additional compatibility.

The simpler rule lets implementations use the existing canonical trailing-field RLP conventions directly, avoids custom `KeyAuthorizationNonce`/zero-normalization machinery, and gives users/verifiers meaningful semantics: if a nonce field is present, its exact bytes are signed and consumed once.
