### PR TITLE
ci(bench): gate OTLP telemetry behind an opt-in flag

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -56,6 +56,22 @@ CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 export PATH="$CARGO_BIN_DIR:$PATH"
 TXGEN_TEMPO_BIN="${TXGEN_TEMPO_BIN:-txgen-tempo}"
 TXGEN_BENCH_BIN="${TXGEN_BENCH_BIN:-bench}"
+BENCH_FEATURES="${BENCH_FEATURES:-jemalloc,asm-keccak,keccak-cache-global}"
+
+if [ "${BENCH_OTLP:-false}" = "true" ]; then
+  if [ -z "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}" ] && [ -n "${GRAFANA_TEMPO:-}" ]; then
+    export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="${GRAFANA_TEMPO%/}/v1/traces"
+  elif [ -z "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}" ] && [ -n "${TEMPO_TELEMETRY_URL:-}" ]; then
+    export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="${TEMPO_TELEMETRY_URL%/}/opentelemetry/v1/traces"
+  fi
+  export OTEL_BSP_MAX_QUEUE_SIZE="${OTEL_BSP_MAX_QUEUE_SIZE:-65536}"
+  export OTEL_BLRP_MAX_QUEUE_SIZE="${OTEL_BLRP_MAX_QUEUE_SIZE:-65536}"
+else
+  unset TEMPO_TELEMETRY_URL
+  unset GRAFANA_TEMPO
+  unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  unset OTEL_EXPORTER_OTLP_HEADERS
+fi
 
 # ============================================================================
 # Install txgen-tempo and bench-cli
@@ -83,7 +99,7 @@ build_tempo() {
   echo "Building $label tempo ($ref)..."
   cd "$src_dir"
   RUSTFLAGS="-C target-cpu=native" \
-    cargo build --profile profiling --bin tempo
+    cargo build --profile profiling --bin tempo --no-default-features --features "$BENCH_FEATURES"
   cd -
 }
 
