### PR TITLE
fix(rpc): return results not panics

### DIFF
--- a/crates/node/src/rpc/consensus/mod.rs
+++ b/crates/node/src/rpc/consensus/mod.rs
@@ -106,11 +106,7 @@ impl<I: ConsensusFeed> TempoConsensusRpc<I> {
 #[async_trait::async_trait]
 impl<I: ConsensusFeed> TempoConsensusApiServer for TempoConsensusRpc<I> {
     async fn get_finalization(&self, query: Query) -> RpcResult<CertifiedBlock> {
-        match self.consensus_feed.get_finalization(query).await {
-            types::Response::Success(obj) => Ok(obj),
-            types::Response::NotReady => todo!(),
-            types::Response::Missing(_) => todo!(),
-        }
+        self.consensus_feed.get_finalization(query).await.into()
     }
 
     async fn get_latest(&self) -> RpcResult<ConsensusState> {

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -74,7 +74,7 @@ impl Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match serde_json::to_string(self) {
             Ok(s) => f.write_str(&s),
-            Err(err) => write!(f, "<failed formatting query: {err}"),
+            Err(err) => write!(f, "<failed formatting query: {err}>"),
         }
     }
 }
@@ -175,9 +175,9 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Success(obj) => write!(f, "success: {obj}`"),
+            Self::Success(obj) => write!(f, "success: {obj}"),
             Self::NotReady => write!(f, "service not ready"),
-            Self::Missing(msg) => write!(f, "missing: {msg}`"),
+            Self::Missing(msg) => write!(f, "missing: {msg}"),
         }
     }
 }


### PR DESCRIPTION
Forgot to wire up the `From` impls for consensus RPC responses.