### PR TITLE
chore(consensus): report if reth did not return a payload ID

### DIFF
--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -517,11 +517,31 @@ where
                 let _ = response.send(Ok(()));
             }
             JustCanonicalizeOrAlsoBuild::AlsoBuild { response, .. } => {
-                if let Some(payload_id) = fcu_response.payload_id {
-                    let _ = response.send(Ok(payload_id));
+                let result = if fcu_response.is_syncing() {
+                    let canonical_block_number = self
+                        .execution_node
+                        .provider()
+                        .canonical_in_memory_state()
+                        .get_canonical_block_number();
+
+                    // Allow a syncing if only behind by 1 block
+                    let min_allowed = height.previous().unwrap_or_default().get();
+                    if canonical_block_number < min_allowed {
+                        Some(Err(eyre::eyre!(
+                            "build request on height {height} too far ahead of canonical height {canonical_block_number}"
+                        )))
+                    } else {
+                        fcu_response.payload_id.map(Ok)
+                    }
+                } else {
+                    fcu_response.payload_id.map(Ok)
+                };
+                if let Some(result) = result {
+                    let _ = response.send(result);
                 }
             }
         }
+
         self.last_canonicalized = new_canonicalized;
         self.reset_fcu_heartbeat_timer();
     }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -473,6 +473,22 @@ where
             return;
         }
 
+        let canonical_block_number = self
+            .execution_node
+            .provider()
+            .canonical_in_memory_state()
+            .get_canonical_block_number();
+
+        // Allow syncing the parent block. Anything deeper will likely timeout
+        if canonical_block_number < height.previous().unwrap_or_default().get()
+            && let JustCanonicalizeOrAlsoBuild::AlsoBuild { response, .. } = maybe_build
+        {
+            let _ = response.send(Err(eyre::eyre!(
+                "build request on height {height} too far ahead of canonical height {canonical_block_number}"
+            )));
+            return;
+        }
+
         info!(
             head_block_hash = %new_canonicalized.forkchoice.head_block_hash,
             head_block_height = %new_canonicalized.head_height,
@@ -517,27 +533,8 @@ where
                 let _ = response.send(Ok(()));
             }
             JustCanonicalizeOrAlsoBuild::AlsoBuild { response, .. } => {
-                let result = if fcu_response.is_syncing() {
-                    let canonical_block_number = self
-                        .execution_node
-                        .provider()
-                        .canonical_in_memory_state()
-                        .get_canonical_block_number();
-
-                    // Allow syncing only for the parent block. Anything deeper would most likely trigger the proposer timeout
-                    if canonical_block_number < height.previous().unwrap_or_default().get() {
-                        Some(Err(eyre::eyre!(
-                            "build request on height {height} too far ahead of canonical height {canonical_block_number}"
-                        )))
-                    } else {
-                        fcu_response.payload_id.map(Ok)
-                    }
-                } else {
-                    fcu_response.payload_id.map(Ok)
-                };
-
-                if let Some(result) = result {
-                    let _ = response.send(result);
+                if let Some(payload_id) = fcu_response.payload_id {
+                    let _ = response.send(Ok(payload_id));
                 }
             }
         }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -525,8 +525,7 @@ where
                         .get_canonical_block_number();
 
                     // Allow a syncing if only behind by 1 block
