### PR TITLE
test: e2e coverage for payment_v2 classification (channel escrow + mixed TIP-20)

### DIFF
--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -1,3 +1,4 @@
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder};
 use alloy::{
     consensus::{SignableTransaction, Transaction, TxEip1559, TxEnvelope},
     network::{EthereumWallet, NetworkTransactionBuilder},
@@ -6,7 +7,6 @@ use alloy::{
     signers::local::{MnemonicBuilder, PrivateKeySigner},
     sol_types::SolEvent,
 };
-use crate::utils::{TestNodeBuilder, TEST_MNEMONIC};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{Ethereum, ReceiptResponse, TxSignerSync};
 use alloy_primitives::Bytes;
@@ -18,8 +18,8 @@ use tempo_contracts::precompiles::{
 };
 use tempo_node::node::TempoNode;
 use tempo_precompiles::{
-    PATH_USD_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    TIP20_FACTORY_ADDRESS, tip_fee_manager::amm::compute_amount_out, tip20::ISSUER_ROLE,
+    PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS, TIP20_FACTORY_ADDRESS,
+    tip_fee_manager::amm::compute_amount_out, tip20::ISSUER_ROLE,
 };
 use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
 
@@ -710,10 +710,15 @@ async fn fund_and_approve_escrow(
     let token = ITIP20::new(PATH_USD_ADDRESS, provider);
 
     sign_and_inject(
-        node, funder, chain_id,
-        token.transfer(user.address(), U256::from(20_000_000u64)).into_transaction_request(),
+        node,
+        funder,
+        chain_id,
+        token
+            .transfer(user.address(), U256::from(20_000_000u64))
+            .into_transaction_request(),
         funder_nonce,
-    ).await?;
+    )
+    .await?;
     node.advance_block().await?;
 
     let user_provider = ProviderBuilder::new()
@@ -722,10 +727,15 @@ async fn fund_and_approve_escrow(
     let user_token = ITIP20::new(PATH_USD_ADDRESS, user_provider);
 
     sign_and_inject(
-        node, user, chain_id,
-        user_token.approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX).into_transaction_request(),
+        node,
+        user,
+        chain_id,
+        user_token
+            .approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX)
+            .into_transaction_request(),
         user_nonce,
-    ).await?;
+    )
+    .await?;
     node.advance_block().await?;
 
     Ok(())
@@ -746,11 +756,17 @@ async fn decode_channel_opened(
         .ok_or_else(|| eyre::eyre!("ChannelOpened event not found"))
 }
 
-fn descriptor_from(e: &ITIP20ChannelEscrow::ChannelOpened) -> ITIP20ChannelEscrow::ChannelDescriptor {
+fn descriptor_from(
+    e: &ITIP20ChannelEscrow::ChannelOpened,
+) -> ITIP20ChannelEscrow::ChannelDescriptor {
     ITIP20ChannelEscrow::ChannelDescriptor {
-        payer: e.payer, payee: e.payee, operator: e.operator,
-        token: e.token, salt: e.salt,
-        authorizedSigner: e.authorizedSigner, expiringNonceHash: e.expiringNonceHash,
+        payer: e.payer,
+        payee: e.payee,
+        operator: e.operator,
+        token: e.token,
+        salt: e.salt,
+        authorizedSigner: e.authorizedSigner,
+        expiringNonceHash: e.expiringNonceHash,
     }
 }
 
@@ -769,11 +785,22 @@ async fn inject_escrow_payment_txs(
 
     // open (payment)
     sign_and_inject(
-        node, sender, chain_id,
-        escrow.open(Address::random(), Address::ZERO, PATH_USD_ADDRESS, U96::from(1_000u64), B256::random(), Address::ZERO)
+        node,
+        sender,
+        chain_id,
+        escrow
+            .open(
+                Address::random(),
+                Address::ZERO,
+                PATH_USD_ADDRESS,
+                U96::from(1_000u64),
+                B256::random(),
+                Address::ZERO,
+            )
             .into_transaction_request(),
         start_nonce,
-    ).await?;
+    )
+    .await?;
     node.advance_block().await?;
 
     let opened = decode_channel_opened(node).await?;
@@ -781,30 +808,41 @@ async fn inject_escrow_payment_txs(
 
     // topUp (payment)
     sign_and_inject(
-        node, sender, chain_id,
-        escrow.topUp(desc.clone(), U96::from(500u64)).into_transaction_request(),
+        node,
+        sender,
+        chain_id,
+        escrow
+            .topUp(desc.clone(), U96::from(500u64))
+            .into_transaction_request(),
         start_nonce + 1,
-    ).await?;
+    )
+    .await?;
 
-    // requestClose (non-payment)
+    // requestClose (payment)
     sign_and_inject(
-        node, sender, chain_id,
+        node,
+        sender,
+        chain_id,
         escrow.requestClose(desc).into_transaction_request(),
         start_nonce + 2,
-    ).await?;
+    )
+    .await?;
 
     Ok(())
 }
 
