### PR TITLE
feat: add Addressbook contract — per-user name→address storage

### DIFF
--- a/tips/verify/src/Addressbook.sol
+++ b/tips/verify/src/Addressbook.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+/// @title Addressbook
+/// @notice Per-user address book: each `msg.sender` owns an independent
+///         namespace of name → address entries.  Only the owner can create,
+///         update, or delete entries in their own book.
+contract Addressbook {
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event EntrySet(address indexed owner, string name, address addr);
+    event EntryRemoved(address indexed owner, string name);
+
+    /*//////////////////////////////////////////////////////////////
+                                ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error EmptyName();
+    error EntryNotFound(string name);
+
+    /*//////////////////////////////////////////////////////////////
+                                STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /// owner → name → address
+    mapping(address => mapping(string => address)) private _entries;
+
+    /// owner → ordered list of names (for enumeration)
+    mapping(address => string[]) private _names;
+
+    /// owner → name → index+1 in _names (0 means not present)
+    mapping(address => mapping(string => uint256)) private _nameIndex;
+
+    /*//////////////////////////////////////////////////////////////
+                            MUTATIVE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Add or update a name → address entry in the caller's book.
+    /// @param name  Human-readable label (must be non-empty).
+    /// @param addr  The address to associate with `name`.
+    function set(string calldata name, address addr) external {
+        if (bytes(name).length == 0) revert EmptyName();
+
+        _entries[msg.sender][name] = addr;
+
+        // Track the name for enumeration if it's new.
+        if (_nameIndex[msg.sender][name] == 0) {
+            _names[msg.sender].push(name);
+            _nameIndex[msg.sender][name] = _names[msg.sender].length; // 1-indexed
+        }
+
+        emit EntrySet(msg.sender, name, addr);
+    }
+
+    /// @notice Remove an entry from the caller's book.
+    /// @param name  The label to remove.
+    function remove(string calldata name) external {
+        uint256 idx = _nameIndex[msg.sender][name];
+        if (idx == 0) revert EntryNotFound(name);
+
+        delete _entries[msg.sender][name];
+
+        // Swap-and-pop to keep enumeration array compact.
+        uint256 lastIdx = _names[msg.sender].length;
+        if (idx != lastIdx) {
+            string memory lastName = _names[msg.sender][lastIdx - 1];
+            _names[msg.sender][idx - 1] = lastName;
+            _nameIndex[msg.sender][lastName] = idx;
+        }
+        _names[msg.sender].pop();
+        delete _nameIndex[msg.sender][name];
+
+        emit EntryRemoved(msg.sender, name);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              VIEW
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Resolve a name in a given owner's book.
+    function get(address owner, string calldata name) external view returns (address) {
+        return _entries[owner][name];
+    }
+
+    /// @notice Return how many entries an owner has.
+    function count(address owner) external view returns (uint256) {
+        return _names[owner].length;
+    }
+
+    /// @notice Return all names in an owner's book.
+    function listNames(address owner) external view returns (string[] memory) {
+        return _names[owner];
+    }
+
+    /// @notice Return all entries (names + addresses) for an owner.
+    function listAll(address owner)
+        external
+        view
+        returns (string[] memory names, address[] memory addrs)
+    {
+        names = _names[owner];
+        addrs = new address[](names.length);
+        for (uint256 i; i < names.length; ++i) {
+            addrs[i] = _entries[owner][names[i]];
+        }
+    }
+
+}

--- a/tips/verify/test/Addressbook.t.sol
+++ b/tips/verify/test/Addressbook.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import { Addressbook } from "../src/Addressbook.sol";
+import { Test } from "forge-std/Test.sol";
+
+/// @title Addressbook Tests
+/// @notice Unit tests for the per-user Addressbook contract.
+contract AddressbookTest is Test {
+
+    Addressbook public book;
+
+    address public alice = address(0x200);
+    address public bob = address(0x300);
+    address public target1 = address(0x1001);
+    address public target2 = address(0x1002);
+    address public target3 = address(0x1003);
+
+    function setUp() public {
+        book = new Addressbook();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            SET + GET
+    //////////////////////////////////////////////////////////////*/
+
+    function test_SetAndGet() public {
+        vm.prank(alice);
+        book.set("vault", target1);
+
+        assertEq(book.get(alice, "vault"), target1);
+    }
+
+    function test_SetOverwrite() public {
+        vm.startPrank(alice);
+        book.set("vault", target1);
+        book.set("vault", target2);
+        vm.stopPrank();
+
+        assertEq(book.get(alice, "vault"), target2);
+        // Overwrite should not duplicate the name in the list.
+        assertEq(book.count(alice), 1);
+    }
+
+    function test_SetEmptyNameReverts() public {
+        vm.prank(alice);
+        vm.expectRevert(Addressbook.EmptyName.selector);
+        book.set("", target1);
+    }
+
+    function test_SetEmitsEvent() public {
+        vm.prank(alice);
+        vm.expectEmit(true, false, false, true);
+        emit Addressbook.EntrySet(alice, "vault", target1);
+        book.set("vault", target1);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ISOLATION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_IsolationBetweenUsers() public {
+        vm.prank(alice);
+        book.set("vault", target1);
+
+        vm.prank(bob);
+        book.set("vault", target2);
+
+        assertEq(book.get(alice, "vault"), target1);
+        assertEq(book.get(bob, "vault"), target2);
+    }
+
+    function test_GetNonexistentReturnsZero() public view {
+        assertEq(book.get(alice, "nope"), address(0));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              REMOVE
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Remove() public {
+        vm.startPrank(alice);
+        book.set("vault", target1);
+        book.remove("vault");
+        vm.stopPrank();
+
+        assertEq(book.get(alice, "vault"), address(0));
+        assertEq(book.count(alice), 0);
+    }
+
+    function test_RemoveNonexistentReverts() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Addressbook.EntryNotFound.selector, "nope"));
+        book.remove("nope");
+    }
+
+    function test_RemoveEmitsEvent() public {
+        vm.startPrank(alice);
+        book.set("vault", target1);
+
+        vm.expectEmit(true, false, false, true);
+        emit Addressbook.EntryRemoved(alice, "vault");
+        book.remove("vault");
+        vm.stopPrank();
+    }
+
+    function test_RemoveMiddleEntry() public {
+        vm.startPrank(alice);
+        book.set("a", target1);
+        book.set("b", target2);
+        book.set("c", target3);
+
+        book.remove("b");
+        vm.stopPrank();
+
+        assertEq(book.count(alice), 2);
+        assertEq(book.get(alice, "a"), target1);
+        assertEq(book.get(alice, "b"), address(0));
+        assertEq(book.get(alice, "c"), target3);
+
+        // The remaining names should still enumerate without gaps.
+        string[] memory names = book.listNames(alice);
+        assertEq(names.length, 2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          ENUMERATION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_ListNamesAndListAll() public {
+        vm.startPrank(alice);
+        book.set("vault", target1);
+        book.set("hot", target2);
+        vm.stopPrank();
+
+        string[] memory names = book.listNames(alice);
+        assertEq(names.length, 2);
+
+        (string[] memory allNames, address[] memory allAddrs) = book.listAll(alice);
+        assertEq(allNames.length, 2);
+        assertEq(allAddrs.length, 2);
+    }
+
+    function test_CountEmpty() public view {
+        assertEq(book.count(alice), 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          RE-ADD AFTER REMOVE
+    //////////////////////////////////////////////////////////////*/
+
+    function test_ReAddAfterRemove() public {
+        vm.startPrank(alice);
+        book.set("vault", target1);
+        book.remove("vault");
+        book.set("vault", target3);
+        vm.stopPrank();
+
+        assertEq(book.get(alice, "vault"), target3);
+        assertEq(book.count(alice), 1);
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds a Solidity `Addressbook` contract in `tips/verify/src/` where each `msg.sender` owns an independent namespace of name → address entries. Only the owner can `set()` or `remove()` entries in their own book; anyone can `get()`, `listNames()`, or `listAll()` on any owner's book.

### Contract API

| Function | Access | Description |
|---|---|---|
| `set(name, addr)` | owner only (`msg.sender`) | Add or update an entry |
| `remove(name)` | owner only | Delete an entry |
| `get(owner, name)` | public view | Resolve a name |
| `count(owner)` | public view | Number of entries |
| `listNames(owner)` | public view | All names |
| `listAll(owner)` | public view | All names + addresses |

### Tests

13 unit tests (all passing) covering: set, overwrite, empty-name revert, event emission, user isolation, get nonexistent, remove, remove-nonexistent revert, remove-middle swap-and-pop, enumeration, and re-add after remove.