### PR TITLE
ci(bench): migrate tempo.nu bench to txgen

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -20,11 +20,6 @@ const E2E_GAS_LIMIT = "1000000000000"
 const E2E_BLOAT_TMP_DIR = "/reth-bench-a/.bench-tmp/e2e-local-init"
 const E2E_BLOAT_FREE_MARGIN_MIB = 51200
 const E2E_DEFAULT_BLOAT = 100
-const TXGEN_DEFAULT_SEED = 99
-const TXGEN_SCRAPE_INTERVAL_MS = 500
-const TXGEN_DRAIN_TIMEOUT_SECS = 300
-const TXGEN_FUND_DRAIN_TIMEOUT_SECS = 120
-const TXGEN_TIP20_TEMPLATE = "contrib/bench/txgen/tip20-template.yaml"
 const E2E_LOCAL_RETH_ARGS = [
     "--ipcdisable"
     "--disable-discovery"
@@ -138,124 +133,6 @@ def e2e-bloat-gib-to-mib [bloat: int] {
 
     print "Error: --bloat must be one of: 1, 10, 100"
     exit 1
-}
-
-def shell-quote [value: any] {
-    let s = ($value | into string)
-    let escaped = ($s | str replace -a "'" "'\"'\"'")
-    $"'($escaped)'"
-}
-
-def shell-join [args: list<any>] {
-    $args | each { |arg| shell-quote $arg } | str join " "
-}
-
-def resolve-command-path [name: string] {
-    let path = (which $name | get -o 0.path | default "")
-    if $path == "" {
-        error make { msg: $"($name) not found in PATH" }
-    }
-    $path
-}
-
-def resolve-bench-binary [repo_dir: string] {
-    for candidate in [$"($repo_dir)/target/release/bench" $"($repo_dir)/target/release/bench-cli"] {
-        if ($candidate | path exists) {
-            return $candidate
-        }
-    }
-    error make { msg: $"txgen bench binary not found under ($repo_dir)/target/release/" }
-}
-
-def resolve-txgen-paths [] {
-    let repo_dir = ($env.TXGEN_REPO_DIR? | default "")
-    let repo = if $repo_dir != "" { $repo_dir | path expand } else { "" }
-    let generator = if ($env.TXGEN_TEMPO_BIN? | default "") != "" {
-        $env.TXGEN_TEMPO_BIN | path expand
-    } else if $repo != "" and ($"($repo)/target/release/txgen-tempo" | path exists) {
-        $"($repo)/target/release/txgen-tempo"
-    } else {
-        resolve-command-path "txgen-tempo"
-    }
-    let bench = if ($env.TXGEN_BENCH_BIN? | default "") != "" {
-        $env.TXGEN_BENCH_BIN | path expand
-    } else if $repo != "" {
-        resolve-bench-binary $repo
-    } else {
-        resolve-command-path "bench"
-    }
-    if not ($generator | path exists) {
-        error make { msg: $"txgen-tempo binary not found: ($generator)" }
-    }
-    if not ($bench | path exists) {
-        error make { msg: $"txgen bench binary not found: ($bench)" }
-    }
-    { txgen_tempo_bin: $generator, txgen_bench_bin: $bench }
-}
-
-def rpc-call [rpc_url: string, payload: string] {
-    let result = (^curl -sf -X POST -H "Content-Type: application/json" -d $payload $rpc_url | complete)
-    if $result.exit_code != 0 {
-        error make { msg: $"RPC call failed: ($payload)" }
-    }
-    let response = ($result.stdout | from json)
-    if (($response | get -o error) != null) {
-        let rpc_error = ($response | get error)
-        error make { msg: $"RPC error: ($rpc_error | to json -r)" }
-    }
-    $response
-}
-
-def fetch-chain-id [rpc_url: string] {
-    let response = (rpc-call $rpc_url '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}')
-    $response.result | into int
-}
-
-def wait-for-txpool-drain [rpc_url: string, timeout_secs: int] {
-    mut zero_count = 0
-    mut waited = 0
-    while $waited < $timeout_secs {
-        let response = (rpc-call $rpc_url '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}')
-        let pending = ($response.result.pending | into int)
-        if $pending == 0 {
-            $zero_count = $zero_count + 1
-            if $zero_count >= 3 { return }
-        } else {
-            $zero_count = 0
-        }
-        sleep 1sec
-        $waited = $waited + 1
-    }
-    print $"  Warning: txpool drain timeout reached after ($timeout_secs)s"
-}
-
-def fund-txgen-accounts [txgen_bin: string, spec_path: string, rpc_url: string] {
-    let result = (^$txgen_bin addresses -s $spec_path -f shell | complete)
-    if $result.exit_code != 0 {
-        error make { msg: $"failed to list txgen addresses for ($spec_path)" }
-    }
-
-    let addresses = ($result.stdout | str trim | split row " " | where { |addr| $addr != "" })
-    if ($addresses | is-empty) {
-        error make { msg: $"txgen spec produced no addresses: ($spec_path)" }
-    }
-
-    print $"  Funding (($addresses | length)) txgen account\(s\)..."
-    $addresses | par-each { |address|
-        rpc-call $rpc_url $"{\"jsonrpc\":\"2.0\",\"method\":\"tempo_fundAddress\",\"params\":[\"($address)\"],\"id\":1}" | ignore
-    } | ignore
-
-    print "  Waiting for faucet transactions to drain..."
-    wait-for-txpool-drain $rpc_url $TXGEN_FUND_DRAIN_TIMEOUT_SECS
-}
-
-def sanitize-txgen-bench-args [bench_args: string] {
-    if $bench_args == "" {
-        return ""
-    }
-    $bench_args
-        | str replace --all --regex '--existing-recipients=(true|false)' ''
-        | str trim
 }
 
 def validator-dirs-in-localnet [localnet_dir: string] {
@@ -788,68 +665,34 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
 
     if $phase_exit == 0 {
-        let bench_env_export = if $ctx.bench_env != "" { $"export ($ctx.bench_env) && " } else { "" }
-        if $ctx.preset != "tip20" {
-            print $"Error: txgen e2e currently supports only preset=tip20 \(got ($ctx.preset)\)"
-            $phase_exit = 1
-        } else {
-            let ignored_bench_args = (sanitize-txgen-bench-args $ctx.bench_args)
-            if $ignored_bench_args != "" {
-                print $"  Warning: txgen path is ignoring unsupported bench args: ($ignored_bench_args)"
+        let sender_exit = (try {
+            txgen-require-tip20-preset $ctx.preset
+            txgen-validate-tip20-bench-args $ctx.bench_args
+            let bench_result = (txgen-run-tip20-pipeline
+                --txgen-tempo-bin $ctx.txgen.txgen_tempo_bin
+                --txgen-bench-bin $ctx.txgen.txgen_bench_bin
+                --generate-rpc-url $a_rpc
+                --submit-rpc-url $a_rpc
+                --metrics-url "http://127.0.0.1:9001/metrics"
+                --report-path $"($ctx.results_dir)/report-($phase).json"
+                --tps $ctx.tps
+                --duration $ctx.duration
+                --accounts $ctx.accounts
+                --max-concurrent-requests $ctx.max_concurrent_requests
+                --bench-env $ctx.bench_env
+                --git-ref $run.ref
+                --build-profile $ctx.profile
+                --benchmark-mode "e2e")
+            if not $bench_result.ok {
+                $bench_result.exit_code
+            } else {
+                0
             }
-            let chain_id = (fetch-chain-id $a_rpc)
-            $env.TXGEN_ACCOUNTS = ($ctx.accounts | into string)
-            let spec_path = ($TXGEN_TIP20_TEMPLATE | path expand)
-            fund-txgen-accounts $ctx.txgen.txgen_tempo_bin $spec_path $a_rpc
-
-            let report_path = $"($ctx.results_dir)/report-($phase).json"
-            let tx_count = [($ctx.tps * $ctx.duration) 1] | math max
-            let txgen_cmd = [
-                $ctx.txgen.txgen_tempo_bin
-                "generate"
-                "-s" $spec_path
-                "-n" $tx_count
-                "--seed" $TXGEN_DEFAULT_SEED
-                "--rpc" $a_rpc
-            ]
-            let bench_cmd = [
-                $ctx.txgen.txgen_bench_bin
-                "send"
-                "--rpc-url" $a_rpc
-                "--tps" $ctx.tps
-                "--max-concurrent" $ctx.max_concurrent_requests
-                "--metrics-url" "http://127.0.0.1:9001/metrics"
-                "--scrape-interval-ms" $TXGEN_SCRAPE_INTERVAL_MS
-                "--drain-timeout" $TXGEN_DRAIN_TIMEOUT_SECS
-                "--duration" $ctx.duration
-                "--report" $"json:($report_path)"
-                "-m" $"chain_id=($chain_id)"
-                "-m" $"target_tps=($ctx.tps)"
-                "-m" $"run_duration_secs=($ctx.duration)"
-                "-m" $"accounts=($ctx.accounts)"
-                "-m" $"total_connections=($ctx.max_concurrent_requests)"
-                "-m" "tip20_weight=1.0"
-                "-m" "place_order_weight=0.0"
-                "-m" "swap_weight=0.0"
-                "-m" "erc20_weight=0.0"
-                "-m" $"node_commit_sha=($run.ref)"
-                "-m" $"build_profile=($ctx.profile)"
-                "-m" "mode=e2e"
-            ]
-            print $"Running local e2e txgen sender: ($txgen_cmd | str join ' ') | ($bench_cmd | str join ' ')"
-            let txgen_cmd_str = (shell-join $txgen_cmd)
-            let bench_cmd_str = (shell-join $bench_cmd)
-            let pipeline = $"set -euo pipefail; ($bench_env_export)ulimit -Sn unlimited && ($txgen_cmd_str) | ($bench_cmd_str)"
-            let bench_result = (bash -lc $pipeline | complete)
-            if $bench_result.stdout != "" { print $bench_result.stdout }
-            if $bench_result.stderr != "" { print $bench_result.stderr }
-            $phase_exit = $bench_result.exit_code
-
-            if not ($report_path | path exists) {
-                print $"ERROR: txgen sender for ($phase) produced no ($report_path)"
-                $phase_exit = 1
-            }
-        }
+        } catch { |e|
+            print $"Error: local e2e txgen sender failed for ($phase): ($e.msg)"
+            1
+        })
+        $phase_exit = $sender_exit
     } else {
         print $"Skipping local e2e sender for ($phase) because readiness checks failed"
     }
@@ -874,7 +717,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
-    --preset: string = ""                               # Preset: tip20, erc20, swap, order, tempo-mix
+    --preset: string = ""                               # Preset: tip20
     --tps: int = 10000                                  # Target TPS
     --duration: int = 300                               # Duration in seconds
     --accounts: int = 1000                              # Number of accounts
@@ -909,14 +752,8 @@ def "main e2e" [
         print "Error: --preset tip20 is required for e2e txgen"
         exit 1
     }
-    if not ($preset in $PRESETS) {
-        print $"Unknown preset: ($preset). Available: ($PRESETS | columns | str join ', ')"
-        exit 1
-    }
-    if $preset != "tip20" {
-        print $"Error: e2e txgen currently supports only --preset tip20 \(got '($preset)'\)"
-        exit 1
-    }
+    txgen-require-tip20-preset $preset
+    txgen-validate-tip20-bench-args $bench_args
     if $tracy not-in ["off" "on" "full"] {
         print $"Error: --tracy must be one of: off, on, full \(got '($tracy)'\)"
         exit 1
@@ -1083,7 +920,7 @@ def "main e2e" [
     }
     let baseline_tempo = (worktree-bin $baseline_wt $profile "tempo")
     let feature_tempo = (worktree-bin $feature_wt $profile "tempo")
-    let txgen = resolve-txgen-paths
+    let txgen = txgen-resolve-binaries
     let samply_args_list = if $samply_args == "" { [] } else { $samply_args | split row " " }
     let ctx = {
         genesis: $genesis_path

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -666,11 +666,10 @@ def run-local-e2e-phase [run: record, ctx: record] {
 
     if $phase_exit == 0 {
         let sender_exit = (try {
-            txgen-require-tip20-preset $ctx.preset
-            txgen-validate-tip20-bench-args $ctx.bench_args
-            let bench_result = (txgen-run-tip20-pipeline
+            let bench_result = (txgen-run-preset-pipeline
                 --txgen-tempo-bin $ctx.txgen.txgen_tempo_bin
                 --txgen-bench-bin $ctx.txgen.txgen_bench_bin
+                --preset-path $ctx.preset_path
                 --generate-rpc-url $a_rpc
                 --submit-rpc-url $a_rpc
                 --metrics-url "http://127.0.0.1:9001/metrics"
@@ -717,7 +716,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
 def "main e2e" [
     --baseline: string                                  # Baseline git SHA/ref
     --feature: string                                   # Feature git SHA/ref
-    --preset: string = ""                               # Preset: tip20
+    --preset: string = ""                               # Txgen preset name
     --tps: int = 10000                                  # Target TPS
     --duration: int = 300                               # Duration in seconds
     --accounts: int = 1000                              # Number of accounts
@@ -748,12 +747,8 @@ def "main e2e" [
     --loud                                              # Show node debug logs
     --no-cache                                           # Skip binary cache
 ] {
-    if $preset == "" {
-        print "Error: --preset tip20 is required for e2e txgen"
-        exit 1
-    }
-    txgen-require-tip20-preset $preset
-    txgen-validate-tip20-bench-args $bench_args
+    let preset_path = (txgen-preset-path $preset)
+    txgen-validate-bench-args $bench_args
     if $tracy not-in ["off" "on" "full"] {
         print $"Error: --tracy must be one of: off, on, full \(got '($tracy)'\)"
         exit 1
@@ -946,6 +941,7 @@ def "main e2e" [
             memory: $E2E_B_MEMORY
         }
         preset: $preset
+        preset_path: $preset_path
         tps: $tps
         duration: $duration
         accounts: $accounts

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -36,7 +36,7 @@ def run-txgen-bench-single [
     --duration: int
     --accounts: int
     --max-concurrent-requests: int
-    --preset: string = ""
+    --preset-path: string
     --bench-args: string = ""
     --loud
     --node-args: string = ""
@@ -56,9 +56,6 @@ def run-txgen-bench-single [
     --tracy-offset: int = 0
     --tracing-otlp: string = ""
 ] {
-    txgen-require-tip20-preset $preset
-    txgen-validate-tip20-bench-args $bench_args
-
     print $"=== Starting txgen run: ($run_label) ==="
 
     let log_dir = $"($LOCALNET_DIR)/logs-($run_label)"
@@ -135,9 +132,10 @@ def run-txgen-bench-single [
     } else { false }
 
     let report_path = $"($results_dir)/report-($run_label).json"
-    let bench_result = (txgen-run-tip20-pipeline
+    let bench_result = (txgen-run-preset-pipeline
         --txgen-tempo-bin $txgen_tempo_bin
         --txgen-bench-bin $txgen_bench_bin
+        --preset-path $preset_path
         --generate-rpc-url "http://localhost:8545"
         --submit-rpc-url "http://localhost:8545"
         --metrics-url "http://127.0.0.1:9090/metrics"
@@ -260,8 +258,8 @@ def "main run" [
     if $runtime_mode != "dev" {
         error make { msg: $"txgen benchmark path currently supports only dev/e2e mode \(got ($mode)\)" }
     }
-    txgen-require-tip20-preset $preset
-    txgen-validate-tip20-bench-args $bench_args
+    let preset_path = (txgen-preset-path $preset)
+    txgen-validate-bench-args $bench_args
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
         error make { msg: "--baseline and --feature must both be provided for txgen comparison mode" }
     }
@@ -560,7 +558,7 @@ def "main run" [
             --duration $duration
             --accounts $accounts
             --max-concurrent-requests $max_concurrent_requests
-            --preset $preset
+            --preset-path $preset_path
             --bench-args $bench_args
             --loud=$loud
             --node-args $effective_node_args

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -2,111 +2,11 @@
 
 source ../../tempo.nu
 
-const TXGEN_ACCOUNT_MNEMONIC = "test test test test test test test test test test test junk"
-const TXGEN_DEFAULT_SEED = 99
-const TXGEN_SCRAPE_INTERVAL_MS = 500
-const TXGEN_DRAIN_TIMEOUT_SECS = 300
-const TXGEN_FUND_DRAIN_TIMEOUT_SECS = 120
-const TXGEN_TIP20_TEMPLATE = "contrib/bench/txgen/tip20-template.yaml"
-
-def shell-quote [value: any] {
-    let s = ($value | into string)
-    let escaped = ($s | str replace -a "'" "'\"'\"'")
-    $"'($escaped)'"
-}
-
-def shell-join [args: list<any>] {
-    $args | each { |arg| shell-quote $arg } | str join " "
-}
-
-def resolve-command-path [name: string] {
-    let path = (which $name | get -o 0.path | default "")
-    if $path == "" {
-        error make { msg: $"($name) not found in PATH" }
-    }
-    $path
-}
-
 def resolved-runtime-mode [mode: string] {
     if $mode == "e2e" {
         "dev"
     } else {
         $mode
-    }
-}
-
-def sanitize-bench-args [bench_args: string] {
-    if $bench_args == "" {
-        return ""
-    }
-
-    $bench_args
-        | str replace --all --regex '--existing-recipients=(true|false)' ''
-        | str trim
-}
-
-def resolve-bench-binary [repo_dir: string] {
-    let candidates = [
-        $"($repo_dir)/target/release/bench"
-        $"($repo_dir)/target/release/bench-cli"
-    ]
-
-    for candidate in $candidates {
-        if ($candidate | path exists) {
-            return $candidate
-        }
-    }
-
-    error make { msg: $"txgen bench binary not found under ($repo_dir)/target/release/" }
-}
-
-def resolve-txgen-paths [repo_dir: string, txgen_tempo_bin: string, txgen_bench_bin: string] {
-    let env_repo_dir = ($env.TXGEN_REPO_DIR? | default "")
-    let explicit_repo = $repo_dir != "" or $env_repo_dir != ""
-    let configured_repo = if $repo_dir != "" {
-        $repo_dir | path expand
-    } else if $env_repo_dir != "" {
-        $env_repo_dir | path expand
-    } else {
-        "../txgen" | path expand
-    }
-
-    if $explicit_repo and not ($configured_repo | path exists) {
-        error make { msg: $"txgen repo not found: ($configured_repo)" }
-    }
-    let repo = if ($configured_repo | path exists) { $configured_repo } else { "" }
-
-    let generator = if $txgen_tempo_bin != "" {
-        $txgen_tempo_bin | path expand
-    } else if ($env.TXGEN_TEMPO_BIN? | default "") != "" {
-        $env.TXGEN_TEMPO_BIN | path expand
-    } else if $repo != "" and ($"($repo)/target/release/txgen-tempo" | path exists) {
-        $"($repo)/target/release/txgen-tempo"
-    } else {
-        resolve-command-path "txgen-tempo"
-    }
-
-    let bench = if $txgen_bench_bin != "" {
-        $txgen_bench_bin | path expand
-    } else if ($env.TXGEN_BENCH_BIN? | default "") != "" {
-        $env.TXGEN_BENCH_BIN | path expand
-    } else if $repo != "" {
-        resolve-bench-binary $repo
-    } else {
-        resolve-command-path "bench"
-    }
-
-    if not ($generator | path exists) {
-        error make { msg: $"txgen-tempo binary not found: ($generator)" }
-    }
-    if not ($bench | path exists) {
-        error make { msg: $"txgen bench binary not found: ($bench)" }
-    }
-
-    {
-        repo_dir: $repo
-        txgen_tempo_bin: $generator
-        txgen_bench_bin: $bench
     }
 }
 
@@ -122,68 +22,6 @@ def normalize-tracy-mode [value: any] {
     } else {
         error make { msg: $"--tracy must be one of: off, on, full \(got ($value)\)" }
     }
-}
-
-def rpc-call [rpc_url: string, payload: string] {
-    let result = (^curl -sf -X POST -H "Content-Type: application/json" -d $payload $rpc_url | complete)
-    if $result.exit_code != 0 {
-        error make { msg: $"RPC call failed: ($payload)" }
-    }
-    let response = ($result.stdout | from json)
-    if (($response | get -o error) != null) {
-        let rpc_error = ($response | get error)
-        error make { msg: $"RPC error: ($rpc_error | to json -r)" }
-    }
-    $response
-}
-
-def fetch-chain-id [rpc_url: string] {
-    let response = (rpc-call $rpc_url '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}')
-    $response.result | into int
-}
-
-def wait-for-txpool-drain [rpc_url: string, timeout_secs: int] {
-    mut zero_count = 0
-    mut waited = 0
-
-    while $waited < $timeout_secs {
-        let response = (rpc-call $rpc_url '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}')
-        let pending = ($response.result.pending | into int)
-
-        if $pending == 0 {
-            $zero_count = $zero_count + 1
-            if $zero_count >= 3 {
-                return
-            }
-        } else {
-            $zero_count = 0
-        }
-
-        sleep 1sec
-        $waited = $waited + 1
-    }
-
-    print $"  Warning: txpool drain timeout reached after ($timeout_secs)s"
-}
-
-def fund-txgen-accounts [txgen_bin: string, spec_path: string, rpc_url: string] {
-    let result = (^$txgen_bin addresses -s $spec_path -f shell | complete)
-    if $result.exit_code != 0 {
-        error make { msg: $"failed to list txgen addresses for ($spec_path)" }
-    }
-
-    let addresses = ($result.stdout | str trim | split row " " | where { |addr| $addr != "" })
-    if ($addresses | is-empty) {
-        error make { msg: $"txgen spec produced no addresses: ($spec_path)" }
-    }
-
-    print $"  Funding (($addresses | length)) txgen account\(s\)..."
-    $addresses | par-each { |address|
-        rpc-call $rpc_url $"{\"jsonrpc\":\"2.0\",\"method\":\"tempo_fundAddress\",\"params\":[\"($address)\"],\"id\":1}" | ignore
-    } | ignore
-
-    print "  Waiting for faucet transactions to drain..."
-    wait-for-txpool-drain $rpc_url $TXGEN_FUND_DRAIN_TIMEOUT_SECS
 }
 
 def run-txgen-bench-single [
@@ -218,14 +56,8 @@ def run-txgen-bench-single [
     --tracy-offset: int = 0
     --tracing-otlp: string = ""
 ] {
-    if $preset != "tip20" {
-        error make { msg: $"txgen benchmark path currently supports only preset=tip20 \(got ($preset)\)" }
-    }
-
-    let ignored_bench_args = (sanitize-bench-args $bench_args)
-    if $ignored_bench_args != "" {
-        print $"  Warning: txgen path is ignoring unsupported bench args: ($ignored_bench_args)"
-    }
+    txgen-require-tip20-preset $preset
+    txgen-validate-tip20-bench-args $bench_args
 
     print $"=== Starting txgen run: ($run_label) ==="
 
@@ -302,58 +134,25 @@ def run-txgen-bench-single [
         true
     } else { false }
 
-    let chain_id = (fetch-chain-id "http://localhost:8545")
-    $env.TXGEN_ACCOUNTS = ($accounts | into string)
-    let spec_path = ($TXGEN_TIP20_TEMPLATE | path expand)
-    fund-txgen-accounts $txgen_tempo_bin $spec_path "http://localhost:8545"
-
     let report_path = $"($results_dir)/report-($run_label).json"
-    let tx_count = [($tps * $duration) 1] | math max
-    let txgen_cmd = [
-        $txgen_tempo_bin
-        "generate"
-        "-s" $spec_path
-        "-n" $tx_count
-        "--seed" $TXGEN_DEFAULT_SEED
-        "--rpc" "http://localhost:8545"
-    ]
-    let bench_cmd = [
-        $txgen_bench_bin
-        "send"
-        "--rpc-url" "http://localhost:8545"
-        "--tps" $tps
-        "--max-concurrent" $max_concurrent_requests
-        "--metrics-url" "http://127.0.0.1:9090/metrics"
-        "--scrape-interval-ms" $TXGEN_SCRAPE_INTERVAL_MS
-        "--drain-timeout" $TXGEN_DRAIN_TIMEOUT_SECS
-        "--report" $"json:($report_path)"
-        "-m" $"chain_id=($chain_id)"
-        "-m" $"target_tps=($tps)"
-        "-m" $"run_duration_secs=($duration)"
-        "-m" $"accounts=($accounts)"
-        "-m" $"total_connections=($max_concurrent_requests)"
-        "-m" "tip20_weight=1.0"
-        "-m" "place_order_weight=0.0"
-        "-m" "swap_weight=0.0"
-        "-m" "erc20_weight=0.0"
-        "-m" $"node_commit_sha=($git_ref)"
-        "-m" $"build_profile=($build_profile)"
-        "-m" $"mode=($benchmark_mode)"
-    ]
-    let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }
-    let txgen_cmd_str = (shell-join $txgen_cmd)
-    let bench_cmd_str = (shell-join $bench_cmd)
-
-    print $"  Streaming ($tx_count) txgen transaction\(s\) into bench send..."
-    let pipeline = $"set -euo pipefail; ($bench_env_export)($txgen_cmd_str) | ($bench_cmd_str)"
-    try {
-        bash -lc $pipeline
-    } catch { |e|
-        print $"  txgen benchmark run ($run_label) failed: ($e.msg)"
-        error make { msg: $"txgen benchmark run ($run_label) failed" }
+    let bench_result = (txgen-run-tip20-pipeline
+        --txgen-tempo-bin $txgen_tempo_bin
+        --txgen-bench-bin $txgen_bench_bin
+        --generate-rpc-url "http://localhost:8545"
+        --submit-rpc-url "http://localhost:8545"
+        --metrics-url "http://127.0.0.1:9090/metrics"
+        --report-path $report_path
+        --tps $tps
+        --duration $duration
+        --accounts $accounts
+        --max-concurrent-requests $max_concurrent_requests
+        --bench-env $bench_env
+        --git-ref $git_ref
+        --build-profile $build_profile
+        --benchmark-mode $benchmark_mode)
+    if not $bench_result.ok {
+        error make { msg: $"txgen benchmark run ($run_label) failed with exit code ($bench_result.exit_code)" }
     }
-
-    print $"  Report saved: report-($run_label).json"
 
     if $tracy_capture_started {
         print "  Stopping tracy-capture..."
@@ -456,17 +255,13 @@ def "main run" [
     --baseline-hardfork: string = ""
     --feature-hardfork: string = ""
     --gas-limit: string = ""
-    --txgen-repo-dir: string = ""
-    --txgen-tempo-bin: string = ""
-    --txgen-bench-bin: string = ""
 ] {
     let runtime_mode = (resolved-runtime-mode $mode)
     if $runtime_mode != "dev" {
         error make { msg: $"txgen benchmark path currently supports only dev/e2e mode \(got ($mode)\)" }
     }
-    if $preset != "tip20" {
-        error make { msg: $"txgen benchmark path currently supports only preset=tip20 \(got ($preset)\)" }
-    }
+    txgen-require-tip20-preset $preset
+    txgen-validate-tip20-bench-args $bench_args
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
         error make { msg: "--baseline and --feature must both be provided for txgen comparison mode" }
     }
@@ -474,7 +269,7 @@ def "main run" [
         error make { msg: "txgen benchmark path currently supports comparison mode only" }
     }
 
-    let txgen = (resolve-txgen-paths $txgen_repo_dir $txgen_tempo_bin $txgen_bench_bin)
+    let txgen = (txgen-resolve-binaries)
 
     if $force and ($LOCALNET_DIR | path exists) {
         print "Removing existing localnet data (--force)..."
@@ -566,7 +361,8 @@ def "main run" [
     let meta_dir = $"($datadir)/($BENCH_META_SUBDIR)"
     let genesis_accounts = ([$accounts 3] | math max) + 1
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
-    let txgen_genesis_args = ["--mnemonic" $TXGEN_ACCOUNT_MNEMONIC]
+    let txgen_mnemonic = (txgen-account-mnemonic)
+    let txgen_genesis_args = ["--mnemonic" $txgen_mnemonic]
 
     bench-mount
 
@@ -586,7 +382,7 @@ def "main run" [
             and $marker != null
             and ($marker.bloat_mib | into int) == $bloat
             and ($marker.accounts | into int) == $genesis_accounts
-            and ($marker | get -o txgen_mnemonic | default "") == $TXGEN_ACCOUNT_MNEMONIC
+            and ($marker | get -o txgen_mnemonic | default "") == $txgen_mnemonic
             and ($marker | get -o baseline_hardfork | default "") == ($baseline_hardfork | str upcase)
             and ($marker | get -o feature_hardfork | default "") == ($feature_hardfork | str upcase)
             and ($marker | get -o gas_limit | default "") == $gas_limit
@@ -654,7 +450,7 @@ def "main run" [
                 bloat_mib: $bloat
                 accounts: $genesis_accounts
                 bench_datadir: $datadir
-                txgen_mnemonic: $TXGEN_ACCOUNT_MNEMONIC
+                txgen_mnemonic: $txgen_mnemonic
                 baseline_hardfork: ($baseline_hardfork | str upcase)
                 feature_hardfork: ($feature_hardfork | str upcase)
                 gas_limit: $gas_limit
@@ -668,7 +464,7 @@ def "main run" [
             and $marker != null
             and ($marker.bloat_mib | into int) == $bloat
             and ($marker.accounts | into int) == $genesis_accounts
-            and ($marker | get -o txgen_mnemonic | default "") == $TXGEN_ACCOUNT_MNEMONIC
+            and ($marker | get -o txgen_mnemonic | default "") == $txgen_mnemonic
             and ($marker | get -o gas_limit | default "") == $gas_limit
             and ($"($datadir)/db" | path exists)
             and ($"($meta_dir)/genesis.json" | path exists)
@@ -708,7 +504,7 @@ def "main run" [
                 bloat_mib: $bloat
                 accounts: $genesis_accounts
                 bench_datadir: $datadir
-                txgen_mnemonic: $TXGEN_ACCOUNT_MNEMONIC
+                txgen_mnemonic: $txgen_mnemonic
                 gas_limit: $gas_limit
             } [[$genesis_path_std "genesis.json"]] $bloat $bloat_file
         }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -3,7 +3,7 @@ const TXGEN_HELPER_DEFAULT_SEED = 99
 const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 500
 const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
-const TXGEN_HELPER_TIP20_TEMPLATE = "contrib/bench/txgen/templates/tip20.yaml"
+const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
 
 def txgen-shell-quote [value: any] {
     let s = ($value | into string)
@@ -54,11 +54,45 @@ def txgen-repo-root [] {
     "." | path expand
 }
 
-def txgen-tip20-template-path [] {
-    let spec_path = ([ (txgen-repo-root) $TXGEN_HELPER_TIP20_TEMPLATE ] | path join)
-    if not ($spec_path | path exists) {
-        error make { msg: $"txgen TIP20 template not found: ($spec_path)" }
+def txgen-presets-dir [] {
+    [ (txgen-repo-root) $TXGEN_HELPER_PRESETS_DIR ] | path join
+}
+
+def txgen-available-presets [] {
+    let presets_dir = (txgen-presets-dir)
+    if not ($presets_dir | path exists) {
+        return []
     }
+
+    glob ([ $presets_dir "*.yml" ] | path join)
+        | each { |preset_path| $preset_path | path basename | str replace --regex '\.yml$' '' }
+        | sort
+}
+
+def txgen-available-presets-message [] {
+    let presets = (txgen-available-presets)
+    if ($presets | is-empty) {
+        "none"
+    } else {
+        $presets | str join ", "
+    }
+}
+
+def txgen-preset-path [preset: string] {
+    let preset_name = ($preset | str trim)
+    if $preset_name == "" {
+        error make { msg: $"--preset is required; available txgen presets: (txgen-available-presets-message)" }
+    }
+
+    if not ($preset_name =~ '^[A-Za-z0-9][A-Za-z0-9_-]*$') {
+        error make { msg: $"invalid txgen preset name '($preset_name)'; use a preset basename like 'tip20'" }
+    }
+
+    let spec_path = ([ (txgen-presets-dir) $"($preset_name).yml" ] | path join)
+    if not ($spec_path | path exists) {
+        error make { msg: $"txgen preset not found: ($preset_name); available txgen presets: (txgen-available-presets-message)" }
+    }
+
     $spec_path
 }
 
@@ -66,13 +100,7 @@ def txgen-account-mnemonic [] {
     $TXGEN_HELPER_ACCOUNT_MNEMONIC
 }
 
-def txgen-require-tip20-preset [preset: string] {
-    if $preset != "tip20" {
-        error make { msg: $"txgen benchmark path currently supports only --preset tip20 \(got '($preset)'\)" }
-    }
-}
-
-def txgen-validate-tip20-bench-args [bench_args: string] {
+def txgen-validate-bench-args [bench_args: string] {
     if $bench_args == "" {
         return
     }
@@ -81,7 +109,7 @@ def txgen-validate-tip20-bench-args [bench_args: string] {
         | str replace --all --regex '--existing-recipients(=(true|false))?' ''
         | str trim)
     if $unsupported != "" {
-        error make { msg: $"txgen TIP20 path does not support custom --bench-args yet: ($unsupported)" }
+        error make { msg: $"txgen path does not support custom --bench-args yet: ($unsupported)" }
     }
 }
 
@@ -147,9 +175,10 @@ def txgen-fund-accounts [txgen_bin: string, spec_path: string, rpc_url: string] 
     txgen-wait-for-txpool-drain $rpc_url $TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS
 }
 
-def txgen-run-tip20-pipeline [
+def txgen-run-preset-pipeline [
     --txgen-tempo-bin: string
     --txgen-bench-bin: string
+    --preset-path: string
     --generate-rpc-url: string
     --submit-rpc-url: string
     --metrics-url: string
@@ -165,7 +194,10 @@ def txgen-run-tip20-pipeline [
 ] {
     let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
     $env.TXGEN_ACCOUNTS = ($accounts | into string)
-    let spec_path = (txgen-tip20-template-path)
+    let spec_path = ($preset_path | path expand)
+    if not ($spec_path | path exists) {
+        error make { msg: $"txgen preset file not found: ($spec_path)" }
+    }
     txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
 
     let tx_count = [($tps * $duration) 1] | math max

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -1,0 +1,225 @@
+const TXGEN_HELPER_ACCOUNT_MNEMONIC = "test test test test test test test test test test test junk"
+const TXGEN_HELPER_DEFAULT_SEED = 99
+const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 500
+const TXGEN_HELPER_DRAIN_TIMEOUT_SECS = 300
+const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
+const TXGEN_HELPER_TIP20_TEMPLATE = "contrib/bench/txgen/templates/tip20.yaml"
+
+def txgen-shell-quote [value: any] {
+    let s = ($value | into string)
+    let escaped = ($s | str replace -a "'" "'\"'\"'")
+    $"'($escaped)'"
+}
+
+def txgen-shell-join [args: list<any>] {
+    $args | each { |arg| txgen-shell-quote $arg } | str join " "
+}
+
+def txgen-command-path [name: string] {
+    let path = (which $name | get -o 0.path | default "")
+    if $path == "" {
+        error make { msg: $"($name) not found in PATH" }
+    }
+    $path
+}
+
+def txgen-resolve-configured-bin [configured: string, fallback: string] {
+    if $configured == "" {
+        return (txgen-command-path $fallback)
+    }
+
+    if ($configured | path exists) {
+        return ($configured | path expand)
+    }
+
+    txgen-command-path $configured
+}
+
+def txgen-resolve-binaries [] {
+    let generator = (txgen-resolve-configured-bin ($env.TXGEN_TEMPO_BIN? | default "") "txgen-tempo")
+    let bench = (txgen-resolve-configured-bin ($env.TXGEN_BENCH_BIN? | default "") "bench")
+
+    {
+        txgen_tempo_bin: $generator
+        txgen_bench_bin: $bench
+    }
+}
+
+def txgen-repo-root [] {
+    let result = (git rev-parse --show-toplevel | complete)
+    if $result.exit_code == 0 {
+        return ($result.stdout | str trim)
+    }
+
+    "." | path expand
+}
+
+def txgen-tip20-template-path [] {
+    let spec_path = ([ (txgen-repo-root) $TXGEN_HELPER_TIP20_TEMPLATE ] | path join)
+    if not ($spec_path | path exists) {
+        error make { msg: $"txgen TIP20 template not found: ($spec_path)" }
+    }
+    $spec_path
+}
+
+def txgen-account-mnemonic [] {
+    $TXGEN_HELPER_ACCOUNT_MNEMONIC
+}
+
+def txgen-require-tip20-preset [preset: string] {
+    if $preset != "tip20" {
+        error make { msg: $"txgen benchmark path currently supports only --preset tip20 \(got '($preset)'\)" }
+    }
+}
+
+def txgen-validate-tip20-bench-args [bench_args: string] {
+    if $bench_args == "" {
+        return
+    }
+
+    let unsupported = ($bench_args
+        | str replace --all --regex '--existing-recipients(=(true|false))?' ''
+        | str trim)
+    if $unsupported != "" {
+        error make { msg: $"txgen TIP20 path does not support custom --bench-args yet: ($unsupported)" }
+    }
+}
+
+def txgen-rpc-call [rpc_url: string, payload: string] {
+    let result = (^curl -sf -X POST -H "Content-Type: application/json" -d $payload $rpc_url | complete)
+    if $result.exit_code != 0 {
+        error make { msg: $"RPC call failed: ($payload)" }
+    }
+    let response = ($result.stdout | from json)
+    if (($response | get -o error) != null) {
+        let rpc_error = ($response | get error)
+        error make { msg: $"RPC error: ($rpc_error | to json -r)" }
+    }
+    $response
+}
+
+def txgen-fetch-chain-id [rpc_url: string] {
+    let response = (txgen-rpc-call $rpc_url '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}')
+    $response.result | into int
+}
+
+def txgen-wait-for-txpool-drain [rpc_url: string, timeout_secs: int = $TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS] {
+    mut zero_count = 0
+    mut waited = 0
+
+    while $waited < $timeout_secs {
+        let response = (txgen-rpc-call $rpc_url '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}')
+        let pending = ($response.result.pending | into int)
+
+        if $pending == 0 {
+            $zero_count = $zero_count + 1
+            if $zero_count >= 3 {
+                return
+            }
+        } else {
+            $zero_count = 0
+        }
+
+        sleep 1sec
+        $waited = $waited + 1
+    }
+
+    print $"  Warning: txpool drain timeout reached after ($timeout_secs)s"
+}
+
+def txgen-fund-accounts [txgen_bin: string, spec_path: string, rpc_url: string] {
+    let result = (^$txgen_bin addresses -s $spec_path -f shell | complete)
+    if $result.exit_code != 0 {
+        error make { msg: $"failed to list txgen addresses for ($spec_path)" }
+    }
+
+    let addresses = ($result.stdout | str trim | split row " " | where { |addr| $addr != "" })
+    if ($addresses | is-empty) {
+        error make { msg: $"txgen spec produced no addresses: ($spec_path)" }
+    }
+
+    print $"  Funding (($addresses | length)) txgen account\(s\)..."
+    $addresses | par-each { |address|
+        txgen-rpc-call $rpc_url $"{\"jsonrpc\":\"2.0\",\"method\":\"tempo_fundAddress\",\"params\":[\"($address)\"],\"id\":1}" | ignore
+    } | ignore
+
+    print "  Waiting for faucet transactions to drain..."
+    txgen-wait-for-txpool-drain $rpc_url $TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS
+}
+
+def txgen-run-tip20-pipeline [
+    --txgen-tempo-bin: string
+    --txgen-bench-bin: string
+    --generate-rpc-url: string
+    --submit-rpc-url: string
+    --metrics-url: string
+    --report-path: string
+    --tps: int
+    --duration: int
+    --accounts: int
+    --max-concurrent-requests: int
+    --bench-env: string = ""
+    --git-ref: string = ""
+    --build-profile: string = ""
+    --benchmark-mode: string = ""
+] {
+    let chain_id = (txgen-fetch-chain-id $generate_rpc_url)
+    $env.TXGEN_ACCOUNTS = ($accounts | into string)
+    let spec_path = (txgen-tip20-template-path)
+    txgen-fund-accounts $txgen_tempo_bin $spec_path $generate_rpc_url
+
+    let tx_count = [($tps * $duration) 1] | math max
+    let txgen_cmd = [
+        $txgen_tempo_bin
+        "generate"
+        "-s" $spec_path
+        "-n" $tx_count
+        "--seed" $TXGEN_HELPER_DEFAULT_SEED
+        "--rpc" $generate_rpc_url
+    ]
+    let bench_cmd = [
+        $txgen_bench_bin
+        "send"
+        "--rpc-url" $submit_rpc_url
+        "--tps" $tps
+        "--max-concurrent" $max_concurrent_requests
+        "--metrics-url" $metrics_url
+        "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
+        "--drain-timeout" $TXGEN_HELPER_DRAIN_TIMEOUT_SECS
+        "--duration" $duration
+        "--report" $"json:($report_path)"
+        "-m" $"chain_id=($chain_id)"
+        "-m" $"target_tps=($tps)"
+        "-m" $"run_duration_secs=($duration)"
+        "-m" $"accounts=($accounts)"
+        "-m" $"total_connections=($max_concurrent_requests)"
+        "-m" "tip20_weight=1.0"
+        "-m" "place_order_weight=0.0"
+        "-m" "swap_weight=0.0"
+        "-m" "erc20_weight=0.0"
+        "-m" $"node_commit_sha=($git_ref)"
+        "-m" $"build_profile=($build_profile)"
+        "-m" $"mode=($benchmark_mode)"
+    ]
+
+    let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }
+    let txgen_cmd_str = (txgen-shell-join $txgen_cmd)
+    let bench_cmd_str = (txgen-shell-join $bench_cmd)
+    let pipeline = $"set -euo pipefail; ($bench_env_export)ulimit -Sn unlimited && ($txgen_cmd_str) | ($bench_cmd_str)"
+
+    print $"  Streaming ($tx_count) txgen transaction\(s\) into bench send..."
+    let result = (bash -lc $pipeline | complete)
+    if $result.stdout != "" { print $result.stdout }
+    if $result.stderr != "" { print $result.stderr }
+
+    if $result.exit_code != 0 {
+        return { ok: false, exit_code: $result.exit_code, report_path: $report_path }
+    }
+    if not ($report_path | path exists) {
+        print $"ERROR: txgen sender produced no ($report_path)"
+        return { ok: false, exit_code: 1, report_path: $report_path }
+    }
+
+    print $"  Report saved: ($report_path)"
+    { ok: true, exit_code: 0, report_path: $report_path }
+}

--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -39,3 +39,4 @@ templates:
 mix:
   - template: tip20_transfer
     weight: 100
+

--- a/contrib/bench/txgen/templates/tip20.yaml
+++ b/contrib/bench/txgen/templates/tip20.yaml
@@ -12,7 +12,7 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: erc20.abi.json
+  ERC20: ../erc20.abi.json
 
 templates:
   tip20_transfer:

--- a/tempo.nu
+++ b/tempo.nu
@@ -16,15 +16,6 @@ const METRICS_PROXY_SCRIPT = "contrib/bench/bench-metrics-proxy.py"
 const MINIO_BUCKET = "minio/tempo-binaries"
 const BENCH_META_SUBDIR = ".bench-meta"
 
-# Preset weight configurations: [tip20, erc20, swap, order]
-const PRESETS = {
-    tip20: [1.0, 0.0, 0.0, 0.0],
-    erc20: [0.0, 1.0, 0.0, 0.0],
-    swap: [0.0, 0.0, 1.0, 0.0],
-    order: [0.0, 0.0, 0.0, 1.0],
-    "tempo-mix": [0.8, 0, 0.19, 0.01]
-}
-
 # TIP20 token IDs created by localnet genesis (pathUSD, AlphaUSD, BetaUSD, ThetaUSD)
 const TIP20_TOKEN_IDS = [0, 1, 2, 3]
 
@@ -485,7 +476,7 @@ def run-bench-single [
     --duration: int
     --accounts: int
     --max-concurrent-requests: int
-    --preset: string = ""
+    --preset-path: string
     --bench-args: string = ""
     --loud
     --node-args: string = ""
@@ -591,9 +582,10 @@ def run-bench-single [
     print $"  Running txgen benchmark..."
     let report_path = $"($results_dir)/report-($run_label).json"
     let bench_result = (try {
-        let result = (txgen-run-tip20-pipeline
+        let result = (txgen-run-preset-pipeline
             --txgen-tempo-bin $txgen_tempo_bin
             --txgen-bench-bin $txgen_bench_bin
+            --preset-path $preset_path
             --generate-rpc-url "http://localhost:8545"
             --submit-rpc-url $rpc_urls
             --metrics-url $metrics_url
@@ -1667,7 +1659,7 @@ def "main bench-init" [
 # Run a full benchmark: start infra, localnet, and txgen traffic
 def "main bench" [
     --mode: string = "consensus"                    # Mode: "dev" or "consensus"
-    --preset: string = ""                           # Preset: tip20 (txgen path currently supports tip20 only)
+    --preset: string = ""                           # Txgen preset name
     --tps: int = 10000                              # Target TPS
     --duration: int = 30                            # Duration in seconds
     --accounts: int = 1000                          # Number of accounts
@@ -1711,8 +1703,8 @@ def "main bench" [
         exit 1
     }
 
-    txgen-require-tip20-preset $preset
-    txgen-validate-tip20-bench-args $bench_args
+    let preset_path = (txgen-preset-path $preset)
+    txgen-validate-bench-args $bench_args
     let txgen = (txgen-resolve-binaries)
 
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
@@ -2133,7 +2125,7 @@ def "main bench" [
                 --run-label $run.label --results-dir $results_dir
                 --tps $tps --duration $duration --accounts $accounts
                 --max-concurrent-requests $max_concurrent_requests
-                --preset $preset --bench-args $bench_args
+                --preset-path $preset_path --bench-args $bench_args
                 --loud=$loud --node-args $effective_node_args --bloat $bloat
                 --extra-env $side_env --bench-env $bench_env
                 --git-ref $run.git_ref --build-profile $profile --benchmark-mode $mode
@@ -2247,9 +2239,10 @@ def "main bench" [
     let primary_rpc_url = ($rpc_urls | first)
     let current_sha = (git rev-parse HEAD | str trim)
     let bench_result = (try {
-        let result = (txgen-run-tip20-pipeline
+        let result = (txgen-run-preset-pipeline
             --txgen-tempo-bin $txgen.txgen_tempo_bin
             --txgen-bench-bin $txgen.txgen_bench_bin
+            --preset-path $preset_path
             --generate-rpc-url $primary_rpc_url
             --submit-rpc-url $submit_rpc_url
             --metrics-url "http://127.0.0.1:9001/metrics"
@@ -2378,7 +2371,7 @@ def "main coverage" [
     --invariant-profile: string = "ci"     # Foundry profile for invariants (ci, fuzz500, default)
     --invariant-contract: string = ""      # Run only a specific invariant contract (e.g. TempoTransactionInvariantTest)
     --live                                 # Include live node coverage (runs localnet + traffic)
-    --preset: string = ""                  # Bench preset for live mode (tip20)
+    --preset: string = ""                  # Txgen preset name for live mode
     --script: string = ""                  # External script to run against live node (instead of bench)
     --tps: int = 1000                      # Target TPS for live bench (ignored with --script)
     --duration: int = 10                   # Bench duration in seconds (ignored with --script)
@@ -2399,13 +2392,15 @@ def "main coverage" [
     }
 
     if $live and $script == "" and $preset == "" {
-        print "Error: --live requires --preset tip20 or --script"
-        print "  Available txgen presets: tip20"
+        print "Error: --live requires --preset or --script"
+        print $"  Available txgen presets: (txgen-available-presets-message)"
         exit 1
     }
 
-    if $live and $script == "" {
-        txgen-require-tip20-preset $preset
+    let live_preset_path = if $live and $script == "" {
+        txgen-preset-path $preset
+    } else {
+        ""
     }
 
     if $script != "" and not ($script | path exists) {
@@ -2658,9 +2653,10 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                 let txgen = (txgen-resolve-binaries)
                 print "Running txgen bench..."
                 try {
-                    let bench_result = (txgen-run-tip20-pipeline
+                    let bench_result = (txgen-run-preset-pipeline
                         --txgen-tempo-bin $txgen.txgen_tempo_bin
                         --txgen-bench-bin $txgen.txgen_bench_bin
+                        --preset-path $live_preset_path
                         --generate-rpc-url "http://localhost:8545"
                         --submit-rpc-url "http://localhost:8545"
                         --metrics-url "http://127.0.0.1:9001/metrics"
@@ -2738,9 +2734,9 @@ def main [] {
     print "  nu tempo.nu infra down               Stop the observability stack"
     print "  nu tempo.nu kill                     Kill any running tempo processes"
     print ""
-    print "Bench flags (--preset tip20 required for txgen path):"
+    print "Bench flags (--preset resolves under contrib/bench/txgen/presets):"
     print "  --mode <M>               Mode: dev or consensus (default: consensus)"
-    print "  --preset <P>             Preset: tip20"
+    print "  --preset <P>             Txgen preset name (e.g. tip20)"
     print "  --tps <N>                Target TPS (default: 10000)"
     print "  --duration <N>           Duration in seconds (default: 30)"
     print "  --accounts <N>           Number of accounts (default: 1000)"
@@ -2783,7 +2779,7 @@ def main [] {
     print "  --invariant-profile <P>  Foundry profile for invariants (ci, fuzz500, default; default: ci)"
     print "  --invariant-contract <C> Run only a specific invariant contract"
     print "  --live                   Include live node coverage (runs localnet + traffic)"
-    print "  --preset <P>             Bench preset for live mode (tip20)"
+    print "  --preset <P>             Txgen preset name for live mode"
     print "  --script <PATH>          External script to run against live node (instead of bench)"
     print "  --tps <N>                Target TPS for live bench (default: 1000)"
     print "  --duration <N>           Bench duration in seconds (default: 10)"

--- a/tempo.nu
+++ b/tempo.nu
@@ -2,6 +2,8 @@
 
 # Tempo local utilities
 
+source contrib/bench/txgen/helpers.nu
+
 const BENCH_DIR = "contrib/bench"
 const LOCALNET_DIR = "localnet"
 const LOGS_DIR = "contrib/bench/logs"
@@ -10,7 +12,6 @@ const DEFAULT_PROFILE = "profiling"
 const DEFAULT_FEATURES = "jemalloc,asm-keccak"
 const BENCH_WORKTREES_DIR = ".bench-worktrees"
 const BENCH_RESULTS_DIR = "bench-results"
-const BLOAT_MNEMONIC = "test test test test test test test test test test test junk"
 const METRICS_PROXY_SCRIPT = "contrib/bench/bench-metrics-proxy.py"
 const MINIO_BUCKET = "minio/tempo-binaries"
 const BENCH_META_SUBDIR = ".bench-meta"
@@ -52,8 +53,7 @@ def wrap-samply [cmd: list<string>, samply: bool, samply_args: list<string>] {
 
 # Compute effective features and RUSTFLAGS for tracy builds.
 # The "tracy" cargo feature on bin/tempo already includes tracy-client/ondemand,
-# so we only need to append "tracy" here. tempo-bench doesn't have a tracy feature,
-# so it must be built separately with the base features.
+# so we only need to append "tracy" here.
 def tracy-build-config [features: string, tracy: string] {
     if $tracy == "off" {
         { features: $features, extra_rustflags: "" }
@@ -91,9 +91,9 @@ def build-tempo [bins: list<string>, profile: string, features: string, --no-def
     }
 }
 
-# Find tempo process PIDs (excluding tempo-bench)
+# Find tempo node process PIDs.
 def find-tempo-pids [] {
-    ps | where name =~ "tempo" | where name !~ "tempo-bench" | get pid
+    ps | where name =~ '(^|/)tempo$' | get pid
 }
 
 # Initialize node with state bloat
@@ -335,7 +335,7 @@ def bench-cache-key [commit_sha: string, features: string, no_default_features: 
 def try-cache-download [worktree_dir: string, profile: string, commit_sha: string, cache_key: string] {
     if not (has-mc) { return false }
 
-    let bins = ["tempo" "tempo-bench"]
+    let bins = ["tempo"]
     # Check that all binaries exist in the cache
     for bin in $bins {
         let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
@@ -393,7 +393,7 @@ def cache-upload [worktree_dir: string, profile: string, commit_sha: string, cac
         $"($worktree_dir)/target/($profile)"
     }
 
-    for bin in ["tempo" "tempo-bench"] {
+    for bin in ["tempo"] {
         let local = $"($target_dir)/($bin)"
         let remote = $"($MINIO_BUCKET)/($cache_key)/($bin)"
         print $"Uploading ($bin) to cache for ($commit_sha | str substring 0..8)..."
@@ -405,7 +405,7 @@ def cache-upload [worktree_dir: string, profile: string, commit_sha: string, cac
     }
 }
 
-# Build tempo binaries in a git worktree (with optional MinIO cache)
+# Build tempo binary in a git worktree (with optional MinIO cache)
 def build-in-worktree [worktree_dir: string, ref: string, profile: string, features: string, commit_sha: string, --no-cache, --no-default-features, --extra-rustflags: string = "", --bench-features: string = ""] {
     let cache_key = (bench-cache-key $commit_sha $features $no_default_features)
 
@@ -414,32 +414,14 @@ def build-in-worktree [worktree_dir: string, ref: string, profile: string, featu
         return
     }
 
-    # Build from source — when tracy is enabled, tempo and tempo-bench need different features
-    print $"Building binaries for ($ref) in ($worktree_dir)..."
+    print $"Building tempo for ($ref) in ($worktree_dir)..."
     let rustflags = $"($RUSTFLAGS)($extra_rustflags)"
-    if $bench_features != "" and $bench_features != $features {
-        # Build tempo (with tracy features) and tempo-bench (without) separately
-        let tempo_feature_args = (cargo-feature-args $features $no_default_features)
-        let bench_feature_args = (cargo-feature-args $bench_features $no_default_features)
-        let tempo_cmd = ["cargo" "build" "--profile" $profile]
-            | append $tempo_feature_args
-            | append ["--bin" "tempo"]
-        let bench_cmd = ["cargo" "build" "--profile" $profile]
-            | append $bench_feature_args
-            | append ["--bin" "tempo-bench"]
-        with-env { RUSTFLAGS: $rustflags } {
-            do { cd $worktree_dir; run-external ($tempo_cmd | first) ...($tempo_cmd | skip 1) }
-            do { cd $worktree_dir; run-external ($bench_cmd | first) ...($bench_cmd | skip 1) }
-        }
-    } else {
-        let bin_args = ["--bin" "tempo" "--bin" "tempo-bench"]
-        let feature_args = (cargo-feature-args $features $no_default_features)
-        let build_cmd = ["cargo" "build" "--profile" $profile]
-            | append $feature_args
-            | append $bin_args
-        with-env { RUSTFLAGS: $rustflags } {
-            do { cd $worktree_dir; run-external ($build_cmd | first) ...($build_cmd | skip 1) }
-        }
+    let feature_args = (cargo-feature-args $features $no_default_features)
+    let build_cmd = ["cargo" "build" "--profile" $profile]
+        | append $feature_args
+        | append ["--bin" "tempo"]
+    with-env { RUSTFLAGS: $rustflags } {
+        do { cd $worktree_dir; run-external ($build_cmd | first) ...($build_cmd | skip 1) }
     }
 
     # Upload to cache
@@ -491,7 +473,10 @@ def dedup-args [base_args: list<string>, extra_args: list<string>] {
 # Run a single benchmark run (start node, run bench, stop node, collect report)
 def run-bench-single [
     --tempo-bin: string
-    --bench-bin: string
+    --txgen-tempo-bin: string
+    --txgen-bench-bin: string
+    --rpc-urls: string
+    --metrics-url: string
     --genesis-path: string
     --datadir: string
     --run-label: string
@@ -500,7 +485,6 @@ def run-bench-single [
     --duration: int
     --accounts: int
     --max-concurrent-requests: int
-    --weights: list<float>
     --preset: string = ""
     --bench-args: string = ""
     --loud
@@ -588,7 +572,7 @@ def run-bench-single [
     wait-for-rpc "http://localhost:8545" $rpc_timeout
 
     # Start tracy-capture after RPC is ready (node must be running for connection)
-    # If tracy-offset > 0, delay the capture start in a background job so tempo-bench isn't blocked
+    # If tracy-offset > 0, delay the capture start in a background job so txgen isn't blocked
     let tracy_output = $"($results_dir)/tracy-profile-($run_label).tracy"
     let tracy_capture_started = if $tracy != "off" {
         let seconds_flag = if $tracy_seconds > 0 { $"-s ($tracy_seconds)" } else { "" }
@@ -604,53 +588,33 @@ def run-bench-single [
         true
     } else { false }
 
-    # Run tempo-bench
-    let bench_cmd = [
-        $bench_bin
-        "run-max-tps"
-        "--tps" $"($tps)"
-        "--duration" $"($duration)"
-        "--accounts" $"($accounts)"
-        "--max-concurrent-requests" $"($max_concurrent_requests)"
-        "--target-urls" "http://localhost:8545"
-        "--faucet"
-        "--clear-txpool"
-    ]
-    | append (if $preset != "" {
-        [
-            "--tip20-weight" $"($weights | get 0)"
-            "--erc20-weight" $"($weights | get 1)"
-            "--swap-weight" $"($weights | get 2)"
-            "--place-order-weight" $"($weights | get 3)"
-        ]
-    } else { [] })
-    | append (if $bloat > 0 {
-        [
-            "--mnemonic" $"'($BLOAT_MNEMONIC)'"
-        ]
-    } else { [] })
-    | append (if $bench_args != "" { $bench_args | split row " " } else { [] })
-    | append (if $git_ref != "" { ["--node-commit-sha" $git_ref] } else { [] })
-    | append (if $build_profile != "" { ["--build-profile" $build_profile] } else { [] })
-    | append (if $benchmark_mode != "" { ["--benchmark-mode" $benchmark_mode] } else { [] })
-
-    let bench_env_export = if $bench_env != "" { $"export ($bench_env) && " } else { "" }
-    print $"  Running benchmark..."
-    try {
-        bash -c $"($bench_env_export)ulimit -Sn unlimited && ($bench_cmd | str join ' ')"
+    print $"  Running txgen benchmark..."
+    let report_path = $"($results_dir)/report-($run_label).json"
+    let bench_result = (try {
+        let result = (txgen-run-tip20-pipeline
+            --txgen-tempo-bin $txgen_tempo_bin
+            --txgen-bench-bin $txgen_bench_bin
+            --generate-rpc-url "http://localhost:8545"
+            --submit-rpc-url $rpc_urls
+            --metrics-url $metrics_url
+            --report-path $report_path
+            --tps $tps
+            --duration $duration
+            --accounts $accounts
+            --max-concurrent-requests $max_concurrent_requests
+            --bench-env $bench_env
+            --git-ref $git_ref
+            --build-profile $build_profile
+            --benchmark-mode $benchmark_mode)
+        if not $result.ok {
+            print $"  Benchmark run ($run_label) failed with exit code ($result.exit_code)"
+        }
+        $result
     } catch { |e|
         print $"  Benchmark run ($run_label) failed: ($e.msg)"
-    }
-
-    # Collect report
-    if ("report.json" | path exists) {
-        cp report.json $"($results_dir)/report-($run_label).json"
-        rm report.json
-        print $"  Report saved: report-($run_label).json"
-    } else {
-        print $"  ERROR: no report.json found for ($run_label)"
-        error make { msg: $"Benchmark run ($run_label) produced no report.json" }
-    }
+        { ok: false, exit_code: 1, report_path: $report_path }
+    })
+    let bench_failed = not $bench_result.ok
 
     # Stop tracy-capture FIRST (it needs the node alive to flush data)
     if $tracy_capture_started {
@@ -722,6 +686,9 @@ def run-bench-single [
     }
 
     print $"=== Run ($run_label) complete ==="
+    if $bench_failed {
+        error make { msg: $"Benchmark run ($run_label) failed" }
+    }
 }
 
 # Upload a samply profile (.json.gz) to Firefox Profiler and return the short URL.
@@ -1625,7 +1592,7 @@ def restore-system-tuning [tuning_state: record] {
 
 # Initialize the schelk virgin snapshot with genesis + state bloat.
 # Run once (or when changing bloat size). Subsequent `bench` calls skip init
-# if the marker at $HOME/.tempo-bench-meta.json matches the requested config.
+# if the marker in the benchmark datadir matches the requested config.
 def "main bench-init" [
     --bloat: int = 1024                                 # State bloat size in MiB
     --accounts: int = 1000                              # Number of genesis accounts
@@ -1651,7 +1618,7 @@ def "main bench-init" [
     if not $force {
         let marker = (read-bench-marker $datadir)
         if $marker != null {
-            if ($marker.bloat_mib | into int) == $bloat and ($marker.accounts | into int) == $genesis_accounts {
+            if ($marker.bloat_mib | into int) == $bloat and ($marker.accounts | into int) == $genesis_accounts and ($marker | get -o txgen_mnemonic | default "") == (txgen-account-mnemonic) {
                 if ($"($datadir)/db" | path exists) and ($"($meta_dir)/genesis.json" | path exists) {
                     print $"Virgin snapshot already initialized \(bloat=($bloat) MiB, accounts=($genesis_accounts)\). Use --force to re-initialize."
                     return
@@ -1668,8 +1635,9 @@ def "main bench-init" [
     let abs_localnet = ($LOCALNET_DIR | path expand)
     if not ($abs_localnet | path exists) { mkdir $abs_localnet }
     let genesis_path = $"($abs_localnet)/genesis.json"
+    let txgen_genesis_args = ["--mnemonic" (txgen-account-mnemonic)]
     print $"Generating genesis with ($genesis_accounts) accounts..."
-    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis
+    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis
 
     # Generate bloat file
     let bloat_file = $"($abs_localnet)/state_bloat.bin"
@@ -1685,7 +1653,8 @@ def "main bench-init" [
     bench-save-and-promote $datadir $meta_dir {
         bloat_mib: $bloat,
         accounts: $genesis_accounts,
-        bench_datadir: $datadir
+        bench_datadir: $datadir,
+        txgen_mnemonic: (txgen-account-mnemonic)
     } [[$genesis_path "genesis.json"]] $bloat $bloat_file
 
     print $"Virgin snapshot initialized and promoted."
@@ -1695,10 +1664,10 @@ def "main bench-init" [
 # Bench command
 # ============================================================================
 
-# Run a full benchmark: start infra, localnet, and tempo-bench
+# Run a full benchmark: start infra, localnet, and txgen traffic
 def "main bench" [
     --mode: string = "consensus"                    # Mode: "dev" or "consensus"
-    --preset: string = ""                           # Preset: tip20, erc20, swap, order, tempo-mix
+    --preset: string = ""                           # Preset: tip20 (txgen path currently supports tip20 only)
     --tps: int = 10000                              # Target TPS
     --duration: int = 30                            # Duration in seconds
     --accounts: int = 1000                          # Number of accounts
@@ -1713,10 +1682,10 @@ def "main bench" [
     --node-args: string = ""                        # Additional node arguments (space-separated, applied to all runs)
     --baseline-args: string = ""                    # Additional node arguments for baseline runs only (space-separated)
     --feature-args: string = ""                     # Additional node arguments for feature runs only (space-separated)
-    --bench-args: string = ""                       # Additional tempo-bench arguments (space-separated)
+    --bench-args: string = ""                       # Legacy benchmark arguments; only --existing-recipients is ignored for txgen
     --baseline-env: string = ""                     # Environment variables for baseline node runs (KEY=VAL KEY2=VAL2)
     --feature-env: string = ""                      # Environment variables for feature node runs (KEY=VAL KEY2=VAL2)
-    --bench-env: string = ""                        # Environment variables for tempo-bench (KEY=VAL KEY2=VAL2)
+    --bench-env: string = ""                        # Environment variables for txgen/bench (KEY=VAL KEY2=VAL2)
     --bloat: int = 0                                # Generate state bloat (size in MiB) for TIP20 tokens
     --no-infra                                      # Skip starting observability stack (Grafana + Prometheus)
     --baseline: string = ""                         # Git ref for baseline (comparison mode)
@@ -1742,21 +1711,12 @@ def "main bench" [
         exit 1
     }
 
-    # Validate: either preset or bench-args must be provided
-    if $preset == "" and $bench_args == "" {
-        print "Error: either --preset or --bench-args must be provided"
-        print $"  Available presets: ($PRESETS | columns | str join ', ')"
-        exit 1
-    }
+    txgen-require-tip20-preset $preset
+    txgen-validate-tip20-bench-args $bench_args
+    let txgen = (txgen-resolve-binaries)
 
-    # Validate preset if provided
-    if $preset != "" and not ($preset in $PRESETS) {
-        print $"Unknown preset: ($preset). Available: ($PRESETS | columns | str join ', ')"
-        exit 1
-    }
-
-    let weights = if $preset != "" { $PRESETS | get $preset } else { [0.0, 0.0, 0.0, 0.0] }
     let gas_limit_args = if $gas_limit != "" { ["--gas-limit" $gas_limit] } else { [] }
+    let txgen_genesis_args = ["--mnemonic" (txgen-account-mnemonic)]
 
     # Auto-derive tracing OTLP URL: prefer GRAFANA_TEMPO, fall back to TEMPO_TELEMETRY_URL
     let tracing_otlp = if $tracing_otlp == "" and ($env.GRAFANA_TEMPO? | default "" | str length) > 0 {
@@ -1899,13 +1859,7 @@ def "main bench" [
 
         if $baseline == "local" or $feature == "local" {
             print "Building local binaries..."
-            if $tracy != "off" {
-                # Build tempo (with tracy) and tempo-bench (without) separately
-                build-tempo --extra-rustflags $effective_extra_rustflags ["tempo"] $profile $effective_features
-                build-tempo ["tempo-bench"] $profile $features
-            } else {
-                build-tempo ["tempo" "tempo-bench"] $profile $effective_features
-            }
+            build-tempo --extra-rustflags $effective_extra_rustflags ["tempo"] $profile $effective_features
         }
         if $baseline != "local" {
             if $effective_no_cache {
@@ -1925,7 +1879,6 @@ def "main bench" [
         let local_bin = { |name: string| if $profile == "dev" { $"./target/debug/($name)" } else { $"./target/($profile)/($name)" } }
 
         let baseline_tempo = if $baseline == "local" { do $local_bin "tempo" } else { worktree-bin $baseline_wt $profile "tempo" }
-        let baseline_bench_bin = if $baseline == "local" { do $local_bin "tempo-bench" } else { worktree-bin $baseline_wt $profile "tempo-bench" }
         let feature_tempo = if $feature == "local" { do $local_bin "tempo" } else { worktree-bin $feature_wt $profile "tempo" }
 
         # Determine paths (absolute for use inside worktree cd blocks)
@@ -1972,6 +1925,7 @@ def "main bench" [
                 and ($marker | get -o baseline_hardfork | default "") == ($baseline_hardfork | str upcase)
                 and ($marker | get -o feature_hardfork | default "") == ($feature_hardfork | str upcase)
                 and ($marker | get -o gas_limit | default "") == $gas_limit
+                and ($marker | get -o txgen_mnemonic | default "") == (txgen-account-mnemonic)
                 and ($"($baseline_datadir)/db" | path exists)
                 and ($"($feature_datadir)/db" | path exists)
                 and ($"($meta_dir)/genesis-baseline.json" | path exists)
@@ -1989,11 +1943,11 @@ def "main bench" [
                 if ($baseline_genesis_dir | path exists) { rm -rf $baseline_genesis_dir }
                 mkdir $baseline_genesis_dir
                 if $baseline == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
                 } else {
                     do {
                         cd $baseline_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $baseline_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$baseline_genesis_args ...$gas_limit_args
                     }
                 }
                 cp $"($baseline_genesis_dir)/genesis.json" $baseline_genesis_path
@@ -2004,13 +1958,13 @@ def "main bench" [
                 if ($feature_genesis_dir | path exists) { rm -rf $feature_genesis_dir }
                 mkdir $feature_genesis_dir
                 if $feature == "local" {
-                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
+                    cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
                 } else {
                     # Use feature worktree for feature genesis so it picks up any
                     # new hardfork-related genesis changes from the feature branch
                     do {
                         cd $feature_wt
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $feature_genesis_dir -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$feature_genesis_args ...$gas_limit_args
                     }
                 }
                 cp $"($feature_genesis_dir)/genesis.json" $feature_genesis_path
@@ -2047,6 +2001,7 @@ def "main bench" [
                     baseline_hardfork: ($baseline_hardfork | str upcase)
                     feature_hardfork: ($feature_hardfork | str upcase)
                     gas_limit: $gas_limit
+                    txgen_mnemonic: (txgen-account-mnemonic)
                 } [[$baseline_genesis_path "genesis-baseline.json"] [$feature_genesis_path "genesis-feature.json"]] $bloat $bloat_file
 
                 print "Dual-hardfork databases initialized and promoted."
@@ -2064,6 +2019,7 @@ def "main bench" [
                 and ($marker.bloat_mib | into int) == $bloat
                 and ($marker.accounts | into int) == $genesis_accounts
                 and ($marker | get -o gas_limit | default "") == $gas_limit
+                and ($marker | get -o txgen_mnemonic | default "") == (txgen-account-mnemonic)
                 and ($"($datadir)/db" | path exists)
                 and ($"($meta_dir)/genesis.json" | path exists)
             )
@@ -2078,11 +2034,11 @@ def "main bench" [
                     if not ($abs_localnet | path exists) { mkdir $abs_localnet }
                     print $"Generating genesis with ($genesis_accounts) accounts from baseline..."
                     if $baseline == "local" {
-                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis ...$gas_limit_args
+                        cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args
                     } else {
                         do {
                             cd $baseline_wt
-                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts --no-dkg-in-genesis ...$gas_limit_args
+                            cargo run -p tempo-xtask --profile $profile -- generate-genesis --output $abs_localnet -a $genesis_accounts ...$txgen_genesis_args --no-dkg-in-genesis ...$gas_limit_args
                         }
                     }
                 }
@@ -2107,7 +2063,8 @@ def "main bench" [
                     bloat_mib: $bloat,
                     accounts: $genesis_accounts,
                     bench_datadir: $datadir,
-                    gas_limit: $gas_limit
+                    gas_limit: $gas_limit,
+                    txgen_mnemonic: (txgen-account-mnemonic)
                 } [[$genesis_path_std "genesis.json"]] $bloat $bloat_file
 
                 print "Database initialized and promoted to virgin baseline."
@@ -2167,12 +2124,16 @@ def "main bench" [
             let effective_node_args = ([$node_args $side_args] | where { |a| $a != "" } | str join " ")
 
             (run-bench-single
-                --tempo-bin $run.tempo --bench-bin $baseline_bench_bin
+                --tempo-bin $run.tempo
+                --txgen-tempo-bin $txgen.txgen_tempo_bin
+                --txgen-bench-bin $txgen.txgen_bench_bin
+                --rpc-urls "http://localhost:8545"
+                --metrics-url "http://127.0.0.1:9090/metrics"
                 --genesis-path $run.genesis --datadir $run.datadir
                 --run-label $run.label --results-dir $results_dir
                 --tps $tps --duration $duration --accounts $accounts
                 --max-concurrent-requests $max_concurrent_requests
-                --weights $weights --preset $preset --bench-args $bench_args
+                --preset $preset --bench-args $bench_args
                 --loud=$loud --node-args $effective_node_args --bloat $bloat
                 --extra-env $side_env --bench-env $bench_env
                 --git-ref $run.git_ref --build-profile $profile --benchmark-mode $mode
@@ -2238,8 +2199,8 @@ def "main bench" [
         docker compose -f $"($BENCH_DIR)/docker-compose.yml" up -d
     }
 
-    # Build both binaries first
-    build-tempo ["tempo" "tempo-bench"] $profile $features
+    # Build tempo first
+    build-tempo ["tempo"] $profile $features
 
     # Start nodes in background (skip build since we already compiled)
     let num_nodes = if $mode == "dev" { 1 } else { $nodes }
@@ -2281,45 +2242,32 @@ def "main bench" [
     }
     print "All nodes ready!"
 
-    # Run tempo-bench
-    let tempo_bench_bin = if $profile == "dev" {
-        "./target/debug/tempo-bench"
-    } else {
-        $"./target/($profile)/tempo-bench"
-    }
-    let bench_cmd = [
-        $tempo_bench_bin
-        "run-max-tps"
-        "--tps" $"($tps)"
-        "--duration" $"($duration)"
-        "--accounts" $"($accounts)"
-        "--max-concurrent-requests" $"($max_concurrent_requests)"
-        "--target-urls" ($rpc_urls | str join ",")
-        "--faucet"
-        "--clear-txpool"
-    ]
-    | append (if $preset != "" {
-        [
-            "--tip20-weight" $"($weights | get 0)"
-            "--erc20-weight" $"($weights | get 1)"
-            "--swap-weight" $"($weights | get 2)"
-            "--place-order-weight" $"($weights | get 3)"
-        ]
-    } else { [] })
-    | append (if $bloat > 0 {
-        [
-            "--mnemonic" "'test test test test test test test test test test test junk'"
-        ]
-    } else { [] })
-    | append (if $bench_args != "" { $bench_args | split row " " } else { [] })
-    | append ["--node-commit-sha" (git rev-parse HEAD | str trim) "--build-profile" $profile "--benchmark-mode" $mode]
-
-    print $"Running benchmark: ($bench_cmd | str join ' ')"
-    try {
-        bash -c $"ulimit -Sn unlimited && ($bench_cmd | str join ' ')"
-    } catch {
-        print "Benchmark interrupted or failed."
-    }
+    print "Running txgen benchmark..."
+    let submit_rpc_url = ($rpc_urls | str join ",")
+    let primary_rpc_url = ($rpc_urls | first)
+    let current_sha = (git rev-parse HEAD | str trim)
+    let bench_result = (try {
+        let result = (txgen-run-tip20-pipeline
+            --txgen-tempo-bin $txgen.txgen_tempo_bin
+            --txgen-bench-bin $txgen.txgen_bench_bin
+            --generate-rpc-url $primary_rpc_url
+            --submit-rpc-url $submit_rpc_url
+            --metrics-url "http://127.0.0.1:9001/metrics"
+            --report-path "report.json"
+            --tps $tps
+            --duration $duration
+            --accounts $accounts
+            --max-concurrent-requests $max_concurrent_requests
+            --bench-env $bench_env
+            --git-ref $current_sha
+            --build-profile $profile
+            --benchmark-mode $mode)
+        $result
+    } catch { |e|
+        print $"Benchmark interrupted or failed: ($e.msg)"
+        { ok: false, exit_code: 1, report_path: "report.json" }
+    })
+    let single_bench_failed = not $bench_result.ok
 
     # Cleanup
     print "Cleaning up..."
@@ -2339,6 +2287,9 @@ def "main bench" [
     }
 
     restore-system-tuning $tuning_state
+    if $single_bench_failed {
+        error make { msg: "Benchmark interrupted or failed" }
+    }
     print "Done."
 }
 
@@ -2427,7 +2378,7 @@ def "main coverage" [
     --invariant-profile: string = "ci"     # Foundry profile for invariants (ci, fuzz500, default)
     --invariant-contract: string = ""      # Run only a specific invariant contract (e.g. TempoTransactionInvariantTest)
     --live                                 # Include live node coverage (runs localnet + traffic)
-    --preset: string = ""                  # Bench preset for live mode (tip20, erc20, swap, order, tempo-mix)
+    --preset: string = ""                  # Bench preset for live mode (tip20)
     --script: string = ""                  # External script to run against live node (instead of bench)
     --tps: int = 1000                      # Target TPS for live bench (ignored with --script)
     --duration: int = 10                   # Bench duration in seconds (ignored with --script)
@@ -2448,14 +2399,13 @@ def "main coverage" [
     }
 
     if $live and $script == "" and $preset == "" {
-        print "Error: --live requires --preset or --script"
-        print $"  Available presets: ($PRESETS | columns | str join ', ')"
+        print "Error: --live requires --preset tip20 or --script"
+        print "  Available txgen presets: tip20"
         exit 1
     }
 
-    if $live and $preset != "" and not ($preset in $PRESETS) {
-        print $"Unknown preset: ($preset). Available: ($PRESETS | columns | str join ', ')"
-        exit 1
+    if $live and $script == "" {
+        txgen-require-tip20-preset $preset
     }
 
     if $script != "" and not ($script | path exists) {
@@ -2705,31 +2655,27 @@ tempo-precompiles = { path = '($tempo_root)/crates/precompiles' }
                     print "Script finished (or failed)."
                 }
             } else {
-                print "Building tempo-bench..."
-                cargo build --bin tempo-bench
-
-                let weights = $PRESETS | get $preset
-                let bench_bin = "./target/debug/tempo-bench"
-                let bench_cmd = [
-                    $bench_bin
-                    "run-max-tps"
-                    "--tps" $"($tps)"
-                    "--duration" $"($duration)"
-                    "--accounts" $"($accounts)"
-                    "--target-urls" "http://localhost:8545"
-                    "--faucet"
-                    "--clear-txpool"
-                    "--tip20-weight" $"($weights | get 0)"
-                    "--erc20-weight" $"($weights | get 1)"
-                    "--swap-weight" $"($weights | get 2)"
-                    "--place-order-weight" $"($weights | get 3)"
-                ]
-
-                print $"Running bench: ($bench_cmd | str join ' ')"
+                let txgen = (txgen-resolve-binaries)
+                print "Running txgen bench..."
                 try {
-                    run-external ($bench_cmd | first) ...($bench_cmd | skip 1)
-                } catch {
-                    print "Bench finished (or interrupted)."
+                    let bench_result = (txgen-run-tip20-pipeline
+                        --txgen-tempo-bin $txgen.txgen_tempo_bin
+                        --txgen-bench-bin $txgen.txgen_bench_bin
+                        --generate-rpc-url "http://localhost:8545"
+                        --submit-rpc-url "http://localhost:8545"
+                        --metrics-url "http://127.0.0.1:9001/metrics"
+                        --report-path "report.json"
+                        --tps $tps
+                        --duration $duration
+                        --accounts $accounts
+                        --max-concurrent-requests 100
+                        --build-profile "coverage"
+                        --benchmark-mode "coverage")
+                    if not $bench_result.ok {
+                        print "Bench finished (or interrupted)."
+                    }
+                } catch { |e|
+                    print $"Bench finished (or interrupted): ($e.msg)"
                 }
             }
 
@@ -2792,9 +2738,9 @@ def main [] {
     print "  nu tempo.nu infra down               Stop the observability stack"
     print "  nu tempo.nu kill                     Kill any running tempo processes"
     print ""
-    print "Bench flags (either --preset or --bench-args required):"
+    print "Bench flags (--preset tip20 required for txgen path):"
     print "  --mode <M>               Mode: dev or consensus (default: consensus)"
-    print "  --preset <P>             Preset: tip20, erc20, swap, order, tempo-mix"
+    print "  --preset <P>             Preset: tip20"
     print "  --tps <N>                Target TPS (default: 10000)"
     print "  --duration <N>           Duration in seconds (default: 30)"
     print "  --accounts <N>           Number of accounts (default: 1000)"
@@ -2814,7 +2760,7 @@ def main [] {
     print "  --node-args <ARGS>       Additional node arguments (space-separated, all runs)"
     print "  --baseline-args <ARGS>       Additional node arguments for baseline runs only"
     print "  --feature-args <ARGS>        Additional node arguments for feature runs only"
-    print "  --bench-args <ARGS>      Additional tempo-bench arguments (space-separated)"
+    print "  --bench-args <ARGS>      Legacy benchmark arguments (only --existing-recipients is ignored)"
     print "  --bloat <N>              Generate TIP20 state bloat (size in MiB)"
     print "  --gas-limit <N>          Block gas limit for genesis (raw number, default: 1000000000000)"
     print ""
@@ -2837,7 +2783,7 @@ def main [] {
     print "  --invariant-profile <P>  Foundry profile for invariants (ci, fuzz500, default; default: ci)"
     print "  --invariant-contract <C> Run only a specific invariant contract"
     print "  --live                   Include live node coverage (runs localnet + traffic)"
-    print "  --preset <P>             Bench preset for live mode"
+    print "  --preset <P>             Bench preset for live mode (tip20)"
     print "  --script <PATH>          External script to run against live node (instead of bench)"
     print "  --tps <N>                Target TPS for live bench (default: 1000)"
     print "  --duration <N>           Bench duration in seconds (default: 10)"
@@ -2855,14 +2801,14 @@ def main [] {
     print ""
     print "Examples:"
     print "  nu tempo.nu bench --preset tip20 --tps 20000 --duration 60"
-    print "  nu tempo.nu bench --preset tempo-mix --tps 5000 --samply --reset"
+    print "  nu tempo.nu bench --preset tip20 --tps 5000 --samply --reset"
     print "  nu tempo.nu coverage --tests                              # unit + integration tests"
     print "  nu tempo.nu coverage --invariants                         # forge invariant fuzz (precompile coverage)"
     print "  nu tempo.nu coverage --tests --invariants                 # merged: cargo + forge coverage"
     print "  nu tempo.nu coverage --invariants --invariant-profile fuzz500  # deeper fuzz run"
     print "  nu tempo.nu coverage --live --preset tip20 --open         # live tx coverage"
     print "  nu tempo.nu coverage --live --script /path/to/test.sh     # live + external script"
-    print "  nu tempo.nu coverage --tests --live --preset tempo-mix    # everything merged"
+    print "  nu tempo.nu coverage --tests --live --preset tip20        # everything merged"
     print "  nu tempo.nu infra up"
     print "  nu tempo.nu localnet --mode dev --samply --accounts 50000 --reset"
     print "  nu tempo.nu localnet --mode dev --bloat 1024 --reset"


### PR DESCRIPTION
- Replaces `tempo-bench` execution in `tempo.nu` and related bench flows with `txgen-tempo generate | bench send`.
- Adds shared txgen helpers and moves the canonical TIP20 template under `contrib/bench/txgen/templates/`.
- Restricts the first pass of the txgen path to `--preset tip20` and removes the old `tempo-bench` build/cache path.