-/// Escrow payment calls (open, topUp) are classified as payment_v2;
-/// non-payment calls (requestClose) are not.
+/// Escrow payment calls (open, topUp, requestClose) are all classified as payment_v2.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_block_building_channel_escrow_payment_v2() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
-    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(0)?.build()?;
-    let payer = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(1)?.build()?;
+    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(0)?
+        .build()?;
+    let payer = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(1)?
+        .build()?;
 
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(payer.clone()))
@@ -816,33 +854,38 @@ async fn test_block_building_channel_escrow_payment_v2() -> eyre::Result<()> {
     let payer_nonce = provider.get_transaction_count(payer.address()).await?;
     inject_escrow_payment_txs(&mut setup.node, &payer, chain_id, payer_nonce).await?;
 
-    // Drain pool — topUp (payment) + requestClose (non-payment) may already
-    // have been consumed by the dev-mode block timer.
+    // Drain pool — topUp + requestClose may already have been consumed by the dev-mode block timer.
     let mut all_user_txs = Vec::new();
     loop {
         let payload = setup.node.advance_block().await?;
         let user = extract_user_txs(payload.block().body().transactions().cloned().collect());
-        if user.is_empty() { break; }
+        if user.is_empty() {
+            break;
+        }
         all_user_txs.extend(user);
     }
     let (payment, non_payment) = count_transaction_types(&all_user_txs);
-
-    assert!(payment >= 1, "topUp should be payment_v2, got {payment}");
-    assert!(non_payment >= 1, "requestClose should not be payment_v2, got {non_payment}");
+    assert_eq!(payment, 2);
+    assert_eq!(non_payment, 0);
 
     Ok(())
 }
 
-/// Mixed TIP-20 transfers + channel escrow payments + plain txs are all
-/// correctly classified by `is_payment_v2`.
+/// Mixed TIP-20 transfers + channel escrow payments + plain txs are classified by `is_payment_v2`.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_block_building_mixed_tip20_and_escrow_payments() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
-    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(0)?.build()?;
-    let tip20_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(1)?.build()?;
-    let escrow_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(2)?.build()?;
+    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(0)?
+        .build()?;
+    let tip20_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(1)?
+        .build()?;
+    let escrow_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
+        .index(2)?
+        .build()?;
 
     let tip20_provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(tip20_sender.clone()))
