### PR TITLE
feat: include consensus archives in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12462,6 +12462,7 @@ dependencies = [
  "alloy-signer-trezor",
  "alloy-sol-types",
  "base64 0.22.1",
+ "blake3",
  "clap",
  "commonware-codec",
  "commonware-consensus",
@@ -12502,6 +12503,8 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "tar",
+ "tempfile",
  "tempo-alloy",
  "tempo-chainspec",
  "tempo-commonware-node",
@@ -12522,6 +12525,8 @@ dependencies = [
  "tracing",
  "tracy-client",
  "url",
+ "walkdir",
+ "zstd",
 ]
 
 [[package]]

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -101,6 +101,15 @@ pyroscope = { workspace = true, optional = true }
 pyroscope_pprofrs = { workspace = true, optional = true }
 tracy-client = { workspace = true, optional = true }
 
+# `tempo snapshot-manifest` (see `src/snapshot_manifest.rs`).
+blake3 = "1.8"
+tar = "0.4"
+walkdir = "2.5"
+zstd = "0.13"
+
+[dev-dependencies]
+tempfile.workspace = true
+
 [[bin]]
 name = "tempo"
 path = "src/main.rs"

--- a/bin/tempo/src/main.rs
+++ b/bin/tempo/src/main.rs
@@ -42,6 +42,8 @@ static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 mod defaults;
 mod init_state;
 mod p2p_proxy;
+mod snapshot_download;
+mod snapshot_manifest;
 mod tempo_cmd;
 
 use clap::{CommandFactory, FromArgMatches};
@@ -313,12 +315,15 @@ fn main() -> eyre::Result<()> {
     tempo_node::init_version_metadata();
     defaults::init_defaults();
 
-    let mut cli = match TempoCli::command()
+    // `tempo snapshot-manifest` and `tempo download` wrap the Reth variants, so they
+    // cannot be added without colliding. Mutate those subcommands with the wrapped ones.
+    let matches = match TempoCli::command()
         .about("Tempo")
+        .mut_subcommand("snapshot-manifest", |_| snapshot_manifest::Args::command())
+        .mut_subcommand("download", |_| snapshot_download::Args::command())
         .try_get_matches_from(std::env::args_os())
-        .and_then(|matches| TempoCli::from_arg_matches(&matches))
     {
-        Ok(cli) => cli,
+        Ok(matches) => matches,
         Err(err) => {
             if err.kind() == clap::error::ErrorKind::InvalidSubcommand {
                 // Unknown subcommand — try the extension launcher.
@@ -344,6 +349,19 @@ fn main() -> eyre::Result<()> {
 
             err.exit();
         }
+    };
+
+    // Detect overwritten subcommands and directly run them as
+    // `from_arg_matches` would map them to their original variants.
+    match matches.subcommand() {
+        Some(("snapshot-manifest", sub)) => return snapshot_manifest::run(sub),
+        Some(("download", sub)) => return snapshot_download::run(sub),
+        _ => {}
+    }
+
+    let mut cli = match TempoCli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(err) => err.exit(),
     };
 
     if let Commands::Node(node_cmd) = &cli.command

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -86,7 +86,7 @@ async fn download_consensus(
     manifest: SnapshotManifest,
     archive_source: ArchiveSource,
 ) -> Result<()> {
-    fs::create_dir_all(&consensus_dir).wrap_err("failed to create consensus dir")?;
+    fs::create_dir_all(consensus_dir).wrap_err("failed to create consensus dir")?;
     for &key in CL_COMPONENT_KEYS {
         let comp = manifest
             .components
@@ -136,7 +136,7 @@ impl ArchiveSource {
         match self {
             Self::Local(dir) => {
                 let path = dir.join(file_name);
-                fs::read(&path).wrap_err_with(|| format!("failed to read {}", path.display()))
+                fs::read(&path).wrap_err_with(|| format!("failed to read {path:?}"))
             }
             Self::Remote { base_url, client } => {
                 let url = if base_url.ends_with('/') {
@@ -249,7 +249,7 @@ fn resolve_archive_source(
     if let Some(path) = manifest_path {
         let parent = path
             .parent()
-            .ok_or_else(|| eyre!("manifest path has no parent: {}", path.display()))?;
+            .ok_or_else(|| eyre!("manifest path has no parent: {path:?}"))?;
 
         return Ok(ArchiveSource::Local(parent.to_path_buf()));
     }

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -1,0 +1,389 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use clap::{ArgMatches, FromArgMatches, Parser};
+use eyre::{Context as _, Result, bail, eyre};
+use reth_cli_commands::download::{
+    DownloadCommand,
+    manifest::{ComponentManifest, OutputFileChecksum, SingleArchive, SnapshotManifest},
+};
+use reth_cli_runner::CliRunner;
+use tar::Archive;
+use tempo_chainspec::spec::TempoChainSpecParser;
+use zstd::Decoder as ZstdDecoder;
+
+use crate::snapshot_manifest::{CL_COMPONENT_KEYS, blake3_hash};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "download",
+    about = "Downloads snapshot archives produced by `tempo snapshot-manifest`."
+)]
+pub(crate) struct Args {
+    #[command(flatten)]
+    inner: DownloadCommand<TempoChainSpecParser>,
+
+    /// Skip the downloading consensus archives
+    #[arg(long)]
+    skip_consensus: bool,
+
+    /// Consensus storage directory. If not set, this will be dirived from --datadir.
+    #[arg(long = "consensus.datadir", value_name = "PATH")]
+    consensus_datadir: Option<PathBuf>,
+}
+
+pub(crate) fn run(matches: &ArgMatches) -> Result<()> {
+    let args = Args::from_arg_matches(matches).map_err(|e| eyre!("{e}"))?;
+
+    let datadir = matches
+        .get_raw("datadir")
+        .and_then(|mut v| v.next())
+        .map(PathBuf::from)
+        .expect("--datadir must be set");
+
+    let manifest_url = matches.get_one::<String>("manifest_url").cloned();
+    let manifest_path = matches.get_one::<PathBuf>("manifest_path").cloned();
+
+    let runner = CliRunner::try_default_runtime().wrap_err("failed to build obtain runtime")?;
+    runner.block_on(async move {
+        eprintln!("running execution layer download...");
+
+        let start = Instant::now();
+        args.inner
+            .execute::<tempo_node::node::TempoNode>()
+            .await
+            .wrap_err("execution layer download failed")?;
+
+        eprintln!("execution layer download finished in {:?}", start.elapsed());
+
+        if args.skip_consensus {
+            eprintln!("--skip-consensus set. skipping consensus layer");
+            return Ok(());
+        }
+
+        let consensus_dir = args
+            .consensus_datadir
+            .unwrap_or_else(|| datadir.join("consensus"));
+
+        let manifest = load_manifest(manifest_url.clone(), manifest_path.clone()).await?;
+        let archive_source = resolve_archive_source(manifest_url, manifest_path, &manifest)?;
+
+        let start = Instant::now();
+        download_consensus(&consensus_dir, manifest, archive_source)
+            .await
+            .wrap_err("consensus layer download failed")?;
+
+        eprintln!("consensus layer download finished in {:?}", start.elapsed());
+        Ok(())
+    })
+}
+
+async fn download_consensus(
+    consensus_dir: &Path,
+    manifest: SnapshotManifest,
+    archive_source: ArchiveSource,
+) -> Result<()> {
+    fs::create_dir_all(&consensus_dir).wrap_err("failed to create consensus dir")?;
+    for &key in CL_COMPONENT_KEYS {
+        let comp = manifest
+            .components
+            .get(key)
+            .ok_or_else(|| eyre!("manifest is missing required CL component `{key}`"))?;
+
+        let SingleArchive {
+            file,
+            size,
+            output_files,
+            ..
+        } = match comp {
+            ComponentManifest::Single(a) => a,
+            ComponentManifest::Chunked(_) => {
+                bail!("`{key}` is not a SingleArchive; manifest format mismatch")
+            }
+        };
+
+        let start = Instant::now();
+        if all_outputs_present(consensus_dir, output_files)? {
+            eprintln!("`{key}`: already present, skipping",);
+            continue;
+        }
+
+        eprintln!("`{key}`: fetching {file} ({size} bytes)...",);
+
+        let bytes = archive_source.fetch(file).await?;
+        extract_and_verify(consensus_dir, &bytes, output_files)
+            .wrap_err_with(|| format!("failed extracting/verifying `{key}` archive"))?;
+
+        eprintln!("`{key}`: extracted in {:?}", start.elapsed());
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+enum ArchiveSource {
+    Local(PathBuf),
+    Remote {
+        base_url: String,
+        client: reqwest::Client,
+    },
+}
+
+impl ArchiveSource {
+    async fn fetch(&self, file_name: &str) -> Result<Vec<u8>> {
+        match self {
+            Self::Local(dir) => {
+                let path = dir.join(file_name);
+                fs::read(&path).wrap_err_with(|| format!("failed to read {}", path.display()))
+            }
+            Self::Remote { base_url, client } => {
+                let url = if base_url.ends_with('/') {
+                    format!("{base_url}{file_name}")
+                } else {
+                    format!("{base_url}/{file_name}")
+                };
+                let resp = client
+                    .get(&url)
+                    .send()
+                    .await
+                    .wrap_err_with(|| format!("failed GET {url}"))?
+                    .error_for_status()
+                    .wrap_err_with(|| format!("non-2xx response from {url}"))?;
+                let bytes = resp
+                    .bytes()
+                    .await
+                    .wrap_err_with(|| format!("failed reading body from {url}"))?;
+                Ok(bytes.to_vec())
+            }
+        }
+    }
+}
+
+/// Check whether every entry in `expected` already exists under `target_dir`
+fn all_outputs_present(target_dir: &Path, expected: &[OutputFileChecksum]) -> Result<bool> {
+    for f in expected {
+        let path = target_dir.join(&f.path);
+        let Ok(metadata) = fs::metadata(&path) else {
+            return Ok(false);
+        };
+
+        if metadata.len() != f.size {
+            return Ok(false);
+        }
+
+        if blake3_hash(&path)? != f.blake3 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Decompress + untar `archive_bytes` into `target_dir`
+fn extract_and_verify(
+    target_dir: &Path,
+    archive_bytes: &[u8],
+    expected: &[OutputFileChecksum],
+) -> Result<usize> {
+    let zstd = ZstdDecoder::new(archive_bytes).wrap_err("failed to init zstd decoder")?;
+    Archive::new(zstd)
+        .unpack(target_dir)
+        .wrap_err("failed to unpack archive")?;
+
+    for OutputFileChecksum { size, path, blake3 } in expected {
+        let target = target_dir.join(path);
+        let metadata = fs::metadata(&target).wrap_err("failed extracting file metadata")?;
+        if metadata.len() != *size {
+            bail!("size mismatch: expected {size}, got {}", metadata.len(),);
+        }
+
+        if blake3_hash(&target)? != *blake3 {
+            bail!("BLAKE3 mismatch");
+        }
+    }
+    Ok(expected.len())
+}
+
+async fn load_manifest(
+    manifest_url: Option<String>,
+    manifest_path: Option<PathBuf>,
+) -> Result<SnapshotManifest> {
+    if let Some(path) = manifest_path {
+        let bytes = fs::read(path).wrap_err("failed to read manifest file")?;
+        return serde_json::from_slice(&bytes).wrap_err("failed to parse manifest.json");
+    }
+
+    if let Some(url) = manifest_url {
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(url)
+            .send()
+            .await
+            .wrap_err("failed to fetch from manifest url")?
+            .error_for_status()
+            .wrap_err("invalid response from manifest url")?;
+        let bytes = resp
+            .bytes()
+            .await
+            .wrap_err("failed to parse manifest from url")?;
+
+        return serde_json::from_slice(&bytes).wrap_err("failed to parse manifest.json");
+    }
+
+    bail!("--manifest-url or --manifest-path must be set")
+}
+
+fn resolve_archive_source(
+    manifest_url: Option<String>,
+    manifest_path: Option<PathBuf>,
+    manifest: &SnapshotManifest,
+) -> Result<ArchiveSource> {
+    if let Some(base) = &manifest.base_url {
+        return Ok(ArchiveSource::Remote {
+            base_url: base.clone(),
+            client: reqwest::Client::new(),
+        });
+    }
+
+    if let Some(path) = manifest_path {
+        let parent = path
+            .parent()
+            .ok_or_else(|| eyre!("manifest path has no parent: {}", path.display()))?;
+
+        return Ok(ArchiveSource::Local(parent.to_path_buf()));
+    }
+
+    if let Some(url) = &manifest_url {
+        let last_slash = url
+            .rfind('/')
+            .ok_or_else(|| eyre!("manifest URL `{url}` has no `/` to derive a base from"))?;
+
+        let base = url[..last_slash].to_string();
+        return Ok(ArchiveSource::Remote {
+            base_url: base,
+            client: reqwest::Client::new(),
+        });
+    }
+
+    bail!("--manifest-url or --manifest-path must be set");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, fs::File};
+
+    use super::*;
+
+    #[test]
+    fn args_parses_mixed_reth_and_tempo_flags() {
+        // Order interleaves tempo + reth flags to exercise both schemas in
+        // the same parse pass.
+        let args = Args::try_parse_from([
+            "tempo",
+            "--manifest-url",
+            "https://snap/manifest.json",
+            "--datadir",
+            "/d",
+            "--consensus.datadir",
+            "/c",
+            "--skip-consensus",
+        ])
+        .unwrap();
+
+        assert!(args.skip_consensus);
+        assert_eq!(args.consensus_datadir.as_deref(), Some(Path::new("/c")));
+    }
+
+    #[test]
+    fn resolve_archive_source_prefers_manifest_base_url() {
+        let manifest = SnapshotManifest {
+            block: 0,
+            chain_id: 1,
+            storage_version: 2,
+            timestamp: 0,
+            base_url: Some("https://from-manifest".into()),
+            reth_version: None,
+            components: BTreeMap::new(),
+        };
+        match resolve_archive_source(
+            Some("https://other/dir/manifest.json".to_string()),
+            None,
+            &manifest,
+        )
+        .unwrap()
+        {
+            ArchiveSource::Remote { base_url, .. } => assert_eq!(base_url, "https://from-manifest"),
+            other => panic!("expected remote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_archive_source_falls_back_to_manifest_path_parent() {
+        let manifest = SnapshotManifest {
+            block: 0,
+            chain_id: 1,
+            storage_version: 2,
+            timestamp: 0,
+            base_url: None,
+            reth_version: None,
+            components: BTreeMap::new(),
+        };
+        match resolve_archive_source(
+            None,
+            Some(PathBuf::from("/snap/dir/manifest.json")),
+            &manifest,
+        )
+        .unwrap()
+        {
+            ArchiveSource::Local(dir) => assert_eq!(dir, Path::new("/snap/dir")),
+            other => panic!("expected local, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_and_verify_round_trip_against_pack_partitions() {
+        // Build a tiny .tar.zst with one file using the same shape as
+        // snapshot_manifest::pack_partitions, then extract and verify.
+        use blake3;
+        use tar::{Builder as TarBuilder, Header};
+        use zstd::Encoder as ZstdEncoder;
+
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("test.tar.zst");
+        let payload = b"hello world";
+        let path_in_archive = "engine-application-metadata/6c656674";
+
+        // Pack.
+        {
+            let file = File::create(&archive_path).unwrap();
+            let mut enc = ZstdEncoder::new(file, 0).unwrap();
+            enc.include_checksum(true).unwrap();
+            let mut tar = TarBuilder::new(enc);
+            let mut header = Header::new_gnu();
+            header.set_size(payload.len() as u64);
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            header.set_cksum();
+            tar.append_data(&mut header, path_in_archive, &payload[..])
+                .unwrap();
+            let enc = tar.into_inner().unwrap();
+            enc.finish().unwrap();
+        }
+
+        let archive_bytes = fs::read(&archive_path).unwrap();
+        let expected = vec![OutputFileChecksum {
+            path: path_in_archive.into(),
+            size: payload.len() as u64,
+            blake3: blake3::hash(payload).to_hex().to_string(),
+        }];
+
+        let target = tempfile::tempdir().unwrap();
+        let extracted = extract_and_verify(target.path(), &archive_bytes, &expected).unwrap();
+        assert_eq!(extracted, 1);
+
+        let on_disk = fs::read(target.path().join(path_in_archive)).unwrap();
+        assert_eq!(on_disk, payload);
+        assert!(all_outputs_present(target.path(), &expected).unwrap());
+    }
+}

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -70,7 +70,7 @@ pub(crate) fn run(matches: &ArgMatches) -> Result<()> {
 impl Args {
     fn execute(self, source_datadir: &Path, output_dir: &Path) -> Result<()> {
         fs::create_dir_all(output_dir)
-            .wrap_err_with(|| format!("failed to create output dir: {}", output_dir.display()))?;
+            .wrap_err_with(|| format!("failed to create output dir: {output_dir:?}"))?;
 
         let consensus_dir = self
             .consensus_source_dir
@@ -78,7 +78,7 @@ impl Args {
             .unwrap_or_else(|| source_datadir.join("consensus"));
 
         if !consensus_dir.is_dir() {
-            bail!("consensus dir does not exist: {}", consensus_dir.display());
+            bail!("consensus dir does not exist: {consensus_dir:?}");
         }
 
         let groups = collect_cl_partitions(&consensus_dir)?;
@@ -129,7 +129,7 @@ impl Args {
             .wrap_err("failed to serialize merged manifest.json")?;
 
         fs::write(&manifest_path, &json)
-            .wrap_err_with(|| format!("failed to write {}", manifest_path.display()))?;
+            .wrap_err_with(|| format!("failed to write {manifest_path:?}"))?;
 
         eprintln!("snapshot manifest: {manifest_path:?}");
 
@@ -220,7 +220,7 @@ fn pack_partitions(
     partitions: &[PathBuf],
 ) -> Result<Vec<OutputFileChecksum>> {
     let file = File::create(archive_path)
-        .wrap_err_with(|| format!("failed to create archive {}", archive_path.display()))?;
+        .wrap_err_with(|| format!("failed to create archive {archive_path:?}"))?;
 
     let mut encoder = ZstdEncoder::new(file, 0).wrap_err("failed to initialize zstd encoder")?;
 
@@ -236,7 +236,7 @@ fn pack_partitions(
             .sort_by_file_name()
             .into_iter()
             .collect::<std::result::Result<Vec<_>, _>>()
-            .wrap_err_with(|| format!("failed walking partition dir {}", partition.display()))?
+            .wrap_err_with(|| format!("failed walking partition dir {partition:?}"))?
             .into_iter()
             .filter(|e| e.file_type().is_file())
             .map(|e| e.into_path())
@@ -249,7 +249,7 @@ fn pack_partitions(
                 .to_path_buf();
 
             let metadata = fs::metadata(&path)
-                .wrap_err_with(|| format!("failed to stat {}", path.display()))?;
+                .wrap_err_with(|| format!("failed to stat {path:?}"))?;
 
             let blake3 = blake3_hash(&path)?;
 
@@ -260,9 +260,9 @@ fn pack_partitions(
             header.set_cksum();
 
             let source =
-                File::open(&path).wrap_err_with(|| format!("failed to open {}", path.display()))?;
+                File::open(&path).wrap_err_with(|| format!("failed to open {path:?}"))?;
             tar.append_data(&mut header, &rel, source)
-                .wrap_err_with(|| format!("failed to append {} to tar", path.display()))?;
+                .wrap_err_with(|| format!("failed to append {path:?} to tar"))?;
 
             outputs.push(OutputFileChecksum {
                 path: rel.to_string_lossy().into_owned(),
@@ -283,7 +283,7 @@ fn pack_partitions(
 /// BLAKE3-hash a file's contents and return the hex digest.
 pub(crate) fn blake3_hash(path: &Path) -> Result<String> {
     let mut file =
-        File::open(path).wrap_err_with(|| format!("failed to open {}", path.display()))?;
+        File::open(path).wrap_err_with(|| format!("failed to open {path:?}"))?;
     let mut hasher = Hasher::new();
     let mut buf = [0u8; 64 * 1024];
     loop {

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -1,0 +1,320 @@
+use std::{
+    fs::{self, File},
+    io::Read,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use blake3::Hasher;
+use clap::{ArgMatches, FromArgMatches, Parser};
+use eyre::{Context as _, Result, bail};
+use reth_cli_commands::download::{
+    manifest::{ComponentManifest, OutputFileChecksum, SingleArchive, SnapshotManifest},
+    manifest_cmd::SnapshotManifestCommand,
+};
+use tar::{Builder as TarBuilder, Header};
+use walkdir::WalkDir;
+use zstd::Encoder as ZstdEncoder;
+
+const DEFAULT_PARTITION_PREFIX: &str = "engine";
+
+const FINALIZED_BLOCKS_INFIX: &str = "finalized_blocks";
+const FINALIZATIONS_INFIX: &str = "finalizations-by-height";
+const APPLICATION_METADATA_SUFFIX: &str = "application-metadata";
+
+const CL_FINALIZED_BLOCKS_KEY: &str = "cl_finalized_blocks";
+const CL_FINALIZATIONS_KEY: &str = "cl_finalizations";
+const CL_APPLICATION_METADATA_KEY: &str = "cl_application_metadata";
+
+const CL_FINALIZED_BLOCKS_FILE: &str = "cl_finalized_blocks.tar.zst";
+const CL_FINALIZATIONS_FILE: &str = "cl_finalizations.tar.zst";
+const CL_APPLICATION_METADATA_FILE: &str = "cl_application_metadata.tar.zst";
+
+/// Component keys advertised in `manifest.components` for our CL archives.
+pub(crate) const CL_COMPONENT_KEYS: &[&str] = &[
+    CL_FINALIZED_BLOCKS_KEY,
+    CL_FINALIZATIONS_KEY,
+    CL_APPLICATION_METADATA_KEY,
+];
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "snapshot-manifest",
+    about = "Generate snapshot archives and a manifest for both the EL (via reth) and the CL."
+)]
+pub(crate) struct Args {
+    #[command(flatten)]
+    inner: SnapshotManifestCommand,
+
+    /// Consensus storage directory. If not set, this will be dirived from --datadir.
+    #[arg(long)]
+    consensus_source_dir: Option<PathBuf>,
+}
+
+pub(crate) fn run(matches: &ArgMatches) -> Result<()> {
+    let args = Args::from_arg_matches(matches).map_err(|e| eyre::eyre!("{e}"))?;
+
+    let source_datadir = matches
+        .get_one::<PathBuf>("source_datadir")
+        .cloned()
+        .expect("--source-dir must be set");
+
+    let output_dir = matches
+        .get_one::<PathBuf>("output_dir")
+        .cloned()
+        .expect("--output-dir must be set");
+
+    args.execute(&source_datadir, &output_dir)
+}
+
+impl Args {
+    fn execute(self, source_datadir: &Path, output_dir: &Path) -> Result<()> {
+        fs::create_dir_all(output_dir)
+            .wrap_err_with(|| format!("failed to create output dir: {}", output_dir.display()))?;
+
+        let consensus_dir = self
+            .consensus_source_dir
+            .clone()
+            .unwrap_or_else(|| source_datadir.join("consensus"));
+
+        if !consensus_dir.is_dir() {
+            bail!("consensus dir does not exist: {}", consensus_dir.display());
+        }
+
+        let groups = collect_cl_partitions(&consensus_dir)?;
+        eprintln!("packaging execution layer static files");
+
+        let start = Instant::now();
+        self.inner
+            .execute()
+            .wrap_err("reth snapshot-manifest (EL packaging) failed")?;
+
+        eprintln!("execution layer snapshot finished in {:?}", start.elapsed());
+
+        // Read back manifest.json so we can amend it.
+        let manifest_path = output_dir.join("manifest.json");
+        let manifest_bytes = fs::read(&manifest_path)
+            .wrap_err_with(|| format!("failed to read {manifest_path:?}"))?;
+
+        let mut manifest: SnapshotManifest = serde_json::from_slice(&manifest_bytes)
+            .wrap_err("failed to parse manifest.json produced by reth snapshot-manifest")?;
+
+        eprintln!("packaging consensus layer archives");
+        for group in &groups {
+            let archive_path = output_dir.join(group.file_name);
+            let start = Instant::now();
+            let output_files = pack_partitions(&archive_path, &consensus_dir, &group.partitions)
+                .wrap_err_with(|| format!("failed to pack {}", group.key,))?;
+
+            let size = fs::metadata(&archive_path)
+                .wrap_err("failed to reach package metadata")?
+                .len();
+
+            let decompressed_size: u64 = output_files.iter().map(|f| f.size).sum();
+            eprintln!("packaged {} in {:?}", group.key, start.elapsed());
+
+            manifest.components.insert(
+                group.key.to_string(),
+                ComponentManifest::Single(SingleArchive {
+                    file: group.file_name.to_string(),
+                    size,
+                    decompressed_size,
+                    blake3: None,
+                    output_files,
+                }),
+            );
+        }
+
+        let json = serde_json::to_string_pretty(&manifest)
+            .wrap_err("failed to serialize merged manifest.json")?;
+
+        fs::write(&manifest_path, &json)
+            .wrap_err_with(|| format!("failed to write {}", manifest_path.display()))?;
+
+        eprintln!("snapshot manifest: {manifest_path:?}");
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct CLGroup {
+    /// Key under `manifest.components`.
+    key: &'static str,
+    /// Output filename, relative to `--output-dir`.
+    file_name: &'static str,
+    /// Absolute paths of the partition directories to include.
+    partitions: Vec<PathBuf>,
+}
+
+fn collect_cl_partitions(consensus_dir: &Path) -> Result<Vec<CLGroup>> {
+    let prefix = DEFAULT_PARTITION_PREFIX;
+
+    let finalized_blocks_marker = format!("{prefix}-{FINALIZED_BLOCKS_INFIX}-");
+    let finalizations_marker = format!("{prefix}-{FINALIZATIONS_INFIX}-");
+    let application_metadata_dir = format!("{prefix}-{APPLICATION_METADATA_SUFFIX}");
+
+    let mut finalized_blocks = Vec::new();
+    let mut finalizations = Vec::new();
+    let mut application_metadata = Vec::new();
+
+    for entry in fs::read_dir(consensus_dir)
+        .wrap_err_with(|| format!("failed to read consensus dir {consensus_dir:?}"))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        if name.starts_with(&finalized_blocks_marker) {
+            finalized_blocks.push(path);
+        } else if name.starts_with(&finalizations_marker) {
+            finalizations.push(path);
+        } else if name == application_metadata_dir.as_str() {
+            application_metadata.push(path);
+        }
+    }
+
+    if finalized_blocks.is_empty() {
+        bail!("no finalized_blocks partitions found under {consensus_dir:?}");
+    }
+
+    if finalizations.is_empty() {
+        bail!("no finalizations-by-height partitions found under {consensus_dir:?}");
+    }
+
+    if application_metadata.is_empty() {
+        bail!("no application metadata partition found under {consensus_dir:?}");
+    }
+
+    finalized_blocks.sort();
+    finalizations.sort();
+
+    let groups = vec![
+        CLGroup {
+            key: CL_FINALIZED_BLOCKS_KEY,
+            file_name: CL_FINALIZED_BLOCKS_FILE,
+            partitions: finalized_blocks,
+        },
+        CLGroup {
+            key: CL_FINALIZATIONS_KEY,
+            file_name: CL_FINALIZATIONS_FILE,
+            partitions: finalizations,
+        },
+        CLGroup {
+            key: CL_APPLICATION_METADATA_KEY,
+            file_name: CL_APPLICATION_METADATA_FILE,
+            partitions: application_metadata,
+        },
+    ];
+
+    Ok(groups)
+}
+
+fn pack_partitions(
+    archive_path: &Path,
+    base_dir: &Path,
+    partitions: &[PathBuf],
+) -> Result<Vec<OutputFileChecksum>> {
+    let file = File::create(archive_path)
+        .wrap_err_with(|| format!("failed to create archive {}", archive_path.display()))?;
+
+    let mut encoder = ZstdEncoder::new(file, 0).wrap_err("failed to initialize zstd encoder")?;
+
+    encoder
+        .include_checksum(true)
+        .wrap_err("failed to enable zstd checksums")?;
+
+    let mut tar = TarBuilder::new(encoder);
+
+    let mut outputs = Vec::new();
+    for partition in partitions {
+        let entries: Vec<PathBuf> = WalkDir::new(partition)
+            .sort_by_file_name()
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .wrap_err_with(|| format!("failed walking partition dir {}", partition.display()))?
+            .into_iter()
+            .filter(|e| e.file_type().is_file())
+            .map(|e| e.into_path())
+            .collect();
+
+        for path in entries {
+            let rel = path
+                .strip_prefix(base_dir)
+                .wrap_err("partition path was not under consensus source dir")?
+                .to_path_buf();
+
+            let metadata = fs::metadata(&path)
+                .wrap_err_with(|| format!("failed to stat {}", path.display()))?;
+
+            let blake3 = blake3_hash(&path)?;
+
+            let mut header = Header::new_gnu();
+            header.set_size(metadata.len());
+            header.set_mode(0o644);
+            header.set_mtime(0);
+            header.set_cksum();
+
+            let source =
+                File::open(&path).wrap_err_with(|| format!("failed to open {}", path.display()))?;
+            tar.append_data(&mut header, &rel, source)
+                .wrap_err_with(|| format!("failed to append {} to tar", path.display()))?;
+
+            outputs.push(OutputFileChecksum {
+                path: rel.to_string_lossy().into_owned(),
+                size: metadata.len(),
+                blake3,
+            });
+        }
+    }
+
+    let encoder = tar.into_inner().wrap_err("failed to finalize tar stream")?;
+    encoder
+        .finish()
+        .wrap_err("failed to finalize zstd stream")?;
+
+    Ok(outputs)
+}
+
+/// BLAKE3-hash a file's contents and return the hex digest.
+pub(crate) fn blake3_hash(path: &Path) -> Result<String> {
+    let mut file =
+        File::open(path).wrap_err_with(|| format!("failed to open {}", path.display()))?;
+    let mut hasher = Hasher::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_partitions_records_blake3_per_file() {
+        let src = tempfile::tempdir().unwrap();
+        let part = src.path().join("engine-finalized_blocks-ordinal");
+        fs::create_dir_all(&part).unwrap();
+        fs::write(part.join("0000000000000000"), b"hello").unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        let archive = out.path().join("test.tar.zst");
+        let outputs = pack_partitions(&archive, src.path(), &[part]).unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].size, 5);
+
+        let expected = blake3::hash(b"hello").to_hex().to_string();
+        assert_eq!(outputs[0].blake3, expected);
+        assert!(archive.exists());
+    }
+}


### PR DESCRIPTION
* Wrap Reth's `snapshot-manifest` and `download` commands

1. Encode the finalization cert for the manifest's block in the manifest.json file
2. Dump the cert on disk to be consumed on startup if empty

## Followups
When starting up the node, if the finalizations archive is empty, we can read the bootstrap finalization and set the floor from there. The snapshots ensure that the block is persisted in the EL
