### PR TITLE
ci(bench): run replay for mainnet and testnet on cron

### DIFF
--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: false
         type: boolean
-      chains:
+      chain:
         description: "Chain to replay"
         required: false
         default: "mainnet"
@@ -59,7 +59,7 @@ jobs:
       is-stale: ${{ steps.refs.outputs.is-stale }}
       stale-age-hours: ${{ steps.refs.outputs.stale-age-hours }}
       nightly-created: ${{ steps.refs.outputs.nightly-created }}
-      chains-json: ${{ steps.config.outputs.chains-json }}
+      chain: ${{ steps.config.outputs.chain }}
       blocks: ${{ steps.config.outputs.blocks }}
       warmup: ${{ steps.config.outputs.warmup }}
       samply: ${{ steps.config.outputs.samply }}
@@ -73,16 +73,16 @@ jobs:
       - name: Resolve inputs
         id: config
         env:
-          INPUT_CHAINS: ${{ inputs.chains || '' }}
+          INPUT_CHAIN: ${{ inputs.chain || '' }}
           EVENT_SCHEDULE: ${{ github.event.schedule || '' }}
           INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
           INPUT_WARMUP: ${{ inputs.warmup || '1000' }}
           INPUT_SAMPLY: ${{ inputs.samply || 'false' }}
         run: |
-          if [ -z "$INPUT_CHAINS" ]; then
+          if [ -z "$INPUT_CHAIN" ]; then
             case "$EVENT_SCHEDULE" in
-              "0 0 * * *") INPUT_CHAINS="mainnet" ;;
-              "1 0 * * *") INPUT_CHAINS="testnet" ;;
+              "0 0 * * *") INPUT_CHAIN="mainnet" ;;
+              "1 0 * * *") INPUT_CHAIN="testnet" ;;
               *)
                 echo "::error::Unknown scheduled replay cron: $EVENT_SCHEDULE"
                 exit 1
@@ -90,11 +90,10 @@ jobs:
             esac
           fi
 
-          case "$INPUT_CHAINS" in
-            mainnet) CHAINS_JSON='["mainnet"]' ;;
-            testnet) CHAINS_JSON='["testnet"]' ;;
+          case "$INPUT_CHAIN" in
+            mainnet|testnet) ;;
             *)
-              echo "::error::Unknown chains value: $INPUT_CHAINS"
+              echo "::error::Unknown chain value: $INPUT_CHAIN"
               exit 1
               ;;
           esac
@@ -115,7 +114,7 @@ jobs:
           fi
 
           {
-            echo "chains-json=$CHAINS_JSON"
+            echo "chain=$INPUT_CHAIN"
             echo "blocks=$INPUT_BLOCKS"
             echo "warmup=$INPUT_WARMUP"
             echo "samply=$SAMPLY"
@@ -200,19 +199,14 @@ jobs:
     if: |
       needs.resolve-refs.outputs.should-skip != 'true' &&
       needs.resolve-refs.outputs.is-stale != 'true'
-    name: bench-replay (${{ matrix.chain }})
+    name: bench-replay (${{ needs.resolve-refs.outputs.chain }})
     uses: ./.github/workflows/bench-replay.yml
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        chain: ${{ fromJSON(needs.resolve-refs.outputs.chains-json) }}
     permissions:
       actions: read
       contents: read
       pull-requests: write
     with:
-      chain: ${{ matrix.chain }}
+      chain: ${{ needs.resolve-refs.outputs.chain }}
       pr: ""
       actor: "replay-nightly"
       baseline: ${{ needs.resolve-refs.outputs.baseline-ref }}

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -1,14 +1,15 @@
 # Scheduled replay regression benchmarks.
 #
-# Runs nightly after the Docker workflow's 09:05 UTC scheduled build. The
-# benchmark compares the latest successful nightly Docker commit against the
-# last commit that completed this scheduled replay workflow successfully.
+# Runs nightly per chain: mainnet at 00:00 UTC and testnet at 00:01 UTC.
+# The benchmark compares the latest successful nightly Docker commit against
+# the last commit that completed this scheduled replay workflow successfully.
 
 name: bench-replay-scheduled
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 0 * * *" # mainnet
+    - cron: "1 0 * * *" # testnet
   workflow_dispatch:
     inputs:
       force:
@@ -17,12 +18,11 @@ on:
         default: false
         type: boolean
       chains:
-        description: "Chain replay set"
+        description: "Chain to replay"
         required: false
-        default: "both"
+        default: "mainnet"
         type: choice
         options:
-          - both
           - mainnet
           - testnet
       blocks:
@@ -73,13 +73,24 @@ jobs:
       - name: Resolve inputs
         id: config
         env:
-          INPUT_CHAINS: ${{ inputs.chains || 'both' }}
+          INPUT_CHAINS: ${{ inputs.chains || '' }}
+          EVENT_SCHEDULE: ${{ github.event.schedule || '' }}
           INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
           INPUT_WARMUP: ${{ inputs.warmup || '1000' }}
           INPUT_SAMPLY: ${{ inputs.samply || 'false' }}
         run: |
+          if [ -z "$INPUT_CHAINS" ]; then
+            case "$EVENT_SCHEDULE" in
+              "0 0 * * *") INPUT_CHAINS="mainnet" ;;
+              "1 0 * * *") INPUT_CHAINS="testnet" ;;
+              *)
+                echo "::error::Unknown scheduled replay cron: $EVENT_SCHEDULE"
+                exit 1
+                ;;
+            esac
+          fi
+
           case "$INPUT_CHAINS" in
-            both) CHAINS_JSON='["mainnet","testnet"]' ;;
             mainnet) CHAINS_JSON='["mainnet"]' ;;
             testnet) CHAINS_JSON='["testnet"]' ;;
             *)


### PR DESCRIPTION
- Schedules `bench-replay-scheduled` twice: mainnet at `0 0 * * *` and testnet at `1 0 * * *`.
- Removes the `both` workflow dispatch option and defaults manual runs to a single chain.
- Infers the scheduled chain from `github.event.schedule` so each cron run benchmarks only its assigned network.