### PR TITLE
fix: reject withdrawals

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -454,7 +454,7 @@ where
             .as_ref()
             .is_some_and(|withdrawals| !withdrawals.is_empty())
         {
-            return Err(BlockExecutionError::msg("withdrawals are not permitted"));
+            return Err(BlockValidationError::msg("withdrawals are not permitted").into());
         }
 
         self.inner.apply_pre_execution_changes()?;

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -447,6 +447,16 @@ where
     type Result = TempoTxResult;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), alloy_evm::block::BlockExecutionError> {
+        if self
+            .inner
+            .ctx
+            .withdrawals
+            .as_ref()
+            .is_some_and(|withdrawals| !withdrawals.is_empty())
+        {
+            return Err(BlockExecutionError::msg("withdrawals must be empty"));
+        }
+
         self.inner.apply_pre_execution_changes()?;
 
         // Deploy 0xEF marker bytecode to precompiles at their activation hardforks.

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -454,7 +454,7 @@ where
             .as_ref()
             .is_some_and(|withdrawals| !withdrawals.is_empty())
         {
-            return Err(BlockExecutionError::msg("withdrawals must be empty"));
+            return Err(BlockExecutionError::msg("withdrawals are not permitted"));
         }
 
         self.inner.apply_pre_execution_changes()?;


### PR DESCRIPTION
Rejects all blocks with non-empty withdrawals list.

We enforce it in executor to make sure that it never is tricked into actually commiting withdrawals even if block was not pre-validated beforehand