### PR TITLE
ci(bench): share schelk restore logic

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -15,8 +15,16 @@
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
 set -euxo pipefail
 
-SCHELK_STATE_PATH="/var/lib/schelk/a.json"
-SCHELK_MOUNT="/reth-bench-a"
+if [ -f /var/lib/schelk/state.json ]; then
+  SCHELK_STATE_PATH="/var/lib/schelk/state.json"
+  SCHELK_MOUNT="/reth-bench"
+elif [ -f /var/lib/schelk/a.json ]; then
+  SCHELK_STATE_PATH="/var/lib/schelk/a.json"
+  SCHELK_MOUNT="/reth-bench-a"
+else
+  echo "::error::No supported schelk state file found"
+  exit 1
+fi
 BENCH_WORK_DIR="${BENCH_WORK_DIR:-bench-results/replay}"
 SNAPSHOT_BUCKET="r2-tempo-snapshots/tempo-node-snapshots"
 TEMPO_SCOPE="tempo-replay.scope"

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -15,7 +15,8 @@
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
 set -euxo pipefail
 
-SCHELK_MOUNT="/reth-bench"
+SCHELK_STATE_PATH="/var/lib/schelk/a.json"
+SCHELK_MOUNT="/reth-bench-a"
 BENCH_WORK_DIR="${BENCH_WORK_DIR:-bench-results/replay}"
 SNAPSHOT_BUCKET="r2-tempo-snapshots/tempo-node-snapshots"
 TEMPO_SCOPE="tempo-replay.scope"
@@ -127,8 +128,8 @@ LOCAL_HASH=""
 [ -f "$SNAPSHOT_HASH_FILE" ] && LOCAL_HASH=$(cat "$SNAPSHOT_HASH_FILE")
 
 # Mount schelk before checking $DATADIR/db existence
-sudo schelk recover -y --kill 2>/dev/null || true
-sudo schelk mount -y
+sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill 2>/dev/null || true
+sudo schelk --state-path "$SCHELK_STATE_PATH" mount -y
 
 if [ "$REMOTE_HASH" != "$LOCAL_HASH" ] || [ ! -d "$DATADIR/db" ]; then
   if [ -n "$LOCAL_HASH" ]; then
@@ -158,7 +159,7 @@ if [ "$REMOTE_HASH" != "$LOCAL_HASH" ] || [ ! -d "$DATADIR/db" ]; then
   fi
 
   sync
-  sudo schelk promote -y
+  sudo schelk --state-path "$SCHELK_STATE_PATH" promote -y
   echo "$REMOTE_HASH" > "$SNAPSHOT_HASH_FILE"
   echo "Snapshot promoted to schelk baseline"
 else
