### PR TITLE
feat(node): support custom state root strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,7 +8322,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8381,7 +8381,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8507,7 +8507,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
@@ -8627,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8776,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9211,7 +9211,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "clap",
  "eyre",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "serde",
  "serde_json",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "bytes",
  "futures",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "bindgen",
  "cc",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "futures",
  "metrics",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9599,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9735,7 +9735,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-network",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9961,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -9985,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "bytes",
  "eyre",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10026,7 +10026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10062,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10205,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10236,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10313,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10386,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10406,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -10748,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10769,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "clap",
  "eyre",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "clap",
  "eyre",
@@ -10832,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10930,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10950,7 +10950,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=7354172#735417251bbcc55036672be53a3ce343aefabdb1"
+source = "git+https://github.com/paradigmxyz/reth?rev=5e2c16912#5e2c16912e1af16b289fd82fc88f3a909c1ac653"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12856,6 +12856,7 @@ version = "1.6.0"
 dependencies = [
  "alloy",
  "alloy-eips 2.0.4",
+ "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
@@ -12878,6 +12879,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reth-chainspec",
  "reth-e2e-test-utils",
+ "reth-engine-tree",
  "reth-errors",
  "reth-ethereum",
  "reth-evm",
@@ -12896,6 +12898,7 @@ dependencies = [
  "reth-rpc-eth-types",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,64 +140,65 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
 reth-codecs = { version = "0.3.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
 reth-primitives-traits = { version = "0.3.1", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7354172" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7354172", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5e2c16912", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -42,6 +42,7 @@ reth-rpc-builder.workspace = true
 reth-node-api.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-node-ethereum.workspace = true
+reth-engine-tree.workspace = true
 
 alloy-serde.workspace = true
 alloy-eips.workspace = true
@@ -64,6 +65,8 @@ serde_json.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+alloy-genesis.workspace = true
+reth-trie.workspace = true
 tempo-e2e.workspace = true
 tempo-transaction-pool = { workspace = true, features = ["test-utils"] }
 alloy-network.workspace = true

--- a/crates/node/examples/custom_state_root.rs
+++ b/crates/node/examples/custom_state_root.rs
@@ -1,0 +1,83 @@
+//! Example: Running a Tempo dev node with a custom state root strategy.
+//!
+//! This demonstrates how to use the [`CustomStateRoot`] hook added in
+//! [paradigmxyz/reth#24130](https://github.com/paradigmxyz/reth/pull/24130)
+//! to override state root computation. The example sets the state root to
+//! `B256::ZERO` for every block.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --example custom_state_root
+//! ```
+
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use reth_ethereum::tasks::Runtime;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_trie::updates::TrieUpdates;
+use tempo_chainspec::spec::TempoChainSpec;
+use tempo_node::{CustomStateRoot, TempoNodeArgs, node::TempoNode, primitives::TempoPrimitives};
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    // A custom state root handler that always returns B256::ZERO.
+    let zero_state_root: CustomStateRoot<TempoPrimitives> =
+        Arc::new(|_input| Ok((B256::ZERO, TrieUpdates::default())));
+
+    let node = TempoNode::new(&TempoNodeArgs::default(), None)
+        .with_custom_state_root(zero_state_root);
+
+    // Build a minimal Tempo chain spec for dev mode.
+    let genesis: alloy_genesis::Genesis = serde_json::from_value(serde_json::json!({
+        "config": {
+            "chainId": 1,
+            "homesteadBlock": 0,
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "constantinopleBlock": 0,
+            "petersburgBlock": 0,
+            "istanbulBlock": 0,
+            "berlinBlock": 0,
+            "londonBlock": 0,
+            "terminalTotalDifficulty": 0,
+            "terminalTotalDifficultyPassed": true,
+            "shanghaiTime": 0,
+            "cancunTime": 0,
+            "pragueTime": 0
+        },
+        "nonce": "0x0",
+        "timestamp": "0x0",
+        "gasLimit": "0x1c9c380",
+        "difficulty": "0x0",
+        "alloc": {
+            "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b": {
+                "balance": "0x4a47e3c12448f4ad000000"
+            }
+        }
+    }))?;
+    let chain_spec: TempoChainSpec = reth_chainspec::ChainSpec::from(genesis).into();
+
+    let node_config = NodeConfig::new(Arc::new(chain_spec))
+        .with_unused_ports()
+        .dev()
+        .with_rpc(RpcServerArgs::default().with_http());
+
+    let runtime = Runtime::test();
+
+    let NodeHandle {
+        node: _node,
+        node_exit_future,
+    } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .node(node)
+        .launch_with_debug_capabilities()
+        .await?;
+
+    println!("Tempo node running with custom zero state root — press Ctrl+C to exit");
+
+    node_exit_future.await
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,6 +16,7 @@ pub mod engine;
 pub mod node;
 pub mod rpc;
 pub mod telemetry;
+pub use reth_engine_tree::tree::payload_validator::{CustomStateRoot, CustomStateRootInput};
 pub use tempo_consensus as consensus;
 pub use tempo_evm as evm;
 pub use tempo_primitives as primitives;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use alloy_primitives::B256;
+use reth_engine_tree::tree::payload_validator::CustomStateRoot;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
     PayloadAttributesBuilder, PayloadTypes,
@@ -20,8 +21,9 @@ use reth_node_builder::{
         PayloadBuilderBuilder, PoolBuilder, TxPoolBuilder, spawn_maintenance_tasks,
     },
     rpc::{
-        BasicEngineValidatorBuilder, EngineValidatorAddOn, NoopEngineApiBuilder,
-        PayloadValidatorBuilder, RethRpcAddOns, RpcAddOns, RpcHandle, RpcHooks,
+        BasicEngineValidatorBuilder, EngineValidatorAddOn, EngineValidatorBuilder,
+        NoopEngineApiBuilder, PayloadValidatorBuilder, RethRpcAddOns, RpcAddOns, RpcHandle,
+        RpcHooks,
     },
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
@@ -89,7 +91,7 @@ impl TempoNodeArgs {
 }
 
 /// Type configuration for a regular Ethereum node.
-#[derive(Debug, Default, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct TempoNode {
     /// Transaction pool builder.
@@ -98,6 +100,30 @@ pub struct TempoNode {
     payload_builder_builder: TempoPayloadBuilderBuilder,
     /// Validator public key for `admin_validatorKey` RPC method.
     validator_key: Option<B256>,
+    /// Optional custom state root computation handler.
+    custom_state_root: Option<CustomStateRoot<TempoPrimitives>>,
+}
+
+impl Default for TempoNode {
+    fn default() -> Self {
+        Self {
+            pool_builder: TempoPoolBuilder::default(),
+            payload_builder_builder: TempoPayloadBuilderBuilder::default(),
+            validator_key: None,
+            custom_state_root: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for TempoNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TempoNode")
+            .field("pool_builder", &self.pool_builder)
+            .field("payload_builder_builder", &self.payload_builder_builder)
+            .field("validator_key", &self.validator_key)
+            .field("custom_state_root", &self.custom_state_root.as_ref().map(|_| ".."))
+            .finish()
+    }
 }
 
 impl TempoNode {
@@ -107,7 +133,21 @@ impl TempoNode {
             pool_builder: args.pool_builder(),
             payload_builder_builder: args.payload_builder_builder(),
             validator_key,
+            custom_state_root: None,
         }
+    }
+
+    /// Sets a custom state root computation handler.
+    ///
+    /// When set, the engine validator will use this handler instead of
+    /// computing the state root via the trie. See [`CustomStateRoot`] for
+    /// details.
+    pub fn with_custom_state_root(
+        mut self,
+        custom_state_root: CustomStateRoot<TempoPrimitives>,
+    ) -> Self {
+        self.custom_state_root = Some(custom_state_root);
+        self
     }
 
     /// Returns a [`ComponentsBuilder`] configured for a regular Tempo node.
@@ -152,6 +192,53 @@ impl NodeTypes for TempoNode {
     type Payload = TempoPayloadTypes;
 }
 
+/// An [`EngineValidatorBuilder`] that wraps [`BasicEngineValidatorBuilder`] and
+/// optionally installs a [`CustomStateRoot`] handler on the resulting validator.
+#[derive(Clone)]
+pub struct TempoEngineValidatorBuilderWithCustomRoot {
+    inner: BasicEngineValidatorBuilder<TempoEngineValidatorBuilder>,
+    custom_state_root: Option<CustomStateRoot<TempoPrimitives>>,
+}
+
+impl std::fmt::Debug for TempoEngineValidatorBuilderWithCustomRoot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TempoEngineValidatorBuilderWithCustomRoot")
+            .field("inner", &self.inner)
+            .field("custom_state_root", &self.custom_state_root.as_ref().map(|_| ".."))
+            .finish()
+    }
+}
+
+impl<Node> EngineValidatorBuilder<Node> for TempoEngineValidatorBuilderWithCustomRoot
+where
+    Node: FullNodeComponents<
+        Types = TempoNode,
+        Evm: reth_node_builder::ConfigureEngineEvm<TempoExecutionData>,
+    >,
+{
+    type EngineValidator =
+        <BasicEngineValidatorBuilder<TempoEngineValidatorBuilder> as EngineValidatorBuilder<
+            Node,
+        >>::EngineValidator;
+
+    async fn build_tree_validator(
+        self,
+        ctx: &AddOnsContext<'_, Node>,
+        tree_config: reth_node_api::TreeConfig,
+        changeset_cache: reth_node_builder::rpc::ChangesetCache,
+    ) -> eyre::Result<Self::EngineValidator> {
+        let validator = self
+            .inner
+            .build_tree_validator(ctx, tree_config, changeset_cache)
+            .await?;
+        if let Some(custom_state_root) = self.custom_state_root {
+            Ok(validator.with_custom_state_root(custom_state_root))
+        } else {
+            Ok(validator)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct TempoAddOns<N: FullNodeTypes<Types = TempoNode>> {
     inner: RpcAddOns<
@@ -159,7 +246,7 @@ pub struct TempoAddOns<N: FullNodeTypes<Types = TempoNode>> {
         TempoEthApiBuilder,
         TempoEngineValidatorBuilder,
         NoopEngineApiBuilder,
-        BasicEngineValidatorBuilder<TempoEngineValidatorBuilder>,
+        TempoEngineValidatorBuilderWithCustomRoot,
         Identity,
     >,
     validator_key: Option<B256>,
@@ -170,13 +257,19 @@ where
     N: FullNodeTypes<Types = TempoNode>,
 {
     /// Creates a new instance from the inner `RpcAddOns`.
-    pub fn new(validator_key: Option<B256>) -> Self {
+    pub fn new(
+        validator_key: Option<B256>,
+        custom_state_root: Option<CustomStateRoot<TempoPrimitives>>,
+    ) -> Self {
         Self {
             inner: RpcAddOns::new(
                 TempoEthApiBuilder::new(validator_key),
                 TempoEngineValidatorBuilder,
                 NoopEngineApiBuilder::default(),
-                BasicEngineValidatorBuilder::default(),
+                TempoEngineValidatorBuilderWithCustomRoot {
+                    inner: BasicEngineValidatorBuilder::default(),
+                    custom_state_root,
+                },
                 Identity::default(),
                 Default::default(),
             ),
@@ -247,7 +340,7 @@ impl<N> EngineValidatorAddOn<NodeAdapter<N>> for TempoAddOns<N>
 where
     N: FullNodeTypes<Types = TempoNode>,
 {
-    type ValidatorBuilder = BasicEngineValidatorBuilder<TempoEngineValidatorBuilder>;
+    type ValidatorBuilder = TempoEngineValidatorBuilderWithCustomRoot;
 
     fn engine_validator_builder(&self) -> Self::ValidatorBuilder {
         self.inner.engine_validator_builder()
@@ -274,7 +367,7 @@ where
     }
 
     fn add_ons(&self) -> Self::AddOns {
-        TempoAddOns::new(self.validator_key)
+        TempoAddOns::new(self.validator_key, self.custom_state_root.clone())
     }
 }
 


### PR DESCRIPTION
## Summary

Integrates the custom state root hook from [paradigmxyz/reth#24130](https://github.com/paradigmxyz/reth/pull/24130) into TempoNode, with an example showing how to run a node that always returns `B256::ZERO` as the state root.

### Changes

- **Bump reth to `5e2c16912`** — includes the custom state root PR plus a few minor engine refactors
- **`TempoNode::with_custom_state_root()`** — configures a `CustomStateRoot<TempoPrimitives>` handler on the node
- **`TempoEngineValidatorBuilderWithCustomRoot`** — wraps `BasicEngineValidatorBuilder` and calls `.with_custom_state_root()` on the resulting validator
- **Re-exports** `CustomStateRoot` and `CustomStateRootInput` from `tempo-node` so downstream consumers don't need a direct `reth-engine-tree` dep
- **`crates/node/examples/custom_state_root.rs`** — minimal dev node that sets the state root to zero

### Usage

```sh
cargo run --example custom_state_root
```

Prompted by: @klkvr