### PR TITLE
chore: update snapshot and tracy URLs from tempoxyz.dev to tempo.xyz

### DIFF
--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -10,8 +10,8 @@ use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::hardfork::TempoHardfork;
 use url::Url;
 
-pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
-const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempo.xyz/4217";
+const SNAPSHOT_API_URL: &str = "https://snapshots.tempo.xyz/api/snapshots";
 
 /// Default OTLP logs filter level for telemetry.
 const DEFAULT_LOGS_OTLP_FILTER: &str = "debug";
@@ -152,8 +152,8 @@ fn init_download_urls() {
     let download_defaults = DownloadDefaults {
         available_snapshots: vec![
             Cow::Owned(format!("{DEFAULT_DOWNLOAD_URL} (mainnet)")),
-            Cow::Borrowed("https://snapshots.tempoxyz.dev/42431 (moderato)"),
-            Cow::Borrowed("https://snapshots.tempoxyz.dev/42429 (andantino)"),
+            Cow::Borrowed("https://snapshots.tempo.xyz/42431 (moderato)"),
+            Cow::Borrowed("https://snapshots.tempo.xyz/42429 (andantino)"),
         ],
         default_base_url: Cow::Borrowed(DEFAULT_DOWNLOAD_URL),
         default_chain_aware_base_url: None,

--- a/tempo.nu
+++ b/tempo.nu
@@ -733,7 +733,7 @@ def upload-tracy-profile [profile_path: string, label: string, commit_sha: strin
     let short_sha = ($commit_sha | str substring 0..7)
     let remote_name = $"($label)-($short_sha)-($timestamp).tracy"
     let mc_alias = "r2"
-    let viewer_base = "https://tracy.tempoxyz.dev"
+    let viewer_base = "https://tracy.tempo.xyz"
 
     try {
         mc cp $profile_path $"($mc_alias)/tracy/profiles/($remote_name)"


### PR DESCRIPTION
Updates all snapshot download URLs and the tracy viewer URL from `tempoxyz.dev` to `tempo.xyz` to match the domain migration.

### Changes
- `bin/tempo/src/defaults.rs`: `snapshots.tempoxyz.dev` → `snapshots.tempo.xyz` (mainnet, moderato, andantino, and API URL)
- `tempo.nu`: `tracy.tempoxyz.dev` → `tracy.tempo.xyz`

Once a binary with these URLs is released, the Cloudflare redirect page rules can be removed.