@@ -179,8 +180,8 @@ run_single() {
   # Recover snapshot
   sudo systemctl stop "$TEMPO_SCOPE" 2>/dev/null || true
   sudo systemctl reset-failed "$TEMPO_SCOPE" 2>/dev/null || true
-  sudo schelk recover -y --kill || sudo schelk full-recover -y || true
-  sudo schelk mount -y
+  sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill || sudo schelk --state-path "$SCHELK_STATE_PATH" full-recover -y || true
+  sudo schelk --state-path "$SCHELK_STATE_PATH" mount -y
   sudo chown -R "$(id -u):$(id -g)" "$SCHELK_MOUNT"
 
   sync
@@ -291,7 +292,7 @@ run_single() {
   sudo systemctl stop "$TEMPO_SCOPE" 2>/dev/null || true
   sudo systemctl reset-failed "$TEMPO_SCOPE" 2>/dev/null || true
   sudo chown -R "$(id -un):$(id -gn)" "$output_dir" 2>/dev/null || true
-  sudo schelk recover -y --kill || true
+  sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill || true
   echo "=== Finished run: $label ==="
 }
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -15,16 +15,8 @@
 #   BENCH_SAMPLY                  – "true" to enable samply profiling (optional)
 set -euxo pipefail
 
-if [ -f /var/lib/schelk/state.json ]; then
-  SCHELK_STATE_PATH="/var/lib/schelk/state.json"
-  SCHELK_MOUNT="/reth-bench"
-elif [ -f /var/lib/schelk/a.json ]; then
-  SCHELK_STATE_PATH="/var/lib/schelk/a.json"
-  SCHELK_MOUNT="/reth-bench-a"
-else
-  echo "::error::No supported schelk state file found"
-  exit 1
-fi
+eval "$(nu bench-schelk.nu detect)"
+
 BENCH_WORK_DIR="${BENCH_WORK_DIR:-bench-results/replay}"
 SNAPSHOT_BUCKET="r2-tempo-snapshots/tempo-node-snapshots"
 TEMPO_SCOPE="tempo-replay.scope"
@@ -65,6 +57,10 @@ CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 export PATH="$CARGO_BIN_DIR:$PATH"
 TXGEN_TEMPO_BIN="${TXGEN_TEMPO_BIN:-txgen-tempo}"
 TXGEN_BENCH_BIN="${TXGEN_BENCH_BIN:-bench}"
+
+bench_schelk() {
+  nu bench-schelk.nu "$@"
+}
 
 # ============================================================================
 # Install txgen-tempo and bench-cli
@@ -136,8 +132,7 @@ LOCAL_HASH=""
 [ -f "$SNAPSHOT_HASH_FILE" ] && LOCAL_HASH=$(cat "$SNAPSHOT_HASH_FILE")
 
 # Mount schelk before checking $DATADIR/db existence
-sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill 2>/dev/null || true
-sudo schelk --state-path "$SCHELK_STATE_PATH" mount -y
+bench_schelk restore "$SCHELK_STATE_PATH" "$SCHELK_MOUNT"
 
 if [ "$REMOTE_HASH" != "$LOCAL_HASH" ] || [ ! -d "$DATADIR/db" ]; then
   if [ -n "$LOCAL_HASH" ]; then
@@ -149,6 +144,7 @@ if [ "$REMOTE_HASH" != "$LOCAL_HASH" ] || [ ! -d "$DATADIR/db" ]; then
   MANIFEST_URL="https://tempo-node-snapshots.tempoxyz.dev/${SNAPSHOT_NAME}/manifest.json"
 
   # Prepare schelk volume for fresh download
+  bench_schelk mark-dirty "$SCHELK_STATE_PATH"
   sudo rm -rf "$DATADIR"
   sudo mkdir -p "$DATADIR"
   sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
@@ -167,7 +163,7 @@ if [ "$REMOTE_HASH" != "$LOCAL_HASH" ] || [ ! -d "$DATADIR/db" ]; then
   fi
 
   sync
-  sudo schelk --state-path "$SCHELK_STATE_PATH" promote -y
+  bench_schelk promote "$SCHELK_STATE_PATH"
   echo "$REMOTE_HASH" > "$SNAPSHOT_HASH_FILE"
   echo "Snapshot promoted to schelk baseline"
 else
@@ -188,12 +184,11 @@ run_single() {
   # Recover snapshot
   sudo systemctl stop "$TEMPO_SCOPE" 2>/dev/null || true
   sudo systemctl reset-failed "$TEMPO_SCOPE" 2>/dev/null || true
-  sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill || sudo schelk --state-path "$SCHELK_STATE_PATH" full-recover -y || true
-  sudo schelk --state-path "$SCHELK_STATE_PATH" mount -y
-  sudo chown -R "$(id -u):$(id -g)" "$SCHELK_MOUNT"
+  bench_schelk restore "$SCHELK_STATE_PATH" "$SCHELK_MOUNT"
 
   sync
   sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+  bench_schelk mark-dirty "$SCHELK_STATE_PATH"
 
   # Build node args
   local NODE_ARGS=(
@@ -300,7 +295,7 @@ run_single() {
   sudo systemctl stop "$TEMPO_SCOPE" 2>/dev/null || true
   sudo systemctl reset-failed "$TEMPO_SCOPE" 2>/dev/null || true
   sudo chown -R "$(id -un):$(id -gn)" "$output_dir" 2>/dev/null || true
-  sudo schelk --state-path "$SCHELK_STATE_PATH" recover -y --kill || true
+  bench_schelk cleanup "$SCHELK_STATE_PATH" || true
   echo "=== Finished run: $label ==="
 }
 

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -134,7 +134,7 @@ permissions:
 jobs:
   bench-replay:
     name: bench-replay
-    runs-on: [self-hosted, Linux, X64, bare-metal]
+    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
     timeout-minutes: 300
     env:
       BENCH_CHAIN: ${{ inputs.chain || 'mainnet' }}

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -146,7 +146,7 @@ permissions:
 jobs:
   bench-replay:
     name: bench-replay
-    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
+    runs-on: [self-hosted, Linux, X64, bare-metal]
     timeout-minutes: 300
     env:
       BENCH_CHAIN: ${{ inputs.chain || 'mainnet' }}

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -134,7 +134,7 @@ permissions:
 jobs:
   bench-replay:
     name: bench-replay
-    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
+    runs-on: [self-hosted, Linux, X64, bare-metal]
     timeout-minutes: 300
     env:
       BENCH_CHAIN: ${{ inputs.chain || 'mainnet' }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -9,6 +9,7 @@ const E2E_A_STATE_PATH = "/var/lib/schelk/a.json"
 const E2E_B_STATE_PATH = "/var/lib/schelk/b.json"
 const E2E_A_MOUNT = "/reth-bench-a"
 const E2E_B_MOUNT = "/reth-bench-b"
+const BENCH_SCHELK_SCRIPT = "bench-schelk.nu"
 const E2E_VALIDATORS = "127.0.0.2:8000,127.0.0.3:8100"
 const E2E_SEED = 42
 const E2E_A_CPUS = "0-7,16-23"
@@ -31,12 +32,23 @@ const E2E_LOCAL_RETH_ARGS = [
     "--tempo.bootnodes-endpoint" "none"
 ]
 
-def schelk [state_path: string, subcommand: string, ...args: string] {
-    sudo schelk --state-path $state_path $subcommand ...$args
+def run-bench-schelk [...args: string] {
+    let result = (nu $BENCH_SCHELK_SCRIPT ...$args | complete)
+    if $result.stdout != "" { print $result.stdout }
+    if $result.stderr != "" { print $result.stderr }
+    if $result.exit_code != 0 {
+        error make { msg: $"bench-schelk failed: ($args | str join ' ')" }
+    }
 }
 
 def schelk-state [state_path: string] {
     sudo cat $state_path | from json
+}
+
+def mark-schelk-dirty-at [state_path: string] {
+    if (has-schelk) {
+        run-bench-schelk "mark-dirty" $state_path
+    }
 }
 
 def validate-schelk-state [a_state_path: string, b_state_path: string] {
@@ -80,21 +92,7 @@ def validate-schelk-state [a_state_path: string, b_state_path: string] {
 
 def bench-restore-at [state_path: string, mount_point: string, datadir: string] {
     if (has-schelk) {
-        print $"Restoring schelk snapshot ($mount_point)..."
-        let state = (schelk-state $state_path)
-        let state_mounted = ($state | get --optional is_mounted) == true
-        let actual_mounted = (mountpoint -q $mount_point | complete).exit_code == 0
-        try {
-            if $state_mounted or $actual_mounted {
-                schelk $state_path recover "-y" "--kill"
-            }
-            schelk $state_path mount
-        } catch {
-            print $"Schelk restore failed for ($mount_point), falling back to full-recover..."
-            schelk $state_path full-recover "-y"
-            schelk $state_path mount
-        }
-        sudo chown -R (whoami | str trim) $mount_point
+        run-bench-schelk "restore" $state_path $mount_point
     } else {
         print $"Restoring snapshot from ($datadir).virgin..."
         rm -rf $datadir
@@ -106,7 +104,7 @@ def bench-restore-at [state_path: string, mount_point: string, datadir: string] 
 def bench-promote-at [state_path: string, datadir: string] {
     if (has-schelk) {
         print $"Promoting schelk scratch to virgin ($state_path)..."
-        schelk $state_path promote "-y" "--kill"
+        run-bench-schelk "promote" $state_path
     } else {
         print $"Saving snapshot to ($datadir).virgin..."
         rm -rf $"($datadir).virgin"
@@ -753,6 +751,9 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let a_otel = $"OTEL_RESOURCE_ATTRIBUTES=benchmark_id=($ctx.benchmark_id),benchmark_run=($phase),runner_role=a,run_type=($run_type),git_ref=($run.ref),reference_epoch=($ctx.reference_epoch) "
     let b_otel = $"OTEL_RESOURCE_ATTRIBUTES=benchmark_id=($ctx.benchmark_id),benchmark_run=($phase),runner_role=b,run_type=($run_type),git_ref=($run.ref),reference_epoch=($ctx.reference_epoch) "
 
+    mark-schelk-dirty-at $ctx.a.state_path
+    mark-schelk-dirty-at $ctx.b.state_path
+
     start-e2e-local-node a $phase $run.tempo $a_args $env_prefix $a_otel $tracy_env_prefix $ctx.samply $ctx.samply_args $ctx.results_dir $ctx.a.cpus $ctx.a.memory
     start-e2e-local-node b $phase $run.tempo $b_args $env_prefix $b_otel $tracy_env_prefix $ctx.samply $ctx.samply_args $ctx.results_dir $ctx.b.cpus $ctx.b.memory
 
@@ -988,6 +989,8 @@ def "main e2e" [
         let init_dir = $"($LOCALNET_DIR)/e2e-local-init"
         let generated_genesis = $"($init_dir)/genesis.json"
         let bloat_file = $"($E2E_BLOAT_TMP_DIR)/state_bloat.bin"
+        mark-schelk-dirty-at $E2E_A_STATE_PATH
+        mark-schelk-dirty-at $E2E_B_STATE_PATH
         if ($init_dir | path exists) { rm -rf $init_dir }
         mkdir $init_dir
         if ($E2E_BLOAT_TMP_DIR | path exists) { rm -rf $E2E_BLOAT_TMP_DIR }

--- a/bench-schelk.nu
+++ b/bench-schelk.nu
@@ -1,0 +1,148 @@
+#!/usr/bin/env nu
+
+def clean-marker [state_path: string] {
+    let marker_dir = ($env.BENCH_SCHELK_MARKER_DIR? | default $env.HOME)
+    let stem = ($state_path | path parse | get stem)
+    $"($marker_dir)/.tempo-bench-schelk-clean-($stem)"
+}
+
+def schelk-state [state_path: string] {
+    sudo cat $state_path | from json
+}
+
+def state-is-mounted [state_path: string] {
+    let state = (schelk-state $state_path)
+    ($state | get --optional is_mounted) == true
+}
+
+def actual-is-mounted [mount_point: string] {
+    (mountpoint -q $mount_point | complete).exit_code == 0
+}
+
+def full-recover [state_path: string] {
+    let marker = (clean-marker $state_path)
+    rm -f $marker
+    sudo schelk --state-path $state_path full-recover -y
+    touch $marker
+}
+
+def cmd-detect [] {
+    if (($env.SCHELK_STATE_PATH? | default "") != "") and (($env.SCHELK_MOUNT? | default "") != "") {
+        print $"SCHELK_STATE_PATH=($env.SCHELK_STATE_PATH)"
+        print $"SCHELK_MOUNT=($env.SCHELK_MOUNT)"
+        return
+    }
+
+    if ("/var/lib/schelk/state.json" | path exists) {
+        print "SCHELK_STATE_PATH=/var/lib/schelk/state.json"
+        print "SCHELK_MOUNT=/reth-bench"
+    } else if ("/var/lib/schelk/a.json" | path exists) {
+        print "SCHELK_STATE_PATH=/var/lib/schelk/a.json"
+        print "SCHELK_MOUNT=/reth-bench-a"
+    } else {
+        print "::error::No supported schelk state file found"
+        exit 1
+    }
+}
+
+def cmd-restore [state_path: string, mount_point: string] {
+    let marker = (clean-marker $state_path)
+
+    print $"Restoring schelk snapshot \(($mount_point)\)..."
+    if (state-is-mounted $state_path) or (actual-is-mounted $mount_point) {
+        let result = (sudo schelk --state-path $state_path recover -y --kill | complete)
+        if $result.stdout != "" { print $result.stdout }
+        if $result.stderr != "" { print $result.stderr }
+        if $result.exit_code == 0 {
+            touch $marker
+        } else {
+            print $"Schelk recover failed for ($mount_point), falling back to full-recover..."
+            full-recover $state_path
+        }
+    } else if ($marker | path exists) {
+        print "Schelk volume is already clean and unmounted; skipping recovery."
+    } else {
+        print "Schelk volume is unmounted without a clean marker; running full-recover."
+        full-recover $state_path
+    }
+
+    let mount_result = (sudo schelk --state-path $state_path mount | complete)
+    if $mount_result.stdout != "" { print $mount_result.stdout }
+    if $mount_result.stderr != "" { print $mount_result.stderr }
+    if $mount_result.exit_code != 0 {
+        print $"Schelk mount failed for ($mount_point), falling back to full-recover..."
+        full-recover $state_path
+        sudo schelk --state-path $state_path mount
+    }
+
+    sudo chown -R (whoami | str trim) $mount_point
+}
+
+def cmd-mark-dirty [state_path: string] {
+    rm -f (clean-marker $state_path)
+}
+
+def cmd-cleanup [state_path: string] {
+    let marker = (clean-marker $state_path)
+    let result = (sudo schelk --state-path $state_path recover -y --kill | complete)
+    if $result.stdout != "" { print $result.stdout }
+    if $result.stderr != "" { print $result.stderr }
+    if $result.exit_code == 0 {
+        touch $marker
+    } else {
+        rm -f $marker
+        exit $result.exit_code
+    }
+}
+
+def cmd-promote [state_path: string] {
+    sudo schelk --state-path $state_path promote -y --kill
+    touch (clean-marker $state_path)
+}
+
+def usage [] {
+    print "Usage:"
+    print "  nu bench-schelk.nu detect"
+    print "  nu bench-schelk.nu restore <state-path> <mount-point>"
+    print "  nu bench-schelk.nu mark-dirty <state-path>"
+    print "  nu bench-schelk.nu cleanup <state-path>"
+    print "  nu bench-schelk.nu promote <state-path>"
+}
+
+def main [command?: string, arg1?: string, arg2?: string] {
+    match $command {
+        "detect" => { cmd-detect },
+        "restore" => {
+            if $arg1 == null or $arg2 == null {
+                usage
+                exit 2
+            }
+            cmd-restore $arg1 $arg2
+        },
+        "mark-dirty" => {
+            if $arg1 == null {
+                usage
+                exit 2
+            }
+            cmd-mark-dirty $arg1
+        },
+        "cleanup" => {
+            if $arg1 == null {
+                usage
+                exit 2
+            }
+            cmd-cleanup $arg1
+        },
+        "promote" => {
+            if $arg1 == null {
+                usage
+                exit 2
+            }
+            cmd-promote $arg1
+        },
+        _ => {
+            usage
+            exit 2
+        },
+    }
+}


### PR DESCRIPTION
* Replay now detects the available schelk state file at runtime, using the legacy `/var/lib/schelk/state.json` + `/reth-bench` layout when present and the dual-schelk side A layout (`/var/lib/schelk/a.json` + `/reth-bench-a`) otherwise (for when we fully change all runners to dual-schelk runner setup).

* Adds `bench-schelk.nu` as the shared schelk helper for replay and e2e benchmarks. It centralizes restore, promote, dirty marking, and cleanup so both benchmark paths use the same snapshot semantics and avoid repeated full-volume recovery when schelk is already clean and unmounted (which replay was hitting between benchmark legs).

The restore flow is:

```text
mounted                         -> recover, mark clean, mount
unmounted + clean marker        -> mount
unmounted + no clean marker     -> full-recover, mark clean, mount
recover/mount failure           -> full-recover, mark clean, mount
```

