### PR TITLE
feat(ci): add nightly replay benchmark workflow

### DIFF
--- a/.github/scripts/bench-replay-scheduled-refs.sh
+++ b/.github/scripts/bench-replay-scheduled-refs.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Resolves baseline and feature refs for scheduled replay benchmark runs.
+#
+# The feature ref is the latest successful scheduled docker.yml build. The
+# baseline ref is the last successful scheduled replay feature ref persisted in
+# the charts repo. If the nightly Docker build is stale or unchanged, the
+# caller can alert, fail, or skip before occupying a benchmark runner.
+#
+# Usage: bench-replay-scheduled-refs.sh <force>
+#   force - "true" to run even if no new nightly commit is available
+#
+# Outputs (via GITHUB_OUTPUT):
+#   baseline-ref
+#   baseline-name
+#   feature-ref
+#   feature-name
+#   should-skip
+#   is-stale
+#   stale-age-hours
+#   nightly-created
+set -euxo pipefail
+
+FORCE="${1:-false}"
+REPO="${GITHUB_REPOSITORY:-tempoxyz/tempo}"
+STATE_REPO="${BENCH_REPLAY_STATE_REPO:-decofe/tempo-bench-charts}"
+STATE_FILE="${BENCH_REPLAY_STATE_FILE:-state/replay-nightly-last-feature-ref}"
+STALE_THRESHOLD_HOURS="${BENCH_REPLAY_STALE_THRESHOLD_HOURS:-24}"
+
+echo "Force: $FORCE"
+echo "Repository: $REPO"
+
+# --- Step 1: Query latest successful scheduled docker.yml run ---
+echo "::group::Querying latest nightly docker build"
+RUNS_JSON=$(gh run list \
+  -R "$REPO" \
+  --workflow=docker.yml \
+  --event=schedule \
+  --status=completed \
+  --limit 10 \
+  --json headSha,createdAt,conclusion)
+
+LATEST=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.conclusion == "success")] | first // empty')
+if [ -z "$LATEST" ]; then
+  echo "::error::No successful scheduled docker.yml run found in the last 10 runs"
+  echo "Runs found: $RUNS_JSON"
+  exit 1
+fi
+
+FEATURE_REF=$(echo "$LATEST" | jq -r '.headSha')
+CREATED_AT=$(echo "$LATEST" | jq -r '.createdAt')
+echo "Latest nightly commit: $FEATURE_REF"
+echo "Built at: $CREATED_AT"
+echo "::endgroup::"
+
+# --- Step 2: Staleness check ---
+echo "::group::Checking nightly staleness"
+NOW_EPOCH=$(date +%s)
+CREATED_EPOCH=$(date -d "$CREATED_AT" +%s 2>/dev/null || \
+  date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null || \
+  date -j -f "%Y-%m-%dT%T%z" "$CREATED_AT" +%s 2>/dev/null || \
+  { echo "::error::Cannot parse date: $CREATED_AT"; exit 1; })
+
+AGE_SECONDS=$(( NOW_EPOCH - CREATED_EPOCH ))
+AGE_HOURS=$(( AGE_SECONDS / 3600 ))
+IS_STALE="false"
+
+if [ "$AGE_HOURS" -gt "$STALE_THRESHOLD_HOURS" ]; then
+  IS_STALE="true"
+  echo "::warning::Stale nightly Docker build: ${AGE_HOURS}h old (threshold: ${STALE_THRESHOLD_HOURS}h)"
+else
+  echo "Nightly Docker build age: ${AGE_HOURS}h"
+fi
+echo "::endgroup::"
+
+# --- Step 3: Read last successful feature ref from charts repo state branch ---
+echo "::group::Reading persisted replay state"
+LAST_FEATURE_REF=""
+STATE_URL="https://raw.githubusercontent.com/${STATE_REPO}/state/${STATE_FILE}"
+if RAW=$(curl -sfL -H "Authorization: token ${DEREK_TOKEN}" "$STATE_URL"); then
+  LAST_FEATURE_REF=$(echo "$RAW" | tr -d '[:space:]')
+  echo "Previous replay feature ref: $LAST_FEATURE_REF"
+else
+  echo "No persisted replay state found"
+fi
+echo "::endgroup::"
+
+# --- Step 4: Determine baseline and skip logic ---
+echo "::group::Resolving refs"
+SHOULD_SKIP="false"
+BASELINE_REF="$FEATURE_REF"
+
+if [ "$IS_STALE" = "true" ]; then
+  BASELINE_REF="${LAST_FEATURE_REF:-$FEATURE_REF}"
+  echo "Stale nightly detected; workflow will fail before benchmarking"
+elif [ -z "$LAST_FEATURE_REF" ]; then
+  BASELINE_REF="$FEATURE_REF"
+  echo "First run; benchmarking nightly against itself to establish replay state"
+elif [ "$LAST_FEATURE_REF" = "$FEATURE_REF" ]; then
+  BASELINE_REF="$LAST_FEATURE_REF"
+  if [ "$FORCE" = "true" ] || [ "$FORCE" = "--force" ]; then
+    echo "No new nightly commit, but force=true; running anyway"
+  else
+    SHOULD_SKIP="true"
+    echo "No new nightly commit since last successful replay; skipping"
+  fi
+else
+  BASELINE_REF="$LAST_FEATURE_REF"
+  echo "New nightly commit detected"
+fi
+
+BASELINE_NAME="nightly-${BASELINE_REF:0:8}"
+FEATURE_NAME="nightly-${FEATURE_REF:0:8}"
+
+echo "Baseline: $BASELINE_REF"
+echo "Feature:  $FEATURE_REF"
+echo "Skip:     $SHOULD_SKIP"
+echo "Stale:    $IS_STALE"
+echo "::endgroup::"
+
+# --- Step 5: Write outputs ---
+{
+  echo "baseline-ref=$BASELINE_REF"
+  echo "baseline-name=$BASELINE_NAME"
+  echo "feature-ref=$FEATURE_REF"
+  echo "feature-name=$FEATURE_NAME"
+  echo "should-skip=$SHOULD_SKIP"
+  echo "is-stale=$IS_STALE"
+  echo "stale-age-hours=$AGE_HOURS"
+  echo "nightly-created=$CREATED_AT"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -1,0 +1,249 @@
+# Scheduled replay regression benchmarks.
+#
+# Runs nightly after the Docker workflow's 09:05 UTC scheduled build. The
+# benchmark compares the latest successful nightly Docker commit against the
+# last commit that completed this scheduled replay workflow successfully.
+
+name: bench-replay-scheduled
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force run even if no new nightly commit is available"
+        required: false
+        default: false
+        type: boolean
+      chains:
+        description: "Chain replay set"
+        required: false
+        default: "both"
+        type: choice
+        options:
+          - both
+          - mainnet
+          - testnet
+      blocks:
+        description: "Number of blocks to benchmark"
+        required: false
+        default: "5000"
+        type: string
+      warmup:
+        description: "Number of warmup blocks"
+        required: false
+        default: "1000"
+        type: string
+      samply:
+        description: "Enable samply profiling"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  resolve-refs:
+    name: resolve-refs
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      baseline-ref: ${{ steps.refs.outputs.baseline-ref }}
+      baseline-name: ${{ steps.refs.outputs.baseline-name }}
+      feature-ref: ${{ steps.refs.outputs.feature-ref }}
+      feature-name: ${{ steps.refs.outputs.feature-name }}
+      should-skip: ${{ steps.refs.outputs.should-skip }}
+      is-stale: ${{ steps.refs.outputs.is-stale }}
+      stale-age-hours: ${{ steps.refs.outputs.stale-age-hours }}
+      nightly-created: ${{ steps.refs.outputs.nightly-created }}
+      chains-json: ${{ steps.config.outputs.chains-json }}
+      blocks: ${{ steps.config.outputs.blocks }}
+      warmup: ${{ steps.config.outputs.warmup }}
+      samply: ${{ steps.config.outputs.samply }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: true
+
+      - name: Resolve inputs
+        id: config
+        env:
+          INPUT_CHAINS: ${{ inputs.chains || 'both' }}
+          INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
+          INPUT_WARMUP: ${{ inputs.warmup || '1000' }}
+          INPUT_SAMPLY: ${{ inputs.samply || 'false' }}
+        run: |
+          case "$INPUT_CHAINS" in
+            both) CHAINS_JSON='["mainnet","testnet"]' ;;
+            mainnet) CHAINS_JSON='["mainnet"]' ;;
+            testnet) CHAINS_JSON='["testnet"]' ;;
+            *)
+              echo "::error::Unknown chains value: $INPUT_CHAINS"
+              exit 1
+              ;;
+          esac
+
+          if ! [[ "$INPUT_BLOCKS" =~ ^[0-9]+$ ]]; then
+            echo "::error::blocks must be a non-negative integer"
+            exit 1
+          fi
+          if ! [[ "$INPUT_WARMUP" =~ ^[0-9]+$ ]]; then
+            echo "::error::warmup must be a non-negative integer"
+            exit 1
+          fi
+
+          if [ "$INPUT_SAMPLY" = "true" ]; then
+            SAMPLY="true"
+          else
+            SAMPLY="false"
+          fi
+
+          {
+            echo "chains-json=$CHAINS_JSON"
+            echo "blocks=$INPUT_BLOCKS"
+            echo "warmup=$INPUT_WARMUP"
+            echo "samply=$SAMPLY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve refs
+        id: refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          INPUT_FORCE: ${{ inputs.force || 'false' }}
+        run: bash .github/scripts/bench-replay-scheduled-refs.sh "$INPUT_FORCE"
+
+      - name: Alert on stale nightly
+        if: steps.refs.outputs.is-stale == 'true'
+        uses: actions/github-script@v8
+        env:
+          SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+          SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
+        with:
+          script: |
+            const token = process.env.SLACK_BENCH_BOT_TOKEN;
+            const channel = process.env.SLACK_BENCH_CHANNEL;
+            if (!token || !channel) {
+              core.warning('Slack credentials not set, skipping stale nightly alert');
+              return;
+            }
+
+            const repo = '${{ github.repository }}';
+            const runUrl = `${context.serverUrl}/${repo}/actions/runs/${context.runId}`;
+            const ageHours = '${{ steps.refs.outputs.stale-age-hours }}';
+            const created = '${{ steps.refs.outputs.nightly-created }}';
+            const featureRef = '${{ steps.refs.outputs.feature-ref }}';
+            const shortSha = featureRef.slice(0, 8);
+            const blocks = [
+              {
+                type: 'header',
+                text: { type: 'plain_text', text: ':rotating_light: Replay Nightly: Docker build is stale', emoji: true },
+              },
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: [
+                    '*Scheduled replay benchmark did not run* because the latest nightly Docker build is stale.',
+                    '',
+                    `The latest nightly image was built from a commit that is *${ageHours}h old* (threshold: 24h).`,
+                    `Stale commit: \`${shortSha}\` (built at ${created})`,
+                    '',
+                    '*Action required:* Check the <https://github.com/' + repo + '/actions/workflows/docker.yml|docker.yml> workflow.',
+                  ].join('\n'),
+                },
+              },
+              {
+                type: 'actions',
+                elements: [{
+                  type: 'button',
+                  text: { type: 'plain_text', text: 'View Run :github:', emoji: true },
+                  url: runUrl,
+                  action_id: 'ci_button',
+                }],
+              },
+            ];
+
+            const resp = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ channel, blocks, text: 'Replay nightly: Docker build is stale', unfurl_links: false }),
+            });
+            const data = await resp.json();
+            if (!data.ok) core.warning(`Slack API error: ${JSON.stringify(data)}`);
+
+      - name: Fail on stale nightly
+        if: steps.refs.outputs.is-stale == 'true'
+        run: |
+          echo "::error::Nightly Docker build is stale (>24h old). Aborting replay benchmark."
+          exit 1
+
+  bench-replay:
+    needs: resolve-refs
+    if: |
+      needs.resolve-refs.outputs.should-skip != 'true' &&
+      needs.resolve-refs.outputs.is-stale != 'true'
+    name: bench-replay (${{ matrix.chain }})
+    uses: ./.github/workflows/bench-replay.yml
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        chain: ${{ fromJSON(needs.resolve-refs.outputs.chains-json) }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    with:
+      chain: ${{ matrix.chain }}
+      pr: ""
+      actor: "replay-nightly"
+      baseline: ${{ needs.resolve-refs.outputs.baseline-ref }}
+      feature: ${{ needs.resolve-refs.outputs.feature-ref }}
+      baseline-name: ${{ needs.resolve-refs.outputs.baseline-name }}
+      feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
+      samply: ${{ needs.resolve-refs.outputs.samply }}
+      baseline-args: ""
+      feature-args: ""
+      blocks: ${{ needs.resolve-refs.outputs.blocks }}
+      warmup: ${{ needs.resolve-refs.outputs.warmup }}
+      comment-id: ""
+    secrets:
+      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+      DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+
+  save-state:
+    needs: [resolve-refs, bench-replay]
+    if: success()
+    name: save-state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push state to charts repo
+        env:
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+          FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+        run: |
+          CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/tempo-bench-charts.git"
+          TMP_DIR=$(mktemp -d)
+
+          if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            true
+          else
+            git init "${TMP_DIR}"
+            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+          fi
+
+          mkdir -p "${TMP_DIR}/state"
+          echo "${FEATURE_REF}" > "${TMP_DIR}/state/replay-nightly-last-feature-ref"
+          git -C "${TMP_DIR}" add state/
+          git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
+          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            commit -m "bench: update replay nightly state to ${FEATURE_REF}"
+          git -C "${TMP_DIR}" push origin HEAD:state
+          rm -rf "${TMP_DIR}"

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -1,7 +1,7 @@
 # Replay benchmark job.
 #
-# Called by bench.yml when mode=replay. Replays real Tempo moderato blocks
-# through the Engine API for an interleaved B-F-F-B comparison.
+# Called by bench.yml when mode=replay. Replays real Tempo blocks through the
+# Engine API for an interleaved B-F-F-B comparison.
 
 name: bench-replay
 
@@ -114,7 +114,7 @@ jobs:
       BENCH_BLOCKS: ${{ inputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ inputs.warmup }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
-      BENCH_WORK_DIR: bench-results/replay
+      BENCH_WORK_DIR: bench-results/replay-${{ inputs.chain || 'mainnet' }}
     steps:
       - name: Resolve checkout ref
         id: checkout-ref
@@ -172,10 +172,11 @@ jobs:
             }
 
       - name: Clean up root-owned files from previous runs
-        run: sudo rm -rf bench-results/
+        run: sudo rm -rf "$BENCH_WORK_DIR"
 
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
 
@@ -239,13 +240,23 @@ jobs:
       - name: Resolve baseline and feature refs
         id: refs
         uses: actions/github-script@v8
+        env:
+          INPUT_BASELINE: ${{ inputs.baseline }}
+          INPUT_FEATURE: ${{ inputs.feature }}
+          INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
+          INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
+          INPUT_SHA: ${{ github.sha }}
+          INPUT_PR_HEAD_SHA: ${{ steps.pr-info.outputs.head-sha }}
+          INPUT_PR_HEAD_REF: ${{ steps.pr-info.outputs.head-ref }}
         with:
           script: |
             const { execSync } = require('child_process');
             const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
 
-            const baselineArg = '${{ inputs.baseline }}';
-            const featureArg = '${{ inputs.feature }}';
+            const baselineArg = process.env.INPUT_BASELINE;
+            const featureArg = process.env.INPUT_FEATURE;
+            const baselineNameArg = process.env.INPUT_BASELINE_NAME;
+            const featureNameArg = process.env.INPUT_FEATURE_NAME;
 
             let baselineRef, baselineName, featureRef, featureName;
 
@@ -256,14 +267,14 @@ jobs:
               } catch {
                 baselineRef = run(`git rev-parse "origin/${baselineArg}"`);
               }