-                    let min_allowed = height.previous().unwrap_or_default().get();
-                    if canonical_block_number < min_allowed {
+                    if canonical_block_number < height.get() {
                         Some(Err(eyre::eyre!(
                             "build request on height {height} too far ahead of canonical height {canonical_block_number}"
                         )))

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -11,7 +11,7 @@ use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{Clock, ContextCell, FutureExt, Handle, Pacer, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
-use eyre::{Report, WrapErr as _, ensure};
+use eyre::{Report, WrapErr as _, ensure, eyre};
 use futures::{
     FutureExt as _, StreamExt as _,
     channel::{
@@ -473,20 +473,17 @@ where
             return;
         }
 
-        let canonical_block_number = self
+        let canonical_block_height = self
             .execution_node
             .provider()
             .canonical_in_memory_state()
             .get_canonical_block_number();
 
-        // Allow syncing the parent block. Anything deeper will likely timeout
-        if canonical_block_number < height.previous().unwrap_or_default().get()
-            && let JustCanonicalizeOrAlsoBuild::AlsoBuild { response, .. } = maybe_build
-        {
-            let _ = response.send(Err(eyre::eyre!(
-                "build request on height {height} too far ahead of canonical height {canonical_block_number}"
-            )));
-            return;
+        // Reject build requests when syncing beyond the parent block
+        let mut attrs = maybe_build.attributes().cloned();
+        if attrs.is_some() && canonical_block_height < height.previous().unwrap_or_default().get() {
+            info!(%canonical_block_height, %height, "build request too far ahead of canonical height");
+            attrs = None;
         }
 
         info!(
@@ -496,14 +493,12 @@ where
             finalized_block_height = %new_canonicalized.finalized_height,
             "sending forkchoice-update",
         );
+
         let fcu_response = match self
             .execution_node
             .add_ons_handle
             .beacon_engine_handle
-            .fork_choice_updated(
-                new_canonicalized.forkchoice,
-                maybe_build.attributes().cloned(),
-            )
+            .fork_choice_updated(new_canonicalized.forkchoice, attrs)
             .pace(&self.context, Duration::from_millis(20))
             .await
             .wrap_err("failed requesting execution layer to update forkchoice state")
@@ -535,6 +530,8 @@ where
             JustCanonicalizeOrAlsoBuild::AlsoBuild { response, .. } => {
                 if let Some(payload_id) = fcu_response.payload_id {
                     let _ = response.send(Ok(payload_id));
+                } else {
+                    let _ = response.send(Err(eyre!("no payload id for the build request")));
                 }
             }
         }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -473,19 +473,6 @@ where
             return;
         }
 
-        let canonical_block_height = self
-            .execution_node
-            .provider()
-            .canonical_in_memory_state()
-            .get_canonical_block_number();
-
-        // Reject build requests when syncing beyond the parent block
-        let mut attrs = maybe_build.attributes().cloned();
-        if attrs.is_some() && canonical_block_height < height.previous().unwrap_or_default().get() {
-            info!(%canonical_block_height, %height, "build request too far ahead of canonical height");
-            attrs = None;
-        }
-
         info!(
             head_block_hash = %new_canonicalized.forkchoice.head_block_hash,
             head_block_height = %new_canonicalized.head_height,
@@ -494,6 +481,7 @@ where
             "sending forkchoice-update",
         );
 
+        let attrs = maybe_build.attributes().cloned();
         let fcu_response = match self
             .execution_node
             .add_ons_handle

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -535,6 +535,7 @@ where
                 } else {
                     fcu_response.payload_id.map(Ok)
                 };
+
                 if let Some(result) = result {
                     let _ = response.send(result);
                 }

--- a/crates/commonware-node/src/executor/actor.rs
+++ b/crates/commonware-node/src/executor/actor.rs
@@ -524,8 +524,8 @@ where
                         .canonical_in_memory_state()
                         .get_canonical_block_number();
 
-                    // Allow a syncing if only behind by 1 block
-                    if canonical_block_number < height.get() {
+                    // Allow syncing only for the parent block. Anything deeper would most likely trigger the proposer timeout
+                    if canonical_block_number < height.previous().unwrap_or_default().get() {
                         Some(Err(eyre::eyre!(
                             "build request on height {height} too far ahead of canonical height {canonical_block_number}"
                         )))


### PR DESCRIPTION
Qe support threading back errors in the response channel so we should populate it if we have no payload id on a build request rather than rely on dropping the channel

Context: When syncing, reth does not return a payload id