### PR TITLE
feat(tip-1028): remove claim rerouting

### DIFF
--- a/crates/contracts/src/precompiles/escrow.rs
+++ b/crates/contracts/src/precompiles/escrow.rs
@@ -22,7 +22,7 @@ crate::sol! {
         }
 
         function blockedReceiptBalance(address token, address recoveryAuthority, uint8 receiptVersion, bytes calldata receipt) external view returns (uint256 amount);
-        function claim(address token, address recoveryAuthority, uint8 receiptVersion, bytes calldata receipt, address to) external;
+        function claim(address token, address recoveryAuthority, uint8 receiptVersion, bytes calldata receipt) external;
 
         event TransferBlocked(address indexed token, address indexed from, address indexed receiver, uint8 receiptVersion, uint64 blockedNonce, uint64 blockedAt, address recipient, uint256 amount, uint8 blockedReason, address recoveryAuthority, bytes32 memo);
         event BlockedReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount);

--- a/crates/contracts/src/precompiles/escrow.rs
+++ b/crates/contracts/src/precompiles/escrow.rs
@@ -25,7 +25,7 @@ crate::sol! {
         function claim(address token, address recoveryAuthority, uint8 receiptVersion, bytes calldata receipt) external;
 
         event TransferBlocked(address indexed token, address indexed from, address indexed receiver, uint8 receiptVersion, uint64 blockedNonce, uint64 blockedAt, address recipient, uint256 amount, uint8 blockedReason, address recoveryAuthority, bytes32 memo);
-        event BlockedReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount);
+        event BlockedReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, uint256 amount);
 
         error UnauthorizedClaimer();
         error InvalidReceiptClaim();

--- a/crates/e2e/src/tests/tip1028_escrow.rs
+++ b/crates/e2e/src/tests/tip1028_escrow.rs
@@ -54,7 +54,6 @@ fn test_escrow_claim_no_recovery() {
         .await?;
 
         let other_wallet = wallet(12)?;
-        let other = other_wallet.address();
         let other_provider = ProviderBuilder::new()
             .wallet(other_wallet)
             .connect_http(http_url.clone());
@@ -65,7 +64,6 @@ fn test_escrow_claim_no_recovery() {
                 Address::ZERO,
                 BLOCKED_RECEIPT_VERSION,
                 blocked.receipt.clone(),
-                other,
             )
             .call()
             .await
@@ -95,7 +93,6 @@ fn test_escrow_claim_no_recovery() {
                 Address::ZERO,
                 BLOCKED_RECEIPT_VERSION,
                 blocked.receipt.clone(),
-                blocked.receiver,
             )
             .gas(GAS)
             .gas_price(GAS_PRICE)
@@ -118,7 +115,6 @@ fn test_escrow_claim_with_recovery() {
     run_escrow_test(1029, |http_url| async move {
         let amount = U256::from(400);
         let recovery = wallet(22)?.address();
-        let destination = wallet(23)?.address();
         let blocked = create_blocked_transfer(
             http_url.clone(),
             20,
@@ -139,7 +135,6 @@ fn test_escrow_claim_with_recovery() {
                 recovery,
                 BLOCKED_RECEIPT_VERSION,
                 blocked.receipt,
-                destination,
             )
             .gas(GAS)
             .gas_price(GAS_PRICE)
@@ -151,7 +146,7 @@ fn test_escrow_claim_with_recovery() {
 
         let token = token_view(http_url, blocked.token);
         assert_eq!(token.balanceOf(blocked.receiver).call().await?, U256::ZERO);
-        assert_eq!(token.balanceOf(destination).call().await?, amount);
+        assert_eq!(token.balanceOf(recovery).call().await?, amount);
         assert_eq!(token.balanceOf(ESCROW_ADDRESS).call().await?, U256::ZERO);
 
         Ok(())

--- a/crates/precompiles/src/tip1028_escrow/mod.rs
+++ b/crates/precompiles/src/tip1028_escrow/mod.rs
@@ -164,7 +164,6 @@ impl TIP1028Escrow {
                 recipient: receipt.recipient,
                 recoveryAuthority: recovery_address,
                 caller: msg_sender,
-                to: claim_target,
                 amount,
             },
         ))?;
@@ -1103,7 +1102,6 @@ mod tests {
                     recipient: receiver,
                     recoveryAuthority: Address::ZERO,
                     caller: receiver,
-                    to: receiver,
                     amount,
                 },
             )]);
@@ -1175,7 +1173,6 @@ mod tests {
                     recipient: receiver,
                     recoveryAuthority: recovery,
                     caller: recovery,
-                    to: recovery,
                     amount,
                 },
             )]);
@@ -1249,7 +1246,6 @@ mod tests {
                     recipient: receiver,
                     recoveryAuthority: RECOVERY_SENDER,
                     caller: originator,
-                    to: originator,
                     amount,
                 },
             )]);
@@ -1459,7 +1455,6 @@ mod tests {
                     recipient: virtual_addr,
                     recoveryAuthority: Address::ZERO,
                     caller: VIRTUAL_MASTER,
-                    to: VIRTUAL_MASTER,
                     amount,
                 },
             )]);

--- a/crates/precompiles/src/tip1028_escrow/mod.rs
+++ b/crates/precompiles/src/tip1028_escrow/mod.rs
@@ -131,10 +131,6 @@ impl TIP1028Escrow {
             return Err(TIP1028EscrowError::invalid_token().into());
         }
 
-        if call.to == ESCROW_ADDRESS {
-            return Err(TIP1028EscrowError::invalid_claim_address().into());
-        }
-
         let receipt = Self::decode_v1(call.receiptVersion, &call.receipt)?;
         let receiver = AddressRegistry::new()
             .resolve_recipient(receipt.recipient)
@@ -144,6 +140,7 @@ impl TIP1028Escrow {
         let recovery_authority =
             RecoveryAuthority::from_address(recovery_address, receiver, receipt.originator);
         recovery_authority.validate_auth(msg_sender)?;
+        let claim_target = recovery_authority.claim_target();
 
         let key = self.receipt_key(call.receiptVersion, call.token, recovery_address, &receipt)?;
         let amount = self.blocked_receipt_amount[key].read()?;
@@ -154,17 +151,7 @@ impl TIP1028Escrow {
         let guard = self.storage.checkpoint();
         self.blocked_receipt_amount[key].write(U256::ZERO)?;
 
-        let reroute = match recovery_authority {
-            RecoveryAuthority::Originator(_) => true,
-            RecoveryAuthority::Receiver(_) | RecoveryAuthority::Contract(_) => call.to != receiver,
-        };
-        TIP20Token::from_address(call.token)?.release_from_escrow(
-            receipt.originator,
-            receiver,
-            call.to,
-            amount,
-            reroute,
-        )?;
+        TIP20Token::from_address(call.token)?.release_from_escrow(claim_target, amount)?;
 
         self.emit_event(TIP1028EscrowEvent::BlockedReceiptClaimed(
             ITIP1028Escrow::BlockedReceiptClaimed {
@@ -177,7 +164,7 @@ impl TIP1028Escrow {
                 recipient: receipt.recipient,
                 recoveryAuthority: recovery_address,
                 caller: msg_sender,
-                to: call.to,
+                to: claim_target,
                 amount,
             },
         ))?;
@@ -262,6 +249,12 @@ impl RecoveryAuthority {
         }
         Ok(())
     }
+
+    fn claim_target(self) -> Address {
+        match self {
+            Self::Receiver(target) | Self::Originator(target) | Self::Contract(target) => target,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -269,7 +262,6 @@ mod tests {
     use super::*;
     use crate::{
         address_registry::AddressRegistry,
-        error::TempoPrecompileError,
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master},
         tip20::ITIP20,
@@ -328,14 +320,12 @@ mod tests {
         token: Address,
         recovery_contract: Address,
         receipt: &ITIP1028Escrow::ClaimReceiptV1,
-        to: Address,
     ) -> ITIP1028Escrow::claimCall {
         ITIP1028Escrow::claimCall {
             token,
             recoveryAuthority: recovery_contract,
             receiptVersion: BLOCKED_RECEIPT_VERSION,
             receipt: receipt.abi_encode().into(),
-            to,
         }
     }
 
@@ -415,7 +405,6 @@ mod tests {
                     recoveryAuthority: Address::ZERO,
                     receiptVersion: BLOCKED_RECEIPT_VERSION,
                     receipt: receipt.abi_encode().into(),
-                    to: receiver,
                 },
             )?;
 
@@ -477,7 +466,7 @@ mod tests {
             let mut escrow = TIP1028Escrow::new();
             let result = escrow.claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             );
             assert_eq!(result.unwrap_err(), TIP20Error::contract_paused().into());
             assert_eq!(
@@ -595,7 +584,7 @@ mod tests {
 
             TIP1028Escrow::new().claim(
                 receiver_a,
-                claim_call(token_a.address(), Address::ZERO, &receipt_a, receiver_a),
+                claim_call(token_a.address(), Address::ZERO, &receipt_a),
             )?;
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
@@ -612,7 +601,7 @@ mod tests {
 
             TIP1028Escrow::new().claim(
                 recovery,
-                claim_call(token_a.address(), recovery, &receipt_b, receiver_b),
+                claim_call(token_a.address(), recovery, &receipt_b),
             )?;
             assert_eq!(
                 token_a.balance_of(ITIP20::balanceOfCall {
@@ -949,7 +938,7 @@ mod tests {
 
             assert_invalid_receipt(TIP1028Escrow::new().claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             ));
 
             block_all_senders(receiver, Address::ZERO)?;
@@ -962,11 +951,11 @@ mod tests {
             )?;
             TIP1028Escrow::new().claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             )?;
             assert_invalid_receipt(TIP1028Escrow::new().claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             ));
 
             Ok(())
@@ -1030,17 +1019,12 @@ mod tests {
 
             assert_unauthorized(TIP1028Escrow::new().claim(
                 stranger,
-                claim_call(token.address(), Address::ZERO, &self_receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &self_receipt),
             ));
             for caller in [recovery_receiver, stranger] {
                 assert_unauthorized(TIP1028Escrow::new().claim(
                     caller,
-                    claim_call(
-                        token.address(),
-                        recovery,
-                        &recovery_receipt,
-                        recovery_receiver,
-                    ),
+                    claim_call(token.address(), recovery, &recovery_receipt),
                 ));
             }
 
@@ -1105,7 +1089,7 @@ mod tests {
             escrow.clear_emitted_events();
             escrow.claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             )?;
 
             escrow.assert_emitted_events(vec![TIP1028EscrowEvent::BlockedReceiptClaimed(
@@ -1151,7 +1135,6 @@ mod tests {
         let originator = Address::random();
         let receiver = Address::random();
         let recovery = Address::random();
-        let destination = Address::random();
         let amount = U256::from(75u64);
 
         StorageCtx::enter(&mut storage, || {
@@ -1179,10 +1162,7 @@ mod tests {
             );
             let mut escrow = TIP1028Escrow::new();
             escrow.clear_emitted_events();
-            escrow.claim(
-                recovery,
-                claim_call(token.address(), recovery, &receipt, destination),
-            )?;
+            escrow.claim(recovery, claim_call(token.address(), recovery, &receipt))?;
 
             escrow.assert_emitted_events(vec![TIP1028EscrowEvent::BlockedReceiptClaimed(
                 ITIP1028Escrow::BlockedReceiptClaimed {
@@ -1195,7 +1175,7 @@ mod tests {
                     recipient: receiver,
                     recoveryAuthority: recovery,
                     caller: recovery,
-                    to: destination,
+                    to: recovery,
                     amount,
                 },
             )]);
@@ -1204,9 +1184,7 @@ mod tests {
                 U256::ZERO
             );
             assert_eq!(
-                token.balance_of(ITIP20::balanceOfCall {
-                    account: destination
-                })?,
+                token.balance_of(ITIP20::balanceOfCall { account: recovery })?,
                 amount
             );
             assert_eq!(
@@ -1221,14 +1199,13 @@ mod tests {
     }
 
     #[test]
-    fn test_claim_rolls_back_on_release_error() -> eyre::Result<()> {
+    fn test_sender_recovery_claim_releases_to_originator() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
         storage.set_timestamp(U256::from(1_728_007u64));
 
         let admin = Address::random();
         let originator = Address::random();
         let receiver = Address::random();
-        let destination = Address::random();
         let amount = U256::from(64u64);
 
         StorageCtx::enter(&mut storage, || {
@@ -1236,7 +1213,7 @@ mod tests {
                 .with_issuer(admin)
                 .with_mint(originator, amount)
                 .apply()?;
-            block_all_senders(receiver, Address::ZERO)?;
+            block_all_senders(receiver, RECOVERY_SENDER)?;
             token.transfer(
                 originator,
                 ITIP20::transferCall {
@@ -1244,7 +1221,6 @@ mod tests {
                     amount,
                 },
             )?;
-            block_all_senders(destination, Address::ZERO)?;
 
             let receipt = receipt_v1(
                 originator,
@@ -1255,18 +1231,94 @@ mod tests {
                 InboundKind::TRANSFER,
                 B256::ZERO,
             );
-            let escrow = TIP1028Escrow::new();
-            let result = TIP1028Escrow::new().claim(
-                receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, destination),
-            );
-            assert!(matches!(
-                result,
-                Err(TempoPrecompileError::TIP20(TIP20Error::PolicyForbids(_)))
-            ));
+            let mut escrow = TIP1028Escrow::new();
+            escrow.clear_emitted_events();
+            escrow.claim(
+                originator,
+                claim_call(token.address(), RECOVERY_SENDER, &receipt),
+            )?;
+
+            escrow.assert_emitted_events(vec![TIP1028EscrowEvent::BlockedReceiptClaimed(
+                ITIP1028Escrow::BlockedReceiptClaimed {
+                    token: token.address(),
+                    receiver,
+                    receiptVersion: BLOCKED_RECEIPT_VERSION,
+                    blockedNonce: 1,
+                    blockedAt: 1_728_007,
+                    originator,
+                    recipient: receiver,
+                    recoveryAuthority: RECOVERY_SENDER,
+                    caller: originator,
+                    to: originator,
+                    amount,
+                },
+            )]);
 
             assert_eq!(
-                receipt_balance(&escrow, token.address(), Address::ZERO, &receipt)?,
+                receipt_balance(&escrow, token.address(), RECOVERY_SENDER, &receipt)?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: ESCROW_ADDRESS
+                })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: receiver })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: originator
+                })?,
+                amount
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_claim_rolls_back_on_release_error() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T6);
+        storage.set_timestamp(U256::from(1_728_011u64));
+
+        let admin = Address::random();
+        let receiver = Address::random();
+        let amount = U256::from(64u64);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::create("T", "T", admin)
+                .with_issuer(admin)
+                .apply()?;
+            block_all_senders(receiver, RECOVERY_SENDER)?;
+            token.mint(
+                admin,
+                ITIP20::mintCall {
+                    to: receiver,
+                    amount,
+                },
+            )?;
+
+            let receipt = receipt_v1(
+                Address::ZERO,
+                receiver,
+                1_728_011,
+                1,
+                BlockedReason::RECEIVE_POLICY,
+                InboundKind::MINT,
+                B256::ZERO,
+            );
+            let escrow = TIP1028Escrow::new();
+            let result = TIP1028Escrow::new().claim(
+                Address::ZERO,
+                claim_call(token.address(), RECOVERY_SENDER, &receipt),
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::invalid_recipient().into());
+
+            assert_eq!(
+                receipt_balance(&escrow, token.address(), RECOVERY_SENDER, &receipt)?,
                 amount
             );
             assert_eq!(
@@ -1277,12 +1329,6 @@ mod tests {
             );
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall { account: receiver })?,
-                U256::ZERO
-            );
-            assert_eq!(
-                token.balance_of(ITIP20::balanceOfCall {
-                    account: destination
-                })?,
                 U256::ZERO
             );
 
@@ -1341,19 +1387,21 @@ mod tests {
 
             assert_invalid_receipt(TIP1028Escrow::new().claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             ));
             assert_invalid_receipt(TIP1028Escrow::new().claim(
                 other_recovery,
-                claim_call(token.address(), other_recovery, &receipt, receiver),
+                claim_call(token.address(), other_recovery, &receipt),
             ));
-            TIP1028Escrow::new().claim(
-                recovery,
-                claim_call(token.address(), recovery, &receipt, receiver),
-            )?;
+            TIP1028Escrow::new()
+                .claim(recovery, claim_call(token.address(), recovery, &receipt))?;
 
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall { account: receiver })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: recovery })?,
                 amount
             );
             Ok(())
@@ -1397,7 +1445,7 @@ mod tests {
             escrow.clear_emitted_events();
             escrow.claim(
                 VIRTUAL_MASTER,
-                claim_call(token.address(), Address::ZERO, &receipt, VIRTUAL_MASTER),
+                claim_call(token.address(), Address::ZERO, &receipt),
             )?;
 
             escrow.assert_emitted_events(vec![TIP1028EscrowEvent::BlockedReceiptClaimed(
@@ -1480,7 +1528,7 @@ mod tests {
             );
             escrow.claim(
                 receiver,
-                claim_call(token.address(), Address::ZERO, &receipt, receiver),
+                claim_call(token.address(), Address::ZERO, &receipt),
             )?;
 
             assert_eq!(

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1246,16 +1246,8 @@ impl TIP20Token {
         Ok(true)
     }
 
-    /// Releases escrowed funds to `to`. Resumes skip policy checks. Reroutes
-    /// revalidate the transfer and receive policies and meter the spending limit.
-    pub(crate) fn release_from_escrow(
-        &mut self,
-        originator: Address,
-        receiver: Address,
-        to: Address,
-        amount: U256,
-        reroute: bool,
-    ) -> Result<()> {
+    /// Releases escrowed funds to the authorized claim target.
+    pub(crate) fn release_from_escrow(&mut self, to: Address, amount: U256) -> Result<()> {
         self.check_not_paused()?;
 
         if to == ESCROW_ADDRESS {
@@ -1264,21 +1256,6 @@ impl TIP20Token {
 
         let destination = Recipient::resolve(to)?;
         destination.validate()?;
-
-        if reroute {
-            let registry = TIP403Registry::new();
-            let policy_id = self.transfer_policy_id()?;
-            if !registry.is_authorized_as(policy_id, destination.target, AuthRole::recipient())? {
-                return Err(TIP20Error::policy_forbids().into());
-            }
-            if registry
-                .validate_receive_policy(self.address, originator, destination.target)?
-                .is_some()
-            {
-                return Err(TIP20Error::policy_forbids().into());
-            }
-            self.check_and_update_spending_limit(receiver, amount)?;
-        }
 
         let escrow_balance = self.get_balance(ESCROW_ADDRESS)?;
         if amount > escrow_balance {


### PR DESCRIPTION
Simplifies TIP-1028 escrow claims so blocked funds release only to the authorized claimant.

Moving funds elsewhere now uses normal TIP-20 transfers instead of special reroute logic inside escrow.