-              baselineName = baselineArg;
+              baselineName = baselineNameArg || baselineArg;
             } else {
               try {
                 baselineRef = run('git merge-base HEAD origin/main');
               } catch {
-                baselineRef = '${{ github.sha }}';
+                baselineRef = process.env.INPUT_SHA;
               }
-              baselineName = 'main';
+              baselineName = baselineNameArg || 'main';
             }
 
             if (featureArg) {
@@ -273,10 +284,10 @@ jobs:
               } catch {
                 featureRef = run(`git rev-parse "origin/${featureArg}"`);
               }
-              featureName = featureArg;
+              featureName = featureNameArg || featureArg;
             } else {
-              featureRef = '${{ steps.pr-info.outputs.head-sha }}';
-              featureName = '${{ steps.pr-info.outputs.head-ref }}';
+              featureRef = process.env.INPUT_PR_HEAD_SHA;
+              featureName = featureNameArg || process.env.INPUT_PR_HEAD_REF;
             }
 
             core.setOutput('baseline-ref', baselineRef);
@@ -344,16 +355,19 @@ jobs:
         if: "!cancelled()"
         uses: actions/upload-artifact@v4
         with:
-          name: tempo-bench-replay-results
-          path: bench-results/
+          name: tempo-bench-replay-${{ inputs.chain || 'mainnet' }}-results
+          path: ${{ env.BENCH_WORK_DIR }}/
 
       - name: Push charts
         id: push-charts
         if: success()
         run: |
-          PR_NUMBER="${BENCH_PR:-0}"
           RUN_ID=${{ github.run_id }}
-          CHART_DIR="pr/${PR_NUMBER}/${RUN_ID}"
+          if [ -n "${BENCH_PR:-}" ]; then
+            CHART_DIR="pr/${BENCH_PR}/${RUN_ID}/${BENCH_CHAIN}"
+          else
+            CHART_DIR="replay/${BENCH_CHAIN}/${RUN_ID}"
+          fi
           CHARTS_REPO="https://x-access-token:${{ secrets.DEREK_TOKEN }}@github.com/decofe/tempo-bench-charts.git"
 
           TMP_DIR=$(mktemp -d)
@@ -368,9 +382,10 @@ jobs:
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
           git -C "${TMP_DIR}" add "${CHART_DIR}"
           git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench charts for PR #${PR_NUMBER} run ${RUN_ID}"
+            commit -m "bench replay charts for ${BENCH_CHAIN} run ${RUN_ID}"
           git -C "${TMP_DIR}" push origin HEAD:main
           echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "path=${CHART_DIR}" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"
 
       - name: Compare & comment
@@ -389,11 +404,10 @@ jobs:
             }
 
             const sha = '${{ steps.push-charts.outputs.sha }}';
-            const prNumber = process.env.BENCH_PR || '0';
-            const runId = '${{ github.run_id }}';
+            const chartPath = '${{ steps.push-charts.outputs.path }}';
 
