### PR TITLE
chore: bump workspace version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12450,7 +12450,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12569,7 +12569,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-bench"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12616,7 +12616,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12673,7 +12673,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -12686,7 +12686,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12717,7 +12717,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12731,7 +12731,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12782,7 +12782,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12812,7 +12812,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -12831,7 +12831,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -12839,7 +12839,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -12852,7 +12852,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-eips 2.0.4",
@@ -12920,7 +12920,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12952,7 +12952,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -12970,7 +12970,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13001,7 +13001,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13049,7 +13049,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -13083,7 +13083,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13108,7 +13108,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13117,7 +13117,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -13156,7 +13156,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13168,7 +13168,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the workspace package version on main to match the completed v1.7.0 release and refreshes Cargo.lock with the updated workspace package versions.