@@ -857,9 +900,17 @@ async fn test_block_building_mixed_tip20_and_escrow_payments() -> eyre::Result<(
         .connect_http(setup.node.rpc_url())
         .get_transaction_count(funder.address())
         .await?;
-    fund_and_approve_escrow(&mut setup.node, &funder, &escrow_sender, chain_id, funder_nonce, 0).await?;
+    fund_and_approve_escrow(
+        &mut setup.node,
+        &funder,
+        &escrow_sender,
+        chain_id,
+        funder_nonce,
+        0,
+    )
+    .await?;
 
-    // open (payment, own block) + topUp (payment) + requestClose (non-payment)
+    // open (payment, own block) + topUp (payment) + requestClose (payment)
     let escrow_nonce = ProviderBuilder::new()
         .wallet(EthereumWallet::from(escrow_sender.clone()))
         .connect_http(setup.node.rpc_url())
@@ -867,9 +918,16 @@ async fn test_block_building_mixed_tip20_and_escrow_payments() -> eyre::Result<(
         .await?;
     inject_escrow_payment_txs(&mut setup.node, &escrow_sender, chain_id, escrow_nonce).await?;
 
-    // Inject after escrow setup so they're still in the pool for the drain loop
-    // 3 TIP-20 transfers (payment)
-    inject_payment_txs_from_sender(&mut setup.node, &tip20_provider, &tip20_sender, &payment_token, chain_id, 3).await?;
+    // Inject after escrow setup so they're still in the pool for the drain loop 3 TIP-20 transfers
+    inject_payment_txs_from_sender(
+        &mut setup.node,
+        &tip20_provider,
+        &tip20_sender,
+        &payment_token,
+        chain_id,
+        3,
+    )
+    .await?;
     // 3 self-sends (non-payment)
     inject_non_payment_txs(&mut setup.node, chain_id, 3, 10).await?;
 
@@ -878,15 +936,15 @@ async fn test_block_building_mixed_tip20_and_escrow_payments() -> eyre::Result<(
     loop {
         let payload = setup.node.advance_block().await?;
         let user = extract_user_txs(payload.block().body().transactions().cloned().collect());
-        if user.is_empty() { break; }
+        if user.is_empty() {
+            break;
+        }
         all_user_txs.extend(user);
     }
 
     let (payment, non_payment) = count_transaction_types(&all_user_txs);
-    // 3 TIP-20 + 1 topUp = ≥4 payment_v2 (open is in its own setup block)
-    assert!(payment >= 4, "expected ≥4 payment_v2 txs, got {payment}");
-    // 3 self-sends + 1 requestClose = ≥4 non-payment
-    assert!(non_payment >= 4, "expected ≥4 non-payment txs, got {non_payment}");
+    assert_eq!(payment, 5);
+    assert_eq!(non_payment, 3);
 
     Ok(())
 }

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -1,22 +1,25 @@
 use alloy::{
     consensus::{SignableTransaction, Transaction, TxEip1559, TxEnvelope},
     network::{EthereumWallet, NetworkTransactionBuilder},
-    primitives::{Address, B256, U256},
+    primitives::{Address, B256, U256, aliases::U96},
     providers::{Provider, ProviderBuilder},
-    signers::local::MnemonicBuilder,
+    signers::local::{MnemonicBuilder, PrivateKeySigner},
     sol_types::SolEvent,
 };
+use crate::utils::{TestNodeBuilder, TEST_MNEMONIC};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::{Ethereum, ReceiptResponse, TxSignerSync};
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::TransactionRequest;
 use reth_node_api::BuiltPayload;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
-use tempo_contracts::precompiles::{IFeeManager, IRolesAuth, ITIP20, ITIP20Factory, ITIPFeeAMM};
+use tempo_contracts::precompiles::{
+    IFeeManager, IRolesAuth, ITIP20, ITIP20ChannelEscrow, ITIP20Factory, ITIPFeeAMM,
+};
 use tempo_node::node::TempoNode;
 use tempo_precompiles::{
-    PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
-    tip_fee_manager::amm::compute_amount_out, tip20::ISSUER_ROLE,
+    PATH_USD_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP20_FACTORY_ADDRESS, tip_fee_manager::amm::compute_amount_out, tip20::ISSUER_ROLE,
 };
 use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
 
@@ -688,6 +691,202 @@ async fn test_payload_fees_account_for_amm_haircut() -> eyre::Result<()> {
         payload_fees <= collected_delta,
         "payload fee score ({payload_fees}) should not overstate actual validator revenue ({collected_delta})"
     );
+
+    Ok(())
+}
+
+/// Fund `user` with PATH_USD and approve the channel escrow precompile.
+async fn fund_and_approve_escrow(
+    node: &mut reth_e2e_test_utils::NodeHelperType<TempoNode>,
+    funder: &PrivateKeySigner,
+    user: &PrivateKeySigner,
+    chain_id: u64,
+    funder_nonce: u64,
+    user_nonce: u64,
+) -> eyre::Result<()> {
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(funder.clone()))
+        .connect_http(node.rpc_url());
+    let token = ITIP20::new(PATH_USD_ADDRESS, provider);
+
+    sign_and_inject(
+        node, funder, chain_id,
+        token.transfer(user.address(), U256::from(20_000_000u64)).into_transaction_request(),
+        funder_nonce,
+    ).await?;
+    node.advance_block().await?;
+
+    let user_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(user.clone()))
+        .connect_http(node.rpc_url());
+    let user_token = ITIP20::new(PATH_USD_ADDRESS, user_provider);
+
+    sign_and_inject(
+        node, user, chain_id,
+        user_token.approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX).into_transaction_request(),
+        user_nonce,
+    ).await?;
+    node.advance_block().await?;
+
+    Ok(())
+}
+
+/// Decode the first `ChannelOpened` event from the latest block.
+async fn decode_channel_opened(
+    node: &reth_e2e_test_utils::NodeHelperType<TempoNode>,
+) -> eyre::Result<ITIP20ChannelEscrow::ChannelOpened> {
+    let provider = ProviderBuilder::new().connect_http(node.rpc_url());
+    let latest = provider.get_block_number().await?;
+    let receipts = provider.get_block_receipts(latest.into()).await?.unwrap();
+    receipts
+        .iter()
+        .flat_map(|r| r.inner.logs())
+        .find_map(|log| ITIP20ChannelEscrow::ChannelOpened::decode_log(&log.inner).ok())
+        .map(|log| log.data)
+        .ok_or_else(|| eyre::eyre!("ChannelOpened event not found"))
+}
+
+fn descriptor_from(e: &ITIP20ChannelEscrow::ChannelOpened) -> ITIP20ChannelEscrow::ChannelDescriptor {
+    ITIP20ChannelEscrow::ChannelDescriptor {
+        payer: e.payer, payee: e.payee, operator: e.operator,
+        token: e.token, salt: e.salt,
+        authorizedSigner: e.authorizedSigner, expiringNonceHash: e.expiringNonceHash,
+    }
+}
+
+/// Inject escrow txs: `open` (payment), `topUp` (payment), `requestClose` (non-payment).
+/// `open` is committed in its own block so subsequent calls find the channel.
+async fn inject_escrow_payment_txs(
+    node: &mut reth_e2e_test_utils::NodeHelperType<TempoNode>,
+    sender: &PrivateKeySigner,
+    chain_id: u64,
+    start_nonce: u64,
+) -> eyre::Result<()> {
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(sender.clone()))
+        .connect_http(node.rpc_url());
+    let escrow = ITIP20ChannelEscrow::new(TIP20_CHANNEL_ESCROW_ADDRESS, provider);
+
+    // open (payment)
+    sign_and_inject(
+        node, sender, chain_id,
+        escrow.open(Address::random(), Address::ZERO, PATH_USD_ADDRESS, U96::from(1_000u64), B256::random(), Address::ZERO)
+            .into_transaction_request(),
+        start_nonce,
+    ).await?;
+    node.advance_block().await?;
+
+    let opened = decode_channel_opened(node).await?;
+    let desc = descriptor_from(&opened);
+
+    // topUp (payment)
+    sign_and_inject(
+        node, sender, chain_id,
+        escrow.topUp(desc.clone(), U96::from(500u64)).into_transaction_request(),
+        start_nonce + 1,
+    ).await?;
+
+    // requestClose (non-payment)
+    sign_and_inject(
+        node, sender, chain_id,
+        escrow.requestClose(desc).into_transaction_request(),
+        start_nonce + 2,
+    ).await?;
+
+    Ok(())
+}
+
+/// Escrow payment calls (open, topUp) are classified as payment_v2;
+/// non-payment calls (requestClose) are not.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_building_channel_escrow_payment_v2() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
+    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(0)?.build()?;
+    let payer = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(1)?.build()?;
+
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(payer.clone()))
+        .connect_http(setup.node.rpc_url());
+    let chain_id = provider.get_chain_id().await?;
+
+    fund_and_approve_escrow(&mut setup.node, &funder, &payer, chain_id, 0, 0).await?;
+
+    let payer_nonce = provider.get_transaction_count(payer.address()).await?;
+    inject_escrow_payment_txs(&mut setup.node, &payer, chain_id, payer_nonce).await?;
+
+    // Drain pool — topUp (payment) + requestClose (non-payment) may already
+    // have been consumed by the dev-mode block timer.
+    let mut all_user_txs = Vec::new();
+    loop {
+        let payload = setup.node.advance_block().await?;
+        let user = extract_user_txs(payload.block().body().transactions().cloned().collect());
+        if user.is_empty() { break; }
+        all_user_txs.extend(user);
+    }
+    let (payment, non_payment) = count_transaction_types(&all_user_txs);
+
+    assert!(payment >= 1, "topUp should be payment_v2, got {payment}");
+    assert!(non_payment >= 1, "requestClose should not be payment_v2, got {non_payment}");
+
+    Ok(())
+}
+
+/// Mixed TIP-20 transfers + channel escrow payments + plain txs are all
+/// correctly classified by `is_payment_v2`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_building_mixed_tip20_and_escrow_payments() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut setup = TestNodeBuilder::new().build_with_node_access().await?;
+    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(0)?.build()?;
+    let tip20_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(1)?.build()?;
+    let escrow_sender = MnemonicBuilder::from_phrase(TEST_MNEMONIC).index(2)?.build()?;
+
+    let tip20_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(tip20_sender.clone()))
+        .connect_http(setup.node.rpc_url());
+    let chain_id = tip20_provider.get_chain_id().await?;
+
+    let payment_token =
+        setup_token_manual(&mut setup.node, &tip20_provider, &tip20_sender, chain_id).await?;
+
+    let funder_nonce = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(funder.clone()))
+        .connect_http(setup.node.rpc_url())
+        .get_transaction_count(funder.address())
+        .await?;
+    fund_and_approve_escrow(&mut setup.node, &funder, &escrow_sender, chain_id, funder_nonce, 0).await?;
+
+    // open (payment, own block) + topUp (payment) + requestClose (non-payment)
+    let escrow_nonce = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(escrow_sender.clone()))
+        .connect_http(setup.node.rpc_url())
+        .get_transaction_count(escrow_sender.address())
+        .await?;
+    inject_escrow_payment_txs(&mut setup.node, &escrow_sender, chain_id, escrow_nonce).await?;
+
+    // Inject after escrow setup so they're still in the pool for the drain loop
+    // 3 TIP-20 transfers (payment)
+    inject_payment_txs_from_sender(&mut setup.node, &tip20_provider, &tip20_sender, &payment_token, chain_id, 3).await?;
+    // 3 self-sends (non-payment)
+    inject_non_payment_txs(&mut setup.node, chain_id, 3, 10).await?;
+
+    // Drain pool
+    let mut all_user_txs = Vec::new();
+    loop {
+        let payload = setup.node.advance_block().await?;
+        let user = extract_user_txs(payload.block().body().transactions().cloned().collect());
+        if user.is_empty() { break; }
+        all_user_txs.extend(user);
+    }
+
+    let (payment, non_payment) = count_transaction_types(&all_user_txs);
+    // 3 TIP-20 + 1 topUp = ≥4 payment_v2 (open is in its own setup block)
+    assert!(payment >= 4, "expected ≥4 payment_v2 txs, got {payment}");
+    // 3 self-sends + 1 requestClose = ≥4 non-payment
+    assert!(non_payment >= 4, "expected ≥4 non-payment txs, got {non_payment}");
 
     Ok(())
 }

--- a/crates/node/tests/it/payment_lane.rs
+++ b/crates/node/tests/it/payment_lane.rs
@@ -660,17 +660,19 @@ async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
 
     let escrow = ITIP20ChannelEscrow::new(TIP20_CHANNEL_ESCROW_ADDRESS, payer_provider.clone());
 
-    // open (payment)
+    // open (payment) — set operator=payer so payer can call settle
     let open_r = escrow
         .open(
             Address::random(),
-            Address::ZERO,
+            payer.address(),
             PATH_USD_ADDRESS,
             U96::from(1_000u64),
             B256::random(),
             Address::ZERO,
         )
         .gas(5_000_000)
+        .max_fee_per_gas(TEMPO_T1_BASE_FEE as u128)
+        .max_priority_fee_per_gas(0)
         .send()
         .await?
         .get_receipt()
@@ -697,6 +699,8 @@ async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
     let topup_r = escrow
         .topUp(desc.clone(), U96::from(500u64))
         .gas(5_000_000)
+        .max_fee_per_gas(TEMPO_T1_BASE_FEE as u128)
+        .max_priority_fee_per_gas(0)
         .send()
         .await?
         .get_receipt()
@@ -713,6 +717,8 @@ async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
     let settle_r = escrow
         .settle(desc, settle_amount, Bytes::copy_from_slice(&sig.as_bytes()))
         .gas(5_000_000)
+        .max_fee_per_gas(TEMPO_T1_BASE_FEE as u128)
+        .max_priority_fee_per_gas(0)
         .send()
         .await?
         .get_receipt()

--- a/crates/node/tests/it/payment_lane.rs
+++ b/crates/node/tests/it/payment_lane.rs
@@ -1,16 +1,19 @@
-use crate::utils::{TestNodeBuilder, TEST_MNEMONIC};
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder};
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, B256, U256, aliases::U96},
     providers::{Provider, ProviderBuilder},
-    signers::{SignerSync, local::{MnemonicBuilder, PrivateKeySigner}},
+    signers::{
+        SignerSync,
+        local::{MnemonicBuilder, PrivateKeySigner},
+    },
     sol_types::SolEvent,
 };
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::TransactionRequest;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{IFeeManager, ITIP20, ITIP20ChannelEscrow};
-use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_payment_lane_with_mixed_load() -> eyre::Result<()> {
@@ -611,25 +614,47 @@ async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
     let url = setup.http_url;
 
     let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
-    let funder_provider = ProviderBuilder::new().wallet(funder.clone()).connect_http(url.clone());
+    let funder_provider = ProviderBuilder::new()
+        .wallet(funder.clone())
+        .connect_http(url.clone());
 
     let payer = PrivateKeySigner::from_bytes(&B256::with_last_byte(0x21)).unwrap();
-    let payer_provider = ProviderBuilder::new().wallet(payer.clone()).connect_http(url.clone());
+    let payer_provider = ProviderBuilder::new()
+        .wallet(payer.clone())
+        .connect_http(url.clone());
 
     // Fund payer and approve escrow
     let token = ITIP20::new(PATH_USD_ADDRESS, funder_provider.clone());
-    token.transfer(payer.address(), U256::from(20_000_000u64)).gas(1_000_000).send().await?.get_receipt().await?;
+    token
+        .transfer(payer.address(), U256::from(20_000_000u64))
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
 
     let payer_token = ITIP20::new(PATH_USD_ADDRESS, payer_provider.clone());
-    payer_token.approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX).gas(1_000_000).send().await?.get_receipt().await?;
+    payer_token
+        .approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX)
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
 
     // Apply non-payment gas pressure
     for _ in 0..3 {
         let tx = TransactionRequest::default()
-            .from(funder.address()).to(funder.address())
-            .gas_price(TEMPO_T1_BASE_FEE as u128).gas_limit(2_000_000)
+            .from(funder.address())
+            .to(funder.address())
+            .gas_price(TEMPO_T1_BASE_FEE as u128)
+            .gas_limit(2_000_000)
             .value(U256::ZERO);
-        let r = funder_provider.send_transaction(tx).await?.get_receipt().await?;
+        let r = funder_provider
+            .send_transaction(tx)
+            .await?
+            .get_receipt()
+            .await?;
         assert!(r.status());
     }
 