-            if (sha) {
-              const baseUrl = `https://raw.githubusercontent.com/decofe/tempo-bench-charts/${sha}/pr/${prNumber}/${runId}`;
+            if (sha && chartPath) {
+              const baseUrl = `https://raw.githubusercontent.com/decofe/tempo-bench-charts/${sha}/${chartPath}`;
               const charts = [
                 { file: 'latency_throughput.png', label: 'Latency, Throughput & Diff' },
                 { file: 'wait_breakdown.png', label: 'Wait Time Breakdown' },
@@ -426,6 +440,33 @@ jobs:
         run: |
           if [ -f "$BENCH_WORK_DIR/comment.md" ]; then
             cat "$BENCH_WORK_DIR/comment.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          CHART_SHA="${{ steps.push-charts.outputs.sha }}"
+          CHART_PATH="${{ steps.push-charts.outputs.path }}"
+          if [ -n "$CHART_SHA" ] && [ -n "$CHART_PATH" ]; then
+            BASE_URL="https://raw.githubusercontent.com/decofe/tempo-bench-charts/${CHART_SHA}/${CHART_PATH}"
+            {
+              echo
+              echo "### Charts"
+              echo
+              echo "<details><summary>Latency, Throughput & Diff</summary>"
+              echo
+              echo "![Latency, Throughput & Diff](${BASE_URL}/latency_throughput.png)"
+              echo
+              echo "</details>"
+              echo
+              echo "<details><summary>Wait Time Breakdown</summary>"
+              echo
+              echo "![Wait Time Breakdown](${BASE_URL}/wait_breakdown.png)"
+              echo
+              echo "</details>"
+              echo
+              echo "<details><summary>Gas vs Latency</summary>"
+              echo
+              echo "![Gas vs Latency](${BASE_URL}/gas_vs_latency.png)"
+              echo
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Update status (failed)


### PR DESCRIPTION
- Adds a scheduled replay benchmark workflow for Tempo mainnet and testnet at `12:00 UTC`, using the latest successful nightly Docker build as the feature ref.
- Adds scheduled ref resolution and state persistence so nightly runs can skip unchanged commits, fail on stale Docker nightlies, and advance the saved replay ref only after successful runs.