### PR TITLE
docs(tip-1040): clarify epochs are not consensus epochs

### DIFF
--- a/tips/tip-1040.md
+++ b/tips/tip-1040.md
@@ -53,6 +53,8 @@ The original single-epoch design (values live for 1–2 epochs) was too rigid fo
 
 ## Epoch Derivation
 
+> **Note:** The "epochs" in this TIP are **not** consensus epochs. They are a TIP-specific construct defined purely from the block number (see below). There is no relationship to validator rotation, committee selection, or any other consensus-layer epoch boundary.
+
 ```
 epoch(block_number) = block_number >> 16
 ```


### PR DESCRIPTION
Adds a note to the Epoch Derivation section clarifying that the epochs in TIP-1040 are a TIP-specific construct derived from block number, unrelated to consensus-layer epochs (validator rotation, committee selection, etc.).

Stacked on #3879.