### PR TITLE
deps: update reth from main (2026-05-11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bc95fd73591644f0022065bef3c027d1a5ed875a53cb19a898d71a00818c1d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4188,7 +4188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8322,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8507,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "clap",
  "eyre",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "bytes",
  "futures",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "futures",
  "metrics",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "bytes",
  "eyre",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10205,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10236,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10313,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10406,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10748,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "clap",
  "eyre",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "clap",
  "eyre",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f9c39fc#f9c39fc0136965d2407a1318a8bc06d88967d2b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11470,7 +11470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11529,7 +11529,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11550,7 +11550,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12445,7 +12445,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14461,7 +14461,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,64 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f9c39fc", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -469,7 +469,7 @@ where
                 // The iterator will handle lane switching internally when appropriate
                 best_txs.mark_invalid(
                     &pool_tx,
-                    &InvalidPoolTransactionError::ExceedsGasLimit(
+                    InvalidPoolTransactionError::ExceedsGasLimit(
                         pool_tx.gas_limit(),
                         non_shared_gas_limit - cumulative_gas_used,
                     ),
@@ -486,7 +486,7 @@ where
             {
                 best_txs.mark_invalid(
                     &pool_tx,
-                    &InvalidPoolTransactionError::Other(Box::new(
+                    InvalidPoolTransactionError::Other(Box::new(
                         TempoPoolTransactionError::ExceedsNonPaymentLimit,
                     )),
                 );
@@ -512,7 +512,7 @@ where
             if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
                 best_txs.mark_invalid(
                     &pool_tx,
-                    &InvalidPoolTransactionError::OversizedData {
+                    InvalidPoolTransactionError::OversizedData {
                         size: estimated_block_size_with_tx,
                         limit: MAX_RLP_BLOCK_SIZE,
                     },
@@ -578,7 +578,7 @@ where
                         trace!(%error, tx = %tx_debug_repr, "skipping invalid transaction and its descendants");
                         best_txs.mark_invalid(
                             &pool_tx,
-                            &InvalidPoolTransactionError::Consensus(
+                            InvalidPoolTransactionError::Consensus(
                                 InvalidTransactionError::TxTypeNotSupported,
                             ),
                         );

--- a/crates/transaction-pool/src/best.rs
+++ b/crates/transaction-pool/src/best.rs
@@ -89,7 +89,7 @@ impl Iterator for MergeBestTransactions {
 }
 
 impl BestTransactions for MergeBestTransactions {
-    fn mark_invalid(&mut self, transaction: &Self::Item, kind: &InvalidPoolTransactionError) {
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
         if transaction.transaction.is_aa_2d() {
             self.aa_2d_pool.mark_invalid(transaction, kind);
         } else {
@@ -169,7 +169,7 @@ where
             {
                 self.inner.mark_invalid(
                     &tx,
-                    &InvalidPoolTransactionError::Consensus(
+                    InvalidPoolTransactionError::Consensus(
                         InvalidTransactionError::InsufficientFunds(
                             (balance, tx.transaction.fee_token_cost()).into(),
                         ),
@@ -187,7 +187,7 @@ impl<I> BestTransactions for StateAwareBestTransactions<I>
 where
     I: BestTransactions<Item = Arc<ValidPoolTransaction<TempoPooledTransaction>>> + Send,
 {
-    fn mark_invalid(&mut self, transaction: &Self::Item, kind: &InvalidPoolTransactionError) {
+    fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
         self.inner.mark_invalid(transaction, kind);
     }
 
@@ -446,7 +446,7 @@ mod tests {
         // Simulate payload builder marking R1 as invalid
         let kind =
             InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported);
-        merged.mark_invalid(&first, &kind);
+        merged.mark_invalid(&first, kind);
 
         // The AA2D descendant must be skipped, while protocol txs still yield.
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*l1.hash()));
@@ -470,7 +470,7 @@ mod tests {
 
         let kind =
             InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported);
-        merged.mark_invalid(&first, &kind);
+        merged.mark_invalid(&first, kind);
 
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*l2.hash()));
         assert!(merged.next().is_none());
@@ -495,7 +495,7 @@ mod tests {
 
         let kind =
             InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported);
-        merged.mark_invalid(&first, &kind);
+        merged.mark_invalid(&first, kind);
 
         assert_eq!(merged.next().map(|tx| *tx.hash()), Some(*right_tx.hash()));
         assert!(merged.next().is_none());

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -1621,7 +1621,7 @@ impl Iterator for BestAA2dTransactions {
 }
 
 impl BestTransactions for BestAA2dTransactions {
-    fn mark_invalid(&mut self, transaction: &Self::Item, _kind: &InvalidPoolTransactionError) {
+    fn mark_invalid(&mut self, transaction: &Self::Item, _kind: InvalidPoolTransactionError) {
         // Skip invalidation for expiring nonce transactions - they are independent
         // and should not block other expiring nonce txs from the same sender
         if transaction.transaction.is_expiring_nonce() {
@@ -3619,7 +3619,7 @@ mod tests {
         let error = reth_transaction_pool::error::InvalidPoolTransactionError::Consensus(
             InvalidTransactionError::TxTypeNotSupported,
         );
-        best.mark_invalid(&first, &error);
+        best.mark_invalid(&first, error);
 
         // The sequence should be in the invalid set, so next tx from same sender should be skipped
         // But since we already consumed tx0, we'd get tx1 next - but the sequence is now invalid
@@ -4646,7 +4646,7 @@ mod tests {
 
         let error =
             InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported);
-        best.mark_invalid(&first, &error);
+        best.mark_invalid(&first, error);
 
         let mut remaining_hashes = HashSet::new();
         for tx in best {


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`f9c39fc...7354172`](https://github.com/paradigmxyz/reth/compare/f9c39fc...7354172)

🔗 Amp thread: https://ampcode.com/threads/T-019e16ce-a063-713a-99d4-1f36e35c2491
**Engine**
- Flush BAL store after saving blocks ([#24087](https://github.com/paradigmxyz/reth/pull/24087))
- Validate BAL gas limit without redecoding ([#24109](https://github.com/paradigmxyz/reth/pull/24109))

**BAL**
- Default BAL requests to optional in net layer ([#24095](https://github.com/paradigmxyz/reth/pull/24095))
- Use native BAL diff diagnostics ([#24118](https://github.com/paradigmxyz/reth/pull/24118))

**DB**
- Disable `posix_fallocate` in mdbx to fix `ENOSPC` on ZFS ([#24108](https://github.com/paradigmxyz/reth/pull/24108))

**Init State**
- Reduce memory usage during large imports ([#23825](https://github.com/paradigmxyz/reth/pull/23825))

**Pool**
- Pass error by value to `mark_invalid` ([#24121](https://github.com/paradigmxyz/reth/pull/24121))

**Bench**
- Require PR author to be an org member for benchmark CI ([#24115](https://github.com/paradigmxyz/reth/pull/24115))
- Route scheduled benchmarks through txgen ([#24117](https://github.com/paradigmxyz/reth/pull/24117))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019e16ce-b7b7-7750-becb-4abd8c2c8fa5
- Bumped `reth` git dependency revision from `f9c39fc` to `7354172` across all `reth-*` workspace dependencies in `Cargo.toml`.
- Updated `BestTransactions::mark_invalid` implementations and call sites to take `InvalidPoolTransactionError` by value instead of by reference (`&InvalidPoolTransactionError`), matching the upstream reth API change.
- Adjusted all `mark_invalid` callers in `crates/payload/builder/src/lib.rs`, `crates/transaction-pool/src/best.rs`, and `crates/transaction-pool/src/tt_2d_pool.rs` (including tests) to pass the error by value.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/25667200098)
