### PR TITLE
docs(tip-1048): x storage precompile (MEV-based expiring storage)

### DIFF
--- a/tips/tip-1048.md
+++ b/tips/tip-1048.md
@@ -1,0 +1,276 @@
+---
+id: TIP-1048
+title: X Storage Precompile
+description: Adds an expiring per-address storage precompile with XSTORE, XLOAD, and XCLEAR.
+authors: TBD
+status: Draft
+related: TIP-1000
+protocolVersion: TBD
+---
+
+# TIP-1048: X Storage Precompile
+
+## Abstract
+
+This TIP introduces a new precompile that stores expiring key-value slots for an address. The precompile exposes three entrypoints: `XSTORE(slot, value, expiry)`, `XLOAD(slot)`, and `XCLEAR(addr, slot)`.
+
+`XSTORE` and `XLOAD` are scoped to `msg.sender`, so each caller gets an isolated slot namespace. `XCLEAR` is permissionless, but it may only succeed once an entry has expired.
+
+This allows us effectively introduce an out-of-protocol solution for clearing expired state, without having to make involved changes to the state trie or introducing new system transactions.
+
+> **Note:** The precompile logic can be built completely out-of-protocol, but we propose this as TIP so that we can also introduce a discounted gas schedule, which encourages the use of temporary storage.
+
+## Motivation
+
+1. **Short-lived state management:**
+   Many applications need short-lived state that persists longer than a single call frame or transaction, but still have an expiry associated with them.
+   Some examples are permit nonces with expiry, keychain state after the key has expired, DEX orders after expiry etc.
+   
+   Persistent contract storage is a poor fit for this pattern because it requires the owner to manage cleanup manually, and every expired entry becomes long-lived state unless someone explicitly removes it. 
+
+2. **Reducing upfront user costs:** 
+   The 250,000 gas introduced in TIP 1000, is necessary to control state growth, but also introduces higher costs for user onboarding. Introducing cheaper temporary storage primitives, would encourage app devs to use state efficient onboarding patterns which is a win-win for all parties.
+
+This TIP introduces a small precompile dedicated to expiring slot storage, with a built-in cleanup path that any actor can trigger once an entry has expired.
+
+
+
+## Assumptions
+
+- Expiry is measured against `block.timestamp`.
+- A slot is live while `block.timestamp <= expiry`.
+- A slot is expired once `block.timestamp > expiry`.
+- `XSTORE` rejects expiries that are not strictly greater than the current `block.timestamp`.
+- `XSTORE` and `XLOAD` key storage by the immediate `msg.sender`, not `tx.origin`.
+- `XCLEAR` can be called by any address and returns `true` only for an expired, not-yet-cleared slot.
+- Clearing a slot sets both its stored value and its expiry to zero.
+
+---
+
+# Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## Precompile Address
+
+The X storage precompile is deployed at the ASCII `X` address:
+
+```text
+0x5800000000000000000000000000000000000000
+```
+
+## Interface
+
+```solidity
+interface IXStorage {
+    /// @notice The requested slot is not currently live.
+    error Expired();
+
+    /// @notice The supplied expiry is not strictly in the future.
+    error InvalidExpiry();
+
+    /// @notice Stores or overwrites a slot owned by msg.sender.
+    /// @param slot Caller-defined slot key.
+    /// @param value Value to store.
+    /// @param expiry Inclusive unix timestamp after which the slot becomes expired.
+    /// @dev Reverts with InvalidExpiry if expiry <= block.timestamp.
+    function XSTORE(bytes32 slot, bytes32 value, uint64 expiry) external;
+
+    /// @notice Loads a slot owned by msg.sender.
+    /// @param slot Caller-defined slot key.
+    /// @return value Stored value.
+    /// @return expiry Stored inclusive unix expiry.
+    /// @dev Reverts with Expired if the slot is expired or has been cleared.
+    function XLOAD(bytes32 slot) external view returns (bytes32 value, uint64 expiry);
+
+    /// @notice Clears an expired slot for any address.
+    /// @param addr Owner of the slot.
+    /// @param slot Caller-defined slot key.
+    /// @return cleared True if the slot was cleared, false otherwise.
+    /// @dev  Returns false when the slot is still live,
+    /// was never written, or has already been cleared.
+    function XCLEAR(address addr, bytes32 slot) external returns (bool cleared);
+}
+```
+
+## Storage Model
+
+The precompile maintains the following logical mapping:
+
+```solidity
+struct XEntry {
+    bytes32 value;
+    bytes32 metadata;
+}
+
+mapping(address => mapping(bytes32 => XEntry)) entries;
+```
+
+Each address has its own independent slot namespace. Two different callers using the same `slot` key MUST read and write different records.
+
+This mapping is a logical model. The implementation MAY use any internal layout so long as the externally visible behavior and gas accounting defined by this TIP are preserved.
+
+## Metadata Encoding
+
+The second storage slot of each entry uses the full 256-bit word with the following layout:
+
+| Bits | Meaning |
+|------|---------|
+| `255` | Version bit |
+| `254:64` | Reserved for future use |
+| `63:0` | expiry |
+
+In this TIP, the current version is `0`, so the version bit is `0`.
+
+For version `0`:
+
+- bit `255` MUST be `0`
+- bits `254:64` MUST be `0`
+- bits `63:0` contain the inclusive unix timestamp used for expiry checks
+
+The reserved middle bits are intentionally left empty for future use. The current API only exposes the `uint64 expiry` timestamp; callers do not provide or observe the other metadata bits in this version.
+
+Under this model, `value` and `expiry` are distinct storage fields. A fresh entry therefore behaves like creation of two state elements for economic analysis.
+
+## Function Semantics
+
+### `XSTORE(slot, value, expiry)`
+
+`XSTORE` uses `msg.sender` as the slot owner. It MUST write `value` and `expiry` into `entries[msg.sender][slot]`, replacing any previous record for that slot.
+
+`XSTORE` MUST revert with `InvalidExpiry()` unless `expiry > block.timestamp`.
+
+If the call succeeds, the precompile MUST store the expiry in the low 64 bits of the metadata slot, and MUST set the version bit and all reserved middle bits to `0`.
+
+### `XLOAD(slot)`
+
+`XLOAD` uses `msg.sender` as the slot owner and reads `entries[msg.sender][slot]`.
+
+If `block.timestamp > expiry`, the call MUST revert with `Expired()` and MUST NOT return the stored value. This includes slots that were previously cleared, since clearing sets `expiry = 0`.
+
+If `block.timestamp <= expiry`, the call MUST return the stored `value` and `expiry`.
+
+## Gas Accounting For `XLOAD`
+
+`XLOAD` MUST charge gas equal to two `SLOAD`s: one for reading the expiry field and one for reading the value field.
+
+Each read MUST be charged according to the warm or cold access state of the corresponding storage slot.
+
+### `XCLEAR(addr, slot)`
+
+`XCLEAR` reads `entries[addr][slot]`.
+
+If `expiry == 0`, the call MUST return `false`.
+
+If `block.timestamp <= expiry`, the call MUST return `false`.
+
+If `block.timestamp > expiry`, it MUST clear the entry by setting `value = 0` and `expiry = 0`, and MUST return `true`.
+
+`XCLEAR` MAY be called by any address for any `addr`; there is no ownership check.
+
+## Gas Accounting For `XCLEAR`
+
+`XCLEAR` MUST first read the target entry's expiry to determine whether the entry is clearable.
+
+If `XCLEAR` does not clear the slot, the call MUST cost exactly as much gas as an `SLOAD` of the expiry slot in the corresponding warm or cold access state. An unsuccessful `XCLEAR` MUST return `false` and MUST NOT add any gas refund.
+
+If `XCLEAR` succeeds, the call MUST be free to execute, MUST return `true`, and MUST add 15,000 gas to the transaction's refund counter. This 15,000 gas refund is the only explicit cleanup incentive introduced by this TIP.
+
+## XSTORE Pricing
+
+Let `ttl = expiry - block.timestamp` as measured at execution time.
+
+`XSTORE` MUST charge gas according to the following lifetime buckets:
+
+| Lifetime | Gas |
+|----------|-----|
+| `ttl <= 1 hour` | 20,000 |
+| `1 hour < ttl <= 1 day` | 40,000 |
+| `1 day < ttl <= 1 week` | 80,000 |
+| `1 week < ttl <= 30 days` | 120,000 |
+| `30 days < ttl <= 365 days` | 200,000 |
+| `365 days < ttl` | 250,000 |
+
+These are the full `XSTORE` gas charges defined by this TIP. `XSTORE` does not additionally inherit ordinary `SSTORE` creation pricing on top of this table.
+
+The pricing follows one simple principle: the longer state is allowed to stay around, the closer it should get to ordinary persistent-state pricing.
+
+Short-lived entries are still cheaper than persistent storage, but they do not start below ordinary storage-write costs. The minimum `20,000` gas tier ensures that `XSTORE` plus a later successful `XCLEAR` can never create net-positive refund farming against the `15,000` gas cleanup refund.
+
+A one-year entry is still cheaper than permanent storage at `200,000` gas. Anything beyond one year is charged `250,000` gas, matching the [TIP-1000](./tip-1000.md) benchmark for permanent state growth.
+
+This keeps temporary storage useful for real application flows, while making sure that very long-lived entries do not underprice effectively persistent state.
+
+## Empty And Cleared Slots
+
+An entry with `expiry = 0` is treated as not live. As a result:
+
+- `XLOAD` on a never-written slot MUST revert with `Expired()`.
+- `XLOAD` on a cleared slot MUST revert with `Expired()`.
+- `XCLEAR` on a never-written or already-cleared slot MUST return `false`.
+
+## Expiring Nonces
+
+Expiring nonces are intentionally left out of this TIP.
+
+Once this precompile is live, we expect to propose a separate TIP that migrates expiring nonces away from the current ring buffer design and onto this precompile. That migration is straightforward because expiring nonces already have a very short maximum lifetime of 30 seconds, so we can just abandon the ring buffer when required
+
+## Future Compatibility
+
+This design intentionally separates the user-facing storage semantics from the cleanup mechanism.
+
+`XSTORE` and `XLOAD` define the core interface and semantics: write a value with an expiry, and read it while it is still live. A future TIP could keep those interfaces the same while changing how expired state is physically managed underneath, for example with separate temporary storage tries, system transactions, or other more sophisticated cleanup mechanisms.
+
+In this version, cleanup is exposed through `XCLEAR`. A future design may keep `XCLEAR` as a compatibility hook, or make it unnecessary if cleanup becomes fully protocol-driven.
+
+## XCLEAR Incentives
+
+This TIP keeps the incentive model simple: successful `XCLEAR` calls receive the existing `15,000` gas storage-clearing refund, and no additional incentive is introduced.
+
+We believe this is sufficient for two reasons - 
+1. Validators are naturally incentivized to keep the state they serve smaller, so many validators can justify running expiry cleanup as a protocol service even when the direct economic return is modest. 
+2. Searchers and arbitrage bots can bundle `XCLEAR` calls into transactions they already intend to send, using the refund to reduce the effective cost of those transactions.
+
+Because of these existing incentives, this TIP does not add any larger or special-purpose cleanup reward.
+
+## Race Conditions
+
+`XCLEAR` has ordering races, not correctness races.
+
+Execution is serialized, so the precompile always checks the current slot state at execution time. This means a stale `XCLEAR` cannot clear a slot that has already been reused with a fresh future expiry: in that case it will see the new live expiry and return `false`.
+
+The main remaining question is economic. There are two cases:
+
+1. **Unsuccessful `XCLEAR`**: costs one `SLOAD` of the expiry/metadata slot and returns `false`.
+2. **Successful `XCLEAR`**: clears the slot, returns `true`, and receives the `15,000` gas refund.
+
+If two actors race to clear the same expired slot, the loser only pays the cost of a single `SLOAD` instead of risking a full transaction revert. This makes `XCLEAR` safe to include inside larger flows and bundles.
+
+This design does not remove ordering races, but it reduces their downside to a small, bounded gas cost while preserving correct state transitions.
+
+## Events
+This TIP does not introduce any events.
+
+## Errors
+
+This TIP introduces the following custom errors:
+
+- `Expired()`: returned by `XLOAD` when the requested slot is not currently live.
+- `InvalidExpiry()`: returned by `XSTORE` when `expiry <= block.timestamp`.
+
+# Invariants
+
+- **Sender isolation**: `XSTORE` and `XLOAD` MUST only access the namespace keyed by `msg.sender`.
+- **Versioned metadata slot**: the metadata slot MUST use the packed layout above, with version bit `0` in this TIP.
+- **Reserved bits zero**: the reserved middle bits in the metadata slot MUST be zero in this version.
+- **Future expiry only**: `XSTORE` MUST only accept expiries strictly greater than the current `block.timestamp`.
+- **Live-read only**: `XLOAD` MUST only return data when `block.timestamp <= expiry`.
+- **Expired-read rejection**: `XLOAD` MUST revert once `block.timestamp > expiry`.
+- **XLOAD price**: `XLOAD` MUST charge gas equal to two `SLOAD`s.
+- **Permissionless cleanup**: Any caller MUST be able to clear an expired slot for any owner.
+- **No premature deletion**: `XCLEAR` MUST return `false` and MUST NOT modify a slot whose expiry has not yet passed.
+- **No repeated cleanup reward**: `XCLEAR` MUST return `false` for never-written and already-cleared slots.
+- **XCLEAR unsuccessful cost**: An unsuccessful `XCLEAR` MUST cost only the corresponding expiry-slot `SLOAD`.
+- **XCLEAR success incentive**: A successful `XCLEAR` MUST return `true` and MUST add exactly 15,000 gas to the transaction refund counter.
+- **Tiered XSTORE price**: `XSTORE` MUST charge according to the lifetime bucket table above.
+- **Overwrite behavior**: A later `XSTORE` for the same `(msg.sender, slot)` pair MUST fully replace the previous `value` and `expiry`.


### PR DESCRIPTION
Reopened from #3631 for renewed discussion.

## TIP-1048: X Storage Precompile

**Approach:** MEV-based expiring storage with arbitrary TTLs and out-of-protocol cleanup.

### Key design points
- Three entrypoints: `XSTORE(slot, value, expiry)`, `XLOAD(slot)`, `XCLEAR(addr, slot)`
- Arbitrary expiry times via `block.timestamp`-based TTL
- Tiered gas pricing: 20k (≤1h) → 250k (>1yr), approaching permanent storage cost for long TTLs
- Permissionless `XCLEAR` with 15k gas refund incentivizes cleanup by validators and searchers
- Cleanup mechanism is hot-swappable — can move to in-protocol later without changing user APIs

### Tradeoffs vs TIP-1040 (Epoch-based)
- ✅ Full flexibility — arbitrary expiry times
- ✅ Simpler Reth changes — uses standard precompile storage
- ✅ Hot-swappable cleanup mechanism
- ❌ Relies on out-of-protocol garbage collection (MEV incentives)
- ❌ State not bounded by design — depends on cleanup actors

See thread discussion: https://tempoxyz.slack.com/archives/C0A761BDJ6P/p1774624334588709

cc @klkvr @mallesh-tempoxyz