@@ -218,13 +234,22 @@ run_single() {
   total_mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
   local mem_limit=$(( total_mem_kb * 95 / 100 * 1024 ))
 
+  local scope_env=(env)
+  local env_name env_value
+  for env_name in TEMPO_TELEMETRY_URL OTEL_EXPORTER_OTLP_TRACES_ENDPOINT OTEL_RESOURCE_ATTRIBUTES OTEL_BSP_MAX_QUEUE_SIZE OTEL_BLRP_MAX_QUEUE_SIZE; do
+    env_value="${!env_name:-}"
+    if [ -n "$env_value" ]; then
+      scope_env+=("${env_name}=${env_value}")
+    fi
+  done
+
   # Start tempo node
   if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
     local samply_bin
     samply_bin="$(which samply)"
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
       -p MemoryMax="$mem_limit" \
-      nice -n -20 \
+      "${scope_env[@]}" nice -n -20 \
       "$samply_bin" record --save-only --presymbolicate --rate 10000 \
       --output "$output_dir/samply-profile.json.gz" \
       -- "$binary" "${NODE_ARGS[@]}" \
@@ -232,7 +257,7 @@ run_single() {
   else
     sudo systemd-run --quiet --scope --collect --unit="$TEMPO_SCOPE" \
       -p MemoryMax="$mem_limit" \
-      nice -n -20 "$binary" "${NODE_ARGS[@]}" \
+      "${scope_env[@]}" nice -n -20 "$binary" "${NODE_ARGS[@]}" \
       > "$log" 2>&1 &
   fi
   stdbuf -oL tail -f "$log" | sed -u "s/^/[$label] /" &

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -81,6 +81,11 @@ on:
         type: string
         required: true
         default: "120"
+      otlp:
+        description: Export OTLP traces and logs.
+        type: boolean
+        required: true
+        default: false
       baseline-args:
         description: Extra args passed only to the baseline node.
         type: string
@@ -187,6 +192,10 @@ on:
       tracy-offset:
         type: string
         required: true
+      otlp:
+        type: string
+        required: false
+        default: "false"
       baseline-args:
         type: string
         required: false
@@ -279,6 +288,8 @@ jobs:
       BENCH_TRACY: ${{ inputs.tracy }}
       BENCH_TRACY_SECONDS: ${{ inputs.tracy-seconds }}
       BENCH_TRACY_OFFSET: ${{ inputs.tracy-offset }}
+      BENCH_OTLP: ${{ inputs.otlp == true || inputs.otlp == 'true' }}
+      BENCH_FEATURES: ${{ (inputs.otlp == true || inputs.otlp == 'true') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature-args }}
       BENCH_GAS_LIMIT: ${{ inputs.gas-limit || '1000000000000' }}
@@ -293,21 +304,26 @@ jobs:
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       BENCH_PR_HEAD_REF: ${{ inputs.pr-head-ref }}
-      TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
-      GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
       SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
       SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
     steps:
-      - name: Mask telemetry URL
-        if: env.TEMPO_TELEMETRY_URL
-        run: echo "::add-mask::$TEMPO_TELEMETRY_URL"
-
-      - name: Mask Grafana Tempo URL
-        if: env.GRAFANA_TEMPO
-        run: echo "::add-mask::$GRAFANA_TEMPO"
+      - name: Configure OTLP telemetry
+        if: env.BENCH_OTLP == 'true'
+        env:
+          TEMPO_TELEMETRY_URL_SECRET: ${{ secrets.TEMPO_TELEMETRY_URL }}
+          GRAFANA_TEMPO_SECRET: ${{ secrets.GRAFANA_TEMPO }}
+        run: |
+          if [ -n "$TEMPO_TELEMETRY_URL_SECRET" ]; then
+            echo "::add-mask::$TEMPO_TELEMETRY_URL_SECRET"
+            printf 'TEMPO_TELEMETRY_URL=%s\n' "$TEMPO_TELEMETRY_URL_SECRET" >> "$GITHUB_ENV"
+          fi
+          if [ -n "$GRAFANA_TEMPO_SECRET" ]; then
+            echo "::add-mask::$GRAFANA_TEMPO_SECRET"
+            printf 'GRAFANA_TEMPO=%s\n' "$GRAFANA_TEMPO_SECRET" >> "$GITHUB_ENV"
+          fi
 
       - name: Mask ClickHouse credentials
         if: env.CLICKHOUSE_URL
@@ -381,10 +397,12 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.BENCH_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const otlp = process.env.BENCH_OTLP === 'true';
+            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const noCache = process.env.BENCH_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
             const gasLimit = process.env.BENCH_GAS_LIMIT;
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${noCacheNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${otlpNote}${noCacheNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -532,6 +550,12 @@ jobs:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
         run: |
+          if [ "$BENCH_OTLP" != "true" ]; then
+            unset TEMPO_TELEMETRY_URL
+            unset GRAFANA_TEMPO
+            unset OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            unset OTEL_EXPORTER_OTLP_HEADERS
+          fi
           cmd=(nu bench-e2e.nu e2e)
           cmd+=(
             --preset "$BENCH_PRESET"
@@ -546,6 +570,8 @@ jobs:
             --baseline-name "${{ steps.refs.outputs.baseline-name }}"
             --feature-name "${{ steps.refs.outputs.feature-name }}"
             --tune
+            --no-default-features
+            --features "$BENCH_FEATURES"
           )
           [ "$BENCH_FORCE_BLOAT" = "true" ] && cmd+=(--force-bloat)
           [ "$BENCH_NO_CACHE" = "true" ] && cmd+=(--no-cache)

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -27,6 +27,10 @@ on:
         description: "Enable samply profiling"
         type: string
         default: "false"
+      otlp:
+        description: "Export OTLP traces and logs"
+        type: boolean
+        default: false
       baseline:
         description: "Baseline git ref (default: merge-base)"
         type: string
@@ -80,6 +84,10 @@ on:
       samply:
         type: string
         required: true
+      otlp:
+        type: string
+        required: false
+        default: "false"
       baseline-args:
         type: string
         required: false
@@ -118,6 +126,10 @@ on:
         required: false
       DEREK_TOKEN:
         required: false
+      TEMPO_TELEMETRY_URL:
+        required: false
+      GRAFANA_TEMPO:
+        required: false
       SLACK_BENCH_BOT_TOKEN:
         required: false
       SLACK_BENCH_CHANNEL:
@@ -141,6 +153,8 @@ jobs:
       BENCH_PR: ${{ inputs.pr }}
       BENCH_ACTOR: ${{ inputs.actor }}
       BENCH_SAMPLY: ${{ inputs.samply }}
+      BENCH_OTLP: ${{ inputs.otlp == true || inputs.otlp == 'true' }}
+      BENCH_FEATURES: ${{ (inputs.otlp == true || inputs.otlp == 'true') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: "--dev.block-time 999999s ${{ inputs.baseline-args }}"
       BENCH_FEATURE_ARGS: "--dev.block-time 999999s ${{ inputs.feature-args }}"
       BENCH_BLOCKS: ${{ inputs.blocks }}
@@ -152,6 +166,21 @@ jobs:
       BENCH_RUN_LABEL: ${{ inputs.run-label || 'Replay Bench' }}
       BENCH_WORK_DIR: bench-results/replay-${{ inputs.chain || 'mainnet' }}
     steps:
+      - name: Configure OTLP telemetry
+        if: env.BENCH_OTLP == 'true'
+        env:
+          TEMPO_TELEMETRY_URL_SECRET: ${{ secrets.TEMPO_TELEMETRY_URL }}
+          GRAFANA_TEMPO_SECRET: ${{ secrets.GRAFANA_TEMPO }}
+        run: |
+          if [ -n "$TEMPO_TELEMETRY_URL_SECRET" ]; then
+            echo "::add-mask::$TEMPO_TELEMETRY_URL_SECRET"
+            printf 'TEMPO_TELEMETRY_URL=%s\n' "$TEMPO_TELEMETRY_URL_SECRET" >> "$GITHUB_ENV"
+          fi
+          if [ -n "$GRAFANA_TEMPO_SECRET" ]; then
+            echo "::add-mask::$GRAFANA_TEMPO_SECRET"
+            printf 'GRAFANA_TEMPO=%s\n' "$GRAFANA_TEMPO_SECRET" >> "$GITHUB_ENV"
+          fi
+
       - name: Resolve checkout ref
         id: checkout-ref
         uses: actions/github-script@v8
@@ -234,8 +263,10 @@ jobs:
             const feature = '${{ inputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const otlp = process.env.BENCH_OTLP === 'true';
+            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const chain = process.env.BENCH_CHAIN || 'mainnet';
-            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** mode: \`replay\`, chain: \`${chain}\`, blocks: \`${blocks}\`, warmup: \`${warmup}\`, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${otlpNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,6 +43,7 @@ jobs:
       tracy: ${{ steps.args.outputs.tracy }}
       tracy-seconds: ${{ steps.args.outputs.tracy-seconds }}
       tracy-offset: ${{ steps.args.outputs.tracy-offset }}
+      otlp: ${{ steps.args.outputs.otlp }}
       baseline-args: ${{ steps.args.outputs.baseline-args }}
       feature-args: ${{ steps.args.outputs.feature-args }}
       gas-limit: ${{ steps.args.outputs.gas-limit }}
@@ -101,7 +102,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
-            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, txgenRef, samply, tracy, tracySeconds, tracyOffset, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
+            let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
 
             pr = String(context.issue.number);
             actor = context.payload.comment.user.login;
@@ -110,9 +111,9 @@ jobs:
             const intArgs = new Set(['duration', 'bloat', 'tps', 'accounts', 'max-concurrent-requests', 'gas-limit', 'tracy-seconds', 'tracy-offset', 'blocks', 'warmup']);
             const refArgs = new Set(['baseline', 'feature', 'txgen-ref']);
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain']);
-            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients']);
+            const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients', 'otlp']);
             const bloatValues = new Set(['1', '10', '100']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '1000', chain: 'mainnet' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '1000', chain: 'mainnet' };
             const unknown = [];
             const invalid = [];
             const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -155,6 +156,12 @@ jobs:
                 } else {
                   defaults[key] = value;
                 }
+              } else if (boolArgs.has(key)) {
+                if (value === 'true' || value === 'false') {
+                  defaults[key] = value;
+                } else {
+                  invalid.push(`\`${key}=${value}\` (must be true or false)`);
+                }
               } else if (key === 'existing-recipients') {
                 if (value === 'false') {
                   defaults['no-existing-recipients'] = 'true';
@@ -177,7 +184,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -201,6 +208,7 @@ jobs:
             tracy = defaults.tracy;
             tracySeconds = defaults['tracy-seconds'];
             tracyOffset = defaults['tracy-offset'];
+            otlp = defaults.otlp;
             baselineArgs = defaults['baseline-args'];
             featureArgs = defaults['feature-args'];
             gasLimit = defaults['gas-limit'];
@@ -220,7 +228,7 @@ jobs:
             const erFlag = `--existing-recipients=${existingRecipients}`;
             benchArgs = benchArgs ? `${benchArgs} ${erFlag}` : erFlag;
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [preset=NAME] [duration=N] [bloat=1|10|100] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N] [baseline=REF] [feature=REF] [txgen-ref=REF] [samply] [otlp] [force-bloat] [no-cache] [no-slack] [existing-recipients=BOOL] [tracy=MODE] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -314,6 +322,7 @@ jobs:
             core.setOutput('tracy', tracy);
             core.setOutput('tracy-seconds', tracySeconds);
             core.setOutput('tracy-offset', tracyOffset);
+            core.setOutput('otlp', otlp);
             core.setOutput('baseline-args', baselineArgs || '');
             core.setOutput('feature-args', featureArgs || '');
             core.setOutput('gas-limit', gasLimit);
@@ -347,6 +356,7 @@ jobs:
           ACK_TXGEN_REF: ${{ steps.args.outputs.txgen-ref }}
           ACK_SAMPLY: ${{ steps.args.outputs.samply }}
           ACK_TRACY: ${{ steps.args.outputs.tracy }}
+          ACK_OTLP: ${{ steps.args.outputs.otlp }}
           ACK_BASELINE_ARGS: ${{ steps.args.outputs.baseline-args }}
           ACK_FEATURE_ARGS: ${{ steps.args.outputs.feature-args }}
           ACK_GAS_LIMIT: ${{ steps.args.outputs.gas-limit }}
@@ -383,13 +393,15 @@ jobs:
             const samplyNote = samply ? ', samply: `enabled`' : '';
             const tracy = process.env.ACK_TRACY;
             const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
+            const otlp = process.env.ACK_OTLP === 'true';
+            const otlpNote = otlp ? ', otlp: `enabled`' : ', otlp: `disabled`';
             const bNa = process.env.ACK_BASELINE_ARGS || '';
             const fNa = process.env.ACK_FEATURE_ARGS || '';
             const naNote = (bNa || fNa) ? `${bNa ? `, baseline-args: \`${bNa}\`` : ''}${fNa ? `, feature-args: \`${fNa}\`` : ''}` : '';
             const gasLimit = process.env.ACK_GAS_LIMIT;
             const noCache = process.env.ACK_NO_CACHE === 'true';
             const noCacheNote = noCache ? ', no-cache: `true`' : '';
-            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${naNote}${noCacheNote}`;
+            const config = `**Config:** mode: \`${mode}\`, preset: \`${preset}\`, duration: \`${duration}s\`, bloat: \`${bloat} GiB\`, tps: \`${tps}\`, accounts: \`${accounts}\`, max-concurrent-requests: \`${maxConcurrentRequests}\`, gas-limit: \`${gasLimit}\`, baseline: \`${baseline}\`, feature: \`${feature}\`, txgen-ref: \`${txgenRef}\`${samplyNote}${tracyNote}${otlpNote}${naNote}${noCacheNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -422,6 +434,7 @@ jobs:
       tracy: ${{ needs.tempo-bench-ack.outputs.tracy }}
       tracy-seconds: ${{ needs.tempo-bench-ack.outputs.tracy-seconds }}
       tracy-offset: ${{ needs.tempo-bench-ack.outputs.tracy-offset }}
+      otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       gas-limit: ${{ needs.tempo-bench-ack.outputs.gas-limit }}
@@ -459,6 +472,7 @@ jobs:
       baseline-name: ${{ needs.tempo-bench-ack.outputs.baseline-name }}
       feature-name: ${{ needs.tempo-bench-ack.outputs.feature-name }}
       samply: ${{ needs.tempo-bench-ack.outputs.samply }}
+      otlp: ${{ needs.tempo-bench-ack.outputs.otlp }}
       baseline-args: ${{ needs.tempo-bench-ack.outputs.baseline-args }}
       feature-args: ${{ needs.tempo-bench-ack.outputs.feature-args }}
       blocks: ${{ needs.tempo-bench-ack.outputs.blocks }}
@@ -469,3 +483,5 @@ jobs:
     secrets:
       DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+      TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
+      GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -883,6 +883,7 @@ def "main e2e" [
     --init-only                                         # Refresh snapshots and exit without running benchmark phases
     --profile: string = $DEFAULT_PROFILE                # Cargo build profile
     --features: string = $DEFAULT_FEATURES              # Cargo features
+    --no-default-features                               # Disable Cargo default features
     --samply                                            # Profile validators with samply
     --samply-args: string = ""                          # Additional samply arguments
     --tracy: string = "off"                             # Tracy profiling: off, on, full
@@ -993,7 +994,7 @@ def "main e2e" [
         if ($E2E_BLOAT_TMP_DIR | path exists) { rm -rf $E2E_BLOAT_TMP_DIR }
         mkdir $E2E_BLOAT_TMP_DIR
 
-        build-tempo ["tempo"] $profile $features
+        build-tempo --no-default-features=$no_default_features ["tempo"] $profile $features
         let tempo_bin = if $profile == "dev" { "./target/debug/tempo" } else { $"./target/($profile)/tempo" }
         let genesis_accounts = ([$accounts 3] | math max) + 1
         print $"Generating local e2e localnet config for validators: ($E2E_VALIDATORS)"
@@ -1070,11 +1071,11 @@ def "main e2e" [
     let effective_extra_rustflags = $tbc.extra_rustflags
     let effective_no_cache = $no_cache or ($tracy != "off")
     if $effective_no_cache {
-        build-in-worktree --no-cache --extra-rustflags $effective_extra_rustflags --bench-features $features $baseline_wt $baseline $profile $effective_features $baseline
-        build-in-worktree --no-cache --extra-rustflags $effective_extra_rustflags --bench-features $features $feature_wt $feature $profile $effective_features $feature
+        build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $baseline_wt $baseline $profile $effective_features $baseline
+        build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $effective_extra_rustflags --bench-features $features $feature_wt $feature $profile $effective_features $feature
     } else {
-        build-in-worktree $baseline_wt $baseline $profile $effective_features $baseline
-        build-in-worktree $feature_wt $feature $profile $effective_features $feature
+        build-in-worktree --no-default-features=$no_default_features $baseline_wt $baseline $profile $effective_features $baseline
+        build-in-worktree --no-default-features=$no_default_features $feature_wt $feature $profile $effective_features $feature
     }
     let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
     let feature_tempo = (worktree-bin $feature_wt $profile "tempo")

--- a/tempo.nu
+++ b/tempo.nu
@@ -63,6 +63,12 @@ def tracy-build-config [features: string, tracy: string] {
     }
 }
 
+def cargo-feature-args [features: string, no_default_features: bool] {
+    let no_default_args = if $no_default_features { ["--no-default-features"] } else { [] }
+    let feature_args = if $features == "" { [] } else { ["--features" $features] }
+    $no_default_args | append $feature_args
+}
+
 # Validate mode is either "dev" or "consensus"
 def validate-mode [mode: string] {
     if $mode != "dev" and $mode != "consensus" {
@@ -72,9 +78,11 @@ def validate-mode [mode: string] {
 }
 
 # Build tempo binary with cargo
-def build-tempo [bins: list<string>, profile: string, features: string, --extra-rustflags: string = ""] {
+def build-tempo [bins: list<string>, profile: string, features: string, --no-default-features, --extra-rustflags: string = ""] {
     let bin_args = ($bins | each { |bin| ["--bin" $bin] } | flatten)
-    let build_cmd = ["cargo" "build" "--profile" $profile "--features" $features]
+    let feature_args = (cargo-feature-args $features $no_default_features)
+    let build_cmd = ["cargo" "build" "--profile" $profile]
+        | append $feature_args
         | append $bin_args
     let rustflags = $"($RUSTFLAGS)($extra_rustflags)"
     print $"Building ($bins | str join ', '): `($build_cmd | str join ' ')`..."
@@ -305,15 +313,32 @@ def resolve-git-ref [ref: string] {
     git rev-parse $ref | str trim
 }
 
+def bench-cache-key [commit_sha: string, features: string, no_default_features: bool] {
+    if not $no_default_features {
+        return $commit_sha
+    }
+
+    let feature_key = if $features == "" {
+        "none"
+    } else {
+        $features
+        | str replace -a "," "_"
+        | str replace -a "/" "_"
+        | str replace -a " " "_"
+    }
+
+    $"($commit_sha)-no-default-($feature_key)"
+}
+
 # Try to download cached binaries from MinIO for a given commit SHA.
 # Returns true on cache hit, false on miss or any failure.
-def try-cache-download [worktree_dir: string, profile: string, commit_sha: string] {
+def try-cache-download [worktree_dir: string, profile: string, commit_sha: string, cache_key: string] {
     if not (has-mc) { return false }
 
     let bins = ["tempo" "tempo-bench"]
     # Check that all binaries exist in the cache
     for bin in $bins {
-        let remote = $"($MINIO_BUCKET)/($commit_sha)/($bin)"
+        let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
         try {
             mc stat $remote | ignore
         } catch {
@@ -331,7 +356,7 @@ def try-cache-download [worktree_dir: string, profile: string, commit_sha: strin
     mkdir $target_dir
 
     for bin in $bins {
-        let remote = $"($MINIO_BUCKET)/($commit_sha)/($bin)"
+        let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
         let local = $"($target_dir)/($bin)"
         print $"Downloading cached ($bin) for ($commit_sha | str substring 0..8)..."
         try {
@@ -359,7 +384,7 @@ def try-cache-download [worktree_dir: string, profile: string, commit_sha: strin
 }
 
 # Upload built binaries to MinIO cache. Failures are non-fatal.
-def cache-upload [worktree_dir: string, profile: string, commit_sha: string] {
+def cache-upload [worktree_dir: string, profile: string, commit_sha: string, cache_key: string] {
     if not (has-mc) { return }
 
     let target_dir = if $profile == "dev" {
@@ -370,7 +395,7 @@ def cache-upload [worktree_dir: string, profile: string, commit_sha: string] {
 
     for bin in ["tempo" "tempo-bench"] {
         let local = $"($target_dir)/($bin)"
-        let remote = $"($MINIO_BUCKET)/($commit_sha)/($bin)"
+        let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
         print $"Uploading ($bin) to cache for ($commit_sha | str substring 0..8)..."
         try {
             mc cp $local $remote
@@ -381,9 +406,11 @@ def cache-upload [worktree_dir: string, profile: string, commit_sha: string] {
 }
 
 # Build tempo binaries in a git worktree (with optional MinIO cache)
-def build-in-worktree [worktree_dir: string, ref: string, profile: string, features: string, commit_sha: string, --no-cache, --extra-rustflags: string = "", --bench-features: string = ""] {
+def build-in-worktree [worktree_dir: string, ref: string, profile: string, features: string, commit_sha: string, --no-cache, --no-default-features, --extra-rustflags: string = "", --bench-features: string = ""] {
+    let cache_key = (bench-cache-key $commit_sha $features $no_default_features)
+
     # Try cache first
-    if not $no_cache and (try-cache-download $worktree_dir $profile $commit_sha) {
+    if not $no_cache and (try-cache-download $worktree_dir $profile $commit_sha $cache_key) {
         return
     }
 
@@ -392,15 +419,23 @@ def build-in-worktree [worktree_dir: string, ref: string, profile: string, featu
     let rustflags = $"($RUSTFLAGS)($extra_rustflags)"
     if $bench_features != "" and $bench_features != $features {
         # Build tempo (with tracy features) and tempo-bench (without) separately
-        let tempo_cmd = ["cargo" "build" "--profile" $profile "--features" $features "--bin" "tempo"]
-        let bench_cmd = ["cargo" "build" "--profile" $profile "--features" $bench_features "--bin" "tempo-bench"]
+        let tempo_feature_args = (cargo-feature-args $features $no_default_features)
+        let bench_feature_args = (cargo-feature-args $bench_features $no_default_features)
+        let tempo_cmd = ["cargo" "build" "--profile" $profile]
+            | append $tempo_feature_args
+            | append ["--bin" "tempo"]
+        let bench_cmd = ["cargo" "build" "--profile" $profile]
+            | append $bench_feature_args
+            | append ["--bin" "tempo-bench"]
         with-env { RUSTFLAGS: $rustflags } {
             do { cd $worktree_dir; run-external ($tempo_cmd | first) ...($tempo_cmd | skip 1) }
             do { cd $worktree_dir; run-external ($bench_cmd | first) ...($bench_cmd | skip 1) }
         }
     } else {
         let bin_args = ["--bin" "tempo" "--bin" "tempo-bench"]
-        let build_cmd = ["cargo" "build" "--profile" $profile "--features" $features]
+        let feature_args = (cargo-feature-args $features $no_default_features)
+        let build_cmd = ["cargo" "build" "--profile" $profile]
+            | append $feature_args
             | append $bin_args
         with-env { RUSTFLAGS: $rustflags } {
             do { cd $worktree_dir; run-external ($build_cmd | first) ...($build_cmd | skip 1) }
@@ -408,7 +443,7 @@ def build-in-worktree [worktree_dir: string, ref: string, profile: string, featu
     }
 
     # Upload to cache
-    cache-upload $worktree_dir $profile $commit_sha
+    cache-upload $worktree_dir $profile $commit_sha $cache_key
 }
 
 # Get the path to a built binary in a worktree


### PR DESCRIPTION
## Summary
- Adds an `otlp` bench flag so OTLP traces and logs are only enabled when explicitly requested.
- Stops benchmark runs from inheriting telemetry endpoints by default, and wires the OTLP feature into the Tempo build when the flag is set.
- Propagates the new setting through bench, replay, and e2e workflows so the config summary reflects whether OTLP is on or off.

Example run: https://github.com/tempoxyz/tempo/actions/runs/25673386470/job/75364418201