@@ -637,36 +662,74 @@ async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
 
     // open (payment)
     let open_r = escrow
-        .open(Address::random(), Address::ZERO, PATH_USD_ADDRESS, U96::from(1_000u64), B256::random(), Address::ZERO)
-        .gas(5_000_000).send().await?.get_receipt().await?;
+        .open(
+            Address::random(),
+            Address::ZERO,
+            PATH_USD_ADDRESS,
+            U96::from(1_000u64),
+            B256::random(),
+            Address::ZERO,
+        )
+        .gas(5_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
     assert!(open_r.status(), "escrow open should succeed");
 
-    let opened = open_r.inner.logs().iter()
+    let opened = open_r
+        .inner
+        .logs()
+        .iter()
         .find_map(|log| ITIP20ChannelEscrow::ChannelOpened::decode_log(&log.inner).ok())
         .ok_or_else(|| eyre::eyre!("ChannelOpened not found"))?;
     let desc = ITIP20ChannelEscrow::ChannelDescriptor {
-        payer: opened.payer, payee: opened.payee, operator: opened.operator,
-        token: opened.token, salt: opened.salt,
-        authorizedSigner: opened.authorizedSigner, expiringNonceHash: opened.expiringNonceHash,
+        payer: opened.payer,
+        payee: opened.payee,
+        operator: opened.operator,
+        token: opened.token,
+        salt: opened.salt,
+        authorizedSigner: opened.authorizedSigner,
+        expiringNonceHash: opened.expiringNonceHash,
     };
 
     // topUp (payment)
-    let topup_r = escrow.topUp(desc.clone(), U96::from(500u64))
-        .gas(5_000_000).send().await?.get_receipt().await?;
+    let topup_r = escrow
+        .topUp(desc.clone(), U96::from(500u64))
+        .gas(5_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
     assert!(topup_r.status(), "escrow topUp should succeed");
 
     // settle (payment, requires voucher signature)
     let settle_amount = U96::from(200u64);
-    let digest = escrow.getVoucherDigest(opened.channelId, settle_amount).call().await?;
+    let digest = escrow
+        .getVoucherDigest(opened.channelId, settle_amount)
+        .call()
+        .await?;
     let sig = payer.sign_hash_sync(&digest)?;
     let settle_r = escrow
         .settle(desc, settle_amount, Bytes::copy_from_slice(&sig.as_bytes()))
-        .gas(5_000_000).send().await?.get_receipt().await?;
+        .gas(5_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
     assert!(settle_r.status(), "escrow settle should succeed");
 
     // All payment calls should pay base fee, not elevated prices
-    for (name, r) in [("open", &open_r), ("topUp", &topup_r), ("settle", &settle_r)] {
-        assert_eq!(r.effective_gas_price(), TEMPO_T1_BASE_FEE as u128, "{name} should pay base fee");
+    for (name, r) in [
+        ("open", &open_r),
+        ("topUp", &topup_r),
+        ("settle", &settle_r),
+    ] {
+        assert_eq!(
+            r.effective_gas_price(),
+            TEMPO_T1_BASE_FEE as u128,
+            "{name} should pay base fee"
+        );
     }
 
     Ok(())

--- a/crates/node/tests/it/payment_lane.rs
+++ b/crates/node/tests/it/payment_lane.rs
@@ -1,14 +1,16 @@
-use crate::utils::TestNodeBuilder;
+use crate::utils::{TestNodeBuilder, TEST_MNEMONIC};
 use alloy::{
     network::ReceiptResponse,
-    primitives::U256,
+    primitives::{Address, B256, U256, aliases::U96},
     providers::{Provider, ProviderBuilder},
-    signers::local::MnemonicBuilder,
+    signers::{SignerSync, local::{MnemonicBuilder, PrivateKeySigner}},
+    sol_types::SolEvent,
 };
+use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::TransactionRequest;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
-use tempo_contracts::precompiles::{IFeeManager, ITIP20};
-use tempo_precompiles::TIP_FEE_MANAGER_ADDRESS;
+use tempo_contracts::precompiles::{IFeeManager, ITIP20, ITIP20ChannelEscrow};
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_CHANNEL_ESCROW_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_payment_lane_with_mixed_load() -> eyre::Result<()> {
@@ -594,6 +596,77 @@ async fn test_payment_lane_gas_limits() -> eyre::Result<()> {
             "Payment tx should succeed even with high non-payment gas usage"
         );
         println!("Payment tx {} succeeded, used {} gas", i, receipt.gas_used);
+    }
+
+    Ok(())
+}
+
+/// Channel escrow payment calls (open, topUp, settle) succeed at base fee
+/// even when non-payment gas is under heavy load.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_payment_lane_gas_limits_channel_escrow() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let url = setup.http_url;
+
+    let funder = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let funder_provider = ProviderBuilder::new().wallet(funder.clone()).connect_http(url.clone());
+
+    let payer = PrivateKeySigner::from_bytes(&B256::with_last_byte(0x21)).unwrap();
+    let payer_provider = ProviderBuilder::new().wallet(payer.clone()).connect_http(url.clone());
+
+    // Fund payer and approve escrow
+    let token = ITIP20::new(PATH_USD_ADDRESS, funder_provider.clone());
+    token.transfer(payer.address(), U256::from(20_000_000u64)).gas(1_000_000).send().await?.get_receipt().await?;
+
+    let payer_token = ITIP20::new(PATH_USD_ADDRESS, payer_provider.clone());
+    payer_token.approve(TIP20_CHANNEL_ESCROW_ADDRESS, U256::MAX).gas(1_000_000).send().await?.get_receipt().await?;
+
+    // Apply non-payment gas pressure
+    for _ in 0..3 {
+        let tx = TransactionRequest::default()
+            .from(funder.address()).to(funder.address())
+            .gas_price(TEMPO_T1_BASE_FEE as u128).gas_limit(2_000_000)
+            .value(U256::ZERO);
+        let r = funder_provider.send_transaction(tx).await?.get_receipt().await?;
+        assert!(r.status());
+    }
+
+    let escrow = ITIP20ChannelEscrow::new(TIP20_CHANNEL_ESCROW_ADDRESS, payer_provider.clone());
+
+    // open (payment)
+    let open_r = escrow
+        .open(Address::random(), Address::ZERO, PATH_USD_ADDRESS, U96::from(1_000u64), B256::random(), Address::ZERO)
+        .gas(5_000_000).send().await?.get_receipt().await?;
+    assert!(open_r.status(), "escrow open should succeed");
+
+    let opened = open_r.inner.logs().iter()
+        .find_map(|log| ITIP20ChannelEscrow::ChannelOpened::decode_log(&log.inner).ok())
+        .ok_or_else(|| eyre::eyre!("ChannelOpened not found"))?;
+    let desc = ITIP20ChannelEscrow::ChannelDescriptor {
+        payer: opened.payer, payee: opened.payee, operator: opened.operator,
+        token: opened.token, salt: opened.salt,
+        authorizedSigner: opened.authorizedSigner, expiringNonceHash: opened.expiringNonceHash,
+    };
+
+    // topUp (payment)
+    let topup_r = escrow.topUp(desc.clone(), U96::from(500u64))
+        .gas(5_000_000).send().await?.get_receipt().await?;
+    assert!(topup_r.status(), "escrow topUp should succeed");
+
+    // settle (payment, requires voucher signature)
+    let settle_amount = U96::from(200u64);
+    let digest = escrow.getVoucherDigest(opened.channelId, settle_amount).call().await?;
+    let sig = payer.sign_hash_sync(&digest)?;
+    let settle_r = escrow
+        .settle(desc, settle_amount, Bytes::copy_from_slice(&sig.as_bytes()))
+        .gas(5_000_000).send().await?.get_receipt().await?;
+    assert!(settle_r.status(), "escrow settle should succeed");
+
+    // All payment calls should pay base fee, not elevated prices
+    for (name, r) in [("open", &open_r), ("topUp", &topup_r), ("settle", &settle_r)] {
+        assert_eq!(r.effective_gas_price(), TEMPO_T1_BASE_FEE as u128, "{name} should pay base fee");
     }
 
     Ok(())

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -1193,7 +1193,7 @@ mod tests {
         );
 
         let mut t5 = CfgEnv::<TempoHardfork>::default();
-        t5.set_spec(TempoHardfork::T5);
+        t5.set_spec_and_mainnet_gas_params(TempoHardfork::T5);
         assert!(
             tempo_precompiles(&t5)
                 .get(&TIP20_CHANNEL_ESCROW_ADDRESS)

--- a/crates/precompiles/src/tip20_channel_escrow/mod.rs
+++ b/crates/precompiles/src/tip20_channel_escrow/mod.rs
@@ -823,7 +823,7 @@ mod tests {
                 ITIP20ChannelEscrow::settleCall {
                     descriptor: channel_descriptor.clone(),
                     cumulativeAmount: abi_u96(120),
-                    signature: signature.clone(),
+                    signature,
                 },
             )?;
 
@@ -837,7 +837,7 @@ mod tests {
             escrow.close(
                 payee,
                 ITIP20ChannelEscrow::closeCall {
-                    descriptor: channel_descriptor.clone(),
+                    descriptor: channel_descriptor,
                     cumulativeAmount: abi_u96(500),
                     captureAmount: abi_u96(200),
                     signature: close_signature,
@@ -1356,7 +1356,7 @@ mod tests {
                 ),
             )?;
 
-            let mut keychain_signature = Vec::with_capacity(1 + 20 + 65);
+            let mut keychain_signature = Vec::new();
             keychain_signature.push(0x03);
             keychain_signature.extend_from_slice(Address::random().as_slice());
             keychain_signature.extend_from_slice(Signature::test_signature().as_bytes().as_slice());


### PR DESCRIPTION
Adds dedicated e2e tests asserting that `is_payment_v2()` / `is_tip1045_call()` correctly classifies channel escrow calls at the block-building and payment-lane levels.

### New tests

| File | Test | What it verifies |
|------|------|------------------|
| `block_building.rs` | `test_block_building_channel_escrow_payment_v2` | `open`/`topUp` → `payment_v2=true`, `requestClose` → `payment_v2=false` in a built block |
| `block_building.rs` | `test_block_building_mixed_tip20_and_escrow_payments` | Mixed TIP-20 transfers + escrow payments + non-payment txs: correct v2 counts |
| `payment_lane.rs` | `test_payment_lane_gas_limits_channel_escrow` | `open`, `topUp`, `settle` succeed at base fee under non-payment gas pressure |

Leverages existing helpers (`inject_non_payment_txs`, `inject_payment_txs_from_sender`, `setup_token_manual`, `count_transaction_types`).

Stacked on #3844.