### PR TITLE
ci(bench): derive default warmup from block count

### DIFF
--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -41,9 +41,9 @@ on:
         default: "5000"
         type: string
       warmup:
-        description: "Number of warmup blocks"
+        description: "Number of warmup blocks (default: one-quarter of blocks)"
         required: false
-        default: "1000"
+        default: ""
         type: string
       samply:
         description: "Enable samply profiling"
@@ -86,7 +86,7 @@ jobs:
           INPUT_CHAIN: ${{ inputs.chain || '' }}
           EVENT_SCHEDULE: ${{ github.event.schedule || '' }}
           INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
-          INPUT_WARMUP: ${{ inputs.warmup || '1000' }}
+          INPUT_WARMUP: ${{ inputs.warmup || '' }}
           INPUT_SAMPLY: ${{ inputs.samply || 'false' }}
         run: |
           if [ -z "$INPUT_CHAIN" ]; then
@@ -112,9 +112,12 @@ jobs:
             echo "::error::blocks must be a non-negative integer"
             exit 1
           fi
-          if ! [[ "$INPUT_WARMUP" =~ ^[0-9]+$ ]]; then
+          if [ -n "$INPUT_WARMUP" ] && ! [[ "$INPUT_WARMUP" =~ ^[0-9]+$ ]]; then
             echo "::error::warmup must be a non-negative integer"
             exit 1
+          fi
+          if [ -z "$INPUT_WARMUP" ]; then
+            INPUT_WARMUP=$(( INPUT_BLOCKS / 4 ))
           fi
 
           if [ "$INPUT_SAMPLY" = "true" ]; then

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -20,9 +20,9 @@ on:
         type: string
         default: "5000"
       warmup:
-        description: "Number of warmup blocks"
+        description: "Number of warmup blocks (default: one-quarter of blocks)"
         type: string
-        default: "1000"
+        default: ""
       samply:
         description: "Enable samply profiling"
         type: string
@@ -157,7 +157,7 @@ jobs:
       BENCH_FEATURES: ${{ (inputs.otlp == true || inputs.otlp == 'true') && 'jemalloc,asm-keccak,keccak-cache-global,otlp' || 'jemalloc,asm-keccak,keccak-cache-global' }}
       BENCH_BASELINE_ARGS: "--dev.block-time 999999s ${{ inputs.baseline-args }}"
       BENCH_FEATURE_ARGS: "--dev.block-time 999999s ${{ inputs.feature-args }}"
-      BENCH_BLOCKS: ${{ inputs.blocks }}
+      BENCH_BLOCKS: ${{ inputs.blocks || '5000' }}
       BENCH_WARMUP_BLOCKS: ${{ inputs.warmup }}
       BENCH_COMMENT_ID: ${{ inputs.comment-id }}
       BENCH_PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
@@ -166,6 +166,28 @@ jobs:
       BENCH_RUN_LABEL: ${{ inputs.run-label || 'Replay Bench' }}
       BENCH_WORK_DIR: bench-results/replay-${{ inputs.chain || 'mainnet' }}
     steps:
+      - name: Resolve benchmark config
+        env:
+          INPUT_BLOCKS: ${{ inputs.blocks || '5000' }}
+          INPUT_WARMUP: ${{ inputs.warmup || '' }}
+        run: |
+          if ! [[ "$INPUT_BLOCKS" =~ ^[0-9]+$ ]]; then
+            echo "::error::blocks must be a non-negative integer"
+            exit 1
+          fi
+          if [ -n "$INPUT_WARMUP" ] && ! [[ "$INPUT_WARMUP" =~ ^[0-9]+$ ]]; then
+            echo "::error::warmup must be a non-negative integer"
+            exit 1
+          fi
+          if [ -z "$INPUT_WARMUP" ]; then
+            INPUT_WARMUP=$(( INPUT_BLOCKS / 4 ))
+          fi
+
+          {
+            echo "BENCH_BLOCKS=$INPUT_BLOCKS"
+            echo "BENCH_WARMUP_BLOCKS=$INPUT_WARMUP"
+          } >> "$GITHUB_ENV"
+
       - name: Configure OTLP telemetry
         if: env.BENCH_OTLP == 'true'
         env:
@@ -207,7 +229,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
-                  body: `cc @${'${{ github.actor }}'}\n\n🚀 Replay benchmark started! [View run](${runUrl})\n\n⏳ **Status:** Running...\n\n**Config:** chain: \`${'${{ inputs.chain || 'mainnet' }}'}\`, blocks: \`${'${{ inputs.blocks || '5000' }}'}\`, warmup: \`${'${{ inputs.warmup || '1000' }}'}\``,
+                  body: `cc @${'${{ github.actor }}'}\n\n🚀 Replay benchmark started! [View run](${runUrl})\n\n⏳ **Status:** Running...\n\n**Config:** chain: \`${'${{ inputs.chain || 'mainnet' }}'}\`, blocks: \`${process.env.BENCH_BLOCKS}\`, warmup: \`${process.env.BENCH_WARMUP_BLOCKS}\``,
                 });
                 core.exportVariable('BENCH_COMMENT_ID', String(comment.id));
                 if (pr.mergeable) {
@@ -488,7 +510,7 @@ jobs:
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const chain = process.env.BENCH_CHAIN || 'mainnet';
             const blocks = process.env.BENCH_BLOCKS || '5000';
-            const warmup = process.env.BENCH_WARMUP_BLOCKS || '1000';
+            const warmup = process.env.BENCH_WARMUP_BLOCKS || String(Math.floor(Number(blocks) / 4));
             const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Replay benchmark complete! [View job](${jobUrl})\n\nChain: \`${chain}\`\nWarmup: \`${warmup}\`\nBlocks: \`${blocks}\`\n\n${comment}`;
 
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -103,6 +103,7 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
           script: |
             let pr, actor, mode, preset, duration, bloat, tps, accounts, maxConcurrentRequests, baseline, feature, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, baselineArgs, featureArgs, gasLimit, runType, forceBloat, noCache, noSlack, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup;
+            let explicitWarmup = false;
 
             pr = String(context.issue.number);
             actor = context.payload.comment.user.login;
@@ -113,9 +114,10 @@ jobs:
             const stringArgs = new Set(['mode', 'preset', 'tracy', 'baseline-args', 'feature-args', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain']);
             const boolArgs = new Set(['samply', 'force-bloat', 'no-cache', 'no-slack', 'no-existing-recipients', 'otlp']);
             const bloatValues = new Set(['1', '10', '100']);
-            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '1000', chain: 'mainnet' };
+            const defaults = { mode: 'e2e', preset: 'tip20', duration: '300', bloat: '100', tps: '10000', accounts: '1000', 'max-concurrent-requests': '100', baseline: '', feature: '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '30', 'tracy-offset': '120', otlp: 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'no-existing-recipients': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet' };
             const unknown = [];
             const invalid = [];
+            const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
             const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
             // Parse args, handling quoted values like key="value with spaces"
             const parts = [];
@@ -149,6 +151,7 @@ jobs:
                   invalid.push(`\`${key}=${value}\` (must be a positive integer)`);
                 } else {
                   defaults[key] = value;
+                  if (key === 'warmup') explicitWarmup = true;
                 }
               } else if (refArgs.has(key)) {
                 if (!value) {
@@ -223,6 +226,9 @@ jobs:
             blocks = defaults.blocks;
             warmup = defaults.warmup;
             var chain = defaults.chain;
+            if (!explicitWarmup) {
+              warmup = defaultWarmup(blocks);
+            }
 
             const existingRecipients = defaults['no-existing-recipients'] !== 'true';
             const erFlag = `--existing-recipients=${existingRecipients}`;


### PR DESCRIPTION
Derives replay benchmark warmup defaults from the configured block count so manual and scheduled runs default to one-quarter warmup. Explicit warmup values continue to override the